### PR TITLE
test(gateway): plan 0016 M2 — harness pgvector + harness_smoke

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 thiserror = "2"
 anyhow = "1"
 
+# Test isolation — plan 0016 M2-T5. Enables `#[serial_test::serial]`
+# on tests that mutate process-global state (env vars, static caches).
+serial_test = "3"
+
 # Crypto / Security
 ring = "0.17"
 base64 = "0.22"

--- a/crates/garraia-auth/src/jwt.rs
+++ b/crates/garraia-auth/src/jwt.rs
@@ -153,6 +153,53 @@ impl JwtIssuer {
         Ok(data.claims)
     }
 
+    /// **Test-only constructor** — plan 0016 M2-T1.
+    ///
+    /// Builds a `JwtIssuer` from a single string secret used for BOTH
+    /// `jwt_secret` and `refresh_hmac_secret`. The secret is
+    /// deterministically padded to 32 bytes if shorter. This is the
+    /// only way the gateway integration harness can produce a working
+    /// `JwtIssuer` without threading the production `JwtConfig` /
+    /// `AuthConfig` plumbing through test infra.
+    ///
+    /// Gated behind `#[cfg(any(test, feature = "test-support"))]` so
+    /// it is invisible to production builds. Mirrors the pattern
+    /// already used by `LoginPool::raw` and `SignupPool::raw`.
+    ///
+    /// **Never** call this from non-test code. An audit rule:
+    /// `rg 'new_for_test' crates/` must return only hits preceded by
+    /// the `#[cfg(...)]` gate or inside `tests/` directories.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn new_for_test(secret: &str) -> Self {
+        // Pad the secret to 32 bytes if shorter, preserving it as
+        // a prefix. Longer secrets pass through. This keeps the
+        // test ergonomic — callers pass a short literal — while
+        // still satisfying the ≥32-byte validation that `new` enforces.
+        let mut padded = secret.to_string();
+        while padded.len() < 32 {
+            padded.push('=');
+        }
+        let cfg = JwtConfig {
+            jwt_secret: SecretString::from(padded.clone()),
+            refresh_hmac_secret: SecretString::from(padded),
+        };
+        Self::new(cfg).expect("JwtIssuer::new_for_test should always succeed after padding")
+    }
+
+    /// **Test-only access-token minter** — plan 0016 M2-T1.
+    ///
+    /// Thin wrapper over [`Self::issue_access`] that discards the
+    /// expiry timestamp and panics on error. Convenient for tests
+    /// that just want a valid bearer token for a given user.
+    ///
+    /// Gated behind `#[cfg(any(test, feature = "test-support"))]`.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn issue_access_for_test(&self, user_id: Uuid) -> String {
+        self.issue_access(user_id)
+            .map(|(token, _exp)| token)
+            .expect("issue_access_for_test should always succeed on a test issuer")
+    }
+
     /// Generate a fresh opaque refresh token and its HMAC-SHA256 hash.
     /// 32 random bytes from `OsRng`, URL-safe base64 (no padding).
     pub fn issue_refresh(&self) -> Result<RefreshTokenPair, AuthError> {
@@ -351,5 +398,19 @@ mod tests {
             .hmac_refresh(pair.plaintext.expose_secret())
             .expect("hmac_refresh must not fail with a 32-byte secret");
         assert_eq!(recomputed, pair.hmac_hash);
+    }
+
+    #[test]
+    fn new_for_test_and_issue_access_for_test_roundtrip() {
+        // Short secret: padded to 32 bytes internally.
+        let issuer = JwtIssuer::new_for_test("unit-secret");
+        // Use a deterministic non-nil UUID so the `sub` claim is
+        // unmistakable in the assertion. Parsing is infallible on a
+        // literal — no v4 feature required.
+        let uid = Uuid::parse_str("11111111-2222-3333-4444-555555555555").unwrap();
+        let token = issuer.issue_access_for_test(uid);
+        let claims = issuer.verify_access(&token).expect("verify");
+        assert_eq!(claims.sub, uid);
+        assert_eq!(claims.iss, ISSUER);
     }
 }

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -76,6 +76,7 @@ test-helpers = ["garraia-auth/test-support"]
 
 [dev-dependencies]
 tempfile = "3"
+serial_test = { workspace = true }
 wiremock = "0.6"
 tokio-tungstenite = "0.26"
 tokio = { workspace = true }

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -74,6 +74,16 @@ telemetry = ["dep:garraia-telemetry"]
 # can call `JwtIssuer::new_for_test`.
 test-helpers = ["garraia-auth/test-support"]
 
+# Plan 0016 M2 review fix H-2 (code-reviewer): declare `harness_smoke`
+# as requiring the `test-helpers` feature so running
+# `cargo test -p garraia-gateway --test harness_smoke` without
+# `--features test-helpers` produces a clear Cargo-level error instead
+# of a confusing "unresolved import" error from rustc.
+[[test]]
+name = "harness_smoke"
+path = "tests/harness_smoke.rs"
+required-features = ["test-helpers"]
+
 [dev-dependencies]
 tempfile = "3"
 serial_test = { workspace = true }

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -66,6 +66,13 @@ default = ["telemetry"]
 mcp-http = ["garraia-agents/mcp-http"]
 tls = ["dep:axum-server"]
 telemetry = ["dep:garraia-telemetry"]
+# Plan 0016 M2 — exposes test-only helpers on `GatewayServer` so the
+# integration test harness (`tests/common/mod.rs`) can build a Router
+# without running the full bootstrap pipeline. WARNING: MUST NOT be
+# enabled by any production binary or non-test crate. Transitively
+# enables the `test-support` feature of `garraia-auth` so the harness
+# can call `JwtIssuer::new_for_test`.
+test-helpers = ["garraia-auth/test-support"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/garraia-gateway/src/server.rs
+++ b/crates/garraia-gateway/src/server.rs
@@ -552,6 +552,66 @@ impl GatewayServer {
     }
 }
 
+/// **Test-only router builder** — plan 0016 M2-T2.
+///
+/// Thin wrapper around the production `router::build_router` that
+/// skips the filesystem / bootstrap side effects of the normal
+/// `GatewayServer::run` path:
+///
+/// * No agent runtime compilation from config (`AgentRuntime::new()`)
+/// * No channel bootstrap (`ChannelRegistry::new()`)
+/// * No MCP filesystem I/O (the harness sets `GARRAIA_CONFIG_DIR`
+///   to a tempdir before calling this so `McpPersistenceService`
+///   cannot pollute the developer's real config directory)
+/// * No admin sqlite file (`AdminStore::in_memory()`)
+/// * No TLS, no graceful shutdown listener
+///
+/// The caller injects pre-built `Arc<LoginPool>`, `Arc<SignupPool>`,
+/// `Arc<JwtIssuer>` and optional `Arc<AppPool>` — all produced by
+/// the integration test harness against a testcontainer Postgres.
+///
+/// Returned `Router` is ready for `tower::ServiceExt::oneshot`
+/// without any socket binding.
+///
+/// Gated behind `#[cfg(feature = "test-helpers")]` so the function
+/// is invisible to production builds. MUST NOT be called from any
+/// non-test code path.
+#[cfg(feature = "test-helpers")]
+pub async fn build_router_for_test(
+    config: AppConfig,
+    login_pool: Arc<garraia_auth::LoginPool>,
+    signup_pool: Arc<garraia_auth::SignupPool>,
+    jwt_issuer: Arc<garraia_auth::JwtIssuer>,
+    app_pool: Option<Arc<garraia_auth::AppPool>>,
+) -> axum::Router {
+    use crate::admin;
+    use garraia_agents::AgentRuntime;
+    use garraia_channels::ChannelRegistry;
+
+    // Zero-config minimal runtime + channel registry. No providers,
+    // no tools, no channels wired. Confirmed by team-coordinator gate
+    // against state.rs unit tests.
+    let mut state = AppState::new(
+        config,
+        AgentRuntime::new(),
+        ChannelRegistry::new(),
+    );
+
+    // Inject the auth pieces the harness built against testcontainer.
+    state.set_auth_components(login_pool, signup_pool, jwt_issuer, app_pool);
+    let state: crate::state::SharedState = Arc::new(state);
+
+    // Minimal collaborators expected by the production router.
+    let whatsapp_state: garraia_channels::whatsapp::webhook::WhatsAppState =
+        Arc::new(Vec::new());
+    let admin_store = Arc::new(Mutex::new(
+        admin::store::AdminStore::in_memory()
+            .expect("in-memory admin store should work"),
+    ));
+
+    build_router(state, whatsapp_state, admin_store)
+}
+
 async fn shutdown_signal() {
     let ctrl_c = async {
         tokio::signal::ctrl_c()

--- a/crates/garraia-gateway/tests/common/mod.rs
+++ b/crates/garraia-gateway/tests/common/mod.rs
@@ -23,7 +23,6 @@
 #![allow(dead_code)]
 
 use std::net::SocketAddr;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use axum::body::Body;
@@ -212,12 +211,6 @@ fn minimal_test_config() -> AppConfig {
     let mut cfg = AppConfig::default();
     cfg.memory.enabled = false;
     cfg
-}
-
-/// Helper to grab the config tempdir path for diagnostic assertions.
-#[allow(dead_code)]
-pub fn tempdir_for_debug(h: &Harness) -> PathBuf {
-    h._config_tempdir.path().to_path_buf()
 }
 
 /// Build a `GET` request suitable for `tower::ServiceExt::oneshot`

--- a/crates/garraia-gateway/tests/common/mod.rs
+++ b/crates/garraia-gateway/tests/common/mod.rs
@@ -1,0 +1,248 @@
+//! Integration test harness for `garraia-gateway` (plan 0016 M2-T3).
+//!
+//! Process-wide shared testcontainer (pgvector/pg16) + migrations
+//! 001..010 + three typed pools + `JwtIssuer::new_for_test` + a
+//! prebuilt `axum::Router` via `GatewayServer::build_router_for_test`.
+//! All of that behind a `OnceCell<Arc<Harness>>` so the container
+//! boots exactly once per `cargo test` invocation.
+//!
+//! ## Scope (M2 reduced slice)
+//!
+//! This module exposes ONLY the boot + router. No fixtures, no seed
+//! helpers, no authed-path smoke tests. Those land in plan 0016 M3.
+//!
+//! ## Side-effect isolation
+//!
+//! Before constructing `AppState`, the harness sets
+//! `GARRAIA_CONFIG_DIR` to a process-lifetime tempdir. This diverts
+//! `McpPersistenceService::with_default_path()` (which the normal
+//! gateway bootstrap uses) away from the developer's real
+//! `%APPDATA%\garraia\` directory — a risk flagged by the
+//! team-coordinator pre-gate for plan 0016 M2.
+
+#![allow(dead_code)]
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::extract::ConnectInfo;
+use axum::http::Request;
+use axum::Router;
+use garraia_auth::{AppPool, AppPoolConfig, JwtIssuer, LoginConfig, LoginPool, SignupConfig, SignupPool};
+use garraia_config::AppConfig;
+use garraia_gateway::server::build_router_for_test;
+use garraia_workspace::{Workspace, WorkspaceConfig};
+use testcontainers::runners::AsyncRunner;
+use testcontainers::{ContainerAsync, ImageExt};
+use testcontainers_modules::postgres::Postgres as PgImage;
+use tokio::sync::OnceCell;
+
+static SHARED: OnceCell<Arc<Harness>> = OnceCell::const_new();
+
+/// Process-wide shared test harness.
+///
+/// Obtain via `Harness::get().await`. The container boots exactly
+/// once per test process — subsequent calls return the same `Arc`.
+pub struct Harness {
+    /// Container handle — kept alive for the process lifetime of
+    /// the test binary by the `Arc<Harness>` in `SHARED`.
+    _container: ContainerAsync<PgImage>,
+
+    /// Temp directory used as `GARRAIA_CONFIG_DIR`. Held so it
+    /// survives for the whole test process and is cleaned up when
+    /// `Harness` is dropped.
+    _config_tempdir: tempfile::TempDir,
+
+    /// Superuser URL (`postgres:postgres@...`). Only used by tests
+    /// that legitimately need RLS-bypass (fixture setup in M3).
+    pub admin_url: String,
+
+    /// Typed `garraia_app` RLS-enforced pool.
+    pub app_pool: Arc<AppPool>,
+
+    /// Typed `garraia_login` BYPASSRLS pool.
+    pub login_pool: Arc<LoginPool>,
+
+    /// Typed `garraia_signup` BYPASSRLS pool.
+    pub signup_pool: Arc<SignupPool>,
+
+    /// Deterministic `JwtIssuer` shared by the router + any test
+    /// that needs to mint a bearer token via `issue_access_for_test`.
+    pub jwt: Arc<JwtIssuer>,
+
+    /// Pre-built Axum router. Ready for `tower::ServiceExt::oneshot`
+    /// — no socket binding.
+    pub router: Router,
+}
+
+impl Harness {
+    /// Idempotent process-wide accessor. First call boots the
+    /// container, runs migrations, promotes roles, builds the pools
+    /// and the router. Subsequent calls return the cached `Arc`.
+    pub async fn get() -> Arc<Self> {
+        SHARED
+            .get_or_init(|| async {
+                Arc::new(
+                    Self::boot()
+                        .await
+                        .expect("gateway integration harness boot"),
+                )
+            })
+            .await
+            .clone()
+    }
+
+    async fn boot() -> anyhow::Result<Self> {
+        // 1. Divert GARRAIA_CONFIG_DIR to a tempdir BEFORE anything
+        //    in the gateway touches `default_config_dir()`. This
+        //    prevents `McpPersistenceService::with_default_path()`
+        //    from writing to the developer's real
+        //    `%APPDATA%\garraia\` directory during tests.
+        //
+        //    Safety: `std::env::set_var` is `unsafe` on Edition 2024.
+        //    We run it before spawning any task that reads these
+        //    env vars, so no other thread races us.
+        let config_tempdir = tempfile::tempdir()?;
+        unsafe {
+            std::env::set_var("GARRAIA_CONFIG_DIR", config_tempdir.path());
+        }
+
+        // 2. Boot pgvector/pg16. Cold first run can take several
+        //    minutes on first image pull — that is expected.
+        let container = PgImage::default()
+            .with_name("pgvector/pgvector")
+            .with_tag("pg16")
+            .start()
+            .await?;
+        let host = container.get_host().await?;
+        let port = container.get_host_port_ipv4(5432).await?;
+        let admin_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+        // 3. Apply workspace migrations 001..010 via `Workspace`.
+        Workspace::connect(WorkspaceConfig {
+            database_url: admin_url.clone(),
+            max_connections: 5,
+            migrate_on_start: true,
+        })
+        .await?;
+
+        // 4. Promote the three NOLOGIN roles to LOGIN with
+        //    deterministic passwords. Test-only: container is
+        //    ephemeral and the URLs never leave the process.
+        let admin_pool = sqlx::PgPool::connect(&admin_url).await?;
+        sqlx::query("ALTER ROLE garraia_app    WITH LOGIN PASSWORD 'app-pw'")
+            .execute(&admin_pool)
+            .await?;
+        sqlx::query("ALTER ROLE garraia_login  WITH LOGIN PASSWORD 'login-pw'")
+            .execute(&admin_pool)
+            .await?;
+        sqlx::query("ALTER ROLE garraia_signup WITH LOGIN PASSWORD 'signup-pw'")
+            .execute(&admin_pool)
+            .await?;
+        admin_pool.close().await;
+
+        // 5. Build the three typed pools via their production
+        //    constructors — validates the `SELECT current_user`
+        //    guards identically to how production builds them.
+        let app_url = admin_url.replace("postgres:postgres@", "garraia_app:app-pw@");
+        let app_pool = Arc::new(
+            AppPool::from_dedicated_config(&AppPoolConfig {
+                database_url: app_url,
+                max_connections: 4,
+            })
+            .await?,
+        );
+
+        let login_url = admin_url.replace("postgres:postgres@", "garraia_login:login-pw@");
+        let login_pool = Arc::new(
+            LoginPool::from_dedicated_config(&LoginConfig {
+                database_url: login_url,
+                max_connections: 4,
+            })
+            .await?,
+        );
+
+        let signup_url = admin_url.replace("postgres:postgres@", "garraia_signup:signup-pw@");
+        let signup_pool = Arc::new(
+            SignupPool::from_dedicated_config(&SignupConfig {
+                database_url: signup_url,
+                max_connections: 4,
+            })
+            .await?,
+        );
+
+        // 6. Build a deterministic JWT issuer via the test helper
+        //    (plan 0016 M2-T1). The 32-byte minimum is handled by
+        //    `new_for_test` itself.
+        let jwt = Arc::new(JwtIssuer::new_for_test("harness-jwt-secret"));
+
+        // 7. Build the Router via the gateway test helper. The
+        //    test-helpers feature gate prevents this from being
+        //    reachable in any non-test build.
+        let config = minimal_test_config();
+        let router = build_router_for_test(
+            config,
+            login_pool.clone(),
+            signup_pool.clone(),
+            jwt.clone(),
+            Some(app_pool.clone()),
+        )
+        .await;
+
+        Ok(Self {
+            _container: container,
+            _config_tempdir: config_tempdir,
+            admin_url,
+            app_pool,
+            login_pool,
+            signup_pool,
+            jwt,
+            router,
+        })
+    }
+}
+
+/// Minimal `AppConfig` that satisfies the router builder without
+/// touching any external resource. Relies on `AppConfig::default`
+/// producing non-zero rate limit values (verified by team-coordinator
+/// pre-gate: `default_rate_per_second = 1`, `default_rate_burst_size = 60`).
+fn minimal_test_config() -> AppConfig {
+    let mut cfg = AppConfig::default();
+    cfg.memory.enabled = false;
+    cfg
+}
+
+/// Helper to grab the config tempdir path for diagnostic assertions.
+#[allow(dead_code)]
+pub fn tempdir_for_debug(h: &Harness) -> PathBuf {
+    h._config_tempdir.path().to_path_buf()
+}
+
+/// Build a `GET` request suitable for `tower::ServiceExt::oneshot`
+/// against the harness router.
+///
+/// The production router composition includes a `tower_governor`
+/// rate-limit layer whose default `PeerIpKeyExtractor` reads peer
+/// IP from the request's `ConnectInfo<SocketAddr>` extension. That
+/// extension is normally populated by Axum's TCP listener and is
+/// ABSENT on requests constructed via `Request::builder()` — causing
+/// the governor to bail out with `"Unable To Extract Key!"` and the
+/// handler chain to answer 500.
+///
+/// This helper injects a fixed `127.0.0.1:1` ConnectInfo so the
+/// governor's key extractor succeeds and the real handler runs.
+/// Any additional headers (e.g. `Authorization: Bearer ...`) can
+/// be added via `req.headers_mut()` after calling this.
+pub fn harness_get(path: &str) -> Request<Body> {
+    let mut req = Request::builder()
+        .method("GET")
+        .uri(path)
+        .body(Body::empty())
+        .expect("request builder should succeed");
+    req.extensions_mut().insert(ConnectInfo::<SocketAddr>(
+        "127.0.0.1:1".parse().expect("valid fixed test peer"),
+    ));
+    req
+}

--- a/crates/garraia-gateway/tests/harness_smoke.rs
+++ b/crates/garraia-gateway/tests/harness_smoke.rs
@@ -1,0 +1,49 @@
+//! Smoke test for the gateway integration harness (plan 0016 M2-T4).
+//!
+//! Validates the whole stack end-to-end over a real testcontainer
+//! pgvector/pg16 + migrations 001..010 + typed pools + prebuilt
+//! Router, by doing one `GET /v1/openapi.json` oneshot call and
+//! asserting a 200 with a parseable OpenAPI body.
+//!
+//! This is deliberately the ONLY test in M2. Authed `/v1/me` paths
+//! (401/200/403), seed fixtures, and Swagger `SecurityScheme::Bearer`
+//! wire checks all land in M3 once `fixtures::seed_user_with_group`
+//! is added.
+
+mod common;
+
+use axum::http::StatusCode;
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+use common::{harness_get, Harness};
+
+#[tokio::test]
+async fn harness_boots_and_router_responds_to_openapi_json() {
+    let h = Harness::get().await;
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(harness_get("/v1/openapi.json"))
+        .await
+        .expect("oneshot should succeed");
+
+    let status = resp.status();
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    if status != StatusCode::OK {
+        let body_str = String::from_utf8_lossy(&body);
+        panic!("openapi.json expected 200, got {status}. body: {body_str}");
+    }
+    let v: serde_json::Value = serde_json::from_slice(&body).expect("openapi body is JSON");
+    assert_eq!(
+        v["info"]["title"], "GarraIA REST /v1",
+        "unexpected OpenAPI info.title — router wiring regression?"
+    );
+    assert_eq!(v["info"]["version"], "0.1.0");
+    // Proves `GET /v1/me` is wired under full state (not 503 stub).
+    assert!(
+        v["paths"]["/v1/me"]["get"].is_object(),
+        "/v1/me must be listed in the OpenAPI paths"
+    );
+}

--- a/crates/garraia-gateway/tests/harness_smoke.rs
+++ b/crates/garraia-gateway/tests/harness_smoke.rs
@@ -30,7 +30,12 @@ async fn harness_boots_and_router_responds_to_openapi_json() {
         .expect("oneshot should succeed");
 
     let status = resp.status();
-    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let body = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("failed to collect openapi.json body bytes")
+        .to_bytes();
     if status != StatusCode::OK {
         let body_str = String::from_utf8_lossy(&body);
         panic!("openapi.json expected 200, got {status}. body: {body_str}");

--- a/crates/garraia-gateway/tests/projects_test.rs
+++ b/crates/garraia-gateway/tests/projects_test.rs
@@ -8,6 +8,7 @@ use std::net::TcpListener;
 use garraia_config::AppConfig;
 use garraia_gateway::GatewayServer;
 use serde_json::json;
+use serial_test::serial;
 
 /// Pick a random available port.
 fn random_port() -> u16 {
@@ -60,6 +61,7 @@ async fn start_test_gateway() -> String {
 }
 
 #[tokio::test]
+#[serial]
 async fn project_crud_lifecycle() {
     let base = start_test_gateway().await;
     let client = reqwest::Client::new();
@@ -159,6 +161,7 @@ async fn project_crud_lifecycle() {
 }
 
 #[tokio::test]
+#[serial]
 async fn get_nonexistent_project_returns_404() {
     let base = start_test_gateway().await;
     let client = reqwest::Client::new();
@@ -173,6 +176,7 @@ async fn get_nonexistent_project_returns_404() {
 }
 
 #[tokio::test]
+#[serial]
 async fn update_nonexistent_project_returns_404() {
     let base = start_test_gateway().await;
     let client = reqwest::Client::new();
@@ -188,6 +192,7 @@ async fn update_nonexistent_project_returns_404() {
 }
 
 #[tokio::test]
+#[serial]
 async fn delete_nonexistent_project_returns_404() {
     let base = start_test_gateway().await;
     let client = reqwest::Client::new();

--- a/crates/garraia-gateway/tests/rest_v1_me.rs
+++ b/crates/garraia-gateway/tests/rest_v1_me.rs
@@ -16,6 +16,7 @@ use std::time::Duration;
 
 use garraia_config::AppConfig;
 use garraia_gateway::GatewayServer;
+use serial_test::serial;
 
 fn random_port() -> u16 {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind to random port");
@@ -36,7 +37,12 @@ fn clear_auth_env() {
     }
 }
 
+// `#[serial]` isolates this test from any other that reads or mutates
+// the same env vars. The `clear_auth_env()` call below uses
+// `std::env::remove_var` which is `unsafe` on Edition 2024 and races
+// any concurrent reader in the same process. Plan 0016 M2-T5.
 #[tokio::test]
+#[serial]
 async fn get_v1_me_fails_soft_with_503_problem_details_when_auth_unconfigured() {
     clear_auth_env();
 

--- a/crates/garraia-gateway/tests/skins_test.rs
+++ b/crates/garraia-gateway/tests/skins_test.rs
@@ -8,6 +8,7 @@ use std::net::TcpListener;
 use garraia_config::AppConfig;
 use garraia_gateway::GatewayServer;
 use serde_json::json;
+use serial_test::serial;
 
 /// Pick a random available port.
 fn random_port() -> u16 {
@@ -61,6 +62,7 @@ async fn start_test_gateway_with_skins_dir(skins_dir: &str) -> String {
 }
 
 #[tokio::test]
+#[serial]
 async fn skin_crud_lifecycle() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let skins_path = tmp.path().join("skins");
@@ -145,6 +147,7 @@ async fn skin_crud_lifecycle() {
 }
 
 #[tokio::test]
+#[serial]
 async fn get_nonexistent_skin_returns_404() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let skins_path = tmp.path().join("skins_404");
@@ -164,6 +167,7 @@ async fn get_nonexistent_skin_returns_404() {
 }
 
 #[tokio::test]
+#[serial]
 async fn create_skin_with_path_traversal_returns_400() {
     let tmp = tempfile::tempdir().expect("create temp dir");
     let skins_path = tmp.path().join("skins_traversal");


### PR DESCRIPTION
## Summary

**M2 reduced scope** of plan 0016 (owner-approved): gateway integration test harness + one smoke test. No fixtures, no authed paths, no OpenAPI security scheme — those land in M3.

5 commits on `feat/0016m2-harness`:

| Commit | Task | Change |
|---|---|---|
| `6c4d37d` | M2-T1 | `JwtIssuer::new_for_test(secret)` + `issue_access_for_test(user_id)` in `garraia-auth`, gated behind `#[cfg(any(test, feature = "test-support"))]`. +1 unit test. |
| `1fbbf84` | M2-T2 | New `test-helpers` cargo feature on `garraia-gateway` (transitively enables `garraia-auth/test-support`) + `GatewayServer::build_router_for_test(...)` gated behind `#[cfg(feature = "test-helpers")]`. Thin wrapper over `crate::router::build_router` — no logic duplication. |
| `04c2b2c` | M2-T3+T4 | `crates/garraia-gateway/tests/common/mod.rs` harness (pgvector/pg16 via testcontainers, migrations 001..010, 3 typed pools, `JwtIssuer::new_for_test`, prebuilt Router) + `crates/garraia-gateway/tests/harness_smoke.rs` with 1 test asserting `GET /v1/openapi.json -> 200`. Includes `harness_get(path)` helper injecting a fixed `ConnectInfo<SocketAddr>` so `tower_governor`'s `PeerIpKeyExtractor` resolves on `oneshot` requests. |
| `2161b42` | M2-T5 | `serial_test = "3"` workspace dep + `#[serial]` on the existing fail-soft `rest_v1_me` test (which mutates env vars via `unsafe set_var`). |
| `4bf8011` | review | Applied review findings from parallel `security-auditor` + `code-reviewer` dispatch: `required-features = ["test-helpers"]` on `harness_smoke`, `#[serial]` on pre-existing env-mutating tests (`projects_test.rs` 4 tests, `skins_test.rs` 3 tests), `.expect(...)` on body collect, dead `tempdir_for_debug` removal. |

## What ships

- **`JwtIssuer::new_for_test`** + `issue_access_for_test` — test-only JWT helpers symmetric to `LoginPool::raw()` / `SignupPool::raw()` pattern. Short secrets are padded to 32 bytes so callers can pass short literals.
- **`test-helpers` cargo feature** — disabled by default, WARNING banner in Cargo.toml, transitively enables `garraia-auth/test-support`. Verified by the team-coordinator pre-gate and the security-auditor review that no production crate depends on this feature.
- **`build_router_for_test`** — zero-config `AgentRuntime::new()` + `ChannelRegistry::new()` + `AdminStore::in_memory()` + empty `WhatsAppState`, injects pre-built pools via `set_auth_components`, reuses the production `router::build_router`. No duplication.
- **`tests/common/mod.rs` harness** — `OnceCell<Arc<Harness>>` process-wide shared testcontainer. Diverts `GARRAIA_CONFIG_DIR` to a process-lifetime tempdir BEFORE touching any gateway code (team-coordinator-flagged `McpPersistenceService` filesystem side effect is neutralized). Promotes the 3 NOLOGIN roles to LOGIN with deterministic passwords inside the ephemeral container. Builds the 3 typed pools through each one's production validating constructor (same `SELECT current_user` guard as prod).
- **`harness_smoke` test** — one `#[tokio::test]` proving the whole stack end-to-end: container -> migrations -> pools -> router -> response. Asserts `GET /v1/openapi.json` returns 200 + `info.title` + `info.version` + `/v1/me` is listed under `paths`. This is mode 1 of plan 0016 M1-T4 exercised against a real Postgres for the first time.
- **`serial_test` workspace dep** — `#[serial]` applied to every existing test that mutates env vars via `unsafe set_var`, preventing UB races on Edition 2024.

## What is explicitly NOT in this PR

- `fixtures.rs` + `seed_user_with_group` -> **M3**
- Authed `/v1/me` tests (401 / 200 without group / 200 with group / 403 foreign group) -> **M3**
- `SecurityScheme::Bearer` on OpenAPI + wire validation -> **M3**
- `/v1/groups` real handlers -> **M4**
- Review follow-ups from M1 PR #10 (fail-soft `/docs/*` trailing slash, `impl IntoResponse` nit, `.context()` policy doc note) -> **M5**

## Validations (all green)

- `cargo check --workspace` -> Finished OK
- `cargo clippy -p garraia-auth -p garraia-gateway --lib --tests --features test-helpers` -> zero errors, zero new warnings in touched files
- `cargo test -p garraia-auth --lib` -> **41 passed** (40 + 1 new JWT round-trip)
- `cargo test -p garraia-gateway --lib` -> **161 passed** (intacto)
- `cargo test -p garraia-gateway --test rest_v1_me` -> **1 passed** (fail-soft with `#[serial]`)
- `cargo test -p garraia-gateway --test router_smoke_test` -> **3 passed** (legacy intacto)
- `cargo test -p garraia-gateway --features test-helpers --test harness_smoke` -> **1 passed** (new end-to-end smoke over pgvector/pg16)
- `cargo test -p garraia-gateway --test projects_test` -> **4 passed** (pre-existing, now with `#[serial]`)
- `cargo test -p garraia-gateway --test skins_test` -> **3 passed** (pre-existing, now with `#[serial]`)

## Agent Teams used

**Pre-execution gate:** `team-coordinator` despachado ANTES de tocar código com o escopo reduzido do M2. Retornou **Go** com 2 riscos críticos incorporados antes do coding:

1. `AppState::new` exige `AgentRuntime + ChannelRegistry` — team-coordinator confirmou que `AgentRuntime::new()` e `ChannelRegistry::new()` são zero-config via inspeção dos testes unitários em `state.rs:667-672`.
2. `McpPersistenceService::with_default_path()` faz I/O no `%APPDATA%\garraia\` — risco não listado no plano. Harness foi reforçado para divertir `GARRAIA_CONFIG_DIR` a um tempdir antes de qualquer construção de state.

**Post-implementation review:** `security-auditor` + `code-reviewer` dispatched **in parallel** (Batch Workflow) em uma única mensagem. Ambos retornaram **aprovado com ressalvas**.

### security-auditor findings
- 0 CRITICAL, 0 HIGH, **1 MEDIUM (applied)**, 3 LOW, 2 NITPICK
- **MANDATORY (#1 MEDIUM)**: `#[serial]` ausente em `projects_test.rs` / `skins_test.rs` que chamam `set_var("GARRAIA_CONFIG_DIR", ...)`. Fix: applied `#[serial]` to all 7 tests across the two files.
- LOW/NITPICK (deferred to M3): `admin_url` is `pub` on Harness, no CI guard for `test-helpers` feature unification, hardcoded password comment, rate limit bucket sharing.

### code-reviewer findings
- 0 CRITICAL, **1 HIGH + 1 defensive HIGH (1 applied)**, 3 MEDIUM (1 applied), 3 LOW (1 applied), 3 NITPICK
- **MANDATORY (H-2)**: `required-features = ["test-helpers"]` missing on `[[test]] harness_smoke` in Cargo.toml. Fix: added explicit entry.
- **Applied (M-1)**: `.unwrap()` on `BodyExt::collect` replaced with descriptive `.expect(...)`.
- **Applied (L-3)**: Removed `tempdir_for_debug` dead helper.
- Deferred (all non-blocking): H-1 defensive `#[serial]` on harness_smoke, M-2 doc note on `app_pool` ownership divergence, M-3 URL parsing via `url::Url`, L-1 distinct-secrets helper, L-2 `admin_url` accessor refactor, N-3 `garraia-auth` duplicated in dev-deps.

## Known deferred work (rolled into M3/M4/M5)

| Item | Severity | Target |
|---|---|---|
| `admin_url` as `pub` field -> accessor / newtype | LOW | M3 (when fixtures land) |
| CI grep guard for `test-helpers` feature leakage | LOW | M3 or infrastructure PR |
| URL parsing via `url::Url` in harness | MEDIUM | M3 |
| `pool_for_handlers()` -> `exec_with_tenant` closure API | MEDIUM (carried from M1) | M4 |
| `test-support` -> `__test-support` rename | LOW (carried from M1) | M4 |

## Rollback

All 5 commits are independent and reversible via `git revert`. M1 (PR #10, merged) is not touched. Production handler surface unchanged. Zero breaking change.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy -p garraia-auth -p garraia-gateway --lib --tests --features test-helpers`
- [x] `cargo test -p garraia-auth --lib` (41 passed)
- [x] `cargo test -p garraia-gateway --lib` (161 passed)
- [x] `cargo test -p garraia-gateway --test rest_v1_me` (1 passed)
- [x] `cargo test -p garraia-gateway --features test-helpers --test harness_smoke` (1 passed)
- [x] `cargo test -p garraia-gateway --test router_smoke_test` (3 passed)
- [x] `cargo test -p garraia-gateway --test projects_test` (4 passed, now `#[serial]`)
- [x] `cargo test -p garraia-gateway --test skins_test` (3 passed, now `#[serial]`)
- [ ] Post-merge: bump `plans/README.md` 0016 status from "M1 merged" to "M1+M2 merged, M3+ pending"

Robot: Generated with Claude Code
