### PR TITLE
test(gateway): plan 0016 M3 — SecurityAddon + fixtures + authed /v1/me scenarios

### DIFF
--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -84,6 +84,14 @@ name = "harness_smoke"
 path = "tests/harness_smoke.rs"
 required-features = ["test-helpers"]
 
+# Plan 0016 M3-T3: authed /v1/me integration tests. Same gating as
+# harness_smoke — requires the test-helpers feature so
+# `GatewayServer::build_router_for_test` is visible.
+[[test]]
+name = "rest_v1_me_authed"
+path = "tests/rest_v1_me_authed.rs"
+required-features = ["test-helpers"]
+
 [dev-dependencies]
 tempfile = "3"
 serial_test = { workspace = true }

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -1,13 +1,46 @@
-//! OpenAPI 3.1 aggregator for the `/v1` surface (plan 0015).
+//! OpenAPI 3.1 aggregator for the `/v1` surface (plan 0015 + M3).
 //!
 //! New endpoints go under `paths(...)` and their request/response DTOs
 //! go under `components(schemas(...))`. The aggregated document is
 //! exposed at `/v1/openapi.json` and rendered by Swagger UI at `/docs`.
+//!
+//! Plan 0016 M3 adds a `SecurityAddon` modifier that registers the
+//! `"bearer"` HTTP security scheme (JWT-format) in `components.securitySchemes`.
+//! Handlers reference it via `#[utoipa::path(..., security(("bearer" = [])))]`
+//! — see `me::get_me`.
 
-use utoipa::OpenApi;
+use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
+use utoipa::{Modify, OpenApi};
 
 use super::me::MeResponse;
 use super::problem::ProblemDetails;
+
+/// Plan 0016 M3-T1 — registers a bearer JWT `SecurityScheme` in the
+/// generated OpenAPI document's `components.securitySchemes`. Applied
+/// via `#[openapi(modifiers(&SecurityAddon))]` on [`ApiDoc`].
+///
+/// This is the standard `utoipa` pattern for declaring auth schemes
+/// without tying the runtime validation to the declaration — the
+/// actual verification still happens in `garraia_auth::Principal`.
+pub struct SecurityAddon;
+
+impl Modify for SecurityAddon {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        let components = openapi
+            .components
+            .as_mut()
+            .expect("ApiDoc always has components");
+        components.add_security_scheme(
+            "bearer",
+            SecurityScheme::Http(
+                HttpBuilder::new()
+                    .scheme(HttpAuthScheme::Bearer)
+                    .bearer_format("JWT")
+                    .build(),
+            ),
+        );
+    }
+}
 
 #[derive(OpenApi)]
 #[openapi(
@@ -17,6 +50,7 @@ use super::problem::ProblemDetails;
         description = "Versioned GarraIA gateway REST surface (Fase 3.4)."
     ),
     paths(super::me::get_me),
-    components(schemas(MeResponse, ProblemDetails))
+    components(schemas(MeResponse, ProblemDetails)),
+    modifiers(&SecurityAddon)
 )]
 pub struct ApiDoc;

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -26,10 +26,18 @@ pub struct SecurityAddon;
 
 impl Modify for SecurityAddon {
     fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        // Use `get_or_insert_with(Default::default)` rather than
+        // `.expect("...")` so this modifier is robust to any future
+        // refactor that strips `components(schemas(...))` from the
+        // `ApiDoc` derive. The current derive always yields
+        // `Some(Components { .. })` at macro expansion time, but
+        // the invariant is not compiler-enforced — a silent panic
+        // at `GET /v1/openapi.json` in production would be a
+        // 500-no-body regression that is trivial to prevent here.
+        // Plan 0016 M3 review fix (security + code-reviewer).
         let components = openapi
             .components
-            .as_mut()
-            .expect("ApiDoc always has components");
+            .get_or_insert_with(Default::default);
         components.add_security_scheme(
             "bearer",
             SecurityScheme::Http(

--- a/crates/garraia-gateway/tests/common/fixtures.rs
+++ b/crates/garraia-gateway/tests/common/fixtures.rs
@@ -29,20 +29,26 @@ use super::Harness;
 ///
 /// Returns `(user_id, group_id, jwt_token)`.
 ///
-/// A fresh admin pool is opened on every call and closed on drop —
-/// same pattern as `garraia-auth/tests/common/harness.rs` uses for
-/// role promotion (opens, runs ALTER ROLE, closes). Connection pools
-/// against a local testcontainer are cheap enough for this.
+/// Uses the harness's **shared** `admin_pool` (built once in
+/// `Harness::boot`) instead of opening a fresh pool per call.
+/// Opening a fresh `PgPool` per fixture call would exhaust
+/// Postgres `max_connections` in parallel test suites — a bug
+/// discovered during plan 0016 M3-T3 when 5 `#[tokio::test]`
+/// functions each opened their own fixture pool on top of the
+/// three harness pools (48 connections).
 pub async fn seed_user_with_group(
     h: &Harness,
     email: &str,
 ) -> anyhow::Result<(Uuid, Uuid, String)> {
-    let admin_pool = sqlx::PgPool::connect(&h.admin_url)
-        .await
-        .context("fixture admin_pool connect")?;
-
     let user_id = Uuid::new_v4();
     let group_id = Uuid::new_v4();
+
+    // Single transaction: acquires ONE connection for all 3 inserts
+    // and either commits all or rolls back all. Crucial for parallel
+    // test suites — 5 `#[tokio::test]` × 3 sequential inserts against
+    // a small shared admin_pool hits the `acquire_timeout` otherwise.
+    // Discovered during plan 0016 M3-T3 debugging.
+    let mut tx = h.admin_pool.begin().await.context("fixture tx begin")?;
 
     sqlx::query(
         "INSERT INTO users (id, email, display_name, status) \
@@ -51,7 +57,7 @@ pub async fn seed_user_with_group(
     .bind(user_id)
     .bind(email)
     .bind(format!("Test {}", email))
-    .execute(&admin_pool)
+    .execute(&mut *tx)
     .await
     .context("fixture insert users")?;
 
@@ -62,7 +68,7 @@ pub async fn seed_user_with_group(
     .bind(group_id)
     .bind(format!("Test group for {}", email))
     .bind(user_id)
-    .execute(&admin_pool)
+    .execute(&mut *tx)
     .await
     .context("fixture insert groups")?;
 
@@ -72,11 +78,11 @@ pub async fn seed_user_with_group(
     )
     .bind(group_id)
     .bind(user_id)
-    .execute(&admin_pool)
+    .execute(&mut *tx)
     .await
     .context("fixture insert group_members")?;
 
-    admin_pool.close().await;
+    tx.commit().await.context("fixture tx commit")?;
 
     let token = h.jwt.issue_access_for_test(user_id);
 

--- a/crates/garraia-gateway/tests/common/fixtures.rs
+++ b/crates/garraia-gateway/tests/common/fixtures.rs
@@ -1,0 +1,84 @@
+//! Test fixtures for the gateway integration harness (plan 0016 M3-T2).
+//!
+//! `seed_user_with_group` is the one-stop setup helper used by the
+//! authed `/v1/me` tests. It bypasses RLS by connecting as the
+//! container superuser (`postgres`) and inserting rows directly into
+//! `users`, `groups`, and `group_members`. Token minting uses
+//! `h.jwt.issue_access_for_test(user_id)` so every seeded user has
+//! a valid bearer JWT for the same `JwtIssuer` that the router
+//! verifies against.
+//!
+//! ## Boundary note
+//!
+//! Fixture setup is the one sanctioned place where a test may read
+//! from the superuser URL. Assertions and handler-driven queries
+//! must NOT use the admin pool — they run through the `garraia_app`
+//! RLS-enforced pool via `h.app_pool` or through the HTTP router.
+//!
+//! This mirrors the pattern already validated in
+//! `crates/garraia-auth/tests/common/harness.rs` (plan 0013 path C).
+
+use anyhow::Context;
+use uuid::Uuid;
+
+use super::Harness;
+
+/// Seed one user + one group + one `group_members` row with role
+/// `owner`, then mint a JWT for that user via
+/// `Harness::jwt::issue_access_for_test`.
+///
+/// Returns `(user_id, group_id, jwt_token)`.
+///
+/// A fresh admin pool is opened on every call and closed on drop —
+/// same pattern as `garraia-auth/tests/common/harness.rs` uses for
+/// role promotion (opens, runs ALTER ROLE, closes). Connection pools
+/// against a local testcontainer are cheap enough for this.
+pub async fn seed_user_with_group(
+    h: &Harness,
+    email: &str,
+) -> anyhow::Result<(Uuid, Uuid, String)> {
+    let admin_pool = sqlx::PgPool::connect(&h.admin_url)
+        .await
+        .context("fixture admin_pool connect")?;
+
+    let user_id = Uuid::new_v4();
+    let group_id = Uuid::new_v4();
+
+    sqlx::query(
+        "INSERT INTO users (id, email, display_name, status) \
+         VALUES ($1, $2, $3, 'active')",
+    )
+    .bind(user_id)
+    .bind(email)
+    .bind(format!("Test {}", email))
+    .execute(&admin_pool)
+    .await
+    .context("fixture insert users")?;
+
+    sqlx::query(
+        "INSERT INTO groups (id, name, type, created_by) \
+         VALUES ($1, $2, 'team', $3)",
+    )
+    .bind(group_id)
+    .bind(format!("Test group for {}", email))
+    .bind(user_id)
+    .execute(&admin_pool)
+    .await
+    .context("fixture insert groups")?;
+
+    sqlx::query(
+        "INSERT INTO group_members (group_id, user_id, role, status) \
+         VALUES ($1, $2, 'owner', 'active')",
+    )
+    .bind(group_id)
+    .bind(user_id)
+    .execute(&admin_pool)
+    .await
+    .context("fixture insert group_members")?;
+
+    admin_pool.close().await;
+
+    let token = h.jwt.issue_access_for_test(user_id);
+
+    Ok((user_id, group_id, token))
+}

--- a/crates/garraia-gateway/tests/common/mod.rs
+++ b/crates/garraia-gateway/tests/common/mod.rs
@@ -22,6 +22,8 @@
 
 #![allow(dead_code)]
 
+pub mod fixtures;
+
 use std::net::SocketAddr;
 use std::sync::Arc;
 

--- a/crates/garraia-gateway/tests/common/mod.rs
+++ b/crates/garraia-gateway/tests/common/mod.rs
@@ -58,7 +58,25 @@ pub struct Harness {
 
     /// Superuser URL (`postgres:postgres@...`). Only used by tests
     /// that legitimately need RLS-bypass (fixture setup in M3).
+    /// Prefer `admin_pool` below — it is the sanctioned accessor
+    /// for fixture inserts.
     pub admin_url: String,
+
+    /// Shared superuser `PgPool` built once in `boot()` and reused
+    /// by every fixture call (`seed_user_with_group`, future seed
+    /// helpers). Sized at `max_connections = 8` — fixtures bundle
+    /// their multi-row inserts into a single transaction so one
+    /// fixture call acquires one connection for the duration of
+    /// the inserts, making 8 comfortable headroom for any parallel
+    /// test suite.
+    ///
+    /// Why shared rather than opened-per-fixture: opening a fresh
+    /// `PgPool` per fixture call exhausts Postgres `max_connections`
+    /// (default 100) when combined with the three test pools at
+    /// `max_connections = 16` each and a handful of parallel
+    /// `#[tokio::test]` functions — an issue discovered during
+    /// plan 0016 M3-T3 (timeout in LoginPool extractor lookup).
+    pub admin_pool: sqlx::PgPool,
 
     /// Typed `garraia_app` RLS-enforced pool.
     pub app_pool: Arc<AppPool>,
@@ -96,6 +114,19 @@ impl Harness {
     }
 
     async fn boot() -> anyhow::Result<Self> {
+        // 0. Init a global tracing subscriber so extractor error logs
+        //    (e.g. `group_members_lookup_failed`) surface in test
+        //    output under `cargo test -- --nocapture`. Idempotent:
+        //    `try_init` silently returns Err if a subscriber is
+        //    already installed, which is fine.
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info,garraia_auth=debug")),
+            )
+            .with_test_writer()
+            .try_init();
+
         // 1. Divert GARRAIA_CONFIG_DIR to a tempdir BEFORE anything
         //    in the gateway touches `default_config_dir()`. This
         //    prevents `McpPersistenceService::with_default_path()`
@@ -132,7 +163,16 @@ impl Harness {
         // 4. Promote the three NOLOGIN roles to LOGIN with
         //    deterministic passwords. Test-only: container is
         //    ephemeral and the URLs never leave the process.
-        let admin_pool = sqlx::PgPool::connect(&admin_url).await?;
+        //
+        //    The admin_pool is kept alive on the Harness struct
+        //    (not closed here) so fixture helpers can reuse it
+        //    without opening a fresh pool per call — see the
+        //    doc comment on `Harness::admin_pool` for the
+        //    rationale.
+        let admin_pool = sqlx::postgres::PgPoolOptions::new()
+            .max_connections(8)
+            .connect(&admin_url)
+            .await?;
         sqlx::query("ALTER ROLE garraia_app    WITH LOGIN PASSWORD 'app-pw'")
             .execute(&admin_pool)
             .await?;
@@ -142,16 +182,24 @@ impl Harness {
         sqlx::query("ALTER ROLE garraia_signup WITH LOGIN PASSWORD 'signup-pw'")
             .execute(&admin_pool)
             .await?;
-        admin_pool.close().await;
 
         // 5. Build the three typed pools via their production
         //    constructors — validates the `SELECT current_user`
         //    guards identically to how production builds them.
+        //
+        //    Pool sizes: bumped to 16 after the first parallel run
+        //    of the M3 authed /v1/me tests hit transient pool-timeout
+        //    errors on the LoginPool (5 #[tokio::test] functions each
+        //    firing one extractor lookup in parallel while the
+        //    production LoginPool is sized for 4 concurrent logins).
+        //    16 is comfortable headroom for any reasonable parallel
+        //    test suite without exhausting Postgres max_connections
+        //    (default 100 in pgvector/pg16).
         let app_url = admin_url.replace("postgres:postgres@", "garraia_app:app-pw@");
         let app_pool = Arc::new(
             AppPool::from_dedicated_config(&AppPoolConfig {
                 database_url: app_url,
-                max_connections: 4,
+                max_connections: 16,
             })
             .await?,
         );
@@ -160,7 +208,7 @@ impl Harness {
         let login_pool = Arc::new(
             LoginPool::from_dedicated_config(&LoginConfig {
                 database_url: login_url,
-                max_connections: 4,
+                max_connections: 16,
             })
             .await?,
         );
@@ -169,7 +217,7 @@ impl Harness {
         let signup_pool = Arc::new(
             SignupPool::from_dedicated_config(&SignupConfig {
                 database_url: signup_url,
-                max_connections: 4,
+                max_connections: 16,
             })
             .await?,
         );
@@ -196,6 +244,7 @@ impl Harness {
             _container: container,
             _config_tempdir: config_tempdir,
             admin_url,
+            admin_pool,
             app_pool,
             login_pool,
             signup_pool,

--- a/crates/garraia-gateway/tests/common/mod.rs
+++ b/crates/garraia-gateway/tests/common/mod.rs
@@ -114,19 +114,6 @@ impl Harness {
     }
 
     async fn boot() -> anyhow::Result<Self> {
-        // 0. Init a global tracing subscriber so extractor error logs
-        //    (e.g. `group_members_lookup_failed`) surface in test
-        //    output under `cargo test -- --nocapture`. Idempotent:
-        //    `try_init` silently returns Err if a subscriber is
-        //    already installed, which is fine.
-        let _ = tracing_subscriber::fmt()
-            .with_env_filter(
-                tracing_subscriber::EnvFilter::try_from_default_env()
-                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info,garraia_auth=debug")),
-            )
-            .with_test_writer()
-            .try_init();
-
         // 1. Divert GARRAIA_CONFIG_DIR to a tempdir BEFORE anything
         //    in the gateway touches `default_config_dir()`. This
         //    prevents `McpPersistenceService::with_default_path()`
@@ -169,8 +156,10 @@ impl Harness {
         //    without opening a fresh pool per call — see the
         //    doc comment on `Harness::admin_pool` for the
         //    rationale.
+        // admin_pool: sized at 16 for safe headroom when fixtures
+        // run concurrently. Acquire timeout kept at sqlx default.
         let admin_pool = sqlx::postgres::PgPoolOptions::new()
-            .max_connections(8)
+            .max_connections(16)
             .connect(&admin_url)
             .await?;
         sqlx::query("ALTER ROLE garraia_app    WITH LOGIN PASSWORD 'app-pw'")

--- a/crates/garraia-gateway/tests/common/mod.rs
+++ b/crates/garraia-gateway/tests/common/mod.rs
@@ -64,11 +64,12 @@ pub struct Harness {
 
     /// Shared superuser `PgPool` built once in `boot()` and reused
     /// by every fixture call (`seed_user_with_group`, future seed
-    /// helpers). Sized at `max_connections = 8` — fixtures bundle
-    /// their multi-row inserts into a single transaction so one
-    /// fixture call acquires one connection for the duration of
-    /// the inserts, making 8 comfortable headroom for any parallel
-    /// test suite.
+    /// helpers). Sized at `max_connections = 16` for comfortable
+    /// headroom under parallel test suites — fixtures bundle their
+    /// multi-row inserts into a single transaction so one fixture
+    /// call acquires one connection for the duration of the inserts.
+    /// 16 is well under Postgres default `max_connections = 100` and
+    /// absorbs any realistic combination of parallel seeds.
     ///
     /// Why shared rather than opened-per-fixture: opening a fresh
     /// `PgPool` per fixture call exhausts Postgres `max_connections`

--- a/crates/garraia-gateway/tests/rest_v1_me_authed.rs
+++ b/crates/garraia-gateway/tests/rest_v1_me_authed.rs
@@ -1,9 +1,11 @@
 //! Authed integration tests for `GET /v1/me` (plan 0016 M3-T3).
 //!
 //! Exercises the full Principal extractor chain against a real
-//! pgvector/pg16 container (via `common::Harness`) and a JWT minted
+//! pgvector/pg16 container (via `common::Harness`) and JWTs minted
 //! by the same `JwtIssuer` that the router verifies against (via
-//! `fixtures::seed_user_with_group`). Covers:
+//! `fixtures::seed_user_with_group`). Covers the same 5 scenarios
+//! the plan called for, but **bundled inside one `#[tokio::test]`
+//! function** that runs them sequentially on a single tokio runtime:
 //!
 //!   1. No bearer                 -> 401
 //!   2. Valid bearer, no group    -> 200 (group_id + role absent)
@@ -11,14 +13,29 @@
 //!   4. Valid bearer, foreign grp -> 403
 //!   5. `/v1/openapi.json`        -> 200 + bearer SecurityScheme + /v1/me path
 //!
-//! Separate from `rest_v1_me.rs` on purpose: that file contains the
-//! env-mutating fail-soft test guarded by `#[serial]`, and mixing it
-//! with these non-mutating tests would force all of them to
-//! serialize. This file is pure read-only oneshot — no `#[serial]`.
+//! ## Why one function instead of five?
+//!
+//! During plan 0016 M3-T3 I initially split these into five
+//! `#[tokio::test]` functions. Running them — even with
+//! `#[serial_test::serial]` AND `--test-threads=1` — consistently
+//! produced `pool timed out while waiting for an open connection`
+//! errors on a non-deterministic subset of tests. The root cause
+//! is that each `#[tokio::test]` macro spins up its own tokio
+//! runtime and tears it down when the test body returns; sqlx
+//! `PgPool` connections acquired inside that runtime are not
+//! always released back to the shared `Harness::admin_pool` /
+//! `Harness::login_pool` before the next test's runtime starts
+//! trying to acquire them. The symptom was flaky
+//! `fixture tx begin` timeouts and `group_members lookup` 401s.
+//!
+//! Folding all scenarios into one `#[tokio::test]` function
+//! means one runtime, one linear sequence of acquires and
+//! releases, and 100% deterministic behavior. Failures still
+//! pinpoint the scenario via assertion messages.
 
 mod common;
 
-use axum::http::{HeaderName, HeaderValue, StatusCode};
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
 use http_body_util::BodyExt;
 use tower::ServiceExt;
 
@@ -35,119 +52,137 @@ async fn body_json(resp: axum::response::Response) -> serde_json::Value {
     serde_json::from_slice(&bytes).expect("response body is not JSON")
 }
 
-#[tokio::test]
-async fn get_v1_me_without_bearer_returns_401() {
-    let h = Harness::get().await;
-    let resp = h
-        .router
-        .clone()
-        .oneshot(harness_get("/v1/me"))
-        .await
-        .expect("oneshot should succeed");
-    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
-}
-
-#[tokio::test]
-async fn get_v1_me_with_valid_bearer_no_group_returns_200() {
-    let h = Harness::get().await;
-    let (user_id, _group_id, token) =
-        seed_user_with_group(&h, "no-group@m3.test").await.expect("seed");
-
+fn with_bearer(token: &str) -> Request<axum::body::Body> {
     let mut req = harness_get("/v1/me");
     req.headers_mut().insert(
         HeaderName::from_static("authorization"),
         HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
     );
-
-    let resp = h.router.clone().oneshot(req).await.expect("oneshot");
-    assert_eq!(resp.status(), StatusCode::OK);
-
-    let v = body_json(resp).await;
-    assert_eq!(v["user_id"], user_id.to_string());
-    assert!(
-        v.get("group_id").is_none(),
-        "absent X-Group-Id -> group_id must be skipped in response, got {v}"
-    );
-    assert!(
-        v.get("role").is_none(),
-        "absent X-Group-Id -> role must be skipped in response, got {v}"
-    );
+    req
 }
 
-#[tokio::test]
-async fn get_v1_me_with_valid_bearer_and_member_group_returns_200_with_role() {
-    let h = Harness::get().await;
-    let (user_id, group_id, token) =
-        seed_user_with_group(&h, "member@m3.test").await.expect("seed");
-
-    let mut req = harness_get("/v1/me");
-    req.headers_mut().insert(
-        HeaderName::from_static("authorization"),
-        HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
-    );
+fn with_bearer_and_group(token: &str, group_id: &str) -> Request<axum::body::Body> {
+    let mut req = with_bearer(token);
     req.headers_mut().insert(
         HeaderName::from_static("x-group-id"),
-        HeaderValue::from_str(&group_id.to_string()).unwrap(),
+        HeaderValue::from_str(group_id).unwrap(),
     );
-
-    let resp = h.router.clone().oneshot(req).await.expect("oneshot");
-    assert_eq!(resp.status(), StatusCode::OK);
-
-    let v = body_json(resp).await;
-    assert_eq!(v["user_id"], user_id.to_string());
-    assert_eq!(v["group_id"], group_id.to_string());
-    assert_eq!(v["role"], "owner");
+    req
 }
 
 #[tokio::test]
-async fn get_v1_me_with_valid_bearer_non_member_group_returns_403() {
+async fn v1_me_authed_scenarios() {
     let h = Harness::get().await;
-    let (_user_id, _group_id, token) =
-        seed_user_with_group(&h, "foreign@m3.test").await.expect("seed");
 
-    // Fresh random UUID that was never inserted into groups — the
-    // Principal extractor should fail the membership lookup and
-    // return 403 Forbidden.
-    let foreign_group = uuid::Uuid::new_v4();
+    // ── Scenario 1: no bearer -> 401 ─────────────────────────
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(harness_get("/v1/me"))
+            .await
+            .expect("scenario 1: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "scenario 1: missing bearer must answer 401"
+        );
+    }
 
-    let mut req = harness_get("/v1/me");
-    req.headers_mut().insert(
-        HeaderName::from_static("authorization"),
-        HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
-    );
-    req.headers_mut().insert(
-        HeaderName::from_static("x-group-id"),
-        HeaderValue::from_str(&foreign_group.to_string()).unwrap(),
-    );
+    // ── Scenario 2: valid bearer, no X-Group-Id -> 200 ──────
+    {
+        let (user_id, _group_id, token) = seed_user_with_group(&h, "no-group@m3.test")
+            .await
+            .expect("scenario 2: seed");
+        let resp = h
+            .router
+            .clone()
+            .oneshot(with_bearer(&token))
+            .await
+            .expect("scenario 2: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "scenario 2: bearer without X-Group-Id must answer 200"
+        );
+        let v = body_json(resp).await;
+        assert_eq!(v["user_id"], user_id.to_string());
+        assert!(
+            v.get("group_id").is_none(),
+            "scenario 2: absent X-Group-Id -> response group_id must be skipped, got {v}"
+        );
+        assert!(
+            v.get("role").is_none(),
+            "scenario 2: absent X-Group-Id -> response role must be skipped, got {v}"
+        );
+    }
 
-    let resp = h.router.clone().oneshot(req).await.expect("oneshot");
-    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
-}
+    // ── Scenario 3: valid bearer, owner group -> 200 w/ role ─
+    {
+        let (user_id, group_id, token) = seed_user_with_group(&h, "member@m3.test")
+            .await
+            .expect("scenario 3: seed");
+        let resp = h
+            .router
+            .clone()
+            .oneshot(with_bearer_and_group(&token, &group_id.to_string()))
+            .await
+            .expect("scenario 3: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "scenario 3: member of requested group must answer 200"
+        );
+        let v = body_json(resp).await;
+        assert_eq!(v["user_id"], user_id.to_string());
+        assert_eq!(v["group_id"], group_id.to_string());
+        assert_eq!(v["role"], "owner");
+    }
 
-#[tokio::test]
-async fn openapi_spec_exposes_bearer_security_scheme_and_get_me_path() {
-    let h = Harness::get().await;
-    let resp = h
-        .router
-        .clone()
-        .oneshot(harness_get("/v1/openapi.json"))
-        .await
-        .expect("oneshot");
-    assert_eq!(resp.status(), StatusCode::OK);
+    // ── Scenario 4: valid bearer, foreign group -> 403 ──────
+    {
+        let (_user_id, _group_id, token) = seed_user_with_group(&h, "foreign@m3.test")
+            .await
+            .expect("scenario 4: seed");
+        // Fresh random UUID that was never inserted into `groups`.
+        let foreign_group = uuid::Uuid::new_v4();
+        let resp = h
+            .router
+            .clone()
+            .oneshot(with_bearer_and_group(&token, &foreign_group.to_string()))
+            .await
+            .expect("scenario 4: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "scenario 4: non-member X-Group-Id must answer 403"
+        );
+    }
 
-    let v = body_json(resp).await;
-    // Plan 0016 M3-T1: SecurityAddon registers a bearer HTTP scheme.
-    assert_eq!(
-        v["components"]["securitySchemes"]["bearer"]["scheme"], "bearer",
-        "bearer security scheme missing from OpenAPI components, got {v}"
-    );
-    assert_eq!(
-        v["components"]["securitySchemes"]["bearer"]["bearerFormat"], "JWT",
-        "bearer scheme is present but bearerFormat != JWT"
-    );
-    // Plan 0015 M4: /v1/me is reachable under full router state.
-    assert!(
-        v["paths"]["/v1/me"]["get"].is_object(),
-        "/v1/me GET handler missing from OpenAPI paths"
-    );
+    // ── Scenario 5: OpenAPI spec exposes bearer + /v1/me ───
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(harness_get("/v1/openapi.json"))
+            .await
+            .expect("scenario 5: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "scenario 5: /v1/openapi.json must answer 200"
+        );
+        let v = body_json(resp).await;
+        assert_eq!(
+            v["components"]["securitySchemes"]["bearer"]["scheme"], "bearer",
+            "scenario 5: bearer security scheme missing"
+        );
+        assert_eq!(
+            v["components"]["securitySchemes"]["bearer"]["bearerFormat"], "JWT"
+        );
+        assert!(
+            v["paths"]["/v1/me"]["get"].is_object(),
+            "scenario 5: /v1/me GET handler missing from paths"
+        );
+    }
 }

--- a/crates/garraia-gateway/tests/rest_v1_me_authed.rs
+++ b/crates/garraia-gateway/tests/rest_v1_me_authed.rs
@@ -1,0 +1,153 @@
+//! Authed integration tests for `GET /v1/me` (plan 0016 M3-T3).
+//!
+//! Exercises the full Principal extractor chain against a real
+//! pgvector/pg16 container (via `common::Harness`) and a JWT minted
+//! by the same `JwtIssuer` that the router verifies against (via
+//! `fixtures::seed_user_with_group`). Covers:
+//!
+//!   1. No bearer                 -> 401
+//!   2. Valid bearer, no group    -> 200 (group_id + role absent)
+//!   3. Valid bearer, owner group -> 200 (group_id + role='owner')
+//!   4. Valid bearer, foreign grp -> 403
+//!   5. `/v1/openapi.json`        -> 200 + bearer SecurityScheme + /v1/me path
+//!
+//! Separate from `rest_v1_me.rs` on purpose: that file contains the
+//! env-mutating fail-soft test guarded by `#[serial]`, and mixing it
+//! with these non-mutating tests would force all of them to
+//! serialize. This file is pure read-only oneshot — no `#[serial]`.
+
+mod common;
+
+use axum::http::{HeaderName, HeaderValue, StatusCode};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+use common::fixtures::seed_user_with_group;
+use common::{harness_get, Harness};
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("failed to collect response body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("response body is not JSON")
+}
+
+#[tokio::test]
+async fn get_v1_me_without_bearer_returns_401() {
+    let h = Harness::get().await;
+    let resp = h
+        .router
+        .clone()
+        .oneshot(harness_get("/v1/me"))
+        .await
+        .expect("oneshot should succeed");
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn get_v1_me_with_valid_bearer_no_group_returns_200() {
+    let h = Harness::get().await;
+    let (user_id, _group_id, token) =
+        seed_user_with_group(&h, "no-group@m3.test").await.expect("seed");
+
+    let mut req = harness_get("/v1/me");
+    req.headers_mut().insert(
+        HeaderName::from_static("authorization"),
+        HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+    );
+
+    let resp = h.router.clone().oneshot(req).await.expect("oneshot");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let v = body_json(resp).await;
+    assert_eq!(v["user_id"], user_id.to_string());
+    assert!(
+        v.get("group_id").is_none(),
+        "absent X-Group-Id -> group_id must be skipped in response, got {v}"
+    );
+    assert!(
+        v.get("role").is_none(),
+        "absent X-Group-Id -> role must be skipped in response, got {v}"
+    );
+}
+
+#[tokio::test]
+async fn get_v1_me_with_valid_bearer_and_member_group_returns_200_with_role() {
+    let h = Harness::get().await;
+    let (user_id, group_id, token) =
+        seed_user_with_group(&h, "member@m3.test").await.expect("seed");
+
+    let mut req = harness_get("/v1/me");
+    req.headers_mut().insert(
+        HeaderName::from_static("authorization"),
+        HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+    );
+    req.headers_mut().insert(
+        HeaderName::from_static("x-group-id"),
+        HeaderValue::from_str(&group_id.to_string()).unwrap(),
+    );
+
+    let resp = h.router.clone().oneshot(req).await.expect("oneshot");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let v = body_json(resp).await;
+    assert_eq!(v["user_id"], user_id.to_string());
+    assert_eq!(v["group_id"], group_id.to_string());
+    assert_eq!(v["role"], "owner");
+}
+
+#[tokio::test]
+async fn get_v1_me_with_valid_bearer_non_member_group_returns_403() {
+    let h = Harness::get().await;
+    let (_user_id, _group_id, token) =
+        seed_user_with_group(&h, "foreign@m3.test").await.expect("seed");
+
+    // Fresh random UUID that was never inserted into groups — the
+    // Principal extractor should fail the membership lookup and
+    // return 403 Forbidden.
+    let foreign_group = uuid::Uuid::new_v4();
+
+    let mut req = harness_get("/v1/me");
+    req.headers_mut().insert(
+        HeaderName::from_static("authorization"),
+        HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+    );
+    req.headers_mut().insert(
+        HeaderName::from_static("x-group-id"),
+        HeaderValue::from_str(&foreign_group.to_string()).unwrap(),
+    );
+
+    let resp = h.router.clone().oneshot(req).await.expect("oneshot");
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn openapi_spec_exposes_bearer_security_scheme_and_get_me_path() {
+    let h = Harness::get().await;
+    let resp = h
+        .router
+        .clone()
+        .oneshot(harness_get("/v1/openapi.json"))
+        .await
+        .expect("oneshot");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let v = body_json(resp).await;
+    // Plan 0016 M3-T1: SecurityAddon registers a bearer HTTP scheme.
+    assert_eq!(
+        v["components"]["securitySchemes"]["bearer"]["scheme"], "bearer",
+        "bearer security scheme missing from OpenAPI components, got {v}"
+    );
+    assert_eq!(
+        v["components"]["securitySchemes"]["bearer"]["bearerFormat"], "JWT",
+        "bearer scheme is present but bearerFormat != JWT"
+    );
+    // Plan 0015 M4: /v1/me is reachable under full router state.
+    assert!(
+        v["paths"]["/v1/me"]["get"].is_object(),
+        "/v1/me GET handler missing from OpenAPI paths"
+    );
+}


### PR DESCRIPTION
## Summary

**M3** of plan 0016 (owner-approved reduced scope): bearer scheme in OpenAPI + `seed_user_with_group` fixture + authed `GET /v1/me` scenarios. No real `/v1/groups` handlers (M4), no M2-carried cleanups (M4).

5 commits on `feat/0016m3-authed-me-tests`:

| Commit | Task | Change |
|---|---|---|
| `ae13fc8` | M3-T1 | `SecurityAddon` unit struct + `impl utoipa::Modify` registering a `"bearer"` HTTP scheme (JWT format). Applied via `modifiers(&SecurityAddon)` on the `ApiDoc` derive. |
| `15abeaf` | M3-T2 | `tests/common/fixtures.rs` with `seed_user_with_group(h, email) -> (Uuid, Uuid, String)`. Inserts users + groups + group_members(role=owner) via the shared `admin_pool` and mints a JWT via `h.jwt.issue_access_for_test`. |
| `1684dc9` | M3-T3 original | Added the 5 authed scenarios as separate `#[tokio::test]` functions. Also added `Harness::admin_pool: PgPool` shared field and bumped the 3 typed pools to `max_connections = 16`. |
| `4f8be37` | M3 fixup | Folded the 5 separate `#[tokio::test]` functions into **one** `#[tokio::test] async fn v1_me_authed_scenarios()` that runs the scenarios sequentially inside a single tokio runtime. Motivation: separate runtimes flaked non-deterministically with `pool timed out while waiting for an open connection` errors. Deterministic across 3 back-to-back runs after the consolidation. |
| `5866cad` | M3 review fix | Applied the two mandatory findings from the parallel `security-auditor` + `code-reviewer` dispatch: `get_or_insert_with(Default::default)` replacing `.expect(...)` in `SecurityAddon::modify`, and doc sync on `Harness::admin_pool` (`8` -> `16`). |

## What ships

- **`SecurityAddon` bearer scheme** — `components.securitySchemes.bearer = { scheme: "bearer", bearerFormat: "JWT" }` in the generated OpenAPI document. Closes review finding N-2 from PR #8 (plan 0015 slice 1), which was explicitly deferred to plan 0016 M3. Swagger UI now shows the padlock with the correct scheme.
- **`seed_user_with_group` fixture** — one-stop seed helper used by the authed scenarios. Runs 3 INSERTs in one `admin_pool.begin()` transaction for atomicity and connection-pool economy. Returns `(user_id, group_id, jwt_token)` so callers can send the bearer token and optionally an `X-Group-Id` header.
- **`Harness::admin_pool: PgPool` shared field** — built once in `boot()` (`max_connections = 16`, sqlx default `acquire_timeout`) and reused by every fixture call. Replaces the prior per-fixture `PgPool::connect(&h.admin_url)` pattern that exhausted Postgres `max_connections` under parallel suites.
- **`v1_me_authed_scenarios` bundled integration test** — one `#[tokio::test]`, one tokio runtime, 5 scenarios:
  1. No bearer -> 401
  2. Valid bearer, no `X-Group-Id` -> 200 with absent `group_id` and `role`
  3. Valid bearer, owner of seeded group -> 200 with `group_id` + `role="owner"`
  4. Valid bearer, random foreign group uuid -> 403
  5. `/v1/openapi.json` -> 200 + `components.securitySchemes.bearer.scheme = "bearer"` + `paths./v1/me.get` present

## Root cause of the M3 fixup

The original M3-T3 commit split the 5 scenarios into 5 `#[tokio::test]` functions. Every serialization strategy (`#[serial_test::serial]`, `--test-threads=1`, pool size bumps 4 -> 16, `acquire_timeout=60s`) produced non-deterministic `pool timed out while waiting for an open connection` errors on a non-deterministic subset of tests (2-3 of 5).

Root cause: each `#[tokio::test]` spins up its own tokio runtime and tears it down when the body returns. sqlx `PgPool` connections acquired inside that runtime are tied to it; when the runtime tears down, connections enter a "not yet reclaimed" state that the shared `Harness` pools do not immediately notice. The next test's runtime starts trying to acquire connections and hits sqlx `acquire_timeout` waiting for connections that are effectively orphaned until the pool internal housekeeping catches up.

Fix: one `#[tokio::test]` function with all scenarios in sequence on a single runtime. Each scenario still asserts status / body shape with descriptive failure messages that pinpoint which scenario failed. The trade-off (scenarios cannot be run individually via `-- --exact test_name`) is worth the determinism.

This is documented in `4f8be37`'s commit message as institutional memory for future debugging of similar issues.

## Validations (all green)

- `cargo check --workspace` -> Finished OK
- `cargo clippy -p garraia-auth -p garraia-gateway --lib --tests --features test-helpers` -> zero errors, zero new warnings
- `cargo test -p garraia-auth --lib` -> **41 passed** (intacto desde M2)
- `cargo test -p garraia-gateway --lib` -> **161 passed** (intacto desde M2)
- `cargo test -p garraia-gateway --test rest_v1_me` -> **1 passed** (fail-soft com `#[serial]`, intacto)
- `cargo test -p garraia-gateway --features test-helpers --test harness_smoke` -> **1 passed** (intacto)
- `cargo test -p garraia-gateway --features test-helpers --test rest_v1_me_authed` -> **1 passed** (NEW, 5 scenarios in single runtime, ~16s, 3 back-to-back determinísticos)
- `cargo test -p garraia-gateway --test router_smoke_test` -> **3 passed** (intacto)
- `cargo test -p garraia-gateway --test projects_test` -> **4 passed** (intacto)
- `cargo test -p garraia-gateway --test skins_test` -> **3 passed** (intacto)

## Agent Teams used

**Pre-execution gate:** `team-coordinator` despachado antes do coding. Retornou **Go** com 4 confirmações técnicas + 1 risco menor (rate limiter shared, mas burst=60 é suficiente para 5 requests). Confirmou: (1) `modifiers(&SecurityAddon)` é canônico em utoipa 5.x; (2) `PgPool::connect(&h.admin_url)` per-call é aceitável mas fresh-pool-per-call pode exaurir max_connections (risco validado empiricamente durante M3-T3 e mitigado pelo refactor de shared admin_pool); (3) schemas de `users/groups/group_members` com todas as NOT NULL columns; (4) `MeResponse.role == "owner"` para seed `role='owner'`.

**Post-implementation review:** `security-auditor` + `code-reviewer` dispatched em paralelo (Batch Workflow) em uma única mensagem. Ambos retornaram **aprovado com ressalvas** e convergiram na **mesma fix MANDATORY**: `SecurityAddon::modify::expect()` -> `get_or_insert_with`. Aplicada em `5866cad`.

### security-auditor findings
- 0 CRITICAL, 0 HIGH, **1 MEDIUM (applied)**, 3 LOW, 2 NITPICK
- MEDIUM #1: `.expect(...)` panic risk in SecurityAddon -> **FIXED**
- LOW deferred: admin_url/admin_pool `pub` exposure (M4), hardcoded role passwords (acceptable for ephemeral container), audit rule doc update
- NITPICK: cross-scenario state (verified absent), bearer_format marker is public per RFC 6750

### code-reviewer findings
- 0 CRITICAL, 0 HIGH, **2 IMPORTANT (both applied)**, LOW/NITPICK
- IMPORTANT #1: SecurityAddon `.expect()` -> **FIXED (same finding as security #1)**
- IMPORTANT #2: `admin_pool` doc says `max_connections = 8` but code uses `16` -> **FIXED (doc sync)**
- LOW deferred: M3-T3 + fixup squash (kept deliberately), `with_bearer_*` helper `unwrap` (acceptable in test code), `admin_url` still `pub` (M4)

## Known deferred work (rolled into M4)

| Item | Severity | Target |
|---|---|---|
| `admin_url` as `pub String` exposure -> `pub(super)` or accessor | LOW | M4 |
| URL parsing via `url::Url` in harness instead of `.replace()` | MEDIUM (carried from M2) | M4 |
| `pool_for_handlers()` -> `exec_with_tenant` closure API | MEDIUM (carried from M1) | M4 |
| `test-support` -> `__test-support` rename | LOW (carried from M1) | M4 |
| Real `/v1/groups` handlers (POST + GET {id}) | — | M4 |

## Rollback

All 5 commits are independent and reversible via `git revert`. M1 + M2 (both merged) not touched. Production handler surface unchanged — only the OpenAPI doc changes shipping to clients (bearer scheme addition, no schema breakage).

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy -p garraia-auth -p garraia-gateway --lib --tests --features test-helpers`
- [x] `cargo test -p garraia-auth --lib` (41 passed)
- [x] `cargo test -p garraia-gateway --lib` (161 passed)
- [x] `cargo test -p garraia-gateway --test rest_v1_me` (1 passed)
- [x] `cargo test -p garraia-gateway --features test-helpers --test harness_smoke` (1 passed)
- [x] `cargo test -p garraia-gateway --features test-helpers --test rest_v1_me_authed` (1 passed, 3x back-to-back deterministic)
- [x] `cargo test -p garraia-gateway --test router_smoke_test` (3 passed)
- [x] `cargo test -p garraia-gateway --test projects_test` (4 passed)
- [x] `cargo test -p garraia-gateway --test skins_test` (3 passed)
- [ ] Post-merge: bump `plans/README.md` 0016 status from "M1+M2 merged" to "M1+M2+M3 merged, M4+M5 pending"

Robot: Generated with Claude Code
