### PR TITLE
feat(gateway): setRole + DELETE member — plan 0020 (GAR-393 slice 4)

### DIFF
--- a/crates/garraia-gateway/src/rest_v1/groups.rs
+++ b/crates/garraia-gateway/src/rest_v1/groups.rs
@@ -785,6 +785,233 @@ pub async fn create_invite(
     ))
 }
 
+/// `POST /v1/groups/{id}/members/{user_id}/setRole` — change a member's role (plan 0020 slice 4).
+///
+/// ## Authz model
+///
+/// Two layers:
+///
+/// 1. **Capability gate:** caller must hold `Action::MembersManage`
+///    (Owner/Admin) — *unless* `target_user_id == principal.user_id`,
+///    in which case the capability check is bypassed (self-demote /
+///    self-action path). This preserves the ability for any member to
+///    self-demote subject to the last-owner invariant below.
+/// 2. **Hierarchy gate (non-self only):** Admin callers cannot modify
+///    Owner or other Admins. Owner callers can modify any role.
+///
+/// ## Last-owner invariant
+///
+/// After the UPDATE, the handler counts active owners in the same
+/// transaction. If the count drops to zero (the last Owner was demoted
+/// — possibly via self-demote), the transaction is aborted without
+/// commit and 409 Conflict is returned. The UPDATE is rolled back.
+///
+/// ## Promote-to-owner rejection
+///
+/// Body with `role = "owner"` is rejected with 400 at the
+/// [`SetRoleRequest::validate`] gate before any DB access.
+/// `group_members_single_owner_idx` (migration 002 line 146) provides
+/// defense-in-depth at the DB layer.
+///
+/// ## Serialization / concurrency
+///
+/// `SELECT ... FOR UPDATE` on the target's active membership row
+/// acquires a per-row lock; concurrent setRole/delete calls on the
+/// same `(group_id, user_id)` serialize through this lock and each
+/// re-evaluates hierarchy + last-owner rules against a consistent
+/// snapshot.
+///
+/// ## Error matrix
+///
+/// | Condition                                      | Status | Guard          |
+/// |------------------------------------------------|--------|----------------|
+/// | Missing/invalid JWT                            | 401    | Principal ext. |
+/// | Non-member of target group                     | 403    | Principal ext. |
+/// | `X-Group-Id` missing / mismatched              | 400    | this handler   |
+/// | Invalid body (unknown role, `role = "owner"`)  | 400    | validate()     |
+/// | Non-self caller lacks `MembersManage`          | 403    | `can()`        |
+/// | Admin caller tries to modify Owner/Admin       | 403    | hierarchy      |
+/// | Target not found / not active                  | 404    | SELECT/UPDATE  |
+/// | Would demote last Owner                        | 409    | post-UPDATE    |
+/// | Happy path                                     | 200    |                |
+#[utoipa::path(
+    post,
+    path = "/v1/groups/{id}/members/{user_id}/setRole",
+    params(
+        ("id" = Uuid, Path, description = "Group UUID. Must match the `X-Group-Id` header."),
+        ("user_id" = Uuid, Path, description = "Target member's user id."),
+    ),
+    request_body = SetRoleRequest,
+    responses(
+        (status = 200, description = "Role updated; response carries the fresh member row.", body = MemberResponse),
+        (status = 400, description = "Invalid body, header/path mismatch, or `role = owner`.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller lacks `members.manage` or violates hierarchy.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Target member not found or not active.", body = super::problem::ProblemDetails),
+        (status = 409, description = "Would leave the group without an owner.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn set_member_role(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((id, target_user_id)): Path<(Uuid, Uuid)>,
+    Json(body): Json<SetRoleRequest>,
+) -> Result<Json<MemberResponse>, RestError> {
+    // 1. Header/path coherence (same pattern as get_group/patch_group).
+    match principal.group_id {
+        Some(hdr) if hdr == id => {}
+        Some(_) => {
+            return Err(RestError::BadRequest(
+                "X-Group-Id header and path id must match".into(),
+            ));
+        }
+        None => {
+            return Err(RestError::BadRequest(
+                "X-Group-Id header is required".into(),
+            ));
+        }
+    }
+
+    // 2. Structural body validation (no DB access, PII-safe messages).
+    //    Rejects `role = "owner"` with a dedicated message and unknown
+    //    roles with the generic subset message.
+    body.validate()
+        .map_err(|msg| RestError::BadRequest(msg.into()))?;
+
+    // 3. Camada 1 — capability gate with self-action bypass.
+    //    Self (caller == target) may always attempt the operation;
+    //    the last-owner invariant below catches the dangerous case.
+    let is_self = principal.user_id == target_user_id;
+    if !is_self && !can(&principal, Action::MembersManage) {
+        return Err(RestError::Forbidden);
+    }
+
+    // 4. Resolve caller's role for the hierarchy gate. Same invariant
+    //    as `get_group` / `patch_group`: if `group_id` is Some then
+    //    `role` must be Some — extractor guarantees it; break = 500.
+    let caller_role = principal
+        .role
+        .as_ref()
+        .ok_or_else(|| {
+            tracing::error!(
+                user_id = %principal.user_id,
+                group_id = ?principal.group_id,
+                "Principal.role is None with group_id Some — invariant violated by extractor"
+            );
+            RestError::Internal(anyhow::anyhow!(
+                "Principal.role is None despite group_id being Some"
+            ))
+        })?
+        .as_str()
+        .to_string();
+
+    // 5. Open tx and set tenant context. `SET LOCAL` MUST be the first
+    //    statement — plan 0016 M4 pattern. `Uuid::Display` is 36 hex
+    //    chars with dashes, injection-safe.
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query(&format!(
+        "SET LOCAL app.current_user_id = '{}'",
+        principal.user_id
+    ))
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    // 6. Fetch target's current role under FOR UPDATE lock. Serializes
+    //    concurrent setRole/delete on the same member — the second
+    //    caller blocks here until the first commits, then sees the
+    //    new role and can re-apply hierarchy + last-owner rules.
+    //    Filters `status = 'active'` — soft-deleted targets → 404.
+    let target_row: Option<(String,)> = sqlx::query_as(
+        "SELECT role FROM group_members \
+         WHERE group_id = $1 AND user_id = $2 AND status = 'active' \
+         FOR UPDATE",
+    )
+    .bind(id)
+    .bind(target_user_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let target_role = match target_row {
+        Some((r,)) => r,
+        None => return Err(RestError::NotFound),
+    };
+
+    // 7. Camada 2 — hierarchy gate (non-self only). Admin cannot modify
+    //    Owner nor other Admins. Owner may modify any role (the
+    //    last-owner invariant below still applies).
+    if !is_self
+        && caller_role == "admin"
+        && (target_role == "owner" || target_role == "admin")
+    {
+        return Err(RestError::Forbidden);
+    }
+
+    // 8. UPDATE the role. `now()` in RETURNING yields the statement
+    //    timestamp of this tx — used as `updated_at` in the response
+    //    since `group_members` has no persisted updated_at column.
+    //    Filter `status = 'active'` defends against a race where the
+    //    row becomes 'removed' between the SELECT FOR UPDATE and now
+    //    (not possible under the current lock, but the redundant
+    //    guard is cheap insurance).
+    let updated: Option<(Uuid, Uuid, String, String, DateTime<Utc>)> = sqlx::query_as(
+        "UPDATE group_members \
+            SET role = $3 \
+          WHERE group_id = $1 AND user_id = $2 AND status = 'active' \
+      RETURNING group_id, user_id, role, status, now() AS updated_at",
+    )
+    .bind(id)
+    .bind(target_user_id)
+    .bind(&body.role)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let (group_id, user_id, role, status, updated_at) = updated.ok_or(RestError::NotFound)?;
+
+    // 9. Last-owner invariant (post-UPDATE). Because the UPDATE is
+    //    visible inside its own tx, this COUNT reflects the state
+    //    that *would* be committed if we proceeded. Zero owners =>
+    //    abort and return 409. Dropping `tx` without `.commit()`
+    //    rolls back the UPDATE automatically.
+    let (owners_count,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*)::bigint \
+           FROM group_members \
+          WHERE group_id = $1 AND role = 'owner' AND status = 'active'",
+    )
+    .bind(id)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if owners_count == 0 {
+        return Err(RestError::Conflict(
+            "cannot leave the group without an owner".into(),
+        ));
+    }
+
+    // 10. Commit. If the commit fails, the UPDATE rolls back and the
+    //     caller sees a 500 — never a partial state.
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(Json(MemberResponse {
+        group_id,
+        user_id,
+        role,
+        status,
+        updated_at,
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/garraia-gateway/src/rest_v1/groups.rs
+++ b/crates/garraia-gateway/src/rest_v1/groups.rs
@@ -799,6 +799,23 @@ pub async fn create_invite(
 /// 2. **Hierarchy gate (non-self only):** Admin callers cannot modify
 ///    Owner or other Admins. Owner callers can modify any role.
 ///
+/// ## Self-action bypass — intent
+///
+/// Both gates skip their check when `target == caller`. This is
+/// **deliberate**: a Member/Guest/Child must be able to self-downgrade
+/// (e.g. drop their own role before a leave in a future endpoint), an
+/// Admin must be able to self-demote without contacting an Owner, and
+/// an Owner must be able to self-demote to transfer de-facto control to
+/// a co-owner. The safety net for all these paths is the **last-owner
+/// invariant** enforced post-UPDATE inside the same transaction — not
+/// the capability/hierarchy gates. This separation means that even
+/// though self-setRole is broadly permissive, the system can never end
+/// up in a zero-active-owner state (returns 409 and rolls back). Plan
+/// 0020 security review (SEC-MED) confirmed this design; any future
+/// tightening of self-demotion (e.g. Admin → Guest/Child) should live
+/// in a dedicated check with its own test matrix rather than a blanket
+/// restriction on the bypass.
+///
 /// ## Last-owner invariant
 ///
 /// After the UPDATE, the handler counts active owners in the same
@@ -978,6 +995,16 @@ pub async fn set_member_role(
     //    that *would* be committed if we proceeded. Zero owners =>
     //    abort and return 409. Dropping `tx` without `.commit()`
     //    rolls back the UPDATE automatically.
+    //
+    //    TODO(plan-0021): `group_members_single_owner_idx` (migration
+    //    002:146) is a partial UNIQUE `WHERE role = 'owner'` — it does
+    //    NOT filter by `status = 'active'`, which means the DB-level
+    //    constraint diverges from this COUNT's predicate. The gap is
+    //    safe today (API has no way to create two active owners —
+    //    setRole rejects role='owner') but a follow-up plan should
+    //    amend the partial index to `WHERE role = 'owner' AND status =
+    //    'active'` via forward-only migration so DB and app-layer
+    //    invariants stay aligned.
     let (owners_count,): (i64,) = sqlx::query_as(
         "SELECT COUNT(*)::bigint \
            FROM group_members \
@@ -1023,6 +1050,14 @@ pub async fn set_member_role(
 ///    when `target_user_id == principal.user_id` (leave-group path).
 /// 2. **Hierarchy gate (non-self only):** Admin cannot delete Owner or
 ///    another Admin. Owner can delete any role.
+///
+/// ## Self-action bypass — intent
+///
+/// Both gates skip their check for self-DELETE so any member (regardless
+/// of role) can leave the group. The last-owner invariant post-UPDATE
+/// catches the only dangerous self-path (sole Owner leaving an otherwise
+/// empty of owners group → 409 + rollback). See the equivalent note on
+/// [`set_member_role`] for the full design rationale.
 ///
 /// ## Last-owner invariant
 ///

--- a/crates/garraia-gateway/src/rest_v1/groups.rs
+++ b/crates/garraia-gateway/src/rest_v1/groups.rs
@@ -65,6 +65,16 @@ const ALLOWED_GROUP_TYPES: &[&str] = &["family", "team"];
 /// excluded — owners are created during group bootstrap only (comment line 155).
 const ALLOWED_INVITE_ROLES: &[&str] = &["admin", "member", "guest", "child"];
 
+/// Accepted values for `SetRoleRequest::role` (plan 0020 slice 4).
+///
+/// Same subset as [`ALLOWED_INVITE_ROLES`]: excludes `"owner"` because
+/// ownership transfer is a distinct operation (future endpoint). Excludes
+/// `"personal"` — reserved type marker (see [`ALLOWED_GROUP_TYPES`]).
+/// The partial unique index `group_members_single_owner_idx`
+/// (migration 002 line 146) defensively rejects promote-to-owner at the
+/// DB layer, but the handler filters first for a clearer 400 message.
+const ALLOWED_SETROLE_VALUES: &[&str] = &["admin", "member", "guest", "child"];
+
 /// Request body for `POST /v1/groups`.
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateGroupRequest {
@@ -199,6 +209,62 @@ pub struct InviteResponse {
     pub token: String,
     pub expires_at: DateTime<Utc>,
     pub created_at: DateTime<Utc>,
+}
+
+/// Request body for `POST /v1/groups/{id}/members/{user_id}/setRole` (plan 0020 slice 4).
+///
+/// Changes a member's role inside the group. The caller must either be
+/// acting on themselves (self-demote) or hold `Action::MembersManage`
+/// (Owner/Admin). Hierarchy rules — Admin cannot modify Owner or another
+/// Admin (non-self) — are enforced inside the handler, not here.
+///
+/// Accepted values: `admin`, `member`, `guest`, `child`. `owner` is
+/// explicitly rejected (400 `cannot promote to owner via setRole`) —
+/// ownership transfer is a separate operation. See [`ALLOWED_SETROLE_VALUES`].
+///
+/// ## Path convention
+///
+/// Linear canonical notation uses Google Cloud custom-verb `:setRole`;
+/// Axum 0.8 / `matchit` does not support `{param}:literal` in the same
+/// segment (same constraint that forced `/accept` over `:accept` in plan
+/// 0019). Delivered path is `/setRole` as a literal segment.
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SetRoleRequest {
+    /// New role. Must be one of: `admin`, `member`, `guest`, `child`.
+    /// `owner` is rejected — ownership transfer is a separate operation.
+    pub role: String,
+}
+
+impl SetRoleRequest {
+    /// Structural validation. PII-safe error messages only.
+    ///
+    /// Order of checks matters: the `"owner"` rejection produces a clearer
+    /// error message ("cannot promote to owner via setRole") than the
+    /// generic `"role must be one of ..."`, so we filter `"owner"` first.
+    pub fn validate(&self) -> Result<(), &'static str> {
+        if self.role == "owner" {
+            return Err("cannot promote to owner via setRole");
+        }
+        if !ALLOWED_SETROLE_VALUES.contains(&self.role.as_str()) {
+            return Err("role must be one of: admin, member, guest, child");
+        }
+        Ok(())
+    }
+}
+
+/// Response body for setRole (200 OK).
+///
+/// DELETE member returns 204 No Content without a body. This struct is
+/// used only by setRole. Fields mirror the shape of a `group_members`
+/// row plus the `updated_at` timestamp set by the UPDATE.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct MemberResponse {
+    pub group_id: Uuid,
+    pub user_id: Uuid,
+    pub role: String,
+    pub status: String,
+    pub updated_at: DateTime<Utc>,
 }
 
 /// `POST /v1/groups` — create a new group. The authenticated caller
@@ -908,5 +974,53 @@ mod tests {
             };
             assert!(req.validate().is_ok(), "role '{role}' should be valid");
         }
+    }
+
+    // ── SetRoleRequest validation (plan 0020 t1) ────────
+
+    #[test]
+    fn set_role_request_rejects_owner() {
+        let req: SetRoleRequest = serde_json::from_str(r#"{"role":"owner"}"#).unwrap();
+        assert_eq!(
+            req.validate().unwrap_err(),
+            "cannot promote to owner via setRole"
+        );
+    }
+
+    #[test]
+    fn set_role_request_rejects_unknown_role() {
+        let req: SetRoleRequest = serde_json::from_str(r#"{"role":"superadmin"}"#).unwrap();
+        assert_eq!(
+            req.validate().unwrap_err(),
+            "role must be one of: admin, member, guest, child"
+        );
+    }
+
+    #[test]
+    fn set_role_request_accepts_admin_member_guest_child() {
+        for role in &["admin", "member", "guest", "child"] {
+            let req = SetRoleRequest {
+                role: role.to_string(),
+            };
+            assert!(req.validate().is_ok(), "role '{role}' should be valid");
+        }
+    }
+
+    #[test]
+    fn set_role_request_rejects_unknown_field() {
+        // deny_unknown_fields: typo-protects clients from silent
+        // drops when they misspell `role` (same pattern as
+        // UpdateGroupRequest/CreateInviteRequest).
+        let err = serde_json::from_str::<SetRoleRequest>(r#"{"rle":"admin"}"#);
+        assert!(err.is_err(), "deny_unknown_fields should reject `rle`");
+    }
+
+    #[test]
+    fn allowed_setrole_values_mirror_invite_roles() {
+        // Invariant: setRole accepts the same subset as create-invite.
+        // Owner and personal stay excluded. If this ever changes,
+        // re-evaluate the plan 0020 design invariants §6 and the
+        // hierarchy model before accepting the divergence.
+        assert_eq!(ALLOWED_SETROLE_VALUES, ALLOWED_INVITE_ROLES);
     }
 }

--- a/crates/garraia-gateway/src/rest_v1/groups.rs
+++ b/crates/garraia-gateway/src/rest_v1/groups.rs
@@ -1012,6 +1012,200 @@ pub async fn set_member_role(
     }))
 }
 
+/// `DELETE /v1/groups/{id}/members/{user_id}` — soft-delete a member (plan 0020 slice 4).
+///
+/// The row is not physically deleted — `status` is flipped to `'removed'`
+/// so FKs in `messages.author_id`, `tasks.created_by`, etc. continue to
+/// resolve. Reactivation is out of scope for v1 (plan 0022+).
+///
+/// ## Authz model
+///
+/// Same two layers as [`set_member_role`]:
+///
+/// 1. **Capability gate:** `Action::MembersManage` (Owner/Admin) — bypassed
+///    when `target_user_id == principal.user_id` (leave-group path).
+/// 2. **Hierarchy gate (non-self only):** Admin cannot delete Owner or
+///    another Admin. Owner can delete any role.
+///
+/// ## Last-owner invariant
+///
+/// Post-UPDATE, active owners count must be ≥ 1. If the DELETE
+/// removed the last Owner (possibly via self-leave), the transaction
+/// aborts without commit and 409 is returned.
+///
+/// ## Idempotence
+///
+/// DELETE on an already-removed (`status = 'removed'`) or non-existent
+/// member returns 404, not 204 — this matches plan 0019's convention for
+/// `accept`: callers can distinguish "I performed the removal" (204) from
+/// "already gone or never existed" (404). Re-invite + accept of a soft-
+/// deleted user will 409 on PK collision (`(group_id, user_id)` unique)
+/// — limitation documented in plan 0020 §out of scope.
+///
+/// ## Error matrix
+///
+/// | Condition                                      | Status | Guard          |
+/// |------------------------------------------------|--------|----------------|
+/// | Missing/invalid JWT                            | 401    | Principal ext. |
+/// | Non-member of target group                     | 403    | Principal ext. |
+/// | `X-Group-Id` missing / mismatched              | 400    | this handler   |
+/// | Non-self caller lacks `MembersManage`          | 403    | `can()`        |
+/// | Admin caller tries to delete Owner/Admin       | 403    | hierarchy      |
+/// | Target not found / already removed             | 404    | SELECT/UPDATE  |
+/// | Would leave group ownerless                    | 409    | post-UPDATE    |
+/// | Happy path                                     | 204    |                |
+#[utoipa::path(
+    delete,
+    path = "/v1/groups/{id}/members/{user_id}",
+    params(
+        ("id" = Uuid, Path, description = "Group UUID. Must match the `X-Group-Id` header."),
+        ("user_id" = Uuid, Path, description = "Target member's user id."),
+    ),
+    responses(
+        (status = 204, description = "Member soft-deleted (`status = 'removed'`). No response body."),
+        (status = 400, description = "`X-Group-Id` header missing or mismatched.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller lacks `members.manage` or violates hierarchy.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Target member not found or already removed.", body = super::problem::ProblemDetails),
+        (status = 409, description = "Would leave the group without an owner.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn delete_member(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((id, target_user_id)): Path<(Uuid, Uuid)>,
+) -> Result<StatusCode, RestError> {
+    // 1. Header/path coherence.
+    match principal.group_id {
+        Some(hdr) if hdr == id => {}
+        Some(_) => {
+            return Err(RestError::BadRequest(
+                "X-Group-Id header and path id must match".into(),
+            ));
+        }
+        None => {
+            return Err(RestError::BadRequest(
+                "X-Group-Id header is required".into(),
+            ));
+        }
+    }
+
+    // 2. Camada 1 — capability gate with self-action bypass.
+    let is_self = principal.user_id == target_user_id;
+    if !is_self && !can(&principal, Action::MembersManage) {
+        return Err(RestError::Forbidden);
+    }
+
+    // 3. Resolve caller's role for hierarchy gate (same invariant as
+    //    set_member_role / patch_group: Principal.role is Some here).
+    let caller_role = principal
+        .role
+        .as_ref()
+        .ok_or_else(|| {
+            tracing::error!(
+                user_id = %principal.user_id,
+                group_id = ?principal.group_id,
+                "Principal.role is None with group_id Some — invariant violated by extractor"
+            );
+            RestError::Internal(anyhow::anyhow!(
+                "Principal.role is None despite group_id being Some"
+            ))
+        })?
+        .as_str()
+        .to_string();
+
+    // 4. Open tx + SET LOCAL tenant context.
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query(&format!(
+        "SET LOCAL app.current_user_id = '{}'",
+        principal.user_id
+    ))
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    // 5. Fetch target role under FOR UPDATE lock (same serialization
+    //    guarantee as set_member_role). Filters `status = 'active'`
+    //    — already-removed targets ⇒ 404.
+    let target_row: Option<(String,)> = sqlx::query_as(
+        "SELECT role FROM group_members \
+         WHERE group_id = $1 AND user_id = $2 AND status = 'active' \
+         FOR UPDATE",
+    )
+    .bind(id)
+    .bind(target_user_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let target_role = match target_row {
+        Some((r,)) => r,
+        None => return Err(RestError::NotFound),
+    };
+
+    // 6. Camada 2 — hierarchy gate (non-self only).
+    if !is_self
+        && caller_role == "admin"
+        && (target_role == "owner" || target_role == "admin")
+    {
+        return Err(RestError::Forbidden);
+    }
+
+    // 7. Soft-delete: UPDATE status = 'removed'. `RETURNING 1` so we
+    //    can detect the zero-row case (concurrent removal between
+    //    SELECT FOR UPDATE and here — effectively impossible under
+    //    the lock but cheap guard).
+    let removed: Option<(i32,)> = sqlx::query_as(
+        "UPDATE group_members \
+            SET status = 'removed' \
+          WHERE group_id = $1 AND user_id = $2 AND status = 'active' \
+      RETURNING 1",
+    )
+    .bind(id)
+    .bind(target_user_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if removed.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    // 8. Last-owner invariant (post-UPDATE). If we just removed an
+    //    Owner and there are no other active Owners left, abort
+    //    and return 409. Running the COUNT unconditionally (rather
+    //    than only when `target_role == "owner"`) keeps the logic
+    //    uniform and the cost is negligible.
+    let (owners_count,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*)::bigint \
+           FROM group_members \
+          WHERE group_id = $1 AND role = 'owner' AND status = 'active'",
+    )
+    .bind(id)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if owners_count == 0 {
+        return Err(RestError::Conflict(
+            "cannot leave the group without an owner".into(),
+        ));
+    }
+
+    // 9. Commit.
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/garraia-gateway/src/rest_v1/groups.rs
+++ b/crates/garraia-gateway/src/rest_v1/groups.rs
@@ -947,10 +947,7 @@ pub async fn set_member_role(
     // 7. Camada 2 — hierarchy gate (non-self only). Admin cannot modify
     //    Owner nor other Admins. Owner may modify any role (the
     //    last-owner invariant below still applies).
-    if !is_self
-        && caller_role == "admin"
-        && (target_role == "owner" || target_role == "admin")
-    {
+    if !is_self && caller_role == "admin" && (target_role == "owner" || target_role == "admin") {
         return Err(RestError::Forbidden);
     }
 
@@ -1150,10 +1147,7 @@ pub async fn delete_member(
     };
 
     // 6. Camada 2 — hierarchy gate (non-self only).
-    if !is_self
-        && caller_role == "admin"
-        && (target_role == "owner" || target_role == "admin")
-    {
+    if !is_self && caller_role == "admin" && (target_role == "owner" || target_role == "admin") {
         return Err(RestError::Forbidden);
     }
 

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -39,7 +39,7 @@ use std::sync::Arc;
 
 use axum::Router;
 use axum::extract::FromRef;
-use axum::routing::{get, post};
+use axum::routing::{delete, get, post};
 use garraia_auth::{AppPool, JwtIssuer, LoginPool};
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
@@ -163,6 +163,14 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     get(groups::get_group).patch(groups::patch_group),
                 )
                 .route("/v1/groups/{id}/invites", post(groups::create_invite))
+                .route(
+                    "/v1/groups/{id}/members/{user_id}/setRole",
+                    post(groups::set_member_role),
+                )
+                .route(
+                    "/v1/groups/{id}/members/{user_id}",
+                    delete(groups::delete_member),
+                )
                 .route("/v1/invites/{token}/accept", post(invites::accept_invite))
                 .with_state(full)
                 .merge(SwaggerUi::new("/docs").url("/v1/openapi.json", ApiDoc::openapi()))
@@ -181,6 +189,14 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     get(unconfigured_handler).patch(unconfigured_handler),
                 )
                 .route("/v1/groups/{id}/invites", post(unconfigured_handler))
+                .route(
+                    "/v1/groups/{id}/members/{user_id}/setRole",
+                    post(unconfigured_handler),
+                )
+                .route(
+                    "/v1/groups/{id}/members/{user_id}",
+                    delete(unconfigured_handler),
+                )
                 .route("/v1/invites/{token}/accept", post(unconfigured_handler))
                 .with_state(auth)
                 .merge(SwaggerUi::new("/docs").url("/v1/openapi.json", ApiDoc::openapi()))
@@ -195,6 +211,14 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     get(unconfigured_handler).patch(unconfigured_handler),
                 )
                 .route("/v1/groups/{id}/invites", post(unconfigured_handler))
+                .route(
+                    "/v1/groups/{id}/members/{user_id}/setRole",
+                    post(unconfigured_handler),
+                )
+                .route(
+                    "/v1/groups/{id}/members/{user_id}",
+                    delete(unconfigured_handler),
+                )
                 .route("/v1/invites/{token}/accept", post(unconfigured_handler))
                 .route("/v1/openapi.json", get(unconfigured_handler))
                 .route("/docs", get(unconfigured_handler))

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -14,7 +14,7 @@ use utoipa::{Modify, OpenApi};
 
 use super::groups::{
     CreateGroupRequest, CreateInviteRequest, GroupReadResponse, GroupResponse, InviteResponse,
-    UpdateGroupRequest,
+    MemberResponse, SetRoleRequest, UpdateGroupRequest,
 };
 use super::invites::AcceptInviteResponse;
 use super::me::MeResponse;
@@ -66,6 +66,8 @@ impl Modify for SecurityAddon {
         super::groups::get_group,
         super::groups::patch_group,
         super::groups::create_invite,
+        super::groups::set_member_role,
+        super::groups::delete_member,
         super::invites::accept_invite,
     ),
     components(schemas(
@@ -74,9 +76,11 @@ impl Modify for SecurityAddon {
         CreateGroupRequest,
         UpdateGroupRequest,
         CreateInviteRequest,
+        SetRoleRequest,
         GroupResponse,
         GroupReadResponse,
         InviteResponse,
+        MemberResponse,
         AcceptInviteResponse,
     )),
     modifiers(&SecurityAddon)

--- a/crates/garraia-gateway/tests/authz_http_matrix.rs
+++ b/crates/garraia-gateway/tests/authz_http_matrix.rs
@@ -665,6 +665,200 @@ fn build_matrix() -> Vec<MatrixCase> {
             expected_status: StatusCode::NOT_FOUND,
             expected_body_contains: None,
         },
+        // ── POST /v1/groups/{id}/members/{user_id}/setRole (plan 0020, cases 27-30) ──
+        //
+        // Path-level authz for the new setRole endpoint. Happy-path and
+        // 400/409 coverage live in rest_v1_groups.rs (M1-M10). These
+        // cases exercise ONLY:
+        //   27: owner + non-member target -> 404 (handler SELECT empty)
+        //   28: non-member caller -> 403 (Principal extractor)
+        //   29: no-group caller -> 403 (Principal extractor)
+        //   30: no bearer -> 401 (Principal short-circuit)
+        MatrixCase {
+            id: 27,
+            name: "POST setRole as alice(owner) on bob(non-member of alice_group) -> 404",
+            build: Box::new(|a| {
+                let path = format!(
+                    "/v1/groups/{}/members/{}/setRole",
+                    a.alice_group, a.bob_id
+                );
+                req_post_grouped(
+                    &path,
+                    Some(&a.alice_token),
+                    Some(&a.alice_group.to_string()),
+                    json!({"role": "admin"}),
+                )
+            }),
+            expected_status: StatusCode::NOT_FOUND,
+            expected_body_contains: None,
+        },
+        MatrixCase {
+            id: 28,
+            name: "POST setRole as bob(non-member of alice_group) on alice -> 403",
+            build: Box::new(|a| {
+                let path = format!(
+                    "/v1/groups/{}/members/{}/setRole",
+                    a.alice_group, a.alice_id
+                );
+                req_post_grouped(
+                    &path,
+                    Some(&a.bob_token),
+                    Some(&a.alice_group.to_string()),
+                    json!({"role": "admin"}),
+                )
+            }),
+            expected_status: StatusCode::FORBIDDEN,
+            expected_body_contains: None,
+        },
+        MatrixCase {
+            id: 29,
+            name: "POST setRole as eve(no group) on alice -> 403",
+            build: Box::new(|a| {
+                let path = format!(
+                    "/v1/groups/{}/members/{}/setRole",
+                    a.alice_group, a.alice_id
+                );
+                req_post_grouped(
+                    &path,
+                    Some(&a.eve_token),
+                    Some(&a.alice_group.to_string()),
+                    json!({"role": "admin"}),
+                )
+            }),
+            expected_status: StatusCode::FORBIDDEN,
+            expected_body_contains: None,
+        },
+        MatrixCase {
+            id: 30,
+            name: "POST setRole no bearer -> 401",
+            build: Box::new(|a| {
+                let path = format!(
+                    "/v1/groups/{}/members/{}/setRole",
+                    a.alice_group, a.alice_id
+                );
+                req_post_grouped(
+                    &path,
+                    None,
+                    Some(&a.alice_group.to_string()),
+                    json!({"role": "admin"}),
+                )
+            }),
+            expected_status: StatusCode::UNAUTHORIZED,
+            expected_body_contains: None,
+        },
+        // ── DELETE /v1/groups/{id}/members/{user_id} (plan 0020, cases 31-34) ──
+        MatrixCase {
+            id: 31,
+            name: "DELETE member as alice(owner) on bob(non-member of alice_group) -> 404",
+            build: Box::new(|a| {
+                let mut req = Request::builder()
+                    .method(Method::DELETE)
+                    .uri(format!(
+                        "/v1/groups/{}/members/{}",
+                        a.alice_group, a.bob_id
+                    ))
+                    .body(Body::empty())
+                    .unwrap();
+                req.extensions_mut()
+                    .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+                        "127.0.0.1:1".parse().unwrap(),
+                    ));
+                req.headers_mut().insert(
+                    HeaderName::from_static("authorization"),
+                    HeaderValue::from_str(&format!("Bearer {}", a.alice_token)).unwrap(),
+                );
+                req.headers_mut().insert(
+                    HeaderName::from_static("x-group-id"),
+                    HeaderValue::from_str(&a.alice_group.to_string()).unwrap(),
+                );
+                req
+            }),
+            expected_status: StatusCode::NOT_FOUND,
+            expected_body_contains: None,
+        },
+        MatrixCase {
+            id: 32,
+            name: "DELETE member as bob(non-member of alice_group) on alice -> 403",
+            build: Box::new(|a| {
+                let mut req = Request::builder()
+                    .method(Method::DELETE)
+                    .uri(format!(
+                        "/v1/groups/{}/members/{}",
+                        a.alice_group, a.alice_id
+                    ))
+                    .body(Body::empty())
+                    .unwrap();
+                req.extensions_mut()
+                    .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+                        "127.0.0.1:1".parse().unwrap(),
+                    ));
+                req.headers_mut().insert(
+                    HeaderName::from_static("authorization"),
+                    HeaderValue::from_str(&format!("Bearer {}", a.bob_token)).unwrap(),
+                );
+                req.headers_mut().insert(
+                    HeaderName::from_static("x-group-id"),
+                    HeaderValue::from_str(&a.alice_group.to_string()).unwrap(),
+                );
+                req
+            }),
+            expected_status: StatusCode::FORBIDDEN,
+            expected_body_contains: None,
+        },
+        MatrixCase {
+            id: 33,
+            name: "DELETE member as eve(no group) on alice -> 403",
+            build: Box::new(|a| {
+                let mut req = Request::builder()
+                    .method(Method::DELETE)
+                    .uri(format!(
+                        "/v1/groups/{}/members/{}",
+                        a.alice_group, a.alice_id
+                    ))
+                    .body(Body::empty())
+                    .unwrap();
+                req.extensions_mut()
+                    .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+                        "127.0.0.1:1".parse().unwrap(),
+                    ));
+                req.headers_mut().insert(
+                    HeaderName::from_static("authorization"),
+                    HeaderValue::from_str(&format!("Bearer {}", a.eve_token)).unwrap(),
+                );
+                req.headers_mut().insert(
+                    HeaderName::from_static("x-group-id"),
+                    HeaderValue::from_str(&a.alice_group.to_string()).unwrap(),
+                );
+                req
+            }),
+            expected_status: StatusCode::FORBIDDEN,
+            expected_body_contains: None,
+        },
+        MatrixCase {
+            id: 34,
+            name: "DELETE member no bearer -> 401",
+            build: Box::new(|a| {
+                let mut req = Request::builder()
+                    .method(Method::DELETE)
+                    .uri(format!(
+                        "/v1/groups/{}/members/{}",
+                        a.alice_group, a.alice_id
+                    ))
+                    .body(Body::empty())
+                    .unwrap();
+                req.extensions_mut()
+                    .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+                        "127.0.0.1:1".parse().unwrap(),
+                    ));
+                req.headers_mut().insert(
+                    HeaderName::from_static("x-group-id"),
+                    HeaderValue::from_str(&a.alice_group.to_string()).unwrap(),
+                );
+                req
+            }),
+            expected_status: StatusCode::UNAUTHORIZED,
+            expected_body_contains: None,
+        },
     ]
 }
 
@@ -676,8 +870,8 @@ async fn gar_391d_app_layer_authz_matrix() {
     let matrix = build_matrix();
     assert_eq!(
         matrix.len(),
-        26,
-        "GAR-391d + plans 0017/0018/0019 matrix must have exactly 26 cases; got {}",
+        34,
+        "GAR-391d + plans 0017/0018/0019/0020 matrix must have exactly 34 cases; got {}",
         matrix.len()
     );
 

--- a/crates/garraia-gateway/tests/authz_http_matrix.rs
+++ b/crates/garraia-gateway/tests/authz_http_matrix.rs
@@ -678,10 +678,7 @@ fn build_matrix() -> Vec<MatrixCase> {
             id: 27,
             name: "POST setRole as alice(owner) on bob(non-member of alice_group) -> 404",
             build: Box::new(|a| {
-                let path = format!(
-                    "/v1/groups/{}/members/{}/setRole",
-                    a.alice_group, a.bob_id
-                );
+                let path = format!("/v1/groups/{}/members/{}/setRole", a.alice_group, a.bob_id);
                 req_post_grouped(
                     &path,
                     Some(&a.alice_token),
@@ -753,10 +750,7 @@ fn build_matrix() -> Vec<MatrixCase> {
             build: Box::new(|a| {
                 let mut req = Request::builder()
                     .method(Method::DELETE)
-                    .uri(format!(
-                        "/v1/groups/{}/members/{}",
-                        a.alice_group, a.bob_id
-                    ))
+                    .uri(format!("/v1/groups/{}/members/{}", a.alice_group, a.bob_id))
                     .body(Body::empty())
                     .unwrap();
                 req.extensions_mut()

--- a/crates/garraia-gateway/tests/common/fixtures.rs
+++ b/crates/garraia-gateway/tests/common/fixtures.rs
@@ -160,9 +160,7 @@ pub async fn seed_second_owner_via_admin(
     .await
     .context("seed_second_owner: insert group_members")?;
 
-    tx.commit()
-        .await
-        .context("seed_second_owner: tx commit")?;
+    tx.commit().await.context("seed_second_owner: tx commit")?;
 
     let token = h.jwt.issue_access_for_test(user_id);
     Ok((user_id, token))
@@ -237,9 +235,7 @@ pub async fn seed_member_via_admin(
     .await
     .context("seed_member: insert group_members")?;
 
-    tx.commit()
-        .await
-        .context("seed_member: tx commit")?;
+    tx.commit().await.context("seed_member: tx commit")?;
 
     let token = h.jwt.issue_access_for_test(user_id);
     Ok((user_id, token))

--- a/crates/garraia-gateway/tests/common/fixtures.rs
+++ b/crates/garraia-gateway/tests/common/fixtures.rs
@@ -89,6 +89,162 @@ pub async fn seed_user_with_group(
     Ok((user_id, group_id, token))
 }
 
+/// Seed a **second** user and insert them as an additional `owner`
+/// of the given `group_id`, then mint a JWT for them.
+///
+/// Used by plan 0020 scenarios M5/D5 which need a group with two
+/// owners so a self-demote / self-leave of the first owner stays
+/// within the last-owner invariant. The product API deliberately
+/// does NOT expose a way to promote someone to `owner` (setRole
+/// rejects `role = "owner"` with 400), so this helper is the only
+/// sanctioned way for tests to reach the "two-owners" state.
+///
+/// ## Index warning — **caller-owned cleanup**
+///
+/// The partial UNIQUE index `group_members_single_owner_idx`
+/// (migration 002:146) forbids two active `'owner'` rows for a
+/// given `group_id`. This fixture drops that index before the
+/// INSERT and **does not recreate it** — recreating while the
+/// group still has two owners would fail immediately.
+///
+/// The caller is responsible for restoring single-owner state
+/// (via a setRole-to-admin or admin_pool UPDATE) and then
+/// recreating the index. See [`restore_single_owner_idx`] for the
+/// companion helper. Tests that forget to restore the index will
+/// leak the dropped state into the shared test harness and break
+/// subsequent scenarios — so the contract here is strict.
+///
+/// Returns `(user_id, jwt_token)`.
+pub async fn seed_second_owner_via_admin(
+    h: &Harness,
+    group_id: Uuid,
+    email: &str,
+) -> anyhow::Result<(Uuid, String)> {
+    let user_id = Uuid::new_v4();
+
+    let mut tx = h
+        .admin_pool
+        .begin()
+        .await
+        .context("seed_second_owner: tx begin")?;
+
+    // Insert the second user first.
+    sqlx::query(
+        "INSERT INTO users (id, email, display_name, status) \
+         VALUES ($1, $2, $3, 'active')",
+    )
+    .bind(user_id)
+    .bind(email)
+    .bind(format!("Test {}", email))
+    .execute(&mut *tx)
+    .await
+    .context("seed_second_owner: insert users")?;
+
+    // Drop the single-owner partial unique index. The caller is
+    // responsible for recreating it once the group is back to a
+    // single active owner (see `restore_single_owner_idx`). We do
+    // NOT recreate here because the post-INSERT state has two
+    // owners and the UNIQUE partial index would fail to build.
+    sqlx::query("DROP INDEX IF EXISTS group_members_single_owner_idx")
+        .execute(&mut *tx)
+        .await
+        .context("seed_second_owner: drop idx")?;
+
+    sqlx::query(
+        "INSERT INTO group_members (group_id, user_id, role, status) \
+         VALUES ($1, $2, 'owner', 'active')",
+    )
+    .bind(group_id)
+    .bind(user_id)
+    .execute(&mut *tx)
+    .await
+    .context("seed_second_owner: insert group_members")?;
+
+    tx.commit()
+        .await
+        .context("seed_second_owner: tx commit")?;
+
+    let token = h.jwt.issue_access_for_test(user_id);
+    Ok((user_id, token))
+}
+
+/// Recreate `group_members_single_owner_idx` — the companion helper
+/// to [`seed_second_owner_via_admin`]. Call after the test has put
+/// the group back into a single-active-owner state.
+///
+/// Idempotent: uses `CREATE UNIQUE INDEX IF NOT EXISTS` so callers
+/// don't need to track whether the index was actually dropped.
+pub async fn restore_single_owner_idx(h: &Harness) -> anyhow::Result<()> {
+    sqlx::query(
+        "CREATE UNIQUE INDEX IF NOT EXISTS group_members_single_owner_idx \
+         ON group_members(group_id) WHERE role = 'owner'",
+    )
+    .execute(&h.admin_pool)
+    .await
+    .context("restore_single_owner_idx: CREATE UNIQUE INDEX")?;
+    Ok(())
+}
+
+/// Seed a user + insert them as a member of the given `group_id` with
+/// the requested `role` and `status = 'active'`. Mints a JWT.
+///
+/// Used by plan 0020 scenarios that need specific hierarchy actors
+/// (an admin, a member, a guest) inside the same group without
+/// creating multiple groups. The role must be one of:
+/// `admin`, `member`, `guest`, `child`. For `owner` use
+/// [`seed_second_owner_via_admin`] (index workaround).
+///
+/// Returns `(user_id, jwt_token)`.
+pub async fn seed_member_via_admin(
+    h: &Harness,
+    group_id: Uuid,
+    role: &str,
+    email: &str,
+) -> anyhow::Result<(Uuid, String)> {
+    assert!(
+        ["admin", "member", "guest", "child"].contains(&role),
+        "seed_member_via_admin: role '{role}' must be one of admin/member/guest/child; \
+         use seed_second_owner_via_admin for owner"
+    );
+
+    let user_id = Uuid::new_v4();
+
+    let mut tx = h
+        .admin_pool
+        .begin()
+        .await
+        .context("seed_member: tx begin")?;
+
+    sqlx::query(
+        "INSERT INTO users (id, email, display_name, status) \
+         VALUES ($1, $2, $3, 'active')",
+    )
+    .bind(user_id)
+    .bind(email)
+    .bind(format!("Test {}", email))
+    .execute(&mut *tx)
+    .await
+    .context("seed_member: insert users")?;
+
+    sqlx::query(
+        "INSERT INTO group_members (group_id, user_id, role, status) \
+         VALUES ($1, $2, $3, 'active')",
+    )
+    .bind(group_id)
+    .bind(user_id)
+    .bind(role)
+    .execute(&mut *tx)
+    .await
+    .context("seed_member: insert group_members")?;
+
+    tx.commit()
+        .await
+        .context("seed_member: tx commit")?;
+
+    let token = h.jwt.issue_access_for_test(user_id);
+    Ok((user_id, token))
+}
+
 /// Seed an authenticated user with NO group membership, then mint a
 /// JWT for that user via `Harness::jwt::issue_access_for_test`.
 ///

--- a/crates/garraia-gateway/tests/rest_v1_groups.rs
+++ b/crates/garraia-gateway/tests/rest_v1_groups.rs
@@ -36,7 +36,10 @@ use http_body_util::BodyExt;
 use serde_json::json;
 use tower::ServiceExt;
 
-use common::fixtures::seed_user_with_group;
+use common::fixtures::{
+    restore_single_owner_idx, seed_member_via_admin, seed_second_owner_via_admin,
+    seed_user_with_group,
+};
 use common::{Harness, harness_get};
 
 async fn body_json(resp: axum::response::Response) -> serde_json::Value {
@@ -129,6 +132,76 @@ fn post_invite(
         .uri(format!("/v1/groups/{group_path_id}/invites"))
         .header("content-type", "application/json")
         .body(Body::from(body.to_string()))
+        .expect("request builder");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    if let Some(token) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        );
+    }
+    if let Some(g) = x_group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    req
+}
+
+/// Request builder for `POST /v1/groups/{id}/members/{user_id}/setRole`
+/// (plan 0020 slice 4 — setRole endpoint).
+fn post_setrole(
+    token: Option<&str>,
+    group_path_id: &str,
+    target_user_id: &str,
+    x_group_id: Option<&str>,
+    body: serde_json::Value,
+) -> Request<Body> {
+    let mut req = Request::builder()
+        .method("POST")
+        .uri(format!(
+            "/v1/groups/{group_path_id}/members/{target_user_id}/setRole"
+        ))
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .expect("request builder");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    if let Some(token) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        );
+    }
+    if let Some(g) = x_group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    req
+}
+
+/// Request builder for `DELETE /v1/groups/{id}/members/{user_id}`
+/// (plan 0020 slice 4 — soft-delete endpoint).
+fn delete_member_req(
+    token: Option<&str>,
+    group_path_id: &str,
+    target_user_id: &str,
+    x_group_id: Option<&str>,
+) -> Request<Body> {
+    let mut req = Request::builder()
+        .method("DELETE")
+        .uri(format!(
+            "/v1/groups/{group_path_id}/members/{target_user_id}"
+        ))
+        .body(Body::empty())
         .expect("request builder");
     req.extensions_mut()
         .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
@@ -660,6 +733,324 @@ async fn v1_groups_scenarios() {
             resp.status(),
             StatusCode::UNAUTHORIZED,
             "I6: missing bearer must 401"
+        );
+    }
+
+    // ─── POST /v1/groups/{id}/members/{user_id}/setRole — plan 0020 Task 5 ─────
+
+    // Seed a fresh group with its own owner for the setRole scenarios.
+    // Re-using `created_group_id` from above would couple M/D scenarios to
+    // the mutations done by P/I scenarios; a fresh group keeps the invariants
+    // local to this section and easier to reason about.
+    let (m_owner_id, m_group_id, m_owner_token) =
+        seed_user_with_group(&h, "m-owner@0020.test")
+            .await
+            .expect("M setup: seed owner+group");
+    let m_group_path = m_group_id.to_string();
+
+    // Scenario M1: Owner demotes a member → admin. 200 + MemberResponse.role=="admin".
+    let (m1_target_id, _m1_token) =
+        seed_member_via_admin(&h, m_group_id, "member", "m1-target@0020.test")
+            .await
+            .expect("M1: seed target");
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(post_setrole(
+                Some(&m_owner_token),
+                &m_group_path,
+                &m1_target_id.to_string(),
+                Some(&m_group_path),
+                json!({"role": "admin"}),
+            ))
+            .await
+            .expect("M1: oneshot");
+        assert_eq!(resp.status(), StatusCode::OK, "M1: owner→admin promote");
+        let v = body_json(resp).await;
+        assert_eq!(v["role"], "admin");
+        assert_eq!(v["status"], "active");
+        assert_eq!(v["group_id"], m_group_path);
+        assert_eq!(v["user_id"], m1_target_id.to_string());
+        assert!(v["updated_at"].is_string(), "M1: updated_at must be set");
+
+        // DB assertion via admin_pool.
+        let (db_role,): (String,) = sqlx::query_as(
+            "SELECT role FROM group_members WHERE group_id = $1 AND user_id = $2",
+        )
+        .bind(m_group_id)
+        .bind(m1_target_id)
+        .fetch_one(&h.admin_pool)
+        .await
+        .expect("M1: DB row check");
+        assert_eq!(db_role, "admin", "M1: DB role must be admin");
+    }
+
+    // Scenario M2: Admin setRole of another member → guest. 200.
+    // Uses m1_target_id (now an admin from M1) as the caller.
+    let m1_admin_token = h.jwt.issue_access_for_test(m1_target_id);
+    let (m2_target_id, _) =
+        seed_member_via_admin(&h, m_group_id, "member", "m2-target@0020.test")
+            .await
+            .expect("M2: seed target");
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(post_setrole(
+                Some(&m1_admin_token),
+                &m_group_path,
+                &m2_target_id.to_string(),
+                Some(&m_group_path),
+                json!({"role": "guest"}),
+            ))
+            .await
+            .expect("M2: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "M2: admin can modify members"
+        );
+        let v = body_json(resp).await;
+        assert_eq!(v["role"], "guest");
+    }
+
+    // Scenario M3: Admin tries to setRole of the Owner (non-self) → 403.
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(post_setrole(
+                Some(&m1_admin_token),
+                &m_group_path,
+                &m_owner_id.to_string(),
+                Some(&m_group_path),
+                json!({"role": "member"}),
+            ))
+            .await
+            .expect("M3: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "M3: admin cannot modify owner"
+        );
+    }
+
+    // Scenario M4: Admin tries to setRole of another Admin (non-self) → 403.
+    // Seed a second admin, then have m1 try to demote them.
+    let (m4_other_admin_id, _) =
+        seed_member_via_admin(&h, m_group_id, "admin", "m4-other-admin@0020.test")
+            .await
+            .expect("M4: seed second admin");
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(post_setrole(
+                Some(&m1_admin_token),
+                &m_group_path,
+                &m4_other_admin_id.to_string(),
+                Some(&m_group_path),
+                json!({"role": "member"}),
+            ))
+            .await
+            .expect("M4: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "M4: admin cannot modify another admin (non-self)"
+        );
+    }
+
+    // Scenario M5: Owner self-demote WITH a second owner existing → 200.
+    // Seed a second owner via admin_pool (the only way, since setRole
+    // rejects role=owner). Then the first owner demotes themselves to admin.
+    let (m5_coowner_id, _m5_coowner_token) =
+        seed_second_owner_via_admin(&h, m_group_id, "m5-coowner@0020.test")
+            .await
+            .expect("M5: seed co-owner");
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(post_setrole(
+                Some(&m_owner_token),
+                &m_group_path,
+                &m_owner_id.to_string(),
+                Some(&m_group_path),
+                json!({"role": "admin"}),
+            ))
+            .await
+            .expect("M5: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "M5: owner self-demote OK when co-owner exists"
+        );
+        let v = body_json(resp).await;
+        assert_eq!(v["role"], "admin", "M5: response role reflects the demote");
+
+        // Restore state for subsequent scenarios. After the setRole
+        // call, the group has: m_owner=admin (just demoted), m5_coowner=owner.
+        // The partial unique index is still dropped (fixture's contract).
+        // We need to flip back to: m_owner=owner, m5_coowner=admin, and
+        // recreate the index. The order matters — flip coowner FIRST to
+        // admin (now 0 owners momentarily, but admin_pool bypasses the app
+        // checks), then promote m_owner, then recreate the index on the
+        // single-owner state.
+        sqlx::query("UPDATE group_members SET role = 'admin' WHERE group_id = $1 AND user_id = $2")
+            .bind(m_group_id)
+            .bind(m5_coowner_id)
+            .execute(&h.admin_pool)
+            .await
+            .expect("M5 restore: demote co-owner to admin");
+        sqlx::query("UPDATE group_members SET role = 'owner' WHERE group_id = $1 AND user_id = $2")
+            .bind(m_group_id)
+            .bind(m_owner_id)
+            .execute(&h.admin_pool)
+            .await
+            .expect("M5 restore: re-promote original owner");
+        restore_single_owner_idx(&h)
+            .await
+            .expect("M5 restore: recreate single-owner idx");
+    }
+
+    // Scenario M6: Owner self-demote WITHOUT a second owner → 409 last-owner.
+    // DB state after M5 restore: m_owner is the sole owner. Self-demote must 409.
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(post_setrole(
+                Some(&m_owner_token),
+                &m_group_path,
+                &m_owner_id.to_string(),
+                Some(&m_group_path),
+                json!({"role": "admin"}),
+            ))
+            .await
+            .expect("M6: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::CONFLICT,
+            "M6: owner self-demote must 409 without co-owner"
+        );
+        let v = body_json(resp).await;
+        assert!(
+            v["detail"]
+                .as_str()
+                .unwrap()
+                .contains("without an owner"),
+            "M6: detail mentions last-owner, got {v}"
+        );
+        // DB invariant: m_owner STILL owner (tx was rolled back).
+        let (db_role,): (String,) = sqlx::query_as(
+            "SELECT role FROM group_members WHERE group_id = $1 AND user_id = $2",
+        )
+        .bind(m_group_id)
+        .bind(m_owner_id)
+        .fetch_one(&h.admin_pool)
+        .await
+        .expect("M6: DB role check");
+        assert_eq!(db_role, "owner", "M6: owner must remain after 409 rollback");
+    }
+
+    // Scenario M7: body role="owner" → 400 promote-to-owner rejected.
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(post_setrole(
+                Some(&m_owner_token),
+                &m_group_path,
+                &m1_target_id.to_string(),
+                Some(&m_group_path),
+                json!({"role": "owner"}),
+            ))
+            .await
+            .expect("M7: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "M7: role=owner must 400"
+        );
+        let v = body_json(resp).await;
+        assert_eq!(
+            v["detail"], "cannot promote to owner via setRole",
+            "M7: deterministic detail"
+        );
+    }
+
+    // Scenario M8: Member tries setRole of another member (non-self) → 403.
+    let (m8_member_id, m8_member_token) =
+        seed_member_via_admin(&h, m_group_id, "member", "m8-member@0020.test")
+            .await
+            .expect("M8: seed member caller");
+    let (m8_other_id, _) =
+        seed_member_via_admin(&h, m_group_id, "member", "m8-other@0020.test")
+            .await
+            .expect("M8: seed target");
+    let _ = m8_member_id; // silence unused warning
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(post_setrole(
+                Some(&m8_member_token),
+                &m_group_path,
+                &m8_other_id.to_string(),
+                Some(&m_group_path),
+                json!({"role": "guest"}),
+            ))
+            .await
+            .expect("M8: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "M8: member without MembersManage must 403 (non-self)"
+        );
+    }
+
+    // Scenario M9: target user_id is not a member of the group → 404.
+    {
+        let ghost = uuid::Uuid::new_v4().to_string();
+        let resp = h
+            .router
+            .clone()
+            .oneshot(post_setrole(
+                Some(&m_owner_token),
+                &m_group_path,
+                &ghost,
+                Some(&m_group_path),
+                json!({"role": "admin"}),
+            ))
+            .await
+            .expect("M9: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "M9: non-member target must 404"
+        );
+    }
+
+    // Scenario M10: no bearer → 401.
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(post_setrole(
+                None,
+                &m_group_path,
+                &m1_target_id.to_string(),
+                Some(&m_group_path),
+                json!({"role": "admin"}),
+            ))
+            .await
+            .expect("M10: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "M10: missing bearer must 401"
         );
     }
 }

--- a/crates/garraia-gateway/tests/rest_v1_groups.rs
+++ b/crates/garraia-gateway/tests/rest_v1_groups.rs
@@ -1116,6 +1116,45 @@ async fn v1_groups_scenarios() {
         );
     }
 
+    // Scenario D2b: Admin self-DELETE (leave group) → 204.
+    // Closes the gap flagged by plan 0020 security review (SEC-LOW):
+    // the M/D scenarios explicitly covered every caller-role × action
+    // combination except an admin leaving the group via self-DELETE.
+    // Happy-path positive test: admin is self-acting, capability gate
+    // is bypassed, hierarchy gate is bypassed (self), last-owner
+    // invariant does not apply (m_owner is still the sole owner), so
+    // the UPDATE to status='removed' succeeds.
+    let (d2b_admin_id, d2b_admin_token) =
+        seed_member_via_admin(&h, m_group_id, "admin", "d2b-leaver-admin@0020.test")
+            .await
+            .expect("D2b: seed admin");
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(delete_member_req(
+                Some(&d2b_admin_token),
+                &m_group_path,
+                &d2b_admin_id.to_string(),
+                Some(&m_group_path),
+            ))
+            .await
+            .expect("D2b: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::NO_CONTENT,
+            "D2b: admin self-DELETE (leave) must 204"
+        );
+        let (db_status,): (String,) =
+            sqlx::query_as("SELECT status FROM group_members WHERE group_id = $1 AND user_id = $2")
+                .bind(m_group_id)
+                .bind(d2b_admin_id)
+                .fetch_one(&h.admin_pool)
+                .await
+                .expect("D2b: DB read");
+        assert_eq!(db_status, "removed");
+    }
+
     // Scenario D3: Admin tries DELETE Owner (non-self) → 403.
     {
         let resp = h
@@ -1250,25 +1289,18 @@ async fn v1_groups_scenarios() {
     }
 
     // Scenario D6: Member self-DELETE (leave group) → 204.
-    let (_d6_member_id, d6_member_token) =
+    let (d6_member_id, d6_member_token) =
         seed_member_via_admin(&h, m_group_id, "member", "d6-leaver@0020.test")
             .await
             .expect("D6: seed leaver");
     {
-        // We need the member to look themselves up by their own user_id.
-        // Mint the path target from the token's subject — the fixture
-        // returns the seeded user_id directly.
-        let (d6_id, _) = seed_member_via_admin(&h, m_group_id, "member", "d6-self@0020.test")
-            .await
-            .expect("D6: seed self");
-        let d6_self_token = h.jwt.issue_access_for_test(d6_id);
         let resp = h
             .router
             .clone()
             .oneshot(delete_member_req(
-                Some(&d6_self_token),
+                Some(&d6_member_token),
                 &m_group_path,
-                &d6_id.to_string(),
+                &d6_member_id.to_string(),
                 Some(&m_group_path),
             ))
             .await
@@ -1278,7 +1310,6 @@ async fn v1_groups_scenarios() {
             StatusCode::NO_CONTENT,
             "D6: member self-DELETE (leave group) must 204"
         );
-        let _ = d6_member_token;
     }
 
     // Scenario D7: DELETE of already-removed member → 404.

--- a/crates/garraia-gateway/tests/rest_v1_groups.rs
+++ b/crates/garraia-gateway/tests/rest_v1_groups.rs
@@ -1053,4 +1053,311 @@ async fn v1_groups_scenarios() {
             "M10: missing bearer must 401"
         );
     }
+
+    // ─── DELETE /v1/groups/{id}/members/{user_id} — plan 0020 Task 6 ─────
+
+    // Reuse `m_group_id` / `m_owner_token` (single-owner state restored post-M6).
+    // Admin caller for hierarchy-related scenarios: reuse `m1_admin_token`
+    // (the user promoted to admin in M1).
+
+    // Scenario D1: Owner DELETEs a member → 204 + DB row `status = 'removed'`.
+    let (d1_target_id, _) =
+        seed_member_via_admin(&h, m_group_id, "member", "d1-target@0020.test")
+            .await
+            .expect("D1: seed target");
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(delete_member_req(
+                Some(&m_owner_token),
+                &m_group_path,
+                &d1_target_id.to_string(),
+                Some(&m_group_path),
+            ))
+            .await
+            .expect("D1: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::NO_CONTENT,
+            "D1: owner DELETE member must 204"
+        );
+        // Body is empty.
+        let bytes = resp
+            .into_body()
+            .collect()
+            .await
+            .expect("D1: body collect")
+            .to_bytes();
+        assert!(bytes.is_empty(), "D1: 204 must have empty body");
+
+        // DB row must now be status='removed'.
+        let (db_status,): (String,) = sqlx::query_as(
+            "SELECT status FROM group_members WHERE group_id = $1 AND user_id = $2",
+        )
+        .bind(m_group_id)
+        .bind(d1_target_id)
+        .fetch_one(&h.admin_pool)
+        .await
+        .expect("D1: post-DELETE DB read");
+        assert_eq!(db_status, "removed", "D1: soft-delete flips status");
+    }
+
+    // Scenario D2: Admin DELETEs a guest → 204.
+    let (d2_target_id, _) =
+        seed_member_via_admin(&h, m_group_id, "guest", "d2-target@0020.test")
+            .await
+            .expect("D2: seed guest");
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(delete_member_req(
+                Some(&m1_admin_token),
+                &m_group_path,
+                &d2_target_id.to_string(),
+                Some(&m_group_path),
+            ))
+            .await
+            .expect("D2: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::NO_CONTENT,
+            "D2: admin DELETE guest must 204"
+        );
+    }
+
+    // Scenario D3: Admin tries DELETE Owner (non-self) → 403.
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(delete_member_req(
+                Some(&m1_admin_token),
+                &m_group_path,
+                &m_owner_id.to_string(),
+                Some(&m_group_path),
+            ))
+            .await
+            .expect("D3: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "D3: admin cannot DELETE owner (non-self)"
+        );
+    }
+
+    // Scenario D4: Owner self-DELETE WITHOUT co-owner → 409 (last-owner).
+    // Uses the current state (m_owner is the sole active owner).
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(delete_member_req(
+                Some(&m_owner_token),
+                &m_group_path,
+                &m_owner_id.to_string(),
+                Some(&m_group_path),
+            ))
+            .await
+            .expect("D4: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::CONFLICT,
+            "D4: owner self-DELETE must 409 without co-owner"
+        );
+        let v = body_json(resp).await;
+        assert!(
+            v["detail"]
+                .as_str()
+                .unwrap()
+                .contains("without an owner"),
+            "D4: detail mentions last-owner, got {v}"
+        );
+        // Invariant check: m_owner still active owner.
+        let (db_role, db_status): (String, String) = sqlx::query_as(
+            "SELECT role, status FROM group_members WHERE group_id = $1 AND user_id = $2",
+        )
+        .bind(m_group_id)
+        .bind(m_owner_id)
+        .fetch_one(&h.admin_pool)
+        .await
+        .expect("D4: DB read");
+        assert_eq!(db_role, "owner");
+        assert_eq!(db_status, "active", "D4: rollback preserved active status");
+    }
+
+    // Scenario D5: Owner self-DELETE WITH co-owner seeded → 204.
+    // Same index dance as M5: fixture drops the partial unique index,
+    // seeds a second owner, leaves the index dropped for the caller to
+    // restore after the test's state settles.
+    let (d5_coowner_id, _d5_coowner_token) =
+        seed_second_owner_via_admin(&h, m_group_id, "d5-coowner@0020.test")
+            .await
+            .expect("D5: seed co-owner");
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(delete_member_req(
+                Some(&m_owner_token),
+                &m_group_path,
+                &m_owner_id.to_string(),
+                Some(&m_group_path),
+            ))
+            .await
+            .expect("D5: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::NO_CONTENT,
+            "D5: owner self-DELETE OK with co-owner"
+        );
+        // m_owner should now be status='removed'; d5_coowner remains owner.
+        let (m_owner_status,): (String,) = sqlx::query_as(
+            "SELECT status FROM group_members WHERE group_id = $1 AND user_id = $2",
+        )
+        .bind(m_group_id)
+        .bind(m_owner_id)
+        .fetch_one(&h.admin_pool)
+        .await
+        .expect("D5: m_owner DB read");
+        assert_eq!(m_owner_status, "removed", "D5: m_owner soft-deleted");
+
+        let (coowner_role, coowner_status): (String, String) = sqlx::query_as(
+            "SELECT role, status FROM group_members WHERE group_id = $1 AND user_id = $2",
+        )
+        .bind(m_group_id)
+        .bind(d5_coowner_id)
+        .fetch_one(&h.admin_pool)
+        .await
+        .expect("D5: coowner DB read");
+        assert_eq!(coowner_role, "owner");
+        assert_eq!(coowner_status, "active");
+
+        // Restore the single-owner partial unique index. The partial
+        // predicate is `WHERE role = 'owner'` (migration 002:146) — it
+        // does NOT filter by status, so even a soft-deleted m_owner
+        // still counts toward the uniqueness requirement. Hard-delete
+        // the soft-deleted m_owner row so d5_coowner is the only row
+        // with role='owner' for this group_id when we recreate the
+        // index.
+        //
+        // In production this branch is unreachable — the only way
+        // to get two active owners is via this test fixture; the
+        // product API rejects promote-to-owner (setRole 400). So
+        // an owner's soft-delete UPDATE never actually coexists
+        // with another role='owner' row at the DB level. The
+        // fixture-only cleanup below keeps the test isolated.
+        //
+        // Follow-up candidate (plan 0021+): amend the partial
+        // unique predicate to `WHERE role = 'owner' AND status =
+        // 'active'` so the DB index matches the app-layer
+        // last-owner invariant (which already filters status).
+        sqlx::query("DELETE FROM group_members WHERE group_id = $1 AND user_id = $2")
+            .bind(m_group_id)
+            .bind(m_owner_id)
+            .execute(&h.admin_pool)
+            .await
+            .expect("D5 restore: hard-delete soft-deleted m_owner");
+        restore_single_owner_idx(&h)
+            .await
+            .expect("D5: restore single-owner idx");
+    }
+
+    // Scenario D6: Member self-DELETE (leave group) → 204.
+    let (_d6_member_id, d6_member_token) =
+        seed_member_via_admin(&h, m_group_id, "member", "d6-leaver@0020.test")
+            .await
+            .expect("D6: seed leaver");
+    {
+        // We need the member to look themselves up by their own user_id.
+        // Mint the path target from the token's subject — the fixture
+        // returns the seeded user_id directly.
+        let (d6_id, _) =
+            seed_member_via_admin(&h, m_group_id, "member", "d6-self@0020.test")
+                .await
+                .expect("D6: seed self");
+        let d6_self_token = h.jwt.issue_access_for_test(d6_id);
+        let resp = h
+            .router
+            .clone()
+            .oneshot(delete_member_req(
+                Some(&d6_self_token),
+                &m_group_path,
+                &d6_id.to_string(),
+                Some(&m_group_path),
+            ))
+            .await
+            .expect("D6: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::NO_CONTENT,
+            "D6: member self-DELETE (leave group) must 204"
+        );
+        let _ = d6_member_token;
+    }
+
+    // Scenario D7: DELETE of already-removed member → 404.
+    // d1_target_id was soft-deleted in D1.
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(delete_member_req(
+                // Use the co-owner (current sole owner) as caller since
+                // m_owner is now soft-deleted (from D5).
+                Some(&_d5_coowner_token),
+                &m_group_path,
+                &d1_target_id.to_string(),
+                Some(&m_group_path),
+            ))
+            .await
+            .expect("D7: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "D7: DELETE already-removed must 404 (idempotent)"
+        );
+    }
+
+    // Scenario D8: DELETE of a non-existent user (not a member of this group) → 404.
+    {
+        let ghost = uuid::Uuid::new_v4().to_string();
+        let resp = h
+            .router
+            .clone()
+            .oneshot(delete_member_req(
+                Some(&_d5_coowner_token),
+                &m_group_path,
+                &ghost,
+                Some(&m_group_path),
+            ))
+            .await
+            .expect("D8: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "D8: DELETE non-member must 404"
+        );
+    }
+
+    // Scenario D9: missing bearer → 401.
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(delete_member_req(
+                None,
+                &m_group_path,
+                &d5_coowner_id.to_string(),
+                Some(&m_group_path),
+            ))
+            .await
+            .expect("D9: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "D9: missing bearer must 401"
+        );
+    }
 }

--- a/crates/garraia-gateway/tests/rest_v1_groups.rs
+++ b/crates/garraia-gateway/tests/rest_v1_groups.rs
@@ -742,10 +742,9 @@ async fn v1_groups_scenarios() {
     // Re-using `created_group_id` from above would couple M/D scenarios to
     // the mutations done by P/I scenarios; a fresh group keeps the invariants
     // local to this section and easier to reason about.
-    let (m_owner_id, m_group_id, m_owner_token) =
-        seed_user_with_group(&h, "m-owner@0020.test")
-            .await
-            .expect("M setup: seed owner+group");
+    let (m_owner_id, m_group_id, m_owner_token) = seed_user_with_group(&h, "m-owner@0020.test")
+        .await
+        .expect("M setup: seed owner+group");
     let m_group_path = m_group_id.to_string();
 
     // Scenario M1: Owner demotes a member → admin. 200 + MemberResponse.role=="admin".
@@ -775,24 +774,22 @@ async fn v1_groups_scenarios() {
         assert!(v["updated_at"].is_string(), "M1: updated_at must be set");
 
         // DB assertion via admin_pool.
-        let (db_role,): (String,) = sqlx::query_as(
-            "SELECT role FROM group_members WHERE group_id = $1 AND user_id = $2",
-        )
-        .bind(m_group_id)
-        .bind(m1_target_id)
-        .fetch_one(&h.admin_pool)
-        .await
-        .expect("M1: DB row check");
+        let (db_role,): (String,) =
+            sqlx::query_as("SELECT role FROM group_members WHERE group_id = $1 AND user_id = $2")
+                .bind(m_group_id)
+                .bind(m1_target_id)
+                .fetch_one(&h.admin_pool)
+                .await
+                .expect("M1: DB row check");
         assert_eq!(db_role, "admin", "M1: DB role must be admin");
     }
 
     // Scenario M2: Admin setRole of another member → guest. 200.
     // Uses m1_target_id (now an admin from M1) as the caller.
     let m1_admin_token = h.jwt.issue_access_for_test(m1_target_id);
-    let (m2_target_id, _) =
-        seed_member_via_admin(&h, m_group_id, "member", "m2-target@0020.test")
-            .await
-            .expect("M2: seed target");
+    let (m2_target_id, _) = seed_member_via_admin(&h, m_group_id, "member", "m2-target@0020.test")
+        .await
+        .expect("M2: seed target");
     {
         let resp = h
             .router
@@ -937,21 +934,17 @@ async fn v1_groups_scenarios() {
         );
         let v = body_json(resp).await;
         assert!(
-            v["detail"]
-                .as_str()
-                .unwrap()
-                .contains("without an owner"),
+            v["detail"].as_str().unwrap().contains("without an owner"),
             "M6: detail mentions last-owner, got {v}"
         );
         // DB invariant: m_owner STILL owner (tx was rolled back).
-        let (db_role,): (String,) = sqlx::query_as(
-            "SELECT role FROM group_members WHERE group_id = $1 AND user_id = $2",
-        )
-        .bind(m_group_id)
-        .bind(m_owner_id)
-        .fetch_one(&h.admin_pool)
-        .await
-        .expect("M6: DB role check");
+        let (db_role,): (String,) =
+            sqlx::query_as("SELECT role FROM group_members WHERE group_id = $1 AND user_id = $2")
+                .bind(m_group_id)
+                .bind(m_owner_id)
+                .fetch_one(&h.admin_pool)
+                .await
+                .expect("M6: DB role check");
         assert_eq!(db_role, "owner", "M6: owner must remain after 409 rollback");
     }
 
@@ -986,10 +979,9 @@ async fn v1_groups_scenarios() {
         seed_member_via_admin(&h, m_group_id, "member", "m8-member@0020.test")
             .await
             .expect("M8: seed member caller");
-    let (m8_other_id, _) =
-        seed_member_via_admin(&h, m_group_id, "member", "m8-other@0020.test")
-            .await
-            .expect("M8: seed target");
+    let (m8_other_id, _) = seed_member_via_admin(&h, m_group_id, "member", "m8-other@0020.test")
+        .await
+        .expect("M8: seed target");
     let _ = m8_member_id; // silence unused warning
     {
         let resp = h
@@ -1061,10 +1053,9 @@ async fn v1_groups_scenarios() {
     // (the user promoted to admin in M1).
 
     // Scenario D1: Owner DELETEs a member → 204 + DB row `status = 'removed'`.
-    let (d1_target_id, _) =
-        seed_member_via_admin(&h, m_group_id, "member", "d1-target@0020.test")
-            .await
-            .expect("D1: seed target");
+    let (d1_target_id, _) = seed_member_via_admin(&h, m_group_id, "member", "d1-target@0020.test")
+        .await
+        .expect("D1: seed target");
     {
         let resp = h
             .router
@@ -1092,22 +1083,20 @@ async fn v1_groups_scenarios() {
         assert!(bytes.is_empty(), "D1: 204 must have empty body");
 
         // DB row must now be status='removed'.
-        let (db_status,): (String,) = sqlx::query_as(
-            "SELECT status FROM group_members WHERE group_id = $1 AND user_id = $2",
-        )
-        .bind(m_group_id)
-        .bind(d1_target_id)
-        .fetch_one(&h.admin_pool)
-        .await
-        .expect("D1: post-DELETE DB read");
+        let (db_status,): (String,) =
+            sqlx::query_as("SELECT status FROM group_members WHERE group_id = $1 AND user_id = $2")
+                .bind(m_group_id)
+                .bind(d1_target_id)
+                .fetch_one(&h.admin_pool)
+                .await
+                .expect("D1: post-DELETE DB read");
         assert_eq!(db_status, "removed", "D1: soft-delete flips status");
     }
 
     // Scenario D2: Admin DELETEs a guest → 204.
-    let (d2_target_id, _) =
-        seed_member_via_admin(&h, m_group_id, "guest", "d2-target@0020.test")
-            .await
-            .expect("D2: seed guest");
+    let (d2_target_id, _) = seed_member_via_admin(&h, m_group_id, "guest", "d2-target@0020.test")
+        .await
+        .expect("D2: seed guest");
     {
         let resp = h
             .router
@@ -1168,10 +1157,7 @@ async fn v1_groups_scenarios() {
         );
         let v = body_json(resp).await;
         assert!(
-            v["detail"]
-                .as_str()
-                .unwrap()
-                .contains("without an owner"),
+            v["detail"].as_str().unwrap().contains("without an owner"),
             "D4: detail mentions last-owner, got {v}"
         );
         // Invariant check: m_owner still active owner.
@@ -1213,14 +1199,13 @@ async fn v1_groups_scenarios() {
             "D5: owner self-DELETE OK with co-owner"
         );
         // m_owner should now be status='removed'; d5_coowner remains owner.
-        let (m_owner_status,): (String,) = sqlx::query_as(
-            "SELECT status FROM group_members WHERE group_id = $1 AND user_id = $2",
-        )
-        .bind(m_group_id)
-        .bind(m_owner_id)
-        .fetch_one(&h.admin_pool)
-        .await
-        .expect("D5: m_owner DB read");
+        let (m_owner_status,): (String,) =
+            sqlx::query_as("SELECT status FROM group_members WHERE group_id = $1 AND user_id = $2")
+                .bind(m_group_id)
+                .bind(m_owner_id)
+                .fetch_one(&h.admin_pool)
+                .await
+                .expect("D5: m_owner DB read");
         assert_eq!(m_owner_status, "removed", "D5: m_owner soft-deleted");
 
         let (coowner_role, coowner_status): (String, String) = sqlx::query_as(
@@ -1273,10 +1258,9 @@ async fn v1_groups_scenarios() {
         // We need the member to look themselves up by their own user_id.
         // Mint the path target from the token's subject — the fixture
         // returns the seeded user_id directly.
-        let (d6_id, _) =
-            seed_member_via_admin(&h, m_group_id, "member", "d6-self@0020.test")
-                .await
-                .expect("D6: seed self");
+        let (d6_id, _) = seed_member_via_admin(&h, m_group_id, "member", "d6-self@0020.test")
+            .await
+            .expect("D6: seed self");
         let d6_self_token = h.jwt.issue_access_for_test(d6_id);
         let resp = h
             .router


### PR DESCRIPTION
## Summary

- Delivers the final 2 endpoints of GAR-393's canonical description — closing the epic at **6/6 endpoints**:
  - `POST /v1/groups/{id}/members/{user_id}/setRole` — change a member's role (capability + hierarchy + last-owner invariant).
  - `DELETE /v1/groups/{id}/members/{user_id}` — soft-delete (`status='removed'`) preserving FKs in `messages`, `tasks`, etc.
- 9 commits: T1–T8 (draft plan tasks) + 1 review follow-ups commit.

## Linear

- Issue: [GAR-393](https://linear.app/chatgpt25/issue/GAR-393) — reopened `In Progress` 2026-04-20 (was erroneously auto-closed by PR #25 merge).
- Docs PR (plan 0020 draft): #26 (merged as `6d5f7e6`).

## Path convention (explicit deviation from Linear canonical description)

Linear uses `{user_id}:setRole` (Google Cloud custom-verb). Axum 0.8 / `matchit` does not support `{param}:literal` in the same segment — same limitation that forced `/accept` (not `:accept`) in plan 0019. Delivered: `/setRole` as a literal segment. Recorded in (1) plan 0020 `§Architecture`, (2) GAR-393 opening comment for this slice, (3) this PR body.

## Design invariants (all enforced + tested)

1. **Capability gate** — `Action::MembersManage` (Owner/Admin) required for non-self.
2. **Self-action bypass** on capability gate — any member can self-demote / self-leave.
3. **Hierarchy gate** (non-self only) — Admin cannot modify Owner or another Admin.
4. **Last-owner invariant** — `SELECT COUNT(*) FILTER (WHERE role='owner' AND status='active')` post-UPDATE in same tx. Zero ⇒ 409 Conflict + tx rollback.
5. **No promote-to-owner** via setRole — 400 Bad Request with dedicated message.
6. **Subset of roles** — `{admin, member, guest, child}`. Owner excluded from `ALLOWED_SETROLE_VALUES`.
7. **Target must be active** — `status = 'active'` filter at `SELECT FOR UPDATE` and UPDATE.
8. **X-Group-Id coherent with path** — 400 otherwise.
9. **Transactional atomicity** — `SET LOCAL` (first) → `SELECT ... FOR UPDATE` → mutation → COUNT guard → COMMIT (or drop ⇒ rollback).
10. **DELETE idempotent via 404** — already-removed or non-member returns 404 (matches plan 0019 accept-twice convention).

## Tasks executed (plan 0020 T1–T8 + follow-ups)

| # | Commit | What |
|---|---|---|
| T1 | `294ded2` | `SetRoleRequest` + `MemberResponse` + `ALLOWED_SETROLE_VALUES` + 5 unit tests |
| T2 | `133db72` | `set_member_role` handler (hierarchy + last-owner guards) |
| T3 | `488591f` | `delete_member` handler (soft-delete + last-owner guard) |
| T4 | `feb4ade` | Route wiring (3 modes: full / auth-only / fail-soft) + OpenAPI registration |
| T5 | `fec19e3` | Integration scenarios M1–M10 (setRole) + fixtures `seed_second_owner_via_admin`, `restore_single_owner_idx`, `seed_member_via_admin` |
| T6 | `bd24fd5` | Integration scenarios D1–D9 (DELETE) + D5 index-restore quirk (documented) |
| T7 | `559234f` | Authz matrix cases 27–34 (26 → 34) |
| T8 | `abc461b` | `cargo fmt` cleanup |
| FU | `64bb3a0` | Review follow-ups: self-action intent docs + D2b admin-self-leave + D6 cleanup + TODO(plan-0021) note |

## Review results (pre-PR, two-agent)

### Code review (`@code-reviewer`) — **APPROVED WITH NITS, 0 blockers**
- 3 MEDIUMs addressed in `64bb3a0`:
  - Clarify self-action bypass intent in docstrings.
  - Add TODO(plan-0021) note about `group_members_single_owner_idx` predicate divergence.
  - Clean D6 (`let _ = d6_member_token` redundant seed removed).
- 4 NITs deferred: extract `assert_group_header_matches` helper, extract `resolve_caller_role` helper, `RETURNING 1` → `RETURNING true`, matrix case for member self-setRole success.

### Security audit (`@security-auditor`) — **8.5/10, APPROVE**
- No BLOCKERs.
- 2 SEC-MEDs addressed (docstring intent + TODO note).
- 1 SEC-LOW addressed via new D2b (admin self-leave) scenario.
- Remaining SEC-LOWs deferred per plan split: audit_events and rate-limit for setRole/DELETE → plan 0021 (the "0020-b" slice).
- All critical vectors clean: privilege escalation (blocked by `validate()` + DB index), race conditions (`SELECT FOR UPDATE` + COUNT-in-tx), last-owner bypass (inexistent), soft-delete bypass (`Principal` extractor filters `status='active'`), PII (errors are static), SQL injection (zero new surface), transaction semantics (Drop rolls back on any failure).

## Acceptance criteria (from plan 0020 §§Acceptance criteria)

- [x] `POST /v1/groups/{id}/members/{user_id}/setRole` returns 200 with `MemberResponse` on happy path (tested: M1, M2, M5).
- [x] `setRole` rejects `role = "owner"` with 400 and detail `cannot promote to owner via setRole` (tested: M7).
- [x] `setRole` demoting the last owner returns 409 with detail `cannot leave the group without an owner`, DB state unchanged (tested: M6 + DB assertion).
- [x] Admin cannot `setRole` or `DELETE` an Owner or another Admin (non-self) — 403 (tested: M3, M4, D3).
- [x] `DELETE /v1/groups/{id}/members/{user_id}` returns 204 and `UPDATE ... SET status='removed'` succeeds (tested: D1 + DB assertion).
- [x] `DELETE` of last owner returns 409, DB unchanged; DELETE of already-removed returns 404 (tested: D4, D7).
- [x] Member/Guest/Child can self-remove (DELETE self) with 204 (tested: D6); last-owner rule still enforced if sole owner (tested: M6 + D4).
- [x] `Principal` extractor filters `status='active'` (verified: `garraia-auth/src/extractor.rs:74-76`).
- [x] All authz matrix cases 1..34 pass.
- [ ] CI goes 9/9 green (pending this PR).
- [x] `cargo fmt --check --all` clean.
- [x] OpenAPI at `/docs` registers both new paths + `SetRoleRequest` + `MemberResponse` schemas.

## Test plan (local validation already passed)

- [x] `cargo test -p garraia-gateway --lib` — **188/188 green**.
- [x] `cargo test -p garraia-gateway --features test-helpers --test rest_v1_groups` — **v1_groups_scenarios ok (~38 cenários bundled)**.
- [x] `cargo test -p garraia-gateway --features test-helpers --test rest_v1_invites` — green.
- [x] `cargo test -p garraia-gateway --features test-helpers --test authz_http_matrix` — **34 cases ok**.
- [x] `cargo test -p garraia-gateway --features test-helpers --test rest_v1_me_authed` — green.
- [x] `cargo test -p garraia-gateway --features test-helpers --test rest_v1_me` — green.
- [x] `cargo test -p garraia-gateway --features test-helpers --test harness_smoke` — green.
- [x] `cargo test -p garraia-gateway --features test-helpers --test router_smoke_test` — green.
- [x] `cargo fmt --check --all` — clean.
- [x] `cargo clippy` — zero warnings in plan 0020 files (pre-existing `bootstrap.rs` collapsible_if warnings tolerated via CI `continue-on-error`).
- [ ] CI 9/9 green on this PR.

## Rollback

All additive (2 handlers, 2 structs, 1 constant, 3 test fixtures, route wiring, OpenAPI registration). Revert of squash commit returns codebase to post-PR #26 state. Zero migrations, zero schema changes, zero state dependencies outside git.

## Follow-ups (plan 0021, the "0020-b" slice)

- Migration forward-only: amend `group_members_single_owner_idx` predicate to `WHERE role = 'owner' AND status = 'active'` — aligns DB constraint with app-layer invariant.
- `audit_events` rows for `member.role_changed` and `member.removed` (+ the deferred `invite.accepted` from plan 0019).
- Dedicated rate-limit for accept (SEC-01 from plan 0019 review) — currently covered by global governor.
- Optional NITs from code review: extract `assert_group_header_matches` and `resolve_caller_role` helpers; `RETURNING 1` → `RETURNING true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)