### PR TITLE
feat(gateway): PATCH /v1/groups/{id} — plan 0017 (GAR-393 slice 1)

### DIFF
--- a/crates/garraia-gateway/src/rest_v1/groups.rs
+++ b/crates/garraia-gateway/src/rest_v1/groups.rs
@@ -110,17 +110,15 @@ impl UpdateGroupRequest {
         if self.is_empty() {
             return Err("patch body must set at least one field");
         }
-        if let Some(name) = &self.name {
-            if name.trim().is_empty() {
-                return Err("name must not be empty");
-            }
+        if let Some(name) = &self.name
+            && name.trim().is_empty()
+        {
+            return Err("name must not be empty");
         }
-        if let Some(t) = &self.group_type {
-            if !ALLOWED_GROUP_TYPES.contains(&t.as_str()) {
-                // This covers both "personal" (reserved) and any
-                // other unknown value with the same 400 response.
-                return Err("group type must be 'family' or 'team'");
-            }
+        if let Some(t) = &self.group_type
+            && !ALLOWED_GROUP_TYPES.contains(&t.as_str())
+        {
+            return Err("group type must be 'family' or 'team'");
         }
         Ok(())
     }

--- a/crates/garraia-gateway/src/rest_v1/groups.rs
+++ b/crates/garraia-gateway/src/rest_v1/groups.rs
@@ -74,6 +74,58 @@ pub struct GroupResponse {
     pub created_at: DateTime<Utc>,
 }
 
+/// Request body for `PATCH /v1/groups/{group_id}` (plan 0017).
+///
+/// All fields are `Option<T>` — only the fields explicitly set in the
+/// JSON body are applied via `COALESCE($new, column)` in the UPDATE.
+/// Empty body `{}` (all-None) is rejected by [`UpdateGroupRequest::validate`]
+/// with a 400: a no-op PATCH is always a client mistake.
+///
+/// `type = "personal"` is rejected with 400 — same rule as
+/// [`CreateGroupRequest`] (see [`ALLOWED_GROUP_TYPES`] and migration
+/// 001 line 114).
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct UpdateGroupRequest {
+    /// New display name. Rejected if empty after trim.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// New group type. Must be `"family"` or `"team"`. `"personal"` is
+    /// reserved programmatic-only and rejected with 400.
+    #[serde(default, rename = "type")]
+    pub group_type: Option<String>,
+}
+
+impl UpdateGroupRequest {
+    /// True when no field was set. Empty body = client error = 400.
+    pub fn is_empty(&self) -> bool {
+        self.name.is_none() && self.group_type.is_none()
+    }
+
+    /// Structural validation. Returns `Ok(())` if the body is coherent,
+    /// `Err(&'static str)` with a PII-safe detail otherwise. The error
+    /// string is emitted verbatim to clients in the Problem Details
+    /// body, so it must not contain user-identifying data.
+    pub fn validate(&self) -> Result<(), &'static str> {
+        if self.is_empty() {
+            return Err("patch body must set at least one field");
+        }
+        if let Some(name) = &self.name {
+            if name.trim().is_empty() {
+                return Err("name must not be empty");
+            }
+        }
+        if let Some(t) = &self.group_type {
+            if !ALLOWED_GROUP_TYPES.contains(&t.as_str()) {
+                // This covers both "personal" (reserved) and any
+                // other unknown value with the same 400 response.
+                return Err("group type must be 'family' or 'team'");
+            }
+        }
+        Ok(())
+    }
+}
+
 /// Response body for `GET /v1/groups/{id}` (200 OK).
 ///
 /// Includes the caller's `role` (from the `Principal` extractor)
@@ -343,5 +395,85 @@ mod tests {
         let parsed: CreateGroupRequest = serde_json::from_str(s).unwrap();
         assert_eq!(parsed.name, "alpha");
         assert_eq!(parsed.group_type, "team");
+    }
+
+    // ─── plan 0017 Task 1: UpdateGroupRequest ──────────────────────────
+
+    #[test]
+    fn update_group_request_empty_body_all_none() {
+        let req: UpdateGroupRequest = serde_json::from_str("{}").unwrap();
+        assert!(req.name.is_none());
+        assert!(req.group_type.is_none());
+        assert!(req.is_empty());
+    }
+
+    #[test]
+    fn update_group_request_deserializes_type_with_rename() {
+        let req: UpdateGroupRequest =
+            serde_json::from_str(r#"{"type":"family"}"#).unwrap();
+        assert_eq!(req.group_type.as_deref(), Some("family"));
+        assert!(req.name.is_none());
+        assert!(!req.is_empty());
+    }
+
+    #[test]
+    fn update_group_request_name_only_is_not_empty() {
+        let req: UpdateGroupRequest =
+            serde_json::from_str(r#"{"name":"new name"}"#).unwrap();
+        assert_eq!(req.name.as_deref(), Some("new name"));
+        assert!(req.group_type.is_none());
+        assert!(!req.is_empty());
+    }
+
+    #[test]
+    fn update_group_request_validate_rejects_personal_type() {
+        let req = UpdateGroupRequest {
+            name: None,
+            group_type: Some("personal".into()),
+        };
+        assert_eq!(
+            req.validate().unwrap_err(),
+            "group type must be 'family' or 'team'"
+        );
+    }
+
+    #[test]
+    fn update_group_request_validate_rejects_empty_name() {
+        let req = UpdateGroupRequest {
+            name: Some("   ".into()),
+            group_type: None,
+        };
+        assert_eq!(req.validate().unwrap_err(), "name must not be empty");
+    }
+
+    #[test]
+    fn update_group_request_validate_rejects_empty_body() {
+        let req = UpdateGroupRequest {
+            name: None,
+            group_type: None,
+        };
+        assert_eq!(
+            req.validate().unwrap_err(),
+            "patch body must set at least one field"
+        );
+    }
+
+    #[test]
+    fn update_group_request_validate_accepts_valid_family_rename() {
+        let req = UpdateGroupRequest {
+            name: Some("Updated".into()),
+            group_type: Some("family".into()),
+        };
+        assert!(req.validate().is_ok());
+    }
+
+    #[test]
+    fn update_group_request_rejects_unknown_fields() {
+        // deny_unknown_fields: typo-protects clients from silent
+        // drops when they misspell `name`/`type`.
+        let err = serde_json::from_str::<UpdateGroupRequest>(
+            r#"{"nmae":"typo"}"#,
+        );
+        assert!(err.is_err(), "deny_unknown_fields should reject `nmae`");
     }
 }

--- a/crates/garraia-gateway/src/rest_v1/groups.rs
+++ b/crates/garraia-gateway/src/rest_v1/groups.rs
@@ -570,8 +570,7 @@ mod tests {
 
     #[test]
     fn update_group_request_deserializes_type_with_rename() {
-        let req: UpdateGroupRequest =
-            serde_json::from_str(r#"{"type":"family"}"#).unwrap();
+        let req: UpdateGroupRequest = serde_json::from_str(r#"{"type":"family"}"#).unwrap();
         assert_eq!(req.group_type.as_deref(), Some("family"));
         assert!(req.name.is_none());
         assert!(!req.is_empty());
@@ -579,8 +578,7 @@ mod tests {
 
     #[test]
     fn update_group_request_name_only_is_not_empty() {
-        let req: UpdateGroupRequest =
-            serde_json::from_str(r#"{"name":"new name"}"#).unwrap();
+        let req: UpdateGroupRequest = serde_json::from_str(r#"{"name":"new name"}"#).unwrap();
         assert_eq!(req.name.as_deref(), Some("new name"));
         assert!(req.group_type.is_none());
         assert!(!req.is_empty());
@@ -632,9 +630,7 @@ mod tests {
     fn update_group_request_rejects_unknown_fields() {
         // deny_unknown_fields: typo-protects clients from silent
         // drops when they misspell `name`/`type`.
-        let err = serde_json::from_str::<UpdateGroupRequest>(
-            r#"{"nmae":"typo"}"#,
-        );
+        let err = serde_json::from_str::<UpdateGroupRequest>(r#"{"nmae":"typo"}"#);
         assert!(err.is_err(), "deny_unknown_fields should reject `nmae`");
     }
 }

--- a/crates/garraia-gateway/src/rest_v1/groups.rs
+++ b/crates/garraia-gateway/src/rest_v1/groups.rs
@@ -37,7 +37,7 @@ use axum::Json;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use chrono::{DateTime, Utc};
-use garraia_auth::Principal;
+use garraia_auth::{Action, Principal, can};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
@@ -335,6 +335,169 @@ pub async fn get_group(
         })?
         .as_str()
         .to_string();
+
+    Ok(Json(GroupReadResponse {
+        id,
+        name,
+        group_type,
+        created_at,
+        created_by,
+        role,
+    }))
+}
+
+/// `PATCH /v1/groups/{id}` — partial modification of an existing group (plan 0017).
+///
+/// Authz model (mirrors `get_group`'s extractor-first approach):
+///
+/// 1. The `Principal` extractor requires an `X-Group-Id` header and 403's
+///    any caller who is not a member of the target group — so by the time
+///    this handler runs, `principal.group_id` is `Some(_)` and
+///    `principal.role` is `Some(_)`. **Non-members never reach this code.**
+/// 2. This handler then validates `principal.group_id == path_id` (400 if
+///    mismatch, same rule as `get_group`).
+/// 3. Authz capability check via `can(&principal, Action::GroupSettings)`:
+///    - Owner, Admin → allowed (200 on success)
+///    - Member, Guest, Child → 403 Forbidden
+/// 4. Request body is validated structurally before any DB access (empty
+///    body, bad name, reserved `type = "personal"` → 400).
+/// 5. UPDATE runs inside a transaction with `SET LOCAL app.current_user_id`
+///    as the first statement (same pattern as `create_group`). `updated_at
+///    = now()` is set **explicitly** because `groups` has no trigger
+///    (see migration 001 line 115). COALESCE($new, column) implements PATCH
+///    partial-update semantics — only fields the caller sent are overwritten.
+/// 6. UPDATE ... RETURNING fetches the fresh row in the same roundtrip. If
+///    the row vanished between the extractor's membership lookup and this
+///    statement (group hard-deleted), RETURNING is empty → 404.
+///
+/// ## Error response status table
+///
+/// | Condition                                  | Status | Source         |
+/// |--------------------------------------------|--------|----------------|
+/// | No JWT                                     | 401    | JWT extractor  |
+/// | Non-member of target group                 | 403    | Principal ext. |
+/// | `X-Group-Id` header missing / mismatched   | 400    | this handler   |
+/// | Body is `{}` or all-None                   | 400    | validate()     |
+/// | `name` present but blank                   | 400    | validate()     |
+/// | `type` is `"personal"` or unknown          | 400    | validate()     |
+/// | Role is Member/Guest/Child                 | 403    | `can()`        |
+/// | Group row deleted concurrently             | 404    | UPDATE RETURN. |
+/// | Happy path                                 | 200    |                |
+#[utoipa::path(
+    patch,
+    path = "/v1/groups/{id}",
+    params(
+        ("id" = Uuid, Path, description = "Group UUID. Must match the `X-Group-Id` header."),
+    ),
+    request_body = UpdateGroupRequest,
+    responses(
+        (status = 200, description = "Group updated; response carries the fresh row + caller's role.", body = GroupReadResponse),
+        (status = 400, description = "Invalid body, header/path mismatch, or reserved group type.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller lacks `group.settings` capability.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Group vanished between extractor lookup and UPDATE.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn patch_group(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(id): Path<Uuid>,
+    Json(body): Json<UpdateGroupRequest>,
+) -> Result<Json<GroupReadResponse>, RestError> {
+    // 1. Header/path coherence (same rule as `get_group`).
+    match principal.group_id {
+        Some(hdr) if hdr == id => {}
+        Some(_) => {
+            return Err(RestError::BadRequest(
+                "X-Group-Id header and path id must match".into(),
+            ));
+        }
+        None => {
+            return Err(RestError::BadRequest(
+                "X-Group-Id header is required".into(),
+            ));
+        }
+    }
+
+    // 2. Capability check. Owner/Admin pass; Member/Guest/Child get 403.
+    //    Non-members already got 403 at the extractor.
+    if !can(&principal, Action::GroupSettings) {
+        return Err(RestError::Forbidden);
+    }
+
+    // 3. Structural body validation (no DB access, PII-safe messages).
+    body.validate()
+        .map_err(|msg| RestError::BadRequest(msg.into()))?;
+
+    // 4. Resolve role once for the response payload. Same invariant as
+    //    `get_group`: if `group_id` is Some then `role` must be Some —
+    //    the extractor guarantees it, and breaking that invariant is
+    //    a 500, not a silent empty-role leak.
+    let role = principal
+        .role
+        .ok_or_else(|| {
+            tracing::error!(
+                user_id = %principal.user_id,
+                group_id = ?principal.group_id,
+                "Principal.role is None with group_id Some — invariant violated by extractor"
+            );
+            RestError::Internal(anyhow::anyhow!(
+                "Principal.role is None despite group_id being Some"
+            ))
+        })?
+        .as_str()
+        .to_string();
+
+    // 5. Transactional UPDATE. `SET LOCAL` must be the first statement
+    //    inside the tx — plan 0016 M4 pattern. This handler mirrors
+    //    `create_group` (not `get_group`, which has a FIXME about the
+    //    same hazard) so the tenant context is already correct when
+    //    `groups` eventually gains FORCE RLS.
+    //
+    //    SET LOCAL does not accept bind params in Postgres; Uuid Display
+    //    is 36 hex-dashed chars, injection-safe by construction.
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query(&format!(
+        "SET LOCAL app.current_user_id = '{}'",
+        principal.user_id
+    ))
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    // 6. UPDATE with COALESCE ($new, column) — partial modification:
+    //    only fields the caller set are overwritten, the rest stay
+    //    untouched. `updated_at = now()` is ALWAYS in the SET clause
+    //    because `groups` has no trigger (migration 001 line 115).
+    //    RETURNING gives us the fresh row in the same roundtrip.
+    let row: Option<(Uuid, String, String, DateTime<Utc>, Uuid)> = sqlx::query_as(
+        r#"
+        UPDATE groups
+           SET name       = COALESCE($1, name),
+               type       = COALESCE($2, type),
+               updated_at = now()
+         WHERE id = $3
+     RETURNING id, name, type, created_at, created_by
+        "#,
+    )
+    .bind(body.name.as_deref())
+    .bind(body.group_type.as_deref())
+    .bind(id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let (id, name, group_type, created_at, created_by) = row.ok_or(RestError::NotFound)?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
 
     Ok(Json(GroupReadResponse {
         id,

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -157,7 +157,7 @@ pub fn router(app_state: Arc<AppState>) -> Router {
             Router::new()
                 .route("/v1/me", get(me::get_me))
                 .route("/v1/groups", post(groups::create_group))
-                .route("/v1/groups/{id}", get(groups::get_group))
+                .route("/v1/groups/{id}", get(groups::get_group).patch(groups::patch_group))
                 .with_state(full)
                 .merge(SwaggerUi::new("/docs").url("/v1/openapi.json", ApiDoc::openapi()))
         }
@@ -170,7 +170,7 @@ pub fn router(app_state: Arc<AppState>) -> Router {
             Router::new()
                 .route("/v1/me", get(me::get_me))
                 .route("/v1/groups", post(unconfigured_handler))
-                .route("/v1/groups/{id}", get(unconfigured_handler))
+                .route("/v1/groups/{id}", get(unconfigured_handler).patch(unconfigured_handler))
                 .with_state(auth)
                 .merge(SwaggerUi::new("/docs").url("/v1/openapi.json", ApiDoc::openapi()))
         }
@@ -179,7 +179,7 @@ pub fn router(app_state: Arc<AppState>) -> Router {
             Router::new()
                 .route("/v1/me", get(unconfigured_handler))
                 .route("/v1/groups", post(unconfigured_handler))
-                .route("/v1/groups/{id}", get(unconfigured_handler))
+                .route("/v1/groups/{id}", get(unconfigured_handler).patch(unconfigured_handler))
                 .route("/v1/openapi.json", get(unconfigured_handler))
                 .route("/docs", get(unconfigured_handler))
                 .route("/docs/{*rest}", get(unconfigured_handler))

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -157,7 +157,10 @@ pub fn router(app_state: Arc<AppState>) -> Router {
             Router::new()
                 .route("/v1/me", get(me::get_me))
                 .route("/v1/groups", post(groups::create_group))
-                .route("/v1/groups/{id}", get(groups::get_group).patch(groups::patch_group))
+                .route(
+                    "/v1/groups/{id}",
+                    get(groups::get_group).patch(groups::patch_group),
+                )
                 .with_state(full)
                 .merge(SwaggerUi::new("/docs").url("/v1/openapi.json", ApiDoc::openapi()))
         }
@@ -170,7 +173,10 @@ pub fn router(app_state: Arc<AppState>) -> Router {
             Router::new()
                 .route("/v1/me", get(me::get_me))
                 .route("/v1/groups", post(unconfigured_handler))
-                .route("/v1/groups/{id}", get(unconfigured_handler).patch(unconfigured_handler))
+                .route(
+                    "/v1/groups/{id}",
+                    get(unconfigured_handler).patch(unconfigured_handler),
+                )
                 .with_state(auth)
                 .merge(SwaggerUi::new("/docs").url("/v1/openapi.json", ApiDoc::openapi()))
         }
@@ -179,7 +185,10 @@ pub fn router(app_state: Arc<AppState>) -> Router {
             Router::new()
                 .route("/v1/me", get(unconfigured_handler))
                 .route("/v1/groups", post(unconfigured_handler))
-                .route("/v1/groups/{id}", get(unconfigured_handler).patch(unconfigured_handler))
+                .route(
+                    "/v1/groups/{id}",
+                    get(unconfigured_handler).patch(unconfigured_handler),
+                )
                 .route("/v1/openapi.json", get(unconfigured_handler))
                 .route("/docs", get(unconfigured_handler))
                 .route("/docs/{*rest}", get(unconfigured_handler))

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -12,7 +12,7 @@
 use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
 use utoipa::{Modify, OpenApi};
 
-use super::groups::{CreateGroupRequest, GroupReadResponse, GroupResponse};
+use super::groups::{CreateGroupRequest, GroupReadResponse, GroupResponse, UpdateGroupRequest};
 use super::me::MeResponse;
 use super::problem::ProblemDetails;
 
@@ -60,11 +60,13 @@ impl Modify for SecurityAddon {
         super::me::get_me,
         super::groups::create_group,
         super::groups::get_group,
+        super::groups::patch_group,
     ),
     components(schemas(
         MeResponse,
         ProblemDetails,
         CreateGroupRequest,
+        UpdateGroupRequest,
         GroupResponse,
         GroupReadResponse,
     )),

--- a/crates/garraia-gateway/tests/authz_http_matrix.rs
+++ b/crates/garraia-gateway/tests/authz_http_matrix.rs
@@ -179,6 +179,37 @@ fn req_post(path: &str, bearer: Option<&str>, body: Value) -> Request<Body> {
     req
 }
 
+fn req_patch(
+    path: &str,
+    bearer: Option<&str>,
+    x_group_id: Option<&str>,
+    body: Value,
+) -> Request<Body> {
+    let mut req = Request::builder()
+        .method(Method::PATCH)
+        .uri(path)
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    if let Some(token) = bearer {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        );
+    }
+    if let Some(g) = x_group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    req
+}
+
 // ─── Matrix case type ────────────────────────────────────────
 
 /// Type alias for the request-builder closure on each `MatrixCase`.
@@ -407,6 +438,67 @@ fn build_matrix() -> Vec<MatrixCase> {
             expected_status: StatusCode::UNAUTHORIZED,
             expected_body_contains: None,
         },
+        // ── PATCH /v1/groups/{id} (cases 16–19, plan 0017 Task 6) ──
+        MatrixCase {
+            id: 16,
+            name: "PATCH /v1/groups/{alice_group} as alice (owner) -> 200",
+            build: Box::new(|a| {
+                let path = format!("/v1/groups/{}", a.alice_group);
+                req_patch(
+                    &path,
+                    Some(&a.alice_token),
+                    Some(&a.alice_group.to_string()),
+                    json!({"name": "alice-renamed-by-matrix"}),
+                )
+            }),
+            expected_status: StatusCode::OK,
+            expected_body_contains: Some("alice-renamed-by-matrix"),
+        },
+        MatrixCase {
+            id: 17,
+            name: "PATCH /v1/groups/{alice_group} as bob (non-member) -> 403",
+            build: Box::new(|a| {
+                let path = format!("/v1/groups/{}", a.alice_group);
+                req_patch(
+                    &path,
+                    Some(&a.bob_token),
+                    Some(&a.alice_group.to_string()),
+                    json!({"name": "bob-hack"}),
+                )
+            }),
+            expected_status: StatusCode::FORBIDDEN,
+            expected_body_contains: None,
+        },
+        MatrixCase {
+            id: 18,
+            name: "PATCH /v1/groups/{alice_group} as eve (no group) -> 403",
+            build: Box::new(|a| {
+                let path = format!("/v1/groups/{}", a.alice_group);
+                req_patch(
+                    &path,
+                    Some(&a.eve_token),
+                    Some(&a.alice_group.to_string()),
+                    json!({"name": "eve-hack"}),
+                )
+            }),
+            expected_status: StatusCode::FORBIDDEN,
+            expected_body_contains: None,
+        },
+        MatrixCase {
+            id: 19,
+            name: "PATCH /v1/groups/{alice_group} without bearer -> 401",
+            build: Box::new(|a| {
+                let path = format!("/v1/groups/{}", a.alice_group);
+                req_patch(
+                    &path,
+                    None,
+                    Some(&a.alice_group.to_string()),
+                    json!({"name": "anon-hack"}),
+                )
+            }),
+            expected_status: StatusCode::UNAUTHORIZED,
+            expected_body_contains: None,
+        },
     ]
 }
 
@@ -418,8 +510,8 @@ async fn gar_391d_app_layer_authz_matrix() {
     let matrix = build_matrix();
     assert_eq!(
         matrix.len(),
-        15,
-        "GAR-391d matrix must have exactly 15 cases; got {}",
+        19,
+        "GAR-391d + plan 0017 matrix must have exactly 19 cases; got {}",
         matrix.len()
     );
 

--- a/crates/garraia-gateway/tests/rest_v1_groups.rs
+++ b/crates/garraia-gateway/tests/rest_v1_groups.rs
@@ -309,13 +309,12 @@ async fn v1_groups_scenarios() {
     {
         let path = created_group_id.to_string();
         // Capture updated_at BEFORE the PATCH.
-        let (before_ts,): (chrono::DateTime<chrono::Utc>,) = sqlx::query_as(
-            "SELECT updated_at FROM groups WHERE id = $1",
-        )
-        .bind(created_group_id)
-        .fetch_one(&h.admin_pool)
-        .await
-        .expect("P1: pre-PATCH updated_at");
+        let (before_ts,): (chrono::DateTime<chrono::Utc>,) =
+            sqlx::query_as("SELECT updated_at FROM groups WHERE id = $1")
+                .bind(created_group_id)
+                .fetch_one(&h.admin_pool)
+                .await
+                .expect("P1: pre-PATCH updated_at");
 
         let resp = h
             .router
@@ -334,13 +333,12 @@ async fn v1_groups_scenarios() {
         assert_eq!(v["role"], "owner");
 
         // Verify updated_at was bumped in the DB.
-        let (after_ts,): (chrono::DateTime<chrono::Utc>,) = sqlx::query_as(
-            "SELECT updated_at FROM groups WHERE id = $1",
-        )
-        .bind(created_group_id)
-        .fetch_one(&h.admin_pool)
-        .await
-        .expect("P1: post-PATCH updated_at");
+        let (after_ts,): (chrono::DateTime<chrono::Utc>,) =
+            sqlx::query_as("SELECT updated_at FROM groups WHERE id = $1")
+                .bind(created_group_id)
+                .fetch_one(&h.admin_pool)
+                .await
+                .expect("P1: post-PATCH updated_at");
         assert!(
             after_ts > before_ts,
             "P1: updated_at must increase after PATCH; before={before_ts}, after={after_ts}"
@@ -383,7 +381,11 @@ async fn v1_groups_scenarios() {
             ))
             .await
             .expect("P3: oneshot");
-        assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "P3: personal rejected");
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "P3: personal rejected"
+        );
         let v = body_json(resp).await;
         assert!(
             v["detail"].as_str().unwrap().contains("group type"),

--- a/crates/garraia-gateway/tests/rest_v1_groups.rs
+++ b/crates/garraia-gateway/tests/rest_v1_groups.rs
@@ -68,6 +68,37 @@ fn post_groups(token: Option<&str>, body: serde_json::Value) -> Request<Body> {
     req
 }
 
+fn patch_group_by_id(
+    token: Option<&str>,
+    path_id: &str,
+    x_group_id: Option<&str>,
+    body: serde_json::Value,
+) -> Request<Body> {
+    let mut req = Request::builder()
+        .method("PATCH")
+        .uri(format!("/v1/groups/{path_id}"))
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .expect("request builder");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    if let Some(token) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        );
+    }
+    if let Some(g) = x_group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    req
+}
+
 fn get_group_by_id(token: &str, path_id: &str, x_group_id: Option<&str>) -> Request<Body> {
     let mut req = harness_get(&format!("/v1/groups/{path_id}"));
     req.headers_mut().insert(
@@ -267,5 +298,157 @@ async fn v1_groups_scenarios() {
             StatusCode::FORBIDDEN,
             "scenario 7: non-member reading foreign group must 403"
         );
+    }
+
+    // ─── PATCH /v1/groups/{id} — plan 0017 Task 5 ─────────
+
+    // Scenario P1: owner renames group → 200, response carries new name.
+    // Also validates that `updated_at` was bumped in the database
+    // (groups has no trigger — handler must set it explicitly per
+    // migration 001 line 115).
+    {
+        let path = created_group_id.to_string();
+        // Capture updated_at BEFORE the PATCH.
+        let (before_ts,): (chrono::DateTime<chrono::Utc>,) = sqlx::query_as(
+            "SELECT updated_at FROM groups WHERE id = $1",
+        )
+        .bind(created_group_id)
+        .fetch_one(&h.admin_pool)
+        .await
+        .expect("P1: pre-PATCH updated_at");
+
+        let resp = h
+            .router
+            .clone()
+            .oneshot(patch_group_by_id(
+                Some(&creator_token),
+                &path,
+                Some(&path),
+                json!({"name": "Renamed by P1"}),
+            ))
+            .await
+            .expect("P1: oneshot");
+        assert_eq!(resp.status(), StatusCode::OK, "P1: owner rename");
+        let v = body_json(resp).await;
+        assert_eq!(v["name"], "Renamed by P1");
+        assert_eq!(v["role"], "owner");
+
+        // Verify updated_at was bumped in the DB.
+        let (after_ts,): (chrono::DateTime<chrono::Utc>,) = sqlx::query_as(
+            "SELECT updated_at FROM groups WHERE id = $1",
+        )
+        .bind(created_group_id)
+        .fetch_one(&h.admin_pool)
+        .await
+        .expect("P1: post-PATCH updated_at");
+        assert!(
+            after_ts > before_ts,
+            "P1: updated_at must increase after PATCH; before={before_ts}, after={after_ts}"
+        );
+    }
+
+    // Scenario P2: empty body → 400 deterministic detail.
+    {
+        let path = created_group_id.to_string();
+        let resp = h
+            .router
+            .clone()
+            .oneshot(patch_group_by_id(
+                Some(&creator_token),
+                &path,
+                Some(&path),
+                json!({}),
+            ))
+            .await
+            .expect("P2: oneshot");
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "P2: empty body");
+        let v = body_json(resp).await;
+        assert_eq!(
+            v["detail"], "patch body must set at least one field",
+            "P2: deterministic detail"
+        );
+    }
+
+    // Scenario P3: type=personal → 400.
+    {
+        let path = created_group_id.to_string();
+        let resp = h
+            .router
+            .clone()
+            .oneshot(patch_group_by_id(
+                Some(&creator_token),
+                &path,
+                Some(&path),
+                json!({"type": "personal"}),
+            ))
+            .await
+            .expect("P3: oneshot");
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "P3: personal rejected");
+        let v = body_json(resp).await;
+        assert!(
+            v["detail"].as_str().unwrap().contains("group type"),
+            "P3: detail mentions group type, got {v}"
+        );
+    }
+
+    // Scenario P4: non-member PATCH → 403 (Principal extractor).
+    {
+        let path = created_group_id.to_string();
+        let (_other_id, _other_group, other_token) =
+            seed_user_with_group(&h, "p4-outsider@0017.test")
+                .await
+                .expect("P4: seed outsider");
+        let resp = h
+            .router
+            .clone()
+            .oneshot(patch_group_by_id(
+                Some(&other_token),
+                &path,
+                Some(&path),
+                json!({"name": "hacked"}),
+            ))
+            .await
+            .expect("P4: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "P4: non-member PATCH must 403 (extractor)"
+        );
+    }
+
+    // Scenario P5: unauthenticated → 401.
+    {
+        let path = created_group_id.to_string();
+        let resp = h
+            .router
+            .clone()
+            .oneshot(patch_group_by_id(
+                None,
+                &path,
+                Some(&path),
+                json!({"name": "anon"}),
+            ))
+            .await
+            .expect("P5: oneshot");
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED, "P5: no JWT");
+    }
+
+    // Scenario P6: owner changes type team → family → 200.
+    {
+        let path = created_group_id.to_string();
+        let resp = h
+            .router
+            .clone()
+            .oneshot(patch_group_by_id(
+                Some(&creator_token),
+                &path,
+                Some(&path),
+                json!({"type": "family"}),
+            ))
+            .await
+            .expect("P6: oneshot");
+        assert_eq!(resp.status(), StatusCode::OK, "P6: type change");
+        let v = body_json(resp).await;
+        assert_eq!(v["type"], "family", "P6: type reflected in response");
     }
 }


### PR DESCRIPTION
## Summary

Implements **PATCH /v1/groups/{group_id}** — the first mutation endpoint on an existing tenant-root resource. Slice 1 of 3 of [GAR-393](https://linear.app/chatgpt25/issue/GAR-393). POST and GET already shipped via plan 0016 M4.

7 commits, ~330 LOC (150 production + 180 test). Zero migration, zero new role, zero enum change, zero ADR.

### What ships

- **`UpdateGroupRequest`** struct with `Option<String>` fields (name, type) + `validate()` + `is_empty()` + `deny_unknown_fields`
- **`patch_group` handler** — transactional `SET LOCAL app.current_user_id` + authz via `can(&principal, Action::GroupSettings)` + `COALESCE($new, column)` UPDATE + explicit `updated_at = now()` (no trigger in schema) + `RETURNING` for response
- **Route wiring** in all 3 modes (authed + fail-soft stubs)
- **OpenAPI** registration (`paths` + `schemas`)
- **6 bundled integration tests** in `rest_v1_groups.rs` (owner rename + empty body 400 + personal 400 + non-member 403 + 401 + type change 200)
- **4 authz matrix cases** expanding `authz_http_matrix.rs` from 15 → 19 (PATCH × owner/bob/eve/no-bearer)
- **8 unit tests** for `UpdateGroupRequest` (deserialize, validate, empty, personal, unknown fields)
- **Clippy fix** for `collapsible_if` in validate()

### Design invariants (non-negotiable)

1. **PATCH = partial modification** via `COALESCE($new, column)` — not PUT
2. **`updated_at = now()` set explicitly** in every UPDATE — no trigger (migration 001:115)
3. **`type = "personal"` rejected with 400** at 3 layers: validate fn, unit test, integration test
4. **Empty body → 400** with deterministic detail `"patch body must set at least one field"`

### Authz model (empirically validated via testcontainers)

| Condition | Status | Source |
|---|---|---|
| No JWT | 401 | JWT extractor |
| Non-member of target group | **403** | Principal extractor |
| Member without GroupSettings | **403** | `can()` check |
| X-Group-Id missing/mismatch | 400 | handler |
| Body invalid | 400 | `validate()` |
| Row deleted concurrently | 404 | UPDATE RETURNING empty |
| Owner/Admin happy path | 200 | handler |

### Explicitly out of scope

- **LIST /v1/groups** — not in GAR-393's endpoint list
- Invites / members / setRole / DELETE member — slice 2, plan 0018+
- Soft-delete, ETag, schemathesis, concurrency control
- Member-without-GroupSettings end-to-end test (deferred to slice 2 when member fixture ships; unit coverage via can.rs 110-case matrix exists)

## Test plan

- [x] `cargo check --workspace` ✅
- [x] `cargo clippy -p garraia-gateway --no-deps -- -D warnings` — 5 pre-existing warnings in `admin/*` + `bootstrap.rs`, **zero in `rest_v1/*`**
- [x] `cargo test -p garraia-gateway --lib` → **175/175 passed**
- [x] `cargo test --features test-helpers --test rest_v1_groups` → ✅ (13 bundled scenarios incl. 6 PATCH)
- [x] `cargo test --features test-helpers --test authz_http_matrix` → ✅ (19 cases)
- [x] `cargo test --features test-helpers --test rest_v1_me` → ✅
- [x] `cargo test --features test-helpers --test harness_smoke` → ✅
- [x] `cargo test --test router_smoke_test` → 3/3

All integration tests ran against Docker Desktop 29.2.1 with pgvector/pg16 via testcontainers.

### `updated_at` explicitly validated

Scenario P1 does `SELECT updated_at` before and after PATCH via `admin_pool` (bypasses RLS) and asserts `after > before`.

## Linear

- [GAR-393](https://linear.app/chatgpt25/issue/GAR-393) — status `Done` (auto-closed by PR #22 docs merge). Code PR linked below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)