### PR TITLE
feat(gateway): plan 0016 M1 — AppPool newtype + AuthConfig + RestV1State split

### DIFF
--- a/crates/garraia-auth/src/app_pool.rs
+++ b/crates/garraia-auth/src/app_pool.rs
@@ -1,0 +1,295 @@
+//! `AppPool` — the dedicated RLS-enforced Postgres pool for `/v1/*` handlers
+//! that live outside of `garraia-auth`.
+//!
+//! ## Boundary contract
+//!
+//! `AppPool` wraps a [`PgPool`] connected as the `garraia_app` Postgres role.
+//! That role is `NOLOGIN` in production migrations (see migration 007) and
+//! must be promoted to LOGIN by an operator (dev/test) or accessed via
+//! `SET ROLE` in production (plan 0017 decision, deferred). The inner pool
+//! is **private**. The only constructor is
+//! [`AppPool::from_dedicated_config`], which:
+//!
+//! 1. Validates the [`AppPoolConfig`] (URL scheme, pool size).
+//! 2. Connects.
+//! 3. Issues `SELECT current_user::text` and refuses if the answer is
+//!    anything other than `garraia_app`.
+//!
+//! Symmetric to `LoginPool` and `SignupPool` (ADR 0005). The three pools
+//! share the same `AuthError::{Config, WrongRole, Storage}` error surface.
+//!
+//! ## Access patterns
+//!
+//! - **Crate-internal callers** (`garraia-auth` modules): use
+//!   [`AppPool::pool`] which is `pub(crate)`.
+//! - **`rest_v1` handlers in `garraia-gateway`**: use
+//!   [`AppPool::pool_for_handlers`] which is the *only* sanctioned way to
+//!   obtain the raw `PgPool` from a different crate. Every call site must
+//!   be preceded by `SET LOCAL app.current_user_id = $user_id` inside a
+//!   transaction so RLS policies see the correct tenant context. See
+//!   `docs/adr/0005-identity-provider.md` (amendment pending plan 0017).
+//! - **Test-only raw access**: the `test-support` feature exposes a
+//!   `raw()` escape hatch — invisible to production builds.
+//!
+//! There is **no** `From<PgPool> for AppPool` and there is **no**
+//! `pub fn new(pool: PgPool) -> Self`. Adding either is a violation of
+//! ADR 0005 §"Anti-patterns" #4.
+//!
+//! The combination of (a) private field, (b) single validating constructor,
+//! and (c) the static `!Clone` assertion makes "accidentally fan out the
+//! app pool without the role guard" a compile-time error.
+
+use serde::Deserialize;
+use sqlx::postgres::{PgPool, PgPoolOptions};
+use tracing::instrument;
+use validator::Validate;
+
+use crate::error::AuthError;
+
+/// Configuration for the dedicated `garraia_app` pool. Loaded from a
+/// SEPARATE env var (`GARRAIA_APP_DATABASE_URL`) than the login/signup
+/// pools — production deployments MUST keep these credentials in a
+/// distinct vault entry.
+///
+/// Named `AppPoolConfig` (not `AppConfig`) to avoid collision with
+/// `garraia_config::AppConfig` which is the full gateway config struct.
+///
+/// `Debug` is **manually implemented** to redact `database_url`. Mirrors
+/// the `LoginConfig` / `SignupConfig` pattern.
+#[derive(Clone, Deserialize, Validate)]
+pub struct AppPoolConfig {
+    /// Postgres URL. The connection role MUST be `garraia_app`.
+    /// `AppPool::from_dedicated_config` validates this at construction
+    /// time via `SELECT current_user`.
+    #[validate(custom(function = "validate_postgres_url"))]
+    pub database_url: String,
+
+    /// Pool size. Default 10 — larger than login/signup because this
+    /// pool carries the actual read/write traffic of `/v1/*` handlers.
+    /// Still bounded to 50 to match the other pools.
+    #[validate(range(min = 1, max = 50))]
+    pub max_connections: u32,
+}
+
+impl Default for AppPoolConfig {
+    fn default() -> Self {
+        Self {
+            database_url: String::new(),
+            max_connections: 10,
+        }
+    }
+}
+
+impl std::fmt::Debug for AppPoolConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AppPoolConfig")
+            .field("database_url", &"[REDACTED]")
+            .field("max_connections", &self.max_connections)
+            .finish()
+    }
+}
+
+fn validate_postgres_url(url: &str) -> Result<(), validator::ValidationError> {
+    if url.starts_with("postgres://") || url.starts_with("postgresql://") {
+        Ok(())
+    } else {
+        Err(validator::ValidationError::new("invalid_postgres_scheme"))
+    }
+}
+
+/// `AppPool` wraps a [`PgPool`] connected as the `garraia_app` RLS-enforced
+/// role. See module docs for the boundary contract.
+///
+/// **Forbidden:** `impl From<PgPool> for AppPool`, `pub fn new(pool: PgPool)`,
+/// `#[derive(Clone)]`, or any other path that produces an `AppPool` without
+/// the `current_user` validation. ADR 0005 §"Anti-patterns" #4.
+///
+/// `Clone` is intentionally NOT derived — even though the inner `PgPool`
+/// is reference-counted and `Clone`, exposing a `Clone` impl on `AppPool`
+/// would let any caller fan out the pool without going through the
+/// validating constructor. The denial is enforced by a compile-time
+/// `static_assertions::assert_not_impl_all!` test in this module.
+pub struct AppPool {
+    /// Wrapped private `PgPool`. Read-only access via `pool()`
+    /// (`pub(crate)`) for in-crate modules, or `pool_for_handlers()`
+    /// (`pub`) for `rest_v1` handlers in `garraia-gateway`.
+    inner: PgPool,
+}
+
+impl AppPool {
+    /// Return a reference to the inner pool. **Crate-private** so
+    /// `garraia-auth` internal modules (future `exec_with_tenant`
+    /// helper, etc.) can operate against the typed newtype without
+    /// re-implementing the guard.
+    ///
+    /// Currently has no in-crate caller — `#[allow(dead_code)]` is
+    /// intentional and placeholder for plan 0017 which will add an
+    /// `exec_with_tenant` helper that closes over this method.
+    #[allow(dead_code)]
+    pub(crate) fn pool(&self) -> &PgPool {
+        &self.inner
+    }
+
+    /// **Sanctioned cross-crate accessor** for `rest_v1` handlers in
+    /// `garraia-gateway`.
+    ///
+    /// This is the *only* `pub fn` that hands out the raw `PgPool`. It
+    /// exists because the REST handlers live in a separate crate and
+    /// cannot use the `pub(crate)` accessor. Every call site MUST:
+    ///
+    /// 1. Open a `sqlx::Transaction` on the returned pool.
+    /// 2. Issue `SET LOCAL app.current_user_id = $1` binding a
+    ///    trusted `Uuid` (the authenticated `Principal::user_id`).
+    ///    **Never** bind a user-controlled string — SET LOCAL does not
+    ///    accept placeholders, so the Uuid is interpolated via
+    ///    `{uuid}` which is safe by construction (Uuids have a fixed
+    ///    syntax and no quote characters).
+    /// 3. Run the scoped query/queries inside the same transaction.
+    /// 4. Commit or rollback — `SET LOCAL` is cleared at transaction
+    ///    end.
+    ///
+    /// Violating this protocol silently bypasses RLS. A code review
+    /// gate (plan 0016 security-auditor dispatch) verifies every call
+    /// site follows the protocol. A future plan may replace this with
+    /// a closure-based `exec_with_tenant` API to enforce the protocol
+    /// at the type level.
+    ///
+    /// Audit: `rg 'pool_for_handlers' crates/` must return only call
+    /// sites inside `crates/garraia-gateway/src/rest_v1/`.
+    pub fn pool_for_handlers(&self) -> &PgPool {
+        &self.inner
+    }
+
+    /// **Test-only escape hatch** mirroring [`crate::login_pool::LoginPool::raw`]
+    /// for the RLS matrix suite (GAR-392, plan 0013) and future gateway
+    /// integration tests (plan 0016 M2).
+    ///
+    /// Gated behind `#[cfg(any(test, feature = "test-support"))]` so it
+    /// is invisible to any production build.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn raw(&self) -> &PgPool {
+        &self.inner
+    }
+}
+
+impl AppPool {
+    /// Connect to the dedicated `garraia_app` database using the role
+    /// validation guard. Returns [`AuthError::WrongRole`] if the
+    /// connection comes back as anything other than `garraia_app`.
+    ///
+    /// Tracing instrumentation uses `skip(config)` so the
+    /// `database_url` (containing credentials) never lands in any span.
+    #[instrument(skip(config), fields(max_connections = config.max_connections))]
+    pub async fn from_dedicated_config(config: &AppPoolConfig) -> crate::Result<Self> {
+        config
+            .validate()
+            .map_err(|e| AuthError::Config(e.to_string()))?;
+
+        let pool = PgPoolOptions::new()
+            .max_connections(config.max_connections)
+            .connect(&config.database_url)
+            .await
+            .map_err(AuthError::Storage)?;
+
+        // Runtime role guard. We query `current_user` immediately after
+        // connecting and refuse if it isn't `garraia_app`. Any other
+        // role (postgres, garraia_login, garraia_signup, etc.) is a
+        // misconfiguration and must fail loudly.
+        let actual: String = sqlx::query_scalar("SELECT current_user::text")
+            .fetch_one(&pool)
+            .await
+            .map_err(AuthError::Storage)?;
+
+        if actual != "garraia_app" {
+            // Drop the pool explicitly so open connections return to
+            // Postgres immediately and the misconfigured pool cannot
+            // be re-used by any other code path.
+            pool.close().await;
+            return Err(AuthError::WrongRole(actual));
+        }
+
+        Ok(Self { inner: pool })
+    }
+}
+
+impl std::fmt::Debug for AppPool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never expose the inner pool — it carries the connection string.
+        f.debug_struct("AppPool")
+            .field("inner", &"<PgPool[garraia_app]>")
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Compile-time denial of `Clone` on `AppPool`. Adding `#[derive(Clone)]`
+    // or a manual `impl Clone for AppPool` in the future will fail this
+    // assertion at build time. Mirrors LoginPool security review H-1.
+    static_assertions::assert_not_impl_all!(AppPool: Clone);
+
+    #[test]
+    fn debug_does_not_leak_database_url() {
+        let cfg = AppPoolConfig {
+            database_url: "postgres://garraia_app:topsecret@db:5432/garraia".into(),
+            max_connections: 10,
+        };
+        let dbg = format!("{cfg:?}");
+        assert!(!dbg.contains("topsecret"), "Debug must not leak: {dbg}");
+        assert!(!dbg.contains("garraia_app:topsecret"), "Debug must not leak creds: {dbg}");
+        assert!(dbg.contains("[REDACTED]"));
+        assert!(dbg.contains("max_connections: 10"));
+    }
+
+    #[test]
+    fn validates_postgres_scheme() {
+        let mut cfg = AppPoolConfig {
+            database_url: "postgres://garraia_app:pw@h:5432/garraia".into(),
+            max_connections: 10,
+        };
+        assert!(cfg.validate().is_ok());
+
+        cfg.database_url = "postgresql://garraia_app:pw@h:5432/garraia".into();
+        assert!(cfg.validate().is_ok());
+
+        cfg.database_url = "mysql://x".into();
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn validates_max_connections_bounds() {
+        let too_big = AppPoolConfig {
+            database_url: "postgres://garraia_app:pw@h:5432/db".into(),
+            max_connections: 51,
+        };
+        assert!(too_big.validate().is_err());
+
+        let zero = AppPoolConfig {
+            database_url: "postgres://garraia_app:pw@h:5432/db".into(),
+            max_connections: 0,
+        };
+        assert!(zero.validate().is_err());
+    }
+
+    #[test]
+    fn invalid_url_returns_config_error_from_constructor() {
+        // We can't spin up Postgres in a unit test, but we CAN verify
+        // the validator gate fires before any network activity.
+        let cfg = AppPoolConfig {
+            database_url: "not-a-postgres-url".into(),
+            max_connections: 10,
+        };
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let err = rt.block_on(AppPool::from_dedicated_config(&cfg));
+        assert!(matches!(err, Err(AuthError::Config(_))));
+    }
+
+    #[test]
+    fn default_config_is_invalid() {
+        // Default database_url is empty → validator rejects.
+        let cfg = AppPoolConfig::default();
+        assert!(cfg.validate().is_err());
+    }
+}

--- a/crates/garraia-auth/src/lib.rs
+++ b/crates/garraia-auth/src/lib.rs
@@ -51,5 +51,9 @@ pub use internal::signup_user;
 pub use signup_pool::{SignupConfig, SignupPool};
 pub use storage_redacted::RedactedStorageError;
 
+// 0016-M1 — AppPool (garraia_app RLS-enforced pool for /v1 handlers)
+pub mod app_pool;
+pub use app_pool::{AppPool, AppPoolConfig};
+
 /// Convenience `Result` alias for crate APIs.
 pub type Result<T> = std::result::Result<T, AuthError>;

--- a/crates/garraia-config/src/auth.rs
+++ b/crates/garraia-config/src/auth.rs
@@ -15,10 +15,14 @@
 //! | `GARRAIA_REFRESH_HMAC_SECRET` | yes | ≥32 bytes; **distinct** from `GARRAIA_JWT_SECRET`. |
 //! | `GARRAIA_LOGIN_DATABASE_URL` | yes | Postgres URL connecting as the `garraia_login` BYPASSRLS role. |
 //! | `GARRAIA_SIGNUP_DATABASE_URL` | yes | Postgres URL connecting as the `garraia_signup` BYPASSRLS role. |
+//! | `GARRAIA_APP_DATABASE_URL` | **optional** | Postgres URL connecting as the `garraia_app` RLS-enforced role. Used by `/v1/*` handlers outside the auth flow. When absent, `/v1/groups` and future write endpoints fail-soft to 503; `/v1/me` still works. Added in plan 0016 M1. |
 //!
-//! When any required var is missing, [`AuthConfig::from_env`] returns
+//! When any **required** var is missing, [`AuthConfig::from_env`] returns
 //! `Ok(None)` (NOT an error) so the gateway boots in fail-soft mode with the
 //! `/v1/auth/*` endpoints disabled. The bootstrap layer logs a warning.
+//! `GARRAIA_APP_DATABASE_URL` is optional and does NOT trigger fail-soft
+//! — its absence only degrades the `/v1/*` handler surface, not the auth
+//! flow.
 //! Production deployments verify the config at startup via
 //! [`AuthConfig::require_from_env`] which errors instead.
 
@@ -52,6 +56,14 @@ pub struct AuthConfig {
     /// Postgres connection URL for the `garraia_signup` BYPASSRLS pool.
     /// Used by `SignupPool` exclusively.
     pub signup_database_url: SecretString,
+
+    /// Postgres connection URL for the `garraia_app` RLS-enforced pool.
+    /// Used by `AppPool` (plan 0016 M1) for `/v1/*` handlers outside
+    /// the auth flow. **Optional** — when absent, `/v1/groups` and
+    /// future write endpoints fail-soft to 503, but the core auth
+    /// flow and `/v1/me` continue to work. Added in plan 0016 M1
+    /// without breaking existing callers.
+    pub app_database_url: Option<SecretString>,
 }
 
 impl std::fmt::Debug for AuthConfig {
@@ -61,6 +73,10 @@ impl std::fmt::Debug for AuthConfig {
             .field("refresh_hmac_secret", &"[REDACTED]")
             .field("login_database_url", &"[REDACTED]")
             .field("signup_database_url", &"[REDACTED]")
+            .field(
+                "app_database_url",
+                &self.app_database_url.as_ref().map(|_| "[REDACTED]"),
+            )
             .finish()
     }
 }
@@ -91,6 +107,14 @@ impl AuthConfig {
                 "GARRAIA_SIGNUP_DATABASE_URL must be a postgres:// URL".into(),
             ));
         }
+        if let Some(app_url) = self.app_database_url.as_ref() {
+            let app_url = app_url.expose_secret();
+            if !(app_url.starts_with("postgres://") || app_url.starts_with("postgresql://")) {
+                return Err(AuthConfigError::Validation(
+                    "GARRAIA_APP_DATABASE_URL must be a postgres:// URL".into(),
+                ));
+            }
+        }
         Ok(())
     }
 
@@ -115,11 +139,20 @@ impl AuthConfig {
             Err(_) => return Ok(None),
         };
 
+        // Optional: GARRAIA_APP_DATABASE_URL. Plan 0016 M1 — absence
+        // does NOT trigger fail-soft of the whole AuthConfig; it only
+        // means AppPool will not be constructed and /v1/groups-style
+        // handlers will answer 503.
+        let app_db = std::env::var("GARRAIA_APP_DATABASE_URL")
+            .ok()
+            .map(SecretString::from);
+
         let cfg = AuthConfig {
             jwt_secret: SecretString::from(jwt),
             refresh_hmac_secret: SecretString::from(refresh),
             login_database_url: SecretString::from(login_db),
             signup_database_url: SecretString::from(signup_db),
+            app_database_url: app_db,
         };
         cfg.validate_secrets()?;
         Ok(Some(cfg))
@@ -136,11 +169,20 @@ impl AuthConfig {
         let signup_db = std::env::var("GARRAIA_SIGNUP_DATABASE_URL")
             .map_err(|_| AuthConfigError::MissingEnv("GARRAIA_SIGNUP_DATABASE_URL"))?;
 
+        // Optional: GARRAIA_APP_DATABASE_URL. Plan 0016 M1 — even in
+        // `require_from_env` this is treated as optional. Operators
+        // who require /v1/groups-style handlers are responsible for
+        // failing their own boot if `app_database_url` is None.
+        let app_db = std::env::var("GARRAIA_APP_DATABASE_URL")
+            .ok()
+            .map(SecretString::from);
+
         let cfg = AuthConfig {
             jwt_secret: SecretString::from(jwt),
             refresh_hmac_secret: SecretString::from(refresh),
             login_database_url: SecretString::from(login_db),
             signup_database_url: SecretString::from(signup_db),
+            app_database_url: app_db,
         };
         cfg.validate_secrets()?;
         Ok(cfg)
@@ -161,6 +203,9 @@ mod tests {
             signup_database_url: SecretString::from(
                 "postgres://garraia_signup:pw@localhost/garraia".to_string(),
             ),
+            // Plan 0016 M1: optional. Tests default to None to exercise
+            // the "AuthConfig present but AppPool disabled" path.
+            app_database_url: None,
         }
     }
 

--- a/crates/garraia-gateway/src/rest_v1/me.rs
+++ b/crates/garraia-gateway/src/rest_v1/me.rs
@@ -4,7 +4,6 @@
 //! handles the optional `X-Group-Id` membership lookup. This handler
 //! issues no SQL of its own.
 
-use axum::extract::State;
 use axum::Json;
 use garraia_auth::Principal;
 use serde::Serialize;
@@ -12,7 +11,6 @@ use utoipa::ToSchema;
 use uuid::Uuid;
 
 use super::problem::RestError;
-use super::RestV1AuthState;
 
 /// Response body for `GET /v1/me`.
 #[derive(Debug, Serialize, ToSchema)]
@@ -39,10 +37,7 @@ pub struct MeResponse {
     ),
     security(("bearer" = []))
 )]
-pub async fn get_me(
-    State(_state): State<RestV1AuthState>,
-    principal: Principal,
-) -> Result<Json<MeResponse>, RestError> {
+pub async fn get_me(principal: Principal) -> Result<Json<MeResponse>, RestError> {
     Ok(Json(MeResponse {
         user_id: principal.user_id,
         group_id: principal.group_id,

--- a/crates/garraia-gateway/src/rest_v1/me.rs
+++ b/crates/garraia-gateway/src/rest_v1/me.rs
@@ -12,7 +12,7 @@ use utoipa::ToSchema;
 use uuid::Uuid;
 
 use super::problem::RestError;
-use super::RestV1State;
+use super::RestV1AuthState;
 
 /// Response body for `GET /v1/me`.
 #[derive(Debug, Serialize, ToSchema)]
@@ -40,7 +40,7 @@ pub struct MeResponse {
     security(("bearer" = []))
 )]
 pub async fn get_me(
-    State(_state): State<RestV1State>,
+    State(_state): State<RestV1AuthState>,
     principal: Principal,
 ) -> Result<Json<MeResponse>, RestError> {
     Ok(Json(MeResponse {

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -1,8 +1,33 @@
-//! REST `/v1` surface (Fase 3.4, plan 0015).
+//! REST `/v1` surface (Fase 3.4, plan 0015 + plan 0016 M1).
 //!
 //! Versioned HTTP API. All errors follow RFC 9457 Problem Details.
 //! OpenAPI 3.1 spec is generated via `utoipa`; Swagger UI is served at
 //! `/docs`.
+//!
+//! ## State layering (plan 0016 M1-T4)
+//!
+//! Two sub-states are derived from `AppState` at router build time:
+//!
+//! - [`RestV1AuthState`] holds only `jwt_issuer` + `login_pool`. It
+//!   is the state type for handlers that need the `Principal`
+//!   extractor but do not touch the RLS `garraia_app` pool — e.g.
+//!   `GET /v1/me`.
+//! - [`RestV1FullState`] wraps `RestV1AuthState` and adds `app_pool`
+//!   (the `garraia_app` RLS pool). It is the state type for handlers
+//!   that read/write the scoped tenant data — e.g. `/v1/groups/*`.
+//!
+//! The `FromRef` chain on `RestV1FullState` also exposes `jwt_issuer`
+//! and `login_pool`, so the `Principal` extractor works against full
+//! state handlers as well.
+//!
+//! The router builder is a three-way match:
+//!
+//! 1. Auth wired AND app wired → /v1/me and /v1/groups on real handlers
+//! 2. Auth wired, app NOT wired → /v1/me real; /v1/groups as 503 stub
+//! 3. Neither wired → every /v1 route is a 503 stub (fail-soft dev mode)
+//!
+//! In mode 3 the routes are registered explicitly (no `.fallback()`)
+//! so the merged main router keeps its own 404 behavior.
 
 pub mod me;
 pub mod openapi;
@@ -11,9 +36,9 @@ pub mod problem;
 use std::sync::Arc;
 
 use axum::extract::FromRef;
-use axum::routing::get;
+use axum::routing::{get, post};
 use axum::Router;
-use garraia_auth::{JwtIssuer, LoginPool};
+use garraia_auth::{AppPool, JwtIssuer, LoginPool};
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
@@ -22,23 +47,17 @@ use crate::state::AppState;
 use self::openapi::ApiDoc;
 use self::problem::RestError;
 
-/// Sub-state for the `/v1` router. Holds exactly the `Arc`s that the
-/// `garraia_auth::Principal` extractor needs via `FromRef`.
-///
-/// Built from `AppState` when `AuthConfig` is wired (both `jwt_issuer`
-/// and `login_pool` are `Some`). When unwired — i.e. the gateway is
-/// running in fail-soft dev mode — `from_app_state` returns `None` and
-/// the router falls back to a 503 Problem Details handler for every
-/// `/v1/*` path.
+/// Sub-state for `/v1` handlers that only need auth components
+/// (`Principal` extractor + JWT). No `AppPool`. Used by `GET /v1/me`.
 #[derive(Clone)]
-pub struct RestV1State {
+pub struct RestV1AuthState {
     pub jwt_issuer: Arc<JwtIssuer>,
     pub login_pool: Arc<LoginPool>,
 }
 
-impl RestV1State {
+impl RestV1AuthState {
     /// Try to build from the gateway's `AppState`. Returns `None` when
-    /// auth is not configured.
+    /// auth is not configured (fail-soft dev mode).
     pub fn from_app_state(app: &AppState) -> Option<Self> {
         Some(Self {
             jwt_issuer: app.jwt_issuer.clone()?,
@@ -47,46 +66,124 @@ impl RestV1State {
     }
 }
 
-impl FromRef<RestV1State> for Arc<JwtIssuer> {
-    fn from_ref(s: &RestV1State) -> Self {
+impl FromRef<RestV1AuthState> for Arc<JwtIssuer> {
+    fn from_ref(s: &RestV1AuthState) -> Self {
         s.jwt_issuer.clone()
     }
 }
 
-impl FromRef<RestV1State> for Arc<LoginPool> {
-    fn from_ref(s: &RestV1State) -> Self {
+impl FromRef<RestV1AuthState> for Arc<LoginPool> {
+    fn from_ref(s: &RestV1AuthState) -> Self {
         s.login_pool.clone()
     }
 }
 
-/// Build the `/v1` router (Fase 3.4 slice 1).
+/// Sub-state for `/v1` handlers that need both auth + the RLS
+/// `garraia_app` pool. Used by `/v1/groups/*`.
 ///
-/// When `AuthConfig` is wired, returns a router that serves:
-/// - `GET /v1/me` via the `Principal` extractor,
-/// - `/v1/openapi.json` — the generated OpenAPI 3.1 document,
-/// - `GET /docs` — Swagger UI rendering that document.
-///
-/// When `AuthConfig` is missing (fail-soft dev mode), returns a router
-/// with the same route set but every handler answers 503 Problem Details.
-/// Routes are enumerated explicitly (no `.fallback()`) so the merged
-/// main router does not lose its own 404 behavior.
-pub fn router(app_state: Arc<AppState>) -> Router {
-    match RestV1State::from_app_state(&app_state) {
-        Some(sub) => Router::new()
-            .route("/v1/me", get(me::get_me))
-            .with_state(sub)
-            .merge(
-                SwaggerUi::new("/docs").url("/v1/openapi.json", ApiDoc::openapi()),
-            ),
-        None => Router::new()
-            .route("/v1/me", get(unconfigured_handler))
-            .route("/v1/openapi.json", get(unconfigured_handler))
-            .route("/docs", get(unconfigured_handler)),
+/// The `FromRef` chain on this state also exposes `Arc<JwtIssuer>`
+/// and `Arc<LoginPool>`, so the `Principal` extractor compiles
+/// against handlers that use `State<RestV1FullState>`.
+#[derive(Clone)]
+pub struct RestV1FullState {
+    pub auth: RestV1AuthState,
+    pub app_pool: Arc<AppPool>,
+}
+
+impl RestV1FullState {
+    /// Try to build from the gateway's `AppState`. Returns `None`
+    /// unless BOTH auth is configured AND `AppPool` was wired (i.e.
+    /// `GARRAIA_APP_DATABASE_URL` is set and the connect succeeded).
+    pub fn from_app_state(app: &AppState) -> Option<Self> {
+        Some(Self {
+            auth: RestV1AuthState::from_app_state(app)?,
+            app_pool: app.app_pool.clone()?,
+        })
     }
 }
 
-/// Fail-soft handler used when `AuthConfig` is missing. Every `/v1`
-/// route falls back to this while the gateway boots without auth.
+impl FromRef<RestV1FullState> for Arc<JwtIssuer> {
+    fn from_ref(s: &RestV1FullState) -> Self {
+        s.auth.jwt_issuer.clone()
+    }
+}
+
+impl FromRef<RestV1FullState> for Arc<LoginPool> {
+    fn from_ref(s: &RestV1FullState) -> Self {
+        s.auth.login_pool.clone()
+    }
+}
+
+impl FromRef<RestV1FullState> for Arc<AppPool> {
+    fn from_ref(s: &RestV1FullState) -> Self {
+        s.app_pool.clone()
+    }
+}
+
+/// Build the `/v1` router.
+///
+/// Three modes based on what's wired in `AppState`:
+///
+/// 1. **Auth + AppPool wired**: `/v1/me` (real handler), `/v1/groups*`
+///    (stub `unconfigured_handler` in M1 — real handlers land in M4),
+///    `/v1/openapi.json`, `/docs`.
+/// 2. **Auth wired, AppPool missing**: `/v1/me` (real), `/v1/groups*`
+///    answer 503 via `unconfigured_handler`. `/docs` still served.
+/// 3. **Neither wired (fail-soft dev mode)**: every `/v1/*` route
+///    is registered explicitly on `unconfigured_handler`. No
+///    `.fallback()` — the merged main router keeps its 404 behavior
+///    for paths outside `/v1`.
+pub fn router(app_state: Arc<AppState>) -> Router {
+    // Try the most specific state first, then degrade.
+    match (
+        RestV1FullState::from_app_state(&app_state),
+        RestV1AuthState::from_app_state(&app_state),
+    ) {
+        (Some(_full), Some(auth)) => {
+            // Mode 1: auth + AppPool wired. M1 still uses the stub
+            // for /v1/groups because the real handlers land in M4.
+            // The full state is computed and proven wire-able but
+            // currently unused — kept here so M4 can flip the routes
+            // with a single edit.
+            Router::new()
+                .route("/v1/me", get(me::get_me))
+                .route("/v1/groups", post(unconfigured_handler))
+                .route("/v1/groups/{id}", get(unconfigured_handler))
+                .with_state(auth)
+                .merge(
+                    SwaggerUi::new("/docs")
+                        .url("/v1/openapi.json", ApiDoc::openapi()),
+                )
+        }
+        (None, Some(auth)) => {
+            // Mode 2: auth wired, AppPool missing. Same route
+            // surface as mode 1, but /v1/groups is 503 via
+            // explicit fail-soft. /v1/me still works.
+            Router::new()
+                .route("/v1/me", get(me::get_me))
+                .route("/v1/groups", post(unconfigured_handler))
+                .route("/v1/groups/{id}", get(unconfigured_handler))
+                .with_state(auth)
+                .merge(
+                    SwaggerUi::new("/docs")
+                        .url("/v1/openapi.json", ApiDoc::openapi()),
+                )
+        }
+        (_, None) => {
+            // Mode 3: no auth at all. Every route is a stub.
+            Router::new()
+                .route("/v1/me", get(unconfigured_handler))
+                .route("/v1/groups", post(unconfigured_handler))
+                .route("/v1/groups/{id}", get(unconfigured_handler))
+                .route("/v1/openapi.json", get(unconfigured_handler))
+                .route("/docs", get(unconfigured_handler))
+        }
+    }
+}
+
+/// Fail-soft handler used when `AuthConfig` / `AppPool` is missing.
+/// Routes that cannot serve in the current mode fall back here and
+/// answer 503 Problem Details via `RestError::AuthUnconfigured`.
 async fn unconfigured_handler() -> RestError {
     RestError::AuthUnconfigured
 }

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -139,26 +139,37 @@ pub fn router(app_state: Arc<AppState>) -> Router {
         RestV1FullState::from_app_state(&app_state),
         RestV1AuthState::from_app_state(&app_state),
     ) {
-        (Some(_full), Some(auth)) => {
-            // Mode 1: auth + AppPool wired. M1 still uses the stub
-            // for /v1/groups because the real handlers land in M4.
-            // The full state is computed and proven wire-able but
-            // currently unused — kept here so M4 can flip the routes
-            // with a single edit.
+        (Some(full), Some(_auth)) => {
+            // Mode 1: auth + AppPool wired.
+            //
+            // Uses `RestV1FullState` as the router state so the
+            // `FromRef` chain exposes `Arc<JwtIssuer>`,
+            // `Arc<LoginPool>` AND `Arc<AppPool>` at the extractor
+            // level. `GET /v1/me` still compiles against this state
+            // because `RestV1FullState: FromRef<Arc<JwtIssuer>>` and
+            // `FromRef<Arc<LoginPool>>`.
+            //
+            // TODO plan 0016 M4: replace the two
+            // `unconfigured_handler` lines below with the real
+            // handlers (`groups::create_group` + `groups::get_group`)
+            // without touching `.with_state(full)` — the state type
+            // is already correct.
             Router::new()
                 .route("/v1/me", get(me::get_me))
                 .route("/v1/groups", post(unconfigured_handler))
                 .route("/v1/groups/{id}", get(unconfigured_handler))
-                .with_state(auth)
+                .with_state(full)
                 .merge(
                     SwaggerUi::new("/docs")
                         .url("/v1/openapi.json", ApiDoc::openapi()),
                 )
         }
         (None, Some(auth)) => {
-            // Mode 2: auth wired, AppPool missing. Same route
-            // surface as mode 1, but /v1/groups is 503 via
-            // explicit fail-soft. /v1/me still works.
+            // Mode 2: auth wired, AppPool missing. `/v1/me` still
+            // works (uses `RestV1AuthState`); `/v1/groups` answers
+            // 503 via `unconfigured_handler`. Same route surface as
+            // mode 1 so clients see consistent URLs regardless of
+            // whether `GARRAIA_APP_DATABASE_URL` is set.
             Router::new()
                 .route("/v1/me", get(me::get_me))
                 .route("/v1/groups", post(unconfigured_handler))

--- a/crates/garraia-gateway/src/server.rs
+++ b/crates/garraia-gateway/src/server.rs
@@ -206,12 +206,45 @@ impl GatewayServer {
                     refresh_hmac_secret: auth_cfg.refresh_hmac_secret.clone(),
                 });
 
+                // Plan 0016 M1-T3: optional AppPool construction.
+                // Only attempted when GARRAIA_APP_DATABASE_URL is set.
+                // Failures degrade /v1/groups-style handlers to 503
+                // but never block the rest of the auth wiring.
+                let app_pool_opt: Option<Arc<garraia_auth::AppPool>> =
+                    if let Some(app_url) = auth_cfg.app_database_url.as_ref() {
+                        use garraia_auth::AppPoolConfig;
+                        match garraia_auth::AppPool::from_dedicated_config(&AppPoolConfig {
+                            database_url: app_url.expose_secret().to_string(),
+                            max_connections: 10,
+                        })
+                        .await
+                        {
+                            Ok(p) => {
+                                info!("garraia-auth AppPool wired (garraia_app role)");
+                                Some(Arc::new(p))
+                            }
+                            Err(e) => {
+                                warn!(
+                                    error = %e,
+                                    "AppPool connect failed; /v1/groups-style handlers will answer 503"
+                                );
+                                None
+                            }
+                        }
+                    } else {
+                        info!(
+                            "GARRAIA_APP_DATABASE_URL not set; /v1/groups-style handlers will answer 503"
+                        );
+                        None
+                    };
+
                 match (login_pool_result, signup_pool_result, jwt_result) {
                     (Ok(login_pool), Ok(signup_pool), Ok(jwt)) => {
                         state.set_auth_components(
                             Arc::new(login_pool),
                             Arc::new(signup_pool),
                             Arc::new(jwt),
+                            app_pool_opt,
                         );
                         info!("garraia-auth wired (login + signup pools + jwt)");
                     }

--- a/crates/garraia-gateway/src/server.rs
+++ b/crates/garraia-gateway/src/server.rs
@@ -224,8 +224,22 @@ impl GatewayServer {
                                 Some(Arc::new(p))
                             }
                             Err(e) => {
+                                // Security review plan 0016 M1 (M-1):
+                                // route the sqlx::Error through the
+                                // RedactedStorageError wrapper so the
+                                // Postgres connection URL cannot leak
+                                // into the warn! log line. Some sqlx
+                                // 0.8 connect failure variants embed
+                                // substrings of the URL in Display.
+                                let redacted = match e {
+                                    garraia_auth::AuthError::Storage(sqlx_err) => {
+                                        garraia_auth::RedactedStorageError::from(sqlx_err)
+                                            .to_string()
+                                    }
+                                    other => other.to_string(),
+                                };
                                 warn!(
-                                    error = %e,
+                                    error = %redacted,
                                     "AppPool connect failed; /v1/groups-style handlers will answer 503"
                                 );
                                 None

--- a/crates/garraia-gateway/src/state.rs
+++ b/crates/garraia-gateway/src/state.rs
@@ -4,7 +4,9 @@ use std::time::{Duration, Instant};
 
 use dashmap::DashMap;
 use garraia_agents::{AgentRuntime, ChatMessage};
-use garraia_auth::{InternalProvider, JwtIssuer, LoginPool, SessionStore as AuthSessionStore, SignupPool};
+use garraia_auth::{
+    AppPool, InternalProvider, JwtIssuer, LoginPool, SessionStore as AuthSessionStore, SignupPool,
+};
 use garraia_channels::{ChannelRegistry, CommandRegistry};
 use garraia_config::AppConfig;
 use garraia_db::{ChatSessionManager, SessionStore};
@@ -94,6 +96,11 @@ pub struct AppState {
     /// `pub(crate)` per security review L-3 — only the extractor + auth_routes
     /// need it; downstream handlers must NOT acquire the BYPASSRLS pool.
     pub(crate) login_pool: Option<Arc<LoginPool>>,
+    /// Shared `Arc<AppPool>` — the RLS-enforced `garraia_app` pool used by
+    /// `/v1/*` handlers outside the auth flow. `pub(crate)` — only
+    /// `rest_v1` constructs a `RestV1FullState` from it. Absent when
+    /// `GARRAIA_APP_DATABASE_URL` is not configured (plan 0016 M1-T3).
+    pub(crate) app_pool: Option<Arc<AppPool>>,
 }
 
 /// Per-connection session tracking.
@@ -178,18 +185,27 @@ impl AppState {
             auth_session_store: None,
             signup_pool: None,
             login_pool: None,
+            // Plan 0016 M1-T3 — None until bootstrap loads AuthConfig
+            // AND `GARRAIA_APP_DATABASE_URL` is set AND the pool
+            // connects successfully. Independent of the other three
+            // pools: absence only degrades /v1/groups-style handlers.
+            app_pool: None,
         }
     }
 
     /// Attach the garraia-auth components built from `AuthConfig` at bootstrap
-    /// time. All four are wired together: `LoginPool` is shared by
-    /// `InternalProvider` and `SessionStore`. `SignupPool` is independent.
-    /// (GAR-391c)
+    /// time. All four required pools/tokens are wired together: `LoginPool`
+    /// is shared by `InternalProvider` and `SessionStore`. `SignupPool` is
+    /// independent. `AppPool` (plan 0016 M1-T3) is **optional** and wired
+    /// only when `GARRAIA_APP_DATABASE_URL` was set and the connect
+    /// succeeded — handlers that need it fall back to 503 when `None`.
+    /// (GAR-391c + plan 0016 M1-T3)
     pub fn set_auth_components(
         &mut self,
         login_pool: Arc<LoginPool>,
         signup_pool: Arc<SignupPool>,
         jwt_issuer: Arc<JwtIssuer>,
+        app_pool: Option<Arc<AppPool>>,
     ) {
         let provider = Arc::new(InternalProvider::new(login_pool.clone()));
         let session_store = Arc::new(AuthSessionStore::new(login_pool.clone()));
@@ -198,6 +214,7 @@ impl AppState {
         self.auth_session_store = Some(session_store);
         self.signup_pool = Some(signup_pool);
         self.login_pool = Some(login_pool);
+        self.app_pool = app_pool;
     }
 
     /// Attach a persistent session store used to hydrate and persist chat history.


### PR DESCRIPTION
## Summary

**M1 only** of plan 0016 (`plans/0016-fase-3-4-slice-2-apppool-harness-groups.md`). Infrastructure foundation for Fase 3.4 slice 2 — **no `/v1/groups` handlers yet**, those land in M4.

Five commits, ~340 insertions / ~40 deletions across `garraia-auth`, `garraia-config`, `garraia-gateway`.

| Commit | Task | Change |
|---|---|---|
| `b9dfec7` | M1-T1 | `AppPool` newtype in `garraia-auth` (symmetric to `LoginPool`/`SignupPool`, +5 unit tests) |
| `20e4438` | M1-T2 | Optional `GARRAIA_APP_DATABASE_URL` in `AuthConfig` (additive, no breaking change) |
| `aee520f` | M1-T3 | `AppState.app_pool: Option<Arc<AppPool>>` + 4-arg `set_auth_components` + `server.rs` fail-soft wiring |
| `b15e54a` | M1-T4 | Split `RestV1State` → `RestV1AuthState` + `RestV1FullState` (5 `FromRef` impls), router 3-way match, `/v1/groups` routes as `unconfigured_handler` stubs |
| `291ddee` | review | Apply security M-1 (RedactedStorageError wrapper) + code-reviewer H-1 (mode 1 → `with_state(full)`) |

## What ships

- **`AppPool`** — typed newtype wrapping a `PgPool` connected as the `garraia_app` NOLOGIN BYPASSRLS Postgres role. Symmetric to `LoginPool`/`SignupPool` (ADR 0005): private inner, single validating constructor (`from_dedicated_config`), `SELECT current_user` role guard, `!Clone` via `static_assertions`, manual `Debug` redaction, `pub(crate) pool()` + `pub fn pool_for_handlers()` (sanctioned cross-crate accessor with prominent doc note prescribing the `SET LOCAL app.current_user_id` protocol) + `#[cfg(test, feature=test-support)] raw()` escape hatch. 5 unit tests (Debug redaction, postgres scheme validation, max_connections bounds, config-error propagation, default-rejection).
- **`GARRAIA_APP_DATABASE_URL`** — new **optional** env var on `AuthConfig`. Absence does NOT trigger `AuthConfig` fail-soft; it only means `AppPool` is not constructed and `/v1/groups`-style handlers fall back to 503. Zero breaking change for existing `/v1/auth/*` and `/v1/me` deployments.
- **`RestV1AuthState`** + **`RestV1FullState`** — two-level state layering in `rest_v1`. `FromRef<Arc<JwtIssuer>>` and `FromRef<Arc<LoginPool>>` on both; `FromRef<Arc<AppPool>>` only on full. The `Principal` extractor works against both states, so `me::get_me` is now state-agnostic (removed unused `State<_>` extractor).
- **Router 3-way match** — (full / auth-only / neither) with the same URL surface in all modes. Mode 3 (neither) uses explicit routes, not `.fallback()`, so the main router keeps its 404 behavior for non-`/v1` paths.

## What is explicitly NOT in this PR

- **`/v1/groups` handlers** — deferred to M4. Mode 1 and mode 2 both register the routes pointing at `unconfigured_handler`. M4 flips the two lines in mode 1 to `groups::create_group` / `groups::get_group` without touching `.with_state(full)` — the state type is already correct.
- **Gateway test harness** (testcontainer + pgvector) — deferred to M2
- **Authed `/v1/me` integration tests** — deferred to M3 (needs harness)
- **`SecurityScheme::Bearer` in OpenAPI** — deferred to M3
- **Review follow-ups from PR #8** (M-1 `/docs/*` trailing slash, M-3 `impl IntoResponse`, H-1 doc note, N-3 warn on fallback) — deferred to M5

## Validations (all green)

- `cargo check --workspace` → Finished OK
- `cargo clippy -p garraia-auth -p garraia-gateway --lib --tests` → zero errors, zero new warnings in `app_pool`/`rest_v1`
- `cargo test -p garraia-auth --lib` → **40 passed** (incl. 5 new in `app_pool::tests`)
- `cargo test -p garraia-gateway --lib` → **161 passed**
- `cargo test -p garraia-gateway --test rest_v1_me` → **1 passed** (fail-soft 503)
- `cargo test -p garraia-gateway --test router_smoke_test` → **3 passed** (no regression)

## Formal review

Dispatched **in parallel** via Agent Team:

### security-auditor → aprovado com ressalvas
- **M-1 (MANDATORY, fixed in `291ddee`):** `warn!(error = %e, ...)` on `AuthError::Storage(sqlx::Error)` could leak the Postgres URL via sqlx 0.8's Display. Fixed by routing through `garraia_auth::RedactedStorageError`.
- **M-2:** `pool_for_handlers()` has no static enforcement of the SET LOCAL protocol. Acceptable for M1; must be replaced by `exec_with_tenant` closure-based API before or during M4. `FIXME(plan-0016-M4)` note tracked in this PR body.
- **L-1:** `test-support` feature unification risk. Mitigation recommended (rename with `__` prefix, `Cargo.toml` comment). Deferred to M2 follow-up.

### code-reviewer → aprovado com ressalvas
- **H-1 (MANDATORY, fixed in `291ddee`):** Router mode 1 discarded `_full` and used `auth` state — violated architectural invariant. Fixed by `.with_state(full)` and making `get_me` state-agnostic via Principal-only extraction.
- Several nits (duplicated mode 1/2 bodies until M4, `max_connections: 10` hardcoded, audit rg hint wording) — all LOW/NITPICK, deferred.

## SET LOCAL injection note

The prescribed `SET LOCAL app.current_user_id = '{uuid}'` protocol interpolates a `Uuid` via `format!`. `Uuid::Display` emits exactly 36 characters of fixed-format hex with dashes — no quotes, no backticks, no semicolons. **Injection-safe by construction.** Explicitly validated by the security-auditor.

## ADR compliance

- ADR 0005 §\"Anti-patterns\" #4: `AppPool` has no `From<PgPool>`, no `pub fn new(PgPool)`, is not `Clone`. `!Clone` enforced at compile time via `static_assertions::assert_not_impl_all!`.
- CLAUDE.md Regras Absolutas #11/#12/#13: `AppPool` is the only sanctioned tenant-scoped data path; `LoginPool`/`SignupPool` remain untouched.

## Rollback

Each of the 5 commits is independent and reversible via `git revert`. The 4 feature commits land new types/fields; the review-fix commit is a pure refinement.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy -p garraia-auth -p garraia-gateway --lib --tests`
- [x] `cargo test -p garraia-auth --lib` (40 passed)
- [x] `cargo test -p garraia-gateway --lib` (161 passed)
- [x] `cargo test -p garraia-gateway --test rest_v1_me` (1 passed)
- [x] `cargo test -p garraia-gateway --test router_smoke_test` (3 passed)
- [x] `git log --oneline main..HEAD` — 5 focused commits, each with scoped message
- [ ] Post-merge: bump `plans/README.md` 0016 status from `⏳ Aprovado` to `⏳ M1 merged, M2+ pending` (follow-up docs PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)