### PR TITLE
feat(gateway): plan 0016 M4 — real /v1/groups handlers (POST + GET {id})

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2923,6 +2923,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "serial_test",
  "sqlx",
  "teloxide",
  "tempfile",
@@ -7178,6 +7179,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7256,6 +7266,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "secrecy"
@@ -7530,6 +7546,32 @@ dependencies = [
  "typemap_rev",
  "typesize",
  "url",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
 ]
 
 [[package]]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -250,8 +250,8 @@ Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
 
 **Grupos**
 
-- [ ] `POST /v1/groups`
-- [ ] `GET /v1/groups/{group_id}`
+- [x] `POST /v1/groups` — plan 0016 M4, entregue 2026-04-14
+- [x] `GET /v1/groups/{group_id}` — plan 0016 M4, entregue 2026-04-14
 - [ ] `PATCH /v1/groups/{group_id}`
 - [ ] `POST /v1/groups/{group_id}/invites`
 - [ ] `POST /v1/groups/{group_id}/members/{user_id}:setRole`

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -52,6 +52,12 @@ jsonwebtoken = { workspace = true }
 utoipa = { version = "5", features = ["axum_extras", "uuid", "chrono"] }
 utoipa-swagger-ui = { version = "9", features = ["axum", "reqwest"] }
 thiserror = { workspace = true }
+# Plan 0016 M4: real /v1/groups handlers operate on Postgres via
+# `AppPool::pool_for_handlers`, which returns `&sqlx::PgPool`.
+# The handlers need sqlx types (`query_as`, transactions) directly.
+# Feature set mirrors dev-dependencies so prod + test link the
+# same version.
+sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "uuid", "chrono"] }
 dirs = "6"
 governor = "0.8"
 tower_governor = "0.8"

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -109,6 +109,13 @@ required-features = ["test-helpers"]
 tempfile = "3"
 serial_test = { workspace = true }
 wiremock = "0.6"
+# Plan 0016 M4 review fix: the sqlx dep was previously listed in
+# BOTH [dependencies] and [dev-dependencies] with identical feature
+# sets. Cargo deduplicates when features match, so there is no
+# linkage conflict, but the dev-dependencies entry is now redundant
+# because production code imports sqlx directly (via `groups.rs`
+# handlers). The prod entry above carries the canonical feature set;
+# tests inherit it transitively. Removed the dev-dependencies line.
 tokio-tungstenite = "0.26"
 tokio = { workspace = true }
 futures = { workspace = true }
@@ -123,7 +130,6 @@ tower = { workspace = true, features = ["util"] }
 # enumeration. Plan reference: plans/0012-gar-391c-extractor-and-wiring.md.
 testcontainers = "0.23"
 testcontainers-modules = { version = "0.11", features = ["postgres"] }
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "uuid", "chrono"] }
 secrecy = "0.10"
 garraia-workspace = { path = "../garraia-workspace" }
 garraia-auth = { workspace = true }

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -98,6 +98,13 @@ name = "rest_v1_me_authed"
 path = "tests/rest_v1_me_authed.rs"
 required-features = ["test-helpers"]
 
+# Plan 0016 M4-T4: real /v1/groups handlers integration tests.
+# Same gating as harness_smoke / rest_v1_me_authed.
+[[test]]
+name = "rest_v1_groups"
+path = "tests/rest_v1_groups.rs"
+required-features = ["test-helpers"]
+
 [dev-dependencies]
 tempfile = "3"
 serial_test = { workspace = true }

--- a/crates/garraia-gateway/src/rest_v1/groups.rs
+++ b/crates/garraia-gateway/src/rest_v1/groups.rs
@@ -1,0 +1,320 @@
+//! `/v1/groups` real handlers (plan 0016 M4).
+//!
+//! The two endpoints in this module are the first writes landing on
+//! the `garraia_app` RLS-enforced pool (`AppPool::pool_for_handlers`).
+//!
+//! - `POST /v1/groups` — any authenticated caller can create a new
+//!   group. The creator is inserted into `group_members` as `owner`
+//!   inside the same transaction that inserts into `groups`.
+//! - `GET /v1/groups/{id}` — returns the group row + the caller's
+//!   role. Requires `X-Group-Id` header matching the path id (the
+//!   `Principal` extractor's membership lookup is what enforces
+//!   non-members -> 403).
+//!
+//! ## Tenant-context protocol
+//!
+//! Every transaction opens with `SET LOCAL app.current_user_id =
+//! '{uuid}'` as its **first** statement (team-coordinator gate risk
+//! #6). Without an explicit `tx = pool.begin().await?`, `SET LOCAL`
+//! evaporates in Postgres auto-commit mode. Both handlers below
+//! follow this rule.
+//!
+//! For M4 the `SET LOCAL` is defensive scaffolding — `groups` and
+//! `group_members` are not under FORCE RLS (see migrations 001 and
+//! 007). The `garraia_app` role has direct INSERT grants. The
+//! setting becomes load-bearing in M5+ once RLS is extended to
+//! these tables.
+//!
+//! ## SQL injection posture
+//!
+//! `SET LOCAL` does not accept bind parameters in Postgres, so the
+//! `user_id` UUID is interpolated via `format!`. `Uuid::Display`
+//! produces exactly 36 hex-with-dash characters and no metacharacters
+//! — injection-safe by construction. All other parameters use
+//! `sqlx::query::bind` as normal.
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::Json;
+use chrono::{DateTime, Utc};
+use garraia_auth::Principal;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use super::problem::RestError;
+use super::RestV1FullState;
+
+/// Accepted values for `CreateGroupRequest::group_type`.
+///
+/// Mirrors the `CHECK (type IN ('family','team','personal'))`
+/// constraint on `groups.type` in migration 001, but **excludes**
+/// `"personal"` — that variant is reserved for the GAR-413
+/// SQLite→Postgres migration fallback and must not be exposed
+/// via the API layer (see migration 001 line 114 comment).
+const ALLOWED_GROUP_TYPES: &[&str] = &["family", "team"];
+
+/// Request body for `POST /v1/groups`.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct CreateGroupRequest {
+    /// Human-readable group name. Must not be empty after trim.
+    pub name: String,
+    /// Group type. Must be `"family"` or `"team"`.
+    #[serde(rename = "type")]
+    pub group_type: String,
+}
+
+/// Response body for `POST /v1/groups` (201 Created).
+#[derive(Debug, Serialize, ToSchema)]
+pub struct GroupResponse {
+    pub id: Uuid,
+    pub name: String,
+    #[serde(rename = "type")]
+    pub group_type: String,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Response body for `GET /v1/groups/{id}` (200 OK).
+///
+/// Includes the caller's `role` (from the `Principal` extractor)
+/// so clients can avoid an extra `/v1/me` round-trip when rendering
+/// per-role UI affordances.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct GroupReadResponse {
+    pub id: Uuid,
+    pub name: String,
+    #[serde(rename = "type")]
+    pub group_type: String,
+    pub created_at: DateTime<Utc>,
+    pub created_by: Uuid,
+    /// Caller's role in the group, e.g. `"owner"`, `"admin"`,
+    /// `"member"`, `"guest"`, `"child"`.
+    pub role: String,
+}
+
+/// `POST /v1/groups` — create a new group. The authenticated caller
+/// becomes the `owner` in an atomic transaction with the group
+/// creation.
+///
+/// Does NOT require an `X-Group-Id` header — the caller is creating
+/// a brand-new group, not operating on an existing one.
+#[utoipa::path(
+    post,
+    path = "/v1/groups",
+    request_body = CreateGroupRequest,
+    responses(
+        (status = 201, description = "Group created; caller is auto-enrolled as owner.", body = GroupResponse),
+        (status = 400, description = "Invalid group type or empty name.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn create_group(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Json(req): Json<CreateGroupRequest>,
+) -> Result<(StatusCode, Json<GroupResponse>), RestError> {
+    // 1. Validate body.
+    if !ALLOWED_GROUP_TYPES.contains(&req.group_type.as_str()) {
+        return Err(RestError::BadRequest(
+            "group type must be 'family' or 'team'".into(),
+        ));
+    }
+    if req.name.trim().is_empty() {
+        return Err(RestError::BadRequest(
+            "group name must not be empty".into(),
+        ));
+    }
+
+    // 2. Open transaction on `app_pool`. The SET LOCAL below is
+    //    transaction-scoped — if we skipped `begin()` and used the
+    //    pool directly, auto-commit would wrap each statement in
+    //    its own transaction and the tenant context would be lost.
+    //    (team-coordinator M4 gate risk #6)
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    // 3. SET LOCAL tenant context. MUST be the first statement
+    //    inside the transaction. Uuid Display is 36 hex-dashed
+    //    chars, injection-safe.
+    sqlx::query(&format!(
+        "SET LOCAL app.current_user_id = '{}'",
+        principal.user_id
+    ))
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    // 4. INSERT groups, returning the generated id + timestamps.
+    let (id, created_at): (Uuid, DateTime<Utc>) = sqlx::query_as(
+        "INSERT INTO groups (name, type, created_by) \
+         VALUES ($1, $2, $3) \
+         RETURNING id, created_at",
+    )
+    .bind(req.name.trim())
+    .bind(&req.group_type)
+    .bind(principal.user_id)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    // 5. INSERT group_members. The creator becomes the `owner`.
+    sqlx::query(
+        "INSERT INTO group_members (group_id, user_id, role, status) \
+         VALUES ($1, $2, 'owner', 'active')",
+    )
+    .bind(id)
+    .bind(principal.user_id)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    // 6. Commit. On failure, both INSERTs roll back and the caller
+    //    sees an Internal 500 — the creator does NOT end up with
+    //    a dangling group row.
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(GroupResponse {
+            id,
+            name: req.name.trim().to_string(),
+            group_type: req.group_type,
+            created_at,
+        }),
+    ))
+}
+
+/// `GET /v1/groups/{id}` — read a single group by id.
+///
+/// The `Principal` extractor requires an `X-Group-Id` header
+/// matching the path id so the caller's membership is verified
+/// before this handler runs (non-members -> 403 at extractor time).
+/// The handler validates that the header's group id matches the
+/// path id; any mismatch is 400.
+#[utoipa::path(
+    get,
+    path = "/v1/groups/{id}",
+    params(
+        ("id" = Uuid, Path, description = "Group UUID. Must match the `X-Group-Id` header."),
+    ),
+    responses(
+        (status = 200, description = "Group details + caller's role.", body = GroupReadResponse),
+        (status = 400, description = "`X-Group-Id` header missing or mismatches the path id.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member of the requested group.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Group not found (deleted between extractor lookup and read).", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn get_group(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(id): Path<Uuid>,
+) -> Result<Json<GroupReadResponse>, RestError> {
+    // 1. Validate path vs header. The Principal extractor already
+    //    403'd any non-member when the header was supplied; its
+    //    absence or mismatch is a 400 from this handler.
+    match principal.group_id {
+        Some(hdr) if hdr == id => {}
+        Some(_) => {
+            return Err(RestError::BadRequest(
+                "X-Group-Id header and path id must match".into(),
+            ));
+        }
+        None => {
+            return Err(RestError::BadRequest(
+                "X-Group-Id header is required".into(),
+            ));
+        }
+    }
+
+    // 2. Fetch the group row. `groups` is not under RLS, so no
+    //    tenant-context SET LOCAL is needed. `garraia_app` has
+    //    direct SELECT grants.
+    let pool = state.app_pool.pool_for_handlers();
+    let row: Option<(Uuid, String, String, DateTime<Utc>, Uuid)> = sqlx::query_as(
+        "SELECT id, name, type, created_at, created_by FROM groups WHERE id = $1",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let (id, name, group_type, created_at, created_by) = row.ok_or(RestError::NotFound)?;
+
+    // 3. Assemble response. The caller's role is whatever the
+    //    `Principal` extractor stored — always `Some(_)` here
+    //    because the extractor only populates `group_id` when
+    //    membership exists.
+    let role = principal
+        .role
+        .map(|r| r.as_str().to_string())
+        .unwrap_or_default();
+
+    Ok(Json(GroupReadResponse {
+        id,
+        name,
+        group_type,
+        created_at,
+        created_by,
+        role,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allowed_group_types_are_family_and_team_only() {
+        assert_eq!(ALLOWED_GROUP_TYPES, &["family", "team"]);
+        // `personal` is RESERVED per migration 001 line 114 and
+        // must not be exposed via the API.
+        assert!(!ALLOWED_GROUP_TYPES.contains(&"personal"));
+    }
+
+    #[test]
+    fn create_group_response_serializes_with_type_field() {
+        let resp = GroupResponse {
+            id: Uuid::nil(),
+            name: "Test".into(),
+            group_type: "team".into(),
+            created_at: Utc::now(),
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert_eq!(v["id"], "00000000-0000-0000-0000-000000000000");
+        assert_eq!(v["type"], "team");
+        assert_eq!(v["name"], "Test");
+        assert!(v.get("group_type").is_none(), "type rename missing");
+    }
+
+    #[test]
+    fn group_read_response_includes_role_and_created_by() {
+        let resp = GroupReadResponse {
+            id: Uuid::nil(),
+            name: "Test".into(),
+            group_type: "family".into(),
+            created_at: Utc::now(),
+            created_by: Uuid::nil(),
+            role: "owner".into(),
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert_eq!(v["type"], "family");
+        assert_eq!(v["role"], "owner");
+        assert_eq!(v["created_by"], "00000000-0000-0000-0000-000000000000");
+    }
+
+    #[test]
+    fn create_group_request_deserializes_with_type_rename() {
+        let s = r#"{"name":"alpha","type":"team"}"#;
+        let parsed: CreateGroupRequest = serde_json::from_str(s).unwrap();
+        assert_eq!(parsed.name, "alpha");
+        assert_eq!(parsed.group_type, "team");
+    }
+}

--- a/crates/garraia-gateway/src/rest_v1/groups.rs
+++ b/crates/garraia-gateway/src/rest_v1/groups.rs
@@ -126,11 +126,16 @@ pub async fn create_group(
         ));
     }
 
-    // 2. Open transaction on `app_pool`. The SET LOCAL below is
-    //    transaction-scoped — if we skipped `begin()` and used the
-    //    pool directly, auto-commit would wrap each statement in
-    //    its own transaction and the tenant context would be lost.
-    //    (team-coordinator M4 gate risk #6)
+    // 2a. Capture the trimmed name once so the database row and the
+    //     response body cannot diverge if someone later adds another
+    //     use site.
+    let trimmed_name = req.name.trim().to_string();
+
+    // 2b. Open transaction on `app_pool`. The SET LOCAL below is
+    //     transaction-scoped — if we skipped `begin()` and used the
+    //     pool directly, auto-commit would wrap each statement in
+    //     its own transaction and the tenant context would be lost.
+    //     (team-coordinator M4 gate risk #6)
     let pool = state.app_pool.pool_for_handlers();
     let mut tx = pool
         .begin()
@@ -154,7 +159,7 @@ pub async fn create_group(
          VALUES ($1, $2, $3) \
          RETURNING id, created_at",
     )
-    .bind(req.name.trim())
+    .bind(&trimmed_name)
     .bind(&req.group_type)
     .bind(principal.user_id)
     .fetch_one(&mut *tx)
@@ -183,7 +188,7 @@ pub async fn create_group(
         StatusCode::CREATED,
         Json(GroupResponse {
             id,
-            name: req.name.trim().to_string(),
+            name: trimmed_name,
             group_type: req.group_type,
             created_at,
         }),
@@ -234,9 +239,20 @@ pub async fn get_group(
         }
     }
 
-    // 2. Fetch the group row. `groups` is not under RLS, so no
-    //    tenant-context SET LOCAL is needed. `garraia_app` has
-    //    direct SELECT grants.
+    // 2. Fetch the group row. `groups` is not under FORCE RLS today
+    //    (migration 001 line 100 + migration 007), so no
+    //    tenant-context `SET LOCAL` is needed for this SELECT and
+    //    `fetch_optional` runs directly on the pool without a
+    //    transaction wrapper. `garraia_app` has direct SELECT
+    //    grants on `groups`.
+    //
+    //    FIXME(plan-0016-M5 or whenever `groups` gains FORCE RLS):
+    //    convert this to a `tx = pool.begin()` + `SET LOCAL
+    //    app.current_user_id` sequence mirroring `create_group`
+    //    above. The M4 security-auditor flagged this as a
+    //    forward-compat hazard — silent `groups` SELECT bypass
+    //    if RLS is later applied and this handler is left
+    //    untouched.
     let pool = state.app_pool.pool_for_handlers();
     let row: Option<(Uuid, String, String, DateTime<Utc>, Uuid)> = sqlx::query_as(
         "SELECT id, name, type, created_at, created_by FROM groups WHERE id = $1",
@@ -248,14 +264,28 @@ pub async fn get_group(
 
     let (id, name, group_type, created_at, created_by) = row.ok_or(RestError::NotFound)?;
 
-    // 3. Assemble response. The caller's role is whatever the
-    //    `Principal` extractor stored — always `Some(_)` here
-    //    because the extractor only populates `group_id` when
-    //    membership exists.
+    // 3. Assemble response. The caller's `Principal.role` MUST be
+    //    `Some(_)` here: the extractor only populates `group_id`
+    //    when the `group_members` membership lookup found an
+    //    active row, which by definition includes a role. If this
+    //    invariant ever breaks (e.g. a refactor that populates
+    //    `group_id` without pairing a role), we want to fail loud
+    //    with a 500 rather than silently emitting `role: ""` to
+    //    the client. Plan 0016 M4 review fix (code-reviewer HIGH).
     let role = principal
         .role
-        .map(|r| r.as_str().to_string())
-        .unwrap_or_default();
+        .ok_or_else(|| {
+            tracing::error!(
+                user_id = %principal.user_id,
+                group_id = ?principal.group_id,
+                "Principal.role is None with group_id Some — invariant violated by extractor"
+            );
+            RestError::Internal(anyhow::anyhow!(
+                "Principal.role is None despite group_id being Some"
+            ))
+        })?
+        .as_str()
+        .to_string();
 
     Ok(Json(GroupReadResponse {
         id,

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -29,6 +29,7 @@
 //! In mode 3 the routes are registered explicitly (no `.fallback()`)
 //! so the merged main router keeps its own 404 behavior.
 
+pub mod groups;
 pub mod me;
 pub mod openapi;
 pub mod problem;
@@ -149,15 +150,14 @@ pub fn router(app_state: Arc<AppState>) -> Router {
             // because `RestV1FullState: FromRef<Arc<JwtIssuer>>` and
             // `FromRef<Arc<LoginPool>>`.
             //
-            // TODO plan 0016 M4: replace the two
-            // `unconfigured_handler` lines below with the real
-            // handlers (`groups::create_group` + `groups::get_group`)
-            // without touching `.with_state(full)` — the state type
-            // is already correct.
+            // Plan 0016 M4: `/v1/groups` routes now point at the
+            // real handlers (`groups::create_group` + `groups::get_group`).
+            // Modes 2 and 3 still answer 503 via `unconfigured_handler`
+            // because they lack `Arc<AppPool>` in state.
             Router::new()
                 .route("/v1/me", get(me::get_me))
-                .route("/v1/groups", post(unconfigured_handler))
-                .route("/v1/groups/{id}", get(unconfigured_handler))
+                .route("/v1/groups", post(groups::create_group))
+                .route("/v1/groups/{id}", get(groups::get_group))
                 .with_state(full)
                 .merge(
                     SwaggerUi::new("/docs")

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -12,6 +12,7 @@
 use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
 use utoipa::{Modify, OpenApi};
 
+use super::groups::{CreateGroupRequest, GroupReadResponse, GroupResponse};
 use super::me::MeResponse;
 use super::problem::ProblemDetails;
 
@@ -57,8 +58,18 @@ impl Modify for SecurityAddon {
         version = "0.1.0",
         description = "Versioned GarraIA gateway REST surface (Fase 3.4)."
     ),
-    paths(super::me::get_me),
-    components(schemas(MeResponse, ProblemDetails)),
+    paths(
+        super::me::get_me,
+        super::groups::create_group,
+        super::groups::get_group,
+    ),
+    components(schemas(
+        MeResponse,
+        ProblemDetails,
+        CreateGroupRequest,
+        GroupResponse,
+        GroupReadResponse,
+    )),
     modifiers(&SecurityAddon)
 )]
 pub struct ApiDoc;

--- a/crates/garraia-gateway/src/rest_v1/problem.rs
+++ b/crates/garraia-gateway/src/rest_v1/problem.rs
@@ -31,6 +31,19 @@ pub enum RestError {
     Unauthenticated,
     #[error("forbidden")]
     Forbidden,
+    /// Plan 0016 M4: request body fails validation (empty name,
+    /// unknown enum value, header/path mismatch). The `{0}` detail
+    /// is emitted to clients in the Problem Details body, so callers
+    /// MUST NOT embed user-identifying data in it — write only
+    /// structural errors like `"invalid group type"`, not
+    /// `"user alice@example.com cannot pick ..."`.
+    #[error("{0}")]
+    BadRequest(String),
+    /// Plan 0016 M4: resource missing (e.g. group deleted between
+    /// extractor lookup and handler query). No payload — clients
+    /// only see status 404 + title "Not Found".
+    #[error("not found")]
+    NotFound,
     #[error("authentication is not configured on this gateway")]
     AuthUnconfigured,
     #[error("internal error")]
@@ -42,6 +55,8 @@ impl RestError {
         match self {
             RestError::Unauthenticated => StatusCode::UNAUTHORIZED,
             RestError::Forbidden => StatusCode::FORBIDDEN,
+            RestError::BadRequest(_) => StatusCode::BAD_REQUEST,
+            RestError::NotFound => StatusCode::NOT_FOUND,
             RestError::AuthUnconfigured => StatusCode::SERVICE_UNAVAILABLE,
             RestError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
@@ -51,6 +66,8 @@ impl RestError {
         match self {
             RestError::Unauthenticated => "Unauthenticated",
             RestError::Forbidden => "Forbidden",
+            RestError::BadRequest(_) => "Bad Request",
+            RestError::NotFound => "Not Found",
             RestError::AuthUnconfigured => "Service Unavailable",
             RestError::Internal(_) => "Internal Server Error",
         }
@@ -113,5 +130,27 @@ mod tests {
         let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(v["status"], 503);
         assert_eq!(v["title"], "Service Unavailable");
+    }
+
+    #[tokio::test]
+    async fn bad_request_shape_carries_detail() {
+        let resp = RestError::BadRequest("invalid group type".into()).into_response();
+        assert_eq!(resp.status(), 400);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["status"], 400);
+        assert_eq!(v["title"], "Bad Request");
+        assert_eq!(v["detail"], "invalid group type");
+    }
+
+    #[tokio::test]
+    async fn not_found_shape() {
+        let resp = RestError::NotFound.into_response();
+        assert_eq!(resp.status(), 404);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["status"], 404);
+        assert_eq!(v["title"], "Not Found");
+        assert_eq!(v["detail"], "not found");
     }
 }

--- a/crates/garraia-gateway/tests/rest_v1_groups.rs
+++ b/crates/garraia-gateway/tests/rest_v1_groups.rs
@@ -1,0 +1,277 @@
+//! Integration tests for `/v1/groups` real handlers (plan 0016 M4-T4).
+//!
+//! Exercises the first write handlers that land on the
+//! `garraia_app` RLS-enforced pool. Like M3's
+//! `rest_v1_me_authed.rs`, all scenarios are bundled into ONE
+//! `#[tokio::test]` function to avoid the sqlx runtime-teardown
+//! race that split `#[tokio::test]` functions trigger (see
+//! commit `4f8be37` on plan 0016 M3 for the full post-mortem).
+//!
+//! Scenarios covered:
+//!
+//!   1. POST /v1/groups 201 — happy path: seeded user creates a
+//!      `team` group and becomes auto-enrolled as `owner`. Asserts
+//!      201 status, response shape, and that `group_members` has
+//!      the matching row.
+//!   2. POST /v1/groups 400 — invalid type `personal` (reserved
+//!      per migration 001 line 114).
+//!   3. POST /v1/groups 400 — empty `name`.
+//!   4. POST /v1/groups 401 — missing bearer.
+//!   5. GET /v1/groups/{id} 200 — seeded member reads their
+//!      group, receives role `owner`.
+//!   6. GET /v1/groups/{id} 400 — `X-Group-Id` header mismatches
+//!      the path id.
+//!   7. GET /v1/groups/{id} 403 — caller is not a member of the
+//!      requested group.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+
+use common::fixtures::seed_user_with_group;
+use common::{harness_get, Harness};
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("failed to collect response body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("response body is not JSON")
+}
+
+fn post_groups(token: Option<&str>, body: serde_json::Value) -> Request<Body> {
+    let mut req = Request::builder()
+        .method("POST")
+        .uri("/v1/groups")
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .expect("request builder");
+    if let Some(token) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        );
+    }
+    // The tower_governor PeerIpKeyExtractor requires ConnectInfo on
+    // every request served via `oneshot`; harness_get sets that up
+    // for GETs, so we mirror the behavior manually here for POST.
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    req
+}
+
+fn get_group_by_id(
+    token: &str,
+    path_id: &str,
+    x_group_id: Option<&str>,
+) -> Request<Body> {
+    let mut req = harness_get(&format!("/v1/groups/{path_id}"));
+    req.headers_mut().insert(
+        HeaderName::from_static("authorization"),
+        HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+    );
+    if let Some(g) = x_group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    req
+}
+
+#[tokio::test]
+async fn v1_groups_scenarios() {
+    let h = Harness::get().await;
+
+    // ─ Scenario 1: POST 201 happy path ────────────────────────
+    let (creator_id, _creator_group, creator_token) =
+        seed_user_with_group(&h, "scenario1-creator@m4.test")
+            .await
+            .expect("scenario 1: seed creator");
+    let created_group_id: uuid::Uuid = {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(post_groups(
+                Some(&creator_token),
+                json!({"name": "M4 Scenario 1", "type": "team"}),
+            ))
+            .await
+            .expect("scenario 1: oneshot");
+        assert_eq!(resp.status(), StatusCode::CREATED, "scenario 1: POST should 201");
+        let v = body_json(resp).await;
+        assert_eq!(v["name"], "M4 Scenario 1");
+        assert_eq!(v["type"], "team");
+        assert!(v["id"].is_string());
+        assert!(v["created_at"].is_string());
+        let id: uuid::Uuid = v["id"].as_str().unwrap().parse().unwrap();
+
+        // Verify group_members has the creator as owner by reading
+        // through the admin pool (fixture-grade access, not through
+        // the app pool RLS path).
+        let (role,): (String,) = sqlx::query_as(
+            "SELECT role::text FROM group_members \
+             WHERE group_id = $1 AND user_id = $2 AND status = 'active'",
+        )
+        .bind(id)
+        .bind(creator_id)
+        .fetch_one(&h.admin_pool)
+        .await
+        .expect("scenario 1: group_members row should exist");
+        assert_eq!(role, "owner", "scenario 1: creator should be owner");
+        id
+    };
+
+    // ─ Scenario 2: POST 400 invalid type ────────────────────
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(post_groups(
+                Some(&creator_token),
+                json!({"name": "Invalid", "type": "personal"}),
+            ))
+            .await
+            .expect("scenario 2: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "scenario 2: type=personal must be rejected"
+        );
+        let v = body_json(resp).await;
+        assert_eq!(v["status"], 400);
+        assert_eq!(v["title"], "Bad Request");
+        assert!(
+            v["detail"]
+                .as_str()
+                .unwrap()
+                .contains("group type"),
+            "scenario 2: detail should mention group type, got {v}"
+        );
+    }
+
+    // ─ Scenario 3: POST 400 empty name ──────────────────────
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(post_groups(
+                Some(&creator_token),
+                json!({"name": "   ", "type": "team"}),
+            ))
+            .await
+            .expect("scenario 3: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "scenario 3: whitespace-only name must be rejected"
+        );
+        let v = body_json(resp).await;
+        assert!(
+            v["detail"]
+                .as_str()
+                .unwrap()
+                .contains("name"),
+            "scenario 3: detail should mention name, got {v}"
+        );
+    }
+
+    // ─ Scenario 4: POST 401 missing bearer ─────────────────
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(post_groups(
+                None,
+                json!({"name": "Unauthed", "type": "team"}),
+            ))
+            .await
+            .expect("scenario 4: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "scenario 4: missing bearer must 401"
+        );
+    }
+
+    // ─ Scenario 5: GET 200 happy (read own group) ──────────
+    {
+        let path = created_group_id.to_string();
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_group_by_id(&creator_token, &path, Some(&path)))
+            .await
+            .expect("scenario 5: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "scenario 5: member reading own group must 200"
+        );
+        let v = body_json(resp).await;
+        assert_eq!(v["id"], path);
+        assert_eq!(v["name"], "M4 Scenario 1");
+        assert_eq!(v["type"], "team");
+        assert_eq!(v["role"], "owner");
+        assert_eq!(v["created_by"], creator_id.to_string());
+    }
+
+    // ─ Scenario 6: GET 400 header/path mismatch ───────────
+    {
+        let mismatching = uuid::Uuid::new_v4().to_string();
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_group_by_id(
+                &creator_token,
+                &created_group_id.to_string(),
+                Some(&mismatching),
+            ))
+            .await
+            .expect("scenario 6: oneshot");
+        // The Principal extractor runs the membership lookup on the
+        // X-Group-Id header first. Because `mismatching` is not a
+        // group the creator is a member of, the extractor returns
+        // 403 BEFORE the handler's 400-for-mismatch check can run.
+        // Both 400 and 403 are acceptable semantics for this case;
+        // we assert that it is NOT 200 and pin it to whichever the
+        // extractor chose.
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "scenario 6: foreign X-Group-Id header -> Principal extractor 403 (precedes handler 400)"
+        );
+    }
+
+    // ─ Scenario 7: GET 403 non-member of path group ───────
+    {
+        // Seed a fresh user with their own group, then try to read
+        // the creator's group from scenario 1. Principal extractor
+        // fails the membership lookup and 403s before the handler
+        // runs.
+        let (_other_id, _other_group, other_token) =
+            seed_user_with_group(&h, "scenario7-other@m4.test")
+                .await
+                .expect("scenario 7: seed other");
+        let path = created_group_id.to_string();
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_group_by_id(&other_token, &path, Some(&path)))
+            .await
+            .expect("scenario 7: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "scenario 7: non-member reading foreign group must 403"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

**M4** of plan 0016 (owner-tightened minimum slice): first real write handlers on the `garraia_app` RLS-enforced pool. Unblocks the deferred plan 0014 (GAR-391d app-layer cross-group matrix via HTTP) — M4 delivers the two `/v1/groups` endpoints that the matrix needs to exist.

4 commits on `feat/0016m4-groups-handlers`:

| Commit | Task | Change |
|---|---|---|
| `2f9bce7` | M4-T1 | `RestError::BadRequest(String)` -> 400 + `RestError::NotFound` -> 404 variants in `rest_v1/problem.rs`. 2 new unit tests for the Problem Details shapes. |
| `ce911e2` | M4-T2+T3 | New `crates/garraia-gateway/src/rest_v1/groups.rs` with `create_group` (POST /v1/groups) and `get_group` (GET /v1/groups/{id}) handlers + DTOs + 4 unit tests. Router Mode 1 flipped from `unconfigured_handler` stubs to the real handlers. `ApiDoc` derive updated with new paths + schemas. `sqlx = "0.8"` added to `[dependencies]` (was dev-only before). |
| `2771dfa` | M4-T4+T6 | New test binary `tests/rest_v1_groups.rs` with one bundled `#[tokio::test]` running 7 scenarios sequentially. ROADMAP.md §3.4 Grupos: `[x] POST /v1/groups` and `[x] GET /v1/groups/{group_id}`. |
| `d25851d` | M4 review | Applied 4 cheap-win findings from the parallel `security-auditor` + `code-reviewer` dispatch: `unwrap_or_default()` -> explicit `ok_or_else(RestError::Internal)`, `name.trim()` captured in local var, `get_group` FIXME for M5 RLS trigger, `sqlx` dev-deps dedup. |

## What ships

### `POST /v1/groups` (create_group)

- Body: `{"name": string, "type": "family" | "team"}`. Rejects `"personal"` per migration 001 line 114 reservation.
- Auth: any authenticated caller (no `X-Group-Id` header required — caller is creating a brand-new group).
- Behavior: opens `tx = pool_for_handlers().begin()`, then runs `SET LOCAL app.current_user_id = '{uuid}'` as the first statement (forward-compat scaffolding for future RLS on `group_members`), INSERT `groups` RETURNING id + created_at, INSERT `group_members` with `role=owner, status=active`, commits. Atomic rollback on any failure — the creator never ends up with a dangling `groups` row.
- Response 201: `{id, name, type, created_at}`.
- Errors: 400 invalid type, 400 empty name, 401 no bearer, 500 on DB failures.

### `GET /v1/groups/{id}` (get_group)

- Auth: Principal extractor requires `X-Group-Id` header matching the path id. Non-members receive 403 at the extractor level before the handler runs.
- Behavior: SELECT `id, name, type, created_at, created_by FROM groups WHERE id = $1` via `pool_for_handlers()`. `groups` is not under FORCE RLS (migration 001 line 100), so no `SET LOCAL` is needed here — documented with a `FIXME(plan-0016-M5 or whenever groups gains FORCE RLS)` that prescribes the conversion to a transactional pattern the moment RLS is extended.
- Response 200: `{id, name, type, created_at, created_by, role}`. `role` comes from `principal.role` (enforced via `ok_or_else` after M4 review).
- Errors: 400 `X-Group-Id` missing or mismatches path, 401 no bearer, 403 non-member (from extractor), 404 row missing (edge: group deleted between extractor lookup and SELECT).

### Router Mode 1 flip

`crates/garraia-gateway/src/rest_v1/mod.rs` previously had
`unconfigured_handler` stubs for `/v1/groups` routes in the full-state Mode 1 arm. Those are now `groups::create_group` and `groups::get_group`. Mode 2 (auth wired, AppPool missing) and Mode 3 (nothing wired) still use the 503 fail-soft stubs, because they lack `Arc<AppPool>` in state.

### OpenAPI expansion

`ApiDoc` derive now lists:
- `paths(me::get_me, groups::create_group, groups::get_group)`
- `components(schemas(MeResponse, ProblemDetails, CreateGroupRequest, GroupResponse, GroupReadResponse))`
- `modifiers(&SecurityAddon)` (unchanged from M3)

Swagger UI at `/docs` now shows the two new endpoints with their request/response schemas and the Bearer JWT security requirement.

### ROADMAP

`ROADMAP.md` §3.4 Grupos: two checkboxes marked. No other checkbox touched.

## What is explicitly NOT in this PR

- `PATCH /v1/groups/{id}`, invites, member role change endpoints — future §3.4 work
- `/v1/chats`, `/v1/messages`, `/v1/memory`, `/v1/tasks` — future §3.4 work
- `admin_url` accessor refactor — M5
- `exec_with_tenant` closure API refactor (replacing `pool_for_handlers`) — M5
- `test-support` rename (`__test-support`) — M5
- URL parsing via `url::Url` in the test harness — M5
- Fail-soft `/docs/{*path}` wildcard route — M5
- Scenario 8 exercising the "true 400 mismatch" path of `get_group` — documented coverage gap, M5
- `get_group` transactional wrap — deferred with explicit FIXME until `groups` gains FORCE RLS

## Validations (all green)

- `cargo check --workspace` -> Finished OK
- `cargo clippy -p garraia-gateway --lib --tests --features test-helpers` -> zero errors, zero new warnings
- `cargo test -p garraia-auth --lib` -> **41 passed** (unchanged)
- `cargo test -p garraia-gateway --lib` -> **167 passed** (161 M3 + 6 new in M4: 2 problem + 4 groups)
- `cargo test -p garraia-gateway --test rest_v1_me` -> **1 passed** (fail-soft intacto)
- `cargo test -p garraia-gateway --features test-helpers --test harness_smoke` -> **1 passed** (unchanged)
- `cargo test -p garraia-gateway --features test-helpers --test rest_v1_me_authed` -> **1 passed** (5 scenarios, unchanged)
- `cargo test -p garraia-gateway --features test-helpers --test rest_v1_groups` -> **1 passed** (NEW, 7 scenarios, ~16s deterministic)
- `cargo test -p garraia-gateway --test router_smoke_test` -> **3 passed** (legacy intacto)
- `cargo test -p garraia-gateway --test projects_test` -> **4 passed** (legacy intacto)
- `cargo test -p garraia-gateway --test skins_test` -> **3 passed** (legacy intacto)

## Agent Teams used

**Pre-execution gate:** `team-coordinator` dispatched BEFORE any coding. Returned **Go** with 4 critical clarifications:

1. Migration 007 confirms `group_members` is NOT under FORCE RLS in M4 — `SET LOCAL` is forward-compat scaffolding, not load-bearing.
2. Migration 001 line 100 confirms `groups` is not under RLS either.
3. Principal extractor without `X-Group-Id` returns `Principal { group_id: None, role: None }` without error — POST /v1/groups works without the header.
4. `SET LOCAL` MUST be the first statement inside an explicit `tx = pool.begin()` — without the explicit tx, Postgres auto-commit wraps each statement in its own transaction and the tenant context evaporates. This was the critical protocol risk that could have caused silent RLS bypass when RLS is eventually extended.

**Post-implementation review:** `security-auditor` + `code-reviewer` dispatched **in parallel** (Batch Workflow, single message, 2 tool calls). Both returned **aprovado com ressalvas** and both converged on the same highest-severity finding (`unwrap_or_default()` on role).

### security-auditor findings
- 0 CRITICAL, 0 HIGH, **1 MEDIUM (applied)**, 2 LOW (1 applied), 1 NITPICK
- MEDIUM: `get_group` forward-compat hazard when `groups` gains FORCE RLS -> **FIXED** as an explicit `FIXME(plan-0016-M5 or whenever groups gains FORCE RLS)` comment
- LOW: `unwrap_or_default()` on role -> **FIXED** to `ok_or_else(RestError::Internal)` with tracing
- LOW: timing distinguishability between 403 extractor path and 400 handler path — deferred (acceptable M4)
- NITPICK: `BadRequest` PII policy is doc-only (no lint) — deferred

### code-reviewer findings
- 0 CRITICAL, 0 BLOCKER, **1 HIGH (applied)**, 3 MEDIUM (2 applied, 1 deferred with docs), 3 LOW (deferred), 3 NITPICK
- HIGH: same `unwrap_or_default()` finding -> **FIXED**
- MEDIUM: `name.trim()` called twice -> **FIXED** with local `trimmed_name` variable
- MEDIUM: `sqlx` duplicated in `[dependencies]` + `[dev-dependencies]` -> **FIXED**, dev-dep removed with explanatory comment
- MEDIUM: Scenario 6 doesn't exercise the true 400-mismatch branch -> deferred to M5 as documented coverage gap
- LOW: `ALLOWED_GROUP_TYPES` could be an enum -> deferred to M5
- LOW: `post_groups` helper style -> deferred
- NITPICK: `created_by` missing utoipa doc -> deferred
- NITPICK: commit hygiene OK

## Known deferred work (rolled into M5)

| Item | Severity | Reason deferred |
|---|---|---|
| `get_group` transactional wrap | MEDIUM security | Documented with FIXME — trigger is future `groups` FORCE RLS migration |
| Scenario 8: true 400 mismatch branch coverage | MEDIUM code quality | Legitimate test gap, documented in commit message |
| `admin_url` -> accessor or newtype | LOW (carried from M2) | M5 cleanup pass |
| `pool_for_handlers()` -> `exec_with_tenant` closure API | MEDIUM (carried from M1) | M5 refactor slice |
| `test-support` -> `__test-support` rename | LOW (carried from M1) | M5 cleanup |
| URL parsing via `url::Url` in harness | MEDIUM (carried from M2) | M5 cleanup |
| Fail-soft `/docs/{*path}` wildcard | LOW (carried from PR #8 review) | M5 cleanup |
| `SafeDetail(String)` newtype for BadRequest PII policy | NITPICK | Longer-term design |

## Rollback

All 4 commits independent and reversible via `git revert`. M1, M2, M3 (all merged) not touched. The only change visible to production deployments is:
- Two new `/v1/groups` routes on Mode 1 gateways (requires `GARRAIA_APP_DATABASE_URL` set)
- Two new paths + schemas in `/v1/openapi.json`
- `sqlx = "0.8"` transitively loaded as production dep (already loaded as dev-dep in M2, same feature set)

Zero breaking change for existing `/v1/me`, `/v1/auth/*`, `/v1/openapi.json` shape, or any existing test binary.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy -p garraia-gateway --lib --tests --features test-helpers`
- [x] `cargo test -p garraia-auth --lib` (41 passed)
- [x] `cargo test -p garraia-gateway --lib` (167 passed, +6 new)
- [x] `cargo test -p garraia-gateway --test rest_v1_me` (1 passed)
- [x] `cargo test -p garraia-gateway --features test-helpers --test harness_smoke` (1 passed)
- [x] `cargo test -p garraia-gateway --features test-helpers --test rest_v1_me_authed` (1 passed)
- [x] `cargo test -p garraia-gateway --features test-helpers --test rest_v1_groups` (1 passed NEW)
- [x] `cargo test -p garraia-gateway --test router_smoke_test` (3 passed)
- [x] `cargo test -p garraia-gateway --test projects_test` (4 passed)
- [x] `cargo test -p garraia-gateway --test skins_test` (3 passed)
- [ ] Post-merge: bump `plans/README.md` 0016 status from "M1+M2+M3 merged" to "M1+M2+M3+M4 merged, M5 pending"

Robot: Generated with Claude Code
