### PR TITLE
Bug no projeto

### DIFF
--- a/crates/garraia-agents/src/memory_extractor.rs
+++ b/crates/garraia-agents/src/memory_extractor.rs
@@ -56,7 +56,7 @@ Se não houver fatos relevantes, retorne: []"#.to_string(),
 
         let messages = vec![
             ChatMessage {
-                role: ChatRole::System,
+                role: ChatRole::User,
                 content: MessagePart::Text(prompt),
             }
         ];

--- a/crates/garraia-agents/src/ollama.rs
+++ b/crates/garraia-agents/src/ollama.rs
@@ -37,7 +37,16 @@ impl OllamaProvider {
             request.model.clone()
         };
 
-        let messages: Vec<Value> = request
+        let mut messages: Vec<Value> = Vec::new();
+
+        if let Some(system) = &request.system {
+            messages.push(serde_json::json!({
+                "role": "system",
+                "content": system,
+            }));
+        }
+
+        let user_messages: Vec<Value> = request
             .messages
             .iter()
             .map(|msg| {
@@ -105,6 +114,8 @@ impl OllamaProvider {
                 msg_obj
             })
             .collect();
+
+        messages.extend(user_messages);
 
         let mut body = serde_json::json!({
             "model": model,

--- a/crates/garraia-agents/src/runtime.rs
+++ b/crates/garraia-agents/src/runtime.rs
@@ -1165,23 +1165,23 @@ impl AgentRuntime {
     pub async fn chat_completion(
         &self,
         messages: Vec<ChatMessage>,
-        _system: Option<String>,
-        _model: Option<String>,
-        _max_tokens: Option<u32>,
-        _temperature: Option<f32>,
-        _tools: Option<Vec<ToolDefinition>>,
+        system: Option<String>,
+        model: Option<String>,
+        max_tokens: Option<u32>,
+        temperature: Option<f32>,
+        tools: Option<Vec<ToolDefinition>>,
     ) -> Result<String> {
         let provider = self
             .default_provider()
             .ok_or_else(|| Error::Agent("no LLM provider configured".into()))?;
 
         let request = LlmRequest {
-            model: String::new(),
+            model: model.unwrap_or_default(),
             messages,
-            system: None,
-            max_tokens: Some(4096),
-            temperature: None,
-            tools: Vec::new(),
+            system,
+            max_tokens: Some(max_tokens.unwrap_or(4096)),
+            temperature: temperature.map(|t| t as f64),
+            tools: tools.unwrap_or_default(),
         };
 
         let response = provider.complete(&request).await?;
@@ -1228,6 +1228,8 @@ fn estimate_tokens(
 
 /// Drop the oldest messages until the estimated token count fits the budget.
 /// Always keeps at least the last message (the current user input).
+/// Removes messages in pairs (assistant + tool-result) to avoid breaking
+/// the conversation protocol required by LLM APIs.
 fn trim_messages_to_budget(
     messages: &mut Vec<ChatMessage>,
     system: &Option<String>,
@@ -1235,7 +1237,22 @@ fn trim_messages_to_budget(
     max_tokens: usize,
 ) {
     while messages.len() > 1 && estimate_tokens(messages, system, tools) > max_tokens {
+        let has_tool_use = matches!(
+            &messages[0].content,
+            MessagePart::Parts(parts) if parts.iter().any(|b| matches!(b, ContentBlock::ToolUse { .. }))
+        );
+
         messages.remove(0);
+
+        if has_tool_use && messages.len() > 1 {
+            let is_tool_result = matches!(
+                &messages[0].content,
+                MessagePart::Parts(parts) if parts.iter().any(|b| matches!(b, ContentBlock::ToolResult { .. }))
+            );
+            if is_tool_result {
+                messages.remove(0);
+            }
+        }
     }
 }
 

--- a/crates/garraia-agents/src/tools/bash_tool.rs
+++ b/crates/garraia-agents/src/tools/bash_tool.rs
@@ -92,7 +92,11 @@ impl Tool for BashTool {
 
                 // Truncar se exceder limite
                 if combinado.len() > MAX_BYTES_SAIDA {
-                    combinado.truncate(MAX_BYTES_SAIDA);
+                    let mut end = MAX_BYTES_SAIDA;
+                    while end > 0 && !combinado.is_char_boundary(end) {
+                        end -= 1;
+                    }
+                    combinado.truncate(end);
                     combinado.push_str("\n... (saída truncada)");
                 }
 

--- a/crates/garraia-channels/src/discord/convert.rs
+++ b/crates/garraia-channels/src/discord/convert.rs
@@ -165,13 +165,12 @@ pub fn split_discord_chunks(input: &str) -> Vec<String> {
     let mut current_len = 0usize;
 
     for ch in input.chars() {
-        let ch_len = ch.len_utf8();
-        if current_len + ch_len > DISCORD_MESSAGE_CHAR_LIMIT {
+        if current_len + 1 > DISCORD_MESSAGE_CHAR_LIMIT {
             chunks.push(std::mem::take(&mut current));
             current_len = 0;
         }
         current.push(ch);
-        current_len += ch_len;
+        current_len += 1;
     }
 
     if !current.is_empty() {
@@ -242,7 +241,16 @@ mod tests {
         let long = "a".repeat(DISCORD_MESSAGE_CHAR_LIMIT + 10);
         let chunks = split_discord_chunks(&long);
         assert_eq!(chunks.len(), 2);
-        assert_eq!(chunks[0].len(), DISCORD_MESSAGE_CHAR_LIMIT);
-        assert_eq!(chunks[1].len(), 10);
+        assert_eq!(chunks[0].chars().count(), DISCORD_MESSAGE_CHAR_LIMIT);
+        assert_eq!(chunks[1].chars().count(), 10);
+    }
+
+    #[test]
+    fn chunking_counts_chars_not_bytes() {
+        let long: String = "\u{1F600}".repeat(DISCORD_MESSAGE_CHAR_LIMIT + 5);
+        let chunks = split_discord_chunks(&long);
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].chars().count(), DISCORD_MESSAGE_CHAR_LIMIT);
+        assert_eq!(chunks[1].chars().count(), 5);
     }
 }

--- a/crates/garraia-channels/src/registry.rs
+++ b/crates/garraia-channels/src/registry.rs
@@ -44,11 +44,20 @@ impl ChannelRegistry {
     }
 
     pub async fn disconnect_all(&mut self) -> Result<()> {
+        let mut first_error: Option<garraia_common::Error> = None;
         for (name, channel) in &mut self.channels {
             info!("disconnecting channel: {}", name);
-            channel.disconnect().await?;
+            if let Err(e) = channel.disconnect().await {
+                tracing::error!("failed to disconnect channel {}: {}", name, e);
+                if first_error.is_none() {
+                    first_error = Some(e);
+                }
+            }
         }
-        Ok(())
+        match first_error {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
     }
 }
 

--- a/crates/garraia-channels/src/telegram_fmt.rs
+++ b/crates/garraia-channels/src/telegram_fmt.rs
@@ -75,7 +75,7 @@ pub fn to_telegram_markdown(input: &str) -> String {
             result.push('*');
             i += 2;
             while i < len && !(i + 1 < len && chars[i] == '*' && chars[i + 1] == '*') {
-                if is_special(chars[i]) && chars[i] != '*' {
+                if is_special(chars[i]) {
                     result.push('\\');
                 }
                 result.push(chars[i]);

--- a/crates/garraia-cli/src/main.rs
+++ b/crates/garraia-cli/src/main.rs
@@ -348,7 +348,7 @@ fn main() -> Result<()> {
 
     // Init tracing for non-daemon mode (daemon reconfigures after fork)
     let init_tracing = |level: &str| {
-        let log_dir = dirs::home_dir().unwrap().join(".garraia");
+        let log_dir = garraia_dir();
         std::fs::create_dir_all(&log_dir).unwrap_or_else(|e| {
             eprintln!("Warning: failed to create log directory: {}", e);
         });
@@ -886,7 +886,7 @@ fn start_daemon(config: garraia_config::AppConfig) -> Result<()> {
         Ok(()) => {
             // We are now in the child (daemon) process.
             // Re-init tracing to write to the log file.
-            let log_dir = dirs::home_dir().unwrap().join(".garraia");
+            let log_dir = garraia_dir();
             let file_appender = rolling::never(&log_dir, "garraia.log");
 
             tracing_subscriber::fmt()

--- a/crates/garraia-cli/src/migrate.rs
+++ b/crates/garraia-cli/src/migrate.rs
@@ -318,19 +318,21 @@ fn parse_conversation_turns(content: &str) -> Vec<(&str, &str)> {
 }
 
 fn byte_offset_of_line(content: &str, line_num: usize) -> usize {
-    content
+    let offset: usize = content
         .lines()
         .take(line_num)
-        .map(|l| l.len() + 1) // +1 for newline
-        .sum()
+        .map(|l| l.len() + 1)
+        .sum();
+    offset.min(content.len())
 }
 
 fn byte_offset_after_line(content: &str, line_num: usize) -> usize {
-    content
+    let offset: usize = content
         .lines()
         .take(line_num + 1)
         .map(|l| l.len() + 1)
-        .sum()
+        .sum();
+    offset.min(content.len())
 }
 
 fn import_channels(source_dir: &Path, garraia_dir: &Path, report: &mut MigrationReport) {

--- a/crates/garraia-gateway/assets/state.js
+++ b/crates/garraia-gateway/assets/state.js
@@ -1,7 +1,7 @@
 import { EventBus } from './eventBus.js';
 
 export const GarraState = {
-  currentView: "chat",
+  currentView: null,
   memories: [],
   logs: "",
   session: localStorage.getItem("garraia.session_id") || "",

--- a/crates/garraia-gateway/assets/styles.css
+++ b/crates/garraia-gateway/assets/styles.css
@@ -244,9 +244,13 @@ body.ready {
 }
 
 .panel-view {
-  display: flex;
+  display: none;
   flex-direction: column;
   height: 100%;
+}
+
+.panel-view.is-active {
+  display: flex;
 }
 
 .panel {
@@ -1040,9 +1044,6 @@ textarea,
   background-color: var(--brand);
 }
 
-.panel-view:not(.is-active):not([id="view-chat"]) {
-  display: none !important;
-}
 .update-banner {
   display: none;
 }

--- a/crates/garraia-gateway/assets/styles.css
+++ b/crates/garraia-gateway/assets/styles.css
@@ -720,6 +720,8 @@ textarea:focus {
   flex-direction: column;
   gap: 16px;
   overflow-y: auto;
+  flex: 1;
+  min-height: 0;
 }
 
 .card {
@@ -993,11 +995,8 @@ textarea,
   display: flex;
   flex-direction: column;
   gap: 8px;
-  height: calc(100vh - 220px);
-  overflow-y: auto;
 }
 .logs-box {
-  height: calc(100vh - 220px);
   overflow: auto;
   padding: 12px;
   border: 1px solid var(--panel-edge);
@@ -1009,6 +1008,8 @@ textarea,
   font-size: 12px;
   border-radius: 10px;
   white-space: pre-wrap;
+  flex: 1;
+  min-height: 0;
 }
 
 /* Custom WebKit Scrollbars for logs and memories */

--- a/crates/garraia-gateway/src/a2a.rs
+++ b/crates/garraia-gateway/src/a2a.rs
@@ -135,20 +135,40 @@ pub async fn create_task(
                 });
             }
 
-            let task = state.a2a_tasks.get(&task_id).unwrap().clone();
-            (StatusCode::OK, Json(serde_json::json!(task))).into_response()
+            match state.a2a_tasks.get(&task_id) {
+                Some(task) => {
+                    (StatusCode::OK, Json(serde_json::json!(task.clone()))).into_response()
+                }
+                None => {
+                    warn!("A2A task {task_id} vanished after completion");
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(serde_json::json!({ "error": "task state lost" })),
+                    )
+                        .into_response()
+                }
+            }
         }
         Err(e) => {
             warn!("A2A task {task_id} failed: {e}");
             if let Some(mut task) = state.a2a_tasks.get_mut(&task_id) {
                 task.status = TaskStatus::Failed;
             }
-            let task = state.a2a_tasks.get(&task_id).unwrap().clone();
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!(task)),
-            )
-                .into_response()
+            match state.a2a_tasks.get(&task_id) {
+                Some(task) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!(task.clone())),
+                )
+                    .into_response(),
+                None => {
+                    warn!("A2A task {task_id} vanished after failure");
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(serde_json::json!({ "error": format!("task failed: {e}") })),
+                    )
+                        .into_response()
+                }
+            }
         }
     }
 }

--- a/crates/garraia-gateway/src/logs_handler.rs
+++ b/crates/garraia-gateway/src/logs_handler.rs
@@ -17,24 +17,42 @@ pub async fn get_logs() -> impl IntoResponse {
             .into_response();
     }
 
-    match std::fs::read_to_string(&log_path) {
-        Ok(content) => {
-            let lines: Vec<&str> = content.lines().collect();
-            let start = if lines.len() > 1000 { lines.len() - 1000 } else { 0 };
-            let recent_lines = lines[start..].join("\n");
-            
-            (
-                StatusCode::OK,
-                Json(serde_json::json!({ "logs": recent_lines })),
-            )
-                .into_response()
-        },
-        Err(e) => {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": e.to_string() })),
-            )
-                .into_response()
+    const MAX_TAIL_BYTES: u64 = 512 * 1024;
+
+    let read_result = (|| -> std::io::Result<String> {
+        use std::io::{Read, Seek, SeekFrom};
+        let mut file = std::fs::File::open(&log_path)?;
+        let metadata = file.metadata()?;
+        let file_len = metadata.len();
+
+        if file_len > MAX_TAIL_BYTES {
+            file.seek(SeekFrom::End(-(MAX_TAIL_BYTES as i64)))?;
         }
+
+        let mut buf = String::new();
+        file.read_to_string(&mut buf)?;
+
+        if file_len > MAX_TAIL_BYTES {
+            if let Some(pos) = buf.find('\n') {
+                buf = buf[pos + 1..].to_string();
+            }
+        }
+
+        let lines: Vec<&str> = buf.lines().collect();
+        let start = if lines.len() > 1000 { lines.len() - 1000 } else { 0 };
+        Ok(lines[start..].join("\n"))
+    })();
+
+    match read_result {
+        Ok(recent_lines) => (
+            StatusCode::OK,
+            Json(serde_json::json!({ "logs": recent_lines })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": e.to_string() })),
+        )
+            .into_response(),
     }
 }

--- a/crates/garraia-gateway/src/server.rs
+++ b/crates/garraia-gateway/src/server.rs
@@ -104,7 +104,10 @@ impl GatewayServer {
         tokio::spawn(async move {
             use tokio::io::{AsyncBufReadExt, BufReader, AsyncSeekExt};
             use std::io::SeekFrom;
-            let path = dirs::home_dir().unwrap().join(".garraia").join("garraia.log");
+            let Some(path) = dirs::home_dir().map(|h| h.join(".garraia").join("garraia.log")) else {
+                tracing::warn!("could not determine home directory; log tailer disabled");
+                return;
+            };
             
             while !path.exists() {
                 tokio::time::sleep(std::time::Duration::from_millis(500)).await;
@@ -233,9 +236,6 @@ impl GatewayServer {
 
         // Disconnect MCP servers on shutdown
         if let Some(ref manager) = state_for_shutdown.mcp_manager_arc {
-            info!("disconnecting MCP servers...");
-            manager.disconnect_all().await;
-        } else if let Some(ref manager) = state_for_shutdown.mcp_manager {
             info!("disconnecting MCP servers...");
             manager.disconnect_all().await;
         }

--- a/crates/garraia-gateway/src/webchat.html
+++ b/crates/garraia-gateway/src/webchat.html
@@ -977,6 +977,8 @@
         flex-direction: column;
         gap: 16px;
         overflow-y: auto;
+        flex: 1;
+        min-height: 0;
       }
 
       .card {
@@ -1154,6 +1156,123 @@
         .nano-pixel {
           transition: none;
         }
+      }
+
+      /* Memory & Logs Views */
+      .memory-actions {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+
+      .memory-search-input {
+        padding: 6px 10px;
+        border-radius: 10px;
+        border: 1px solid var(--panel-edge);
+        background: var(--panel);
+        color: var(--ink);
+        font-family: "IBM Plex Mono", Consolas, monospace;
+        font-size: 0.82rem;
+        transition:
+          border-color 120ms ease,
+          box-shadow 120ms ease;
+      }
+
+      .memory-search-input:focus {
+        outline: none;
+        border-color: var(--brand);
+        box-shadow: 0 0 0 3px rgba(127, 90, 49, 0.2);
+      }
+
+      .memory-list {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .logs-box {
+        overflow: auto;
+        padding: 12px;
+        border: 1px solid var(--panel-edge);
+        background: var(--bg);
+        color: var(--ink);
+        font-family:
+          "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
+          Consolas, "Liberation Mono", "Courier New", monospace;
+        font-size: 12px;
+        border-radius: 10px;
+        white-space: pre-wrap;
+        flex: 1;
+        min-height: 0;
+      }
+
+      .text-secondary {
+        color: var(--ink-soft);
+      }
+
+      /* Custom scrollbars */
+      .logs-box::-webkit-scrollbar,
+      .memory-list::-webkit-scrollbar,
+      .settings-body::-webkit-scrollbar,
+      .chat::-webkit-scrollbar,
+      .main-wrapper::-webkit-scrollbar {
+        width: 8px;
+        height: 8px;
+      }
+
+      .logs-box::-webkit-scrollbar-track,
+      .memory-list::-webkit-scrollbar-track,
+      .settings-body::-webkit-scrollbar-track,
+      .chat::-webkit-scrollbar-track,
+      .main-wrapper::-webkit-scrollbar-track {
+        background: transparent;
+      }
+
+      .logs-box::-webkit-scrollbar-thumb,
+      .memory-list::-webkit-scrollbar-thumb,
+      .settings-body::-webkit-scrollbar-thumb,
+      .chat::-webkit-scrollbar-thumb,
+      .main-wrapper::-webkit-scrollbar-thumb {
+        background-color: var(--panel-edge);
+        border-radius: 10px;
+      }
+
+      .logs-box::-webkit-scrollbar-thumb:hover,
+      .memory-list::-webkit-scrollbar-thumb:hover,
+      .settings-body::-webkit-scrollbar-thumb:hover,
+      .chat::-webkit-scrollbar-thumb:hover,
+      .main-wrapper::-webkit-scrollbar-thumb:hover {
+        background-color: var(--brand);
+      }
+
+      /* Nav icon styles */
+      .nav-item > svg {
+        width: 20px;
+        height: 20px;
+        fill: none;
+        stroke: currentColor;
+        stroke-width: 2px;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+        flex-shrink: 0;
+      }
+
+      [data-theme="brasil"] .nav-item svg,
+      [data-theme="dark"] .nav-item svg {
+        stroke: var(--ink);
+      }
+
+      /* Hide initially inactive elements */
+      .update-banner {
+        display: none;
+      }
+
+      .gateway-key-section {
+        display: none;
+      }
+
+      .provider-key-section {
+        display: none;
       }
     </style>
   </head>

--- a/crates/garraia-gateway/src/webchat.html
+++ b/crates/garraia-gateway/src/webchat.html
@@ -352,9 +352,13 @@
       }
 
       .panel-view {
-        display: flex;
+        display: none;
         flex-direction: column;
         height: 100%;
+      }
+
+      .panel-view.is-active {
+        display: flex;
       }
 
       .panel {
@@ -1374,7 +1378,7 @@
         </div>
 
         <div class="workspace">
-          <section class="panel panel-view" id="view-chat" data-view-panel="chat">
+          <section class="panel panel-view is-active" id="view-chat" data-view-panel="chat">
             <div class="chat-top">
               <div class="chat-meta">
                 <span>Chat</span>

--- a/crates/garraia-runtime/src/state.rs
+++ b/crates/garraia-runtime/src/state.rs
@@ -33,7 +33,7 @@ impl TaskState {
     pub fn valid_transitions(&self) -> &[TaskState] {
         match self {
             TaskState::Planning => &[TaskState::Executing, TaskState::Failed],
-            TaskState::Executing => &[TaskState::ToolUse, TaskState::Completed, TaskState::Failed],
+            TaskState::Executing => &[TaskState::ToolUse, TaskState::Completed, TaskState::Waiting, TaskState::Failed],
             TaskState::ToolUse => &[TaskState::Executing, TaskState::Waiting, TaskState::Failed],
             TaskState::Waiting => &[TaskState::Executing, TaskState::Failed],
             TaskState::Completed => &[],


### PR DESCRIPTION
Fixes 14 bugs across `garraia-agents`, `garraia-gateway`, `garraia-channels`, `garraia-runtime`, and `garraia-cli` to improve robustness and correctness.

This PR addresses a range of issues including:
- `garraia-agents`: `chat_completion` ignoring optional parameters, Ollama dropping system prompts, memory extractor failing with Anthropic, Bash tool panicking on multi-byte UTF-8 truncation, and `trim_messages_to_budget` breaking conversation protocol.
- `garraia-gateway`: `dirs::home_dir().unwrap()` panic in containers, `.unwrap()` on `DashMap::get()` panic, a dead `else if` branch, and log handler loading entire file into memory.
- `garraia-channels`: Telegram MarkdownV2 unescaped `*` inside bold, Discord chunk splitter counting bytes instead of characters, and `disconnect_all` short-circuiting on first error.
- `garraia-runtime` & `garraia-cli`: Missing state transition `Executing -> Waiting` and an off-by-one panic in byte offset calculation.

---
<p><a href="https://cursor.com/agents/bc-4e93184a-4978-4f2d-a9fd-17f8de8def62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e93184a-4978-4f2d-a9fd-17f8de8def62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

