### PR TITLE
chore(gateway): plan 0016 M5 review follow-ups (H-1/M-3/N-3 + M-1)

### DIFF
--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -182,6 +182,7 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 .route("/v1/groups/{id}", get(unconfigured_handler))
                 .route("/v1/openapi.json", get(unconfigured_handler))
                 .route("/docs", get(unconfigured_handler))
+                .route("/docs/{*rest}", get(unconfigured_handler))
         }
     }
 }

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -189,6 +189,6 @@ pub fn router(app_state: Arc<AppState>) -> Router {
 /// Fail-soft handler used when `AuthConfig` / `AppPool` is missing.
 /// Routes that cannot serve in the current mode fall back here and
 /// answer 503 Problem Details via `RestError::AuthUnconfigured`.
-async fn unconfigured_handler() -> RestError {
+async fn unconfigured_handler() -> impl axum::response::IntoResponse {
     RestError::AuthUnconfigured
 }

--- a/crates/garraia-gateway/src/rest_v1/problem.rs
+++ b/crates/garraia-gateway/src/rest_v1/problem.rs
@@ -46,6 +46,11 @@ pub enum RestError {
     NotFound,
     #[error("authentication is not configured on this gateway")]
     AuthUnconfigured,
+    /// Internal error wrapper. **Callers MUST NOT `.context("...")` with
+    /// user-identifying data (email, user_id, hashes)** before converting
+    /// to `RestError::Internal`: the `Display` impl of `anyhow::Error` will
+    /// print the outermost context in the log span created by
+    /// `IntoResponse`, and that log line is operator-visible.
     #[error("internal error")]
     Internal(#[source] anyhow::Error),
 }
@@ -90,7 +95,10 @@ impl IntoResponse for RestError {
             status: status.as_u16(),
             detail,
         };
-        let json = serde_json::to_vec(&body).unwrap_or_else(|_| b"{}".to_vec());
+        let json = serde_json::to_vec(&body).unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "problem.rs: fallback empty JSON body used");
+            b"{}".to_vec()
+        });
         (status, [("content-type", "application/problem+json")], json).into_response()
     }
 }


### PR DESCRIPTION
## Summary

Closes the review follow-ups from PR #8 (plan 0015) via the **formal body of plan 0016 §M5** — Tasks 16 and 17. Two commits, aditivos, reversíveis commit-a-commit.

- **Task 16 (`7e06525`)** — chore(gateway): review follow-ups H-1/M-3/N-3
  - **M-3:** `unconfigured_handler` now returns `impl IntoResponse` instead of leaking `RestError` as concrete type.
  - **H-1:** doc note on `RestError::Internal` warning callers not to attach PII via `.context()` before conversion (operator-visible log span).
  - **N-3:** fallback JSON serialization path in `problem.rs` now emits `tracing::warn!` instead of silently swallowing the encode error.

- **Task 17 (`e884c99`)** — fix(gateway): cover /docs/* trailing paths in fail-soft mode
  - **M-1:** fail-soft branch (mode 3) only routed bare `/docs` to `unconfigured_handler`, leaving `/docs/swagger-ui.css` and trailing-slash variants to fall through to Axum's default 404 instead of the 503 Problem Details we promise in that mode. Adds the `{*rest}` catch-all alongside the bare route.
  - **Nota vs plano:** plan 0016 Task 17 descrevia isso como "apenas confirmação" assumindo que Task 4 Step 2 já havia coberto. O grep empírico mostrou que não — `mod.rs` linha 184 só tinha o bare `/docs`. Aplicado conforme o fallback previsto no próprio plano ("Step 2: Se ausente, adicionar + commit").

Zero runtime behavior change on the happy path. Modes 1 and 2 (authed) use `SwaggerUi::new("/docs")` that already covers assets via merge.

## Escopo explicitamente excluído

Os itens extras mencionados no comentário de índice `plans/README.md:41` (`admin_url` accessor, `exec_with_tenant` closure API, `test-support` rename, `get_group` transactional wrap, scenario 8 coverage gap) **não estão no corpo formal do plan 0016 §M5** e **não entram neste PR**. Ficam como decisão posterior para 0016.1 / 0017.

## Test plan

- [x] `cargo check --workspace` (19.82s)
- [x] `cargo clippy -p garraia-gateway --no-deps` (exit 0; 5 warnings pré-existentes em `admin/*` + `bootstrap.rs`, zero novos em `rest_v1/*`)
- [x] `cargo test -p garraia-gateway --lib` → **167/167 passed**
- [x] `cargo test --features test-helpers --test rest_v1_me` → ✅ (bundled authed scenarios + fail-soft)
- [x] `cargo test --features test-helpers --test rest_v1_groups` → ✅ (bundled `/v1/groups` matrix)
- [x] `cargo test --features test-helpers --test harness_smoke` → ✅
- [x] `cargo test --features test-helpers --test authz_http_matrix` → ✅ (15-case app-layer cross-group)
- [x] `cargo test --features test-helpers --test router_smoke_test` → 3/3

Todas as suites com `testcontainers` (pgvector/pg16) rodaram localmente contra Docker Desktop 29.2.1.

## Linear

- GAR-391 confirmado `Done` (completedAt `2026-04-15T14:20:25Z`).
- Nenhum ticket Linear dedicado a este sweep — são review nits do PR #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)