### PR TITLE
feat(gateway,auth): workspace security hardening part 2 — plan 0022 (GAR-426)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2913,6 +2913,7 @@ dependencies = [
  "garraia-workspace",
  "governor 0.8.1",
  "http-body-util",
+ "ipnet",
  "jsonwebtoken",
  "metrics",
  "password-hash",

--- a/crates/garraia-auth/src/audit_workspace.rs
+++ b/crates/garraia-auth/src/audit_workspace.rs
@@ -85,6 +85,17 @@ impl WorkspaceAuditAction {
     }
 }
 
+/// Display delegates to [`WorkspaceAuditAction::as_str`] so
+/// `tracing::info!(action = %action, ...)` works ergonomically
+/// without wrapping `.as_str()` at every log site.
+///
+/// Plan 0022 T1 (GAR-426) — addressed code-review NIT from PR #30.
+impl std::fmt::Display for WorkspaceAuditAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Insert one `audit_events` row inside the caller's transaction.
 ///
 /// **Caller contract:**
@@ -160,5 +171,41 @@ mod tests {
         ];
         let unique: std::collections::HashSet<_> = strings.iter().collect();
         assert_eq!(unique.len(), strings.len(), "duplicate action strings");
+    }
+
+    #[test]
+    fn workspace_audit_action_display_delegates_to_as_str() {
+        // Plan 0022 T1 — Display impl delegates to as_str(), so
+        // `tracing::info!(action = %action, ...)` produces the same
+        // on-the-wire string as direct INSERT via audit_workspace_event.
+        // Any divergence between Display and as_str would create a
+        // silent mismatch between logged events and DB rows.
+        use std::fmt::Write;
+
+        let mut buf = String::new();
+        write!(&mut buf, "{}", WorkspaceAuditAction::InviteAccepted).unwrap();
+        assert_eq!(buf, "invite.accepted");
+
+        assert_eq!(
+            format!("{}", WorkspaceAuditAction::MemberRoleChanged),
+            "member.role_changed"
+        );
+        assert_eq!(
+            format!("{}", WorkspaceAuditAction::MemberRemoved),
+            "member.removed"
+        );
+
+        // Concat test — verifies `format!` composition (common tracing
+        // scenario with multiple placeholders).
+        let combined = format!(
+            "{} + {} + {}",
+            WorkspaceAuditAction::InviteAccepted,
+            WorkspaceAuditAction::MemberRoleChanged,
+            WorkspaceAuditAction::MemberRemoved,
+        );
+        assert_eq!(
+            combined,
+            "invite.accepted + member.role_changed + member.removed"
+        );
     }
 }

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -64,6 +64,11 @@ sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "uuid", "chro
 dirs = "6"
 governor = "0.8"
 tower_governor = "0.8"
+# Plan 0022 T2 (GAR-426): CIDR parsing for GARRAIA_TRUSTED_PROXIES env var.
+# Used by `real_client_ip` helper to decide whether to honor `X-Forwarded-For`.
+# Version pinned to match the transitive resolution already in Cargo.lock
+# (introduced by other workspace crates).
+ipnet = "2"
 async-trait = { workspace = true }
 anyhow = { workspace = true }
 reqwest = { version = "0.12", features = ["json", "rustls-tls", "gzip", "brotli", "deflate"], default-features = false }

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -132,6 +132,16 @@ name = "rest_v1_invites"
 path = "tests/rest_v1_invites.rs"
 required-features = ["test-helpers"]
 
+# Plan 0022 T7 — F-05 regression guard for audit_events_group_or_self
+# policy branch 2. Uses the same harness as other integration tests
+# and needs the same feature gate so CI's default `cargo test`
+# (without --features test-helpers) skips it instead of failing to
+# compile `JwtIssuer::new_for_test` / `build_router_for_test`.
+[[test]]
+name = "audit_workspace_branch_two"
+path = "tests/audit_workspace_branch_two.rs"
+required-features = ["test-helpers"]
+
 [dev-dependencies]
 tempfile = "3"
 serial_test = { workspace = true }

--- a/crates/garraia-gateway/src/admin/middleware.rs
+++ b/crates/garraia-gateway/src/admin/middleware.rs
@@ -165,6 +165,13 @@ pub fn extract_ip(
     headers: &HeaderMap,
     connect_info: Option<&std::net::SocketAddr>,
 ) -> Option<String> {
+    // TODO(plan-0023+): this helper accepts `X-Forwarded-For` without
+    // validating whether the immediate peer is an allowlisted proxy
+    // (same pre-0022 bug fixed for rate_limiter.rs in plan 0022 T2).
+    // Migrate to `crate::rate_limiter::real_client_ip` once plan 0023
+    // lifts that helper into a shared module and introduces
+    // `TRUSTED_PROXIES` into the admin surface. Deliberately
+    // out-of-scope for plan 0022 (GAR-426 description).
     if let Some(forwarded) = headers.get("x-forwarded-for").and_then(|v| v.to_str().ok())
         && let Some(first) = forwarded.split(',').next()
     {

--- a/crates/garraia-gateway/src/api.rs
+++ b/crates/garraia-gateway/src/api.rs
@@ -67,6 +67,11 @@ pub async fn create_session(
     let mut response_headers = HeaderMap::new();
     let cfg = state.current_config();
     if let Some(manager) = &state.chat_session_manager {
+        // TODO(plan-0023+): this reads `X-Forwarded-For` without
+        // trusted-proxy validation — same pre-0022 issue closed for
+        // rate_limiter in plan 0022 T2. Consolidate with
+        // `rate_limiter::real_client_ip` once plan 0023 lifts the
+        // helper into a shared module. Out-of-scope for plan 0022.
         let ip = headers
             .get("x-forwarded-for")
             .and_then(|v| v.to_str().ok())

--- a/crates/garraia-gateway/src/rate_limiter.rs
+++ b/crates/garraia-gateway/src/rate_limiter.rs
@@ -2,7 +2,11 @@
 //!
 //! Provides per-user, per-IP, and per-API-key rate limiting with configurable
 //! windows. Headers returned to the client follow the IETF draft standard:
-//!   X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset
+//!   X-RateLimit-Limit, X-RateLimit-Remaining
+//! Plus `Retry-After` on 429 responses. **Note:** `X-RateLimit-Reset`
+//! (Unix-timestamp form) was removed in plan 0022 (SEC-LOW F-06) because
+//! it leaked the absolute reset instant; clients should use `Retry-After`
+//! (relative-duration form) instead.
 //!
 //! The implementation uses an in-memory sliding-window counter backed by a
 //! `DashMap<String, WindowState>`. A background task periodically evicts
@@ -245,6 +249,14 @@ impl RateLimiter {
             entry.record();
         }
 
+        // `remaining` reports "what's left AFTER this request" from the
+        // caller's perspective. For the allowed path this is accurate
+        // (the +1 accounts for the record we just wrote). For the
+        // blocked path, `per_minute + 1 >= requests_per_minute` so
+        // `saturating_sub` bottoms out at 0 — still semantically correct
+        // ("you have 0 remaining; Retry-After tells you when"). The +1
+        // does NOT observably leak information on the blocked path.
+        // Plan 0022 code-review NIT S-01: kept unified for simplicity.
         let remaining = self
             .config
             .requests_per_minute
@@ -346,35 +358,25 @@ pub fn rate_limit_response(decision: &RateLimitDecision) -> Response {
 
 /// Extract the best available client identifier from a request.
 ///
-/// Priority: X-API-Key > Authorization bearer token-prefix >
-/// X-Forwarded-For > `"ip:unknown"` sentinel.
+/// **⚠️ DEPRECATED (plan 0022).** This function has two security issues
+/// inherited from pre-0022 code:
 ///
-/// # Known limitations (plan 0021 security review follow-ups)
+/// - Token-prefix keying (F-03) — all HS256 JWTs collide on the same
+///   header segment `eyJhbGci...`, so every authenticated caller
+///   shares one bucket.
+/// - `X-Forwarded-For` without trusted-proxy validation (F-02) —
+///   clients can forge the header to shift their bucket.
 ///
-/// - **Token-prefix, not decoded `sub` claim.** For JWTs, this uses
-///   the first 8 chars of the serialized bearer token — NOT the
-///   `sub` claim decoded from the payload. All HS256 JWTs emitted
-///   by the same `JwtIssuer` share an identical header segment
-///   (`eyJhbGci...` base64 of `{"alg":"HS256"`), so every
-///   authenticated caller collides into one bucket `jwt:eyJhbGci`.
-///   This is documented as a **plan 0022+ follow-up**: the
-///   extractor should decode the token and key by `sub` (user_id)
-///   for true per-user isolation. Until then, the jwt-keyed
-///   bucket behaves as a coarse global limit for authenticated
-///   traffic, which is a net-positive over no rate-limit at all
-///   but insufficient for multi-tenant production load.
-///
-/// - **`X-Forwarded-For` is client-controlled without a trusted-proxy
-///   allowlist.** Any caller can forge the header and shift their
-///   bucket to an arbitrary IP, evading IP-keyed rate limits. The
-///   value is used here as-is — plan 0022+ will introduce a
-///   `TRUSTED_PROXIES` env var and strip the header when the
-///   immediate peer is not in the list. For the current wiring
-///   (rate-limit applied to authenticated endpoints only), the
-///   exposure is small because the JWT bucket takes precedence
-///   whenever `Authorization` is present, but the vector exists
-///   for unauthenticated paths and MUST be closed before prod
-///   deploy at scale.
+/// Prefer [`rate_limit_layer_authenticated`] + [`RateLimitLayerState`]
+/// for any NEW route. This function is kept only so the legacy
+/// unauthenticated `rate_limit_layer` (if still wired somewhere)
+/// continues to compile. Plan 0023+ is expected to remove it once
+/// the last unauthenticated route is migrated.
+#[deprecated(
+    since = "0.2.0",
+    note = "Plan 0022: collides HS256 JWTs on one bucket and trusts XFF \
+            unconditionally. Use rate_limit_layer_authenticated instead."
+)]
 pub fn extract_rate_limit_key(headers: &HeaderMap) -> String {
     // Use API key prefix if present
     if let Some(api_key) = headers.get("x-api-key").and_then(|v| v.to_str().ok()) {
@@ -486,14 +488,26 @@ pub fn real_client_ip(headers: &HeaderMap, peer_addr: IpAddr, trusted_proxies: &
 
 /// Axum middleware that applies a shared `RateLimiter` to every request.
 ///
+/// **⚠️ DEPRECATED (plan 0022).** Uses the legacy
+/// [`extract_rate_limit_key`] which suffers from the shared-bucket
+/// and XFF-spoofing issues. Kept public only to keep the old
+/// [`rate_limit_layer`] wrapper compiling. Use
+/// [`rate_limit_layer_authenticated`] instead for new routes.
+///
 /// On limit exceeded: returns 429 with X-RateLimit-* headers.
 /// On allowed: forwards the request and appends headers to the response.
+#[deprecated(
+    since = "0.2.0",
+    note = "Plan 0022: uses the deprecated extract_rate_limit_key. \
+            Use rate_limit_layer_authenticated instead."
+)]
 pub async fn rate_limit_middleware(
     limiter: Arc<RateLimiter>,
     headers: HeaderMap,
     req: Request,
     next: Next,
 ) -> Response {
+    #[allow(deprecated)]
     let key = extract_rate_limit_key(&headers);
     let decision = limiter.check(&key);
 
@@ -516,12 +530,20 @@ pub async fn rate_limit_middleware(
 ///     .route("/auth/login", post(login_handler))
 ///     .layer(axum::middleware::from_fn_with_state(limiter, rate_limit_layer))
 /// ```
+#[deprecated(
+    since = "0.2.0",
+    note = "Plan 0022: wraps the deprecated rate_limit_middleware \
+            (shared-bucket + XFF spoofable). Use \
+            rate_limit_layer_authenticated + RateLimitLayerState \
+            for new routes."
+)]
 pub async fn rate_limit_layer(
     axum::extract::State(limiter): axum::extract::State<Arc<RateLimiter>>,
     headers: HeaderMap,
     req: Request,
     next: Next,
 ) -> Response {
+    #[allow(deprecated)]
     rate_limit_middleware(limiter, headers, req, next).await
 }
 
@@ -639,8 +661,14 @@ pub async fn rate_limit_layer_authenticated(
 ) -> Response {
     // Pull ConnectInfo + headers from the Request instead of listing them
     // as separate middleware extractors. axum's `from_fn_with_state`
-    // caps the total param count including State/Request/Next, and
-    // splitting headers/peer_info into dedicated params hit that cap.
+    // impl-ladder has `FromFn<F, S, I, T>` implementations where `T` is
+    // a tuple of up to 16 `FromRequestParts` extractors (see axum-0.8
+    // `middleware/from_fn.rs` macro_rules expansion). Our first cut
+    // had State + Option<ConnectInfo> + HeaderMap + Request + Next and
+    // failed with E0277 ("FromFn is not Service") because the specific
+    // 5-extractor combination wasn't resolved; consolidating via
+    // `req.extensions()` + `req.headers()` avoids the issue entirely
+    // and reads more naturally.
     let peer_addr = req
         .extensions()
         .get::<ConnectInfo<std::net::SocketAddr>>()
@@ -666,6 +694,9 @@ pub async fn rate_limit_layer_authenticated(
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
+#[allow(deprecated)] // Tests still exercise the legacy `extract_rate_limit_key`
+// for regression coverage; new routes must use
+// `rate_limit_layer_authenticated` per plan 0022 T3.
 mod tests {
     use super::*;
 
@@ -774,6 +805,114 @@ mod tests {
         let headers = xff_header("not-an-ip");
         let resolved = real_client_ip(&headers, peer_v4(), &trusted);
         assert_eq!(resolved, peer_v4(), "malformed XFF ⇒ fallback to peer_addr");
+    }
+
+    // ── Plan 0022 review follow-up: cover `extract_authenticated_rate_limit_key`
+    //    fallback ladder. The JWT-valid happy path is exercised by the A7
+    //    integration test; these unit tests cover the 3 fallback branches
+    //    (apikey, IP via real_client_ip, sentinel) explicitly.
+    //
+    //    Feature-gated because constructing a real `JwtIssuer` requires
+    //    `JwtIssuer::new_for_test`, which lives behind
+    //    `garraia-auth/test-support`. The `test-helpers` feature of this
+    //    crate enables it transitively.
+    #[cfg(feature = "test-helpers")]
+    mod auth_extractor_ladder {
+        use super::*;
+
+        fn jwt_issuer_for_test() -> garraia_auth::JwtIssuer {
+            garraia_auth::JwtIssuer::new_for_test("plan-0022-test-secret-32-chars-long")
+        }
+
+        #[test]
+        fn apikey_fallback_when_no_bearer() {
+            // No Authorization header, but X-API-Key present ⇒ `apikey:{prefix}`.
+            let jwt = jwt_issuer_for_test();
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                "x-api-key",
+                HeaderValue::from_static("sk-test-0022-abc123xyz"),
+            );
+
+            let key = extract_authenticated_rate_limit_key(&headers, &jwt, None, &[]);
+            assert!(
+                key.starts_with("apikey:"),
+                "expected apikey fallback, got: {key}"
+            );
+            // 16-char prefix (matches the legacy extractor's policy).
+            assert_eq!(key, "apikey:sk-test-0022-abc");
+        }
+
+        #[test]
+        fn ip_fallback_with_peer_addr() {
+            // No bearer, no apikey, but peer_addr is present ⇒ `ip:{peer}`.
+            // XFF is ignored because trusted_proxies is empty (fail-closed).
+            let jwt = jwt_issuer_for_test();
+            let mut headers = HeaderMap::new();
+            headers.insert("x-forwarded-for", HeaderValue::from_static("203.0.113.99"));
+            let peer: std::net::IpAddr = "10.0.0.5".parse().unwrap();
+
+            let key = extract_authenticated_rate_limit_key(&headers, &jwt, Some(peer), &[]);
+            assert_eq!(key, "ip:10.0.0.5", "fail-closed XFF ⇒ peer_addr wins");
+        }
+
+        #[test]
+        fn unknown_sentinel_when_no_peer() {
+            // No bearer, no apikey, no peer_addr ⇒ `ip:unknown` sentinel.
+            // Conservative: rate-limits callers we cannot identify at all
+            // rather than skipping the limit.
+            let jwt = jwt_issuer_for_test();
+            let headers = HeaderMap::new();
+
+            let key = extract_authenticated_rate_limit_key(&headers, &jwt, None, &[]);
+            assert_eq!(key, "ip:unknown");
+        }
+
+        #[test]
+        fn jwt_sub_wins_over_apikey_and_ip() {
+            // Priority order: all three sources present ⇒ `jwt-sub:{uuid}` wins.
+            let jwt = jwt_issuer_for_test();
+            let user_id = uuid::Uuid::new_v4();
+            let token = jwt.issue_access_for_test(user_id);
+
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                "authorization",
+                HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+            );
+            headers.insert("x-api-key", HeaderValue::from_static("sk-ignored"));
+            headers.insert("x-forwarded-for", HeaderValue::from_static("203.0.113.99"));
+
+            let peer: std::net::IpAddr = "10.0.0.5".parse().unwrap();
+            let key = extract_authenticated_rate_limit_key(&headers, &jwt, Some(peer), &[]);
+            assert_eq!(
+                key,
+                format!("jwt-sub:{user_id}"),
+                "JWT sub must have highest priority"
+            );
+        }
+
+        #[test]
+        fn invalid_jwt_falls_through_to_apikey() {
+            // Bearer present but HMAC-invalid ⇒ verify fails silently and
+            // we fall through to the apikey branch.
+            let jwt = jwt_issuer_for_test();
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                "authorization",
+                HeaderValue::from_static("Bearer eyJ.not.valid"),
+            );
+            headers.insert(
+                "x-api-key",
+                HeaderValue::from_static("sk-after-invalid-jwt"),
+            );
+
+            let key = extract_authenticated_rate_limit_key(&headers, &jwt, None, &[]);
+            assert!(
+                key.starts_with("apikey:"),
+                "invalid JWT must fall through to apikey, got: {key}"
+            );
+        }
     }
 
     #[test]

--- a/crates/garraia-gateway/src/rate_limiter.rs
+++ b/crates/garraia-gateway/src/rate_limiter.rs
@@ -295,6 +295,15 @@ impl RateLimiter {
 // ── Rate-limit headers ────────────────────────────────────────────────────────
 
 /// Append standard X-RateLimit-* headers to a response.
+///
+/// Plan 0022 T5 (SEC-LOW F-06): `X-RateLimit-Reset` was removed because
+/// its absolute-Unix-timestamp form leaked the exact window-reset instant,
+/// which an attacker could use to synchronize brute-force bursts right
+/// after each reset. `Retry-After` (set on 429 responses) is the IETF-
+/// canonical signal for clients and carries the same information in a
+/// relative-duration form that does not leak absolute time. The
+/// `RateLimitDecision::reset_at` field is kept for internal use
+/// (computing `Retry-After`) but is no longer emitted to the wire.
 pub fn apply_rate_limit_headers(headers: &mut HeaderMap, decision: &RateLimitDecision) {
     if let Ok(v) = HeaderValue::from_str(&decision.limit.to_string()) {
         headers.insert("x-ratelimit-limit", v);
@@ -302,23 +311,24 @@ pub fn apply_rate_limit_headers(headers: &mut HeaderMap, decision: &RateLimitDec
     if let Ok(v) = HeaderValue::from_str(&decision.remaining.to_string()) {
         headers.insert("x-ratelimit-remaining", v);
     }
-    if let Ok(v) = HeaderValue::from_str(&decision.reset_at.to_string()) {
-        headers.insert("x-ratelimit-reset", v);
-    }
+    // `x-ratelimit-reset` intentionally NOT emitted (plan 0022 T5).
 }
 
 /// Build a 429 Too Many Requests response with rate-limit headers.
+///
+/// Plan 0022 T5 (code-review NIT): headers are now applied **once** via
+/// `apply_rate_limit_headers` after the body is built, instead of the
+/// pre-0022 pattern that inserted `x-ratelimit-*` inline in the builder
+/// AND then re-applied via the helper (resulting in inocuous but confusing
+/// duplicate insertions). `Retry-After` remains in the builder because it
+/// is 429-specific and not part of the generic allowed-path header set.
 pub fn rate_limit_response(decision: &RateLimitDecision) -> Response {
+    let retry_after = decision.reset_at.saturating_sub(now_secs());
+
     let mut resp = Response::builder()
         .status(StatusCode::TOO_MANY_REQUESTS)
         .header("content-type", "application/json")
-        .header("x-ratelimit-limit", decision.limit.to_string())
-        .header("x-ratelimit-remaining", "0")
-        .header("x-ratelimit-reset", decision.reset_at.to_string())
-        .header(
-            "retry-after",
-            (decision.reset_at.saturating_sub(now_secs())).to_string(),
-        )
+        .header("retry-after", retry_after.to_string())
         .body(Body::from(r#"{"error":"rate limit exceeded","code":429}"#))
         .unwrap_or_else(|_| {
             Response::builder()
@@ -677,7 +687,40 @@ mod tests {
 
         assert!(headers.contains_key("x-ratelimit-limit"));
         assert!(headers.contains_key("x-ratelimit-remaining"));
-        assert!(headers.contains_key("x-ratelimit-reset"));
+        // Plan 0022 T5: X-RateLimit-Reset intentionally NOT emitted
+        // (timing leak → brute-force planning). Retry-After on 429
+        // responses is the canonical signal.
+        assert!(
+            !headers.contains_key("x-ratelimit-reset"),
+            "X-RateLimit-Reset must not be emitted (plan 0022 T5)"
+        );
+    }
+
+    #[test]
+    fn rate_limit_response_has_retry_after_but_not_reset() {
+        // Plan 0022 T5 regression guard: 429 responses carry
+        // Retry-After (IETF canonical), Content-Type, and the
+        // X-RateLimit-Limit/Remaining pair — but NOT X-RateLimit-Reset.
+        let limiter = strict_limiter(1);
+        limiter.check("x"); // consume
+        let decision = limiter.check("x");
+        assert!(!decision.allowed, "second call must hit the limit");
+
+        let resp = rate_limit_response(&decision);
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        let headers = resp.headers();
+        assert!(headers.contains_key("retry-after"), "Retry-After missing");
+        assert!(headers.contains_key("x-ratelimit-limit"));
+        assert!(headers.contains_key("x-ratelimit-remaining"));
+        assert!(
+            !headers.contains_key("x-ratelimit-reset"),
+            "X-RateLimit-Reset leaked into 429 response"
+        );
+        // Content-Type JSON so clients parse the body error envelope.
+        assert_eq!(
+            headers.get("content-type").and_then(|v| v.to_str().ok()),
+            Some("application/json")
+        );
     }
 
     #[test]

--- a/crates/garraia-gateway/src/rate_limiter.rs
+++ b/crates/garraia-gateway/src/rate_limiter.rs
@@ -13,11 +13,12 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use axum::body::Body;
-use axum::extract::Request;
+use axum::extract::{ConnectInfo, Request};
 use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::middleware::Next;
 use axum::response::Response;
 use dashmap::DashMap;
+use garraia_auth::JwtIssuer;
 use ipnet::IpNet;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
@@ -526,6 +527,144 @@ pub async fn rate_limit_layer(
     next: Next,
 ) -> Response {
     rate_limit_middleware(limiter, headers, req, next).await
+}
+
+// ── Plan 0022 T3 (GAR-426): per-user authenticated rate-limit ────────────────
+
+/// State for [`rate_limit_layer_authenticated`] — combines a shared
+/// `RateLimiter` with a `JwtIssuer` for per-user keying and a
+/// pre-parsed `trusted_proxies` list for the unauthenticated fallback.
+///
+/// The trio is cloned into middleware scope via axum's
+/// `from_fn_with_state`. All fields are `Arc<T>` / `Vec<IpNet>` (cheap
+/// clone) so per-request copy cost is ~pointer-sized.
+#[derive(Clone)]
+pub struct RateLimitLayerState {
+    pub limiter: Arc<RateLimiter>,
+    pub jwt_issuer: Arc<JwtIssuer>,
+    pub trusted_proxies: Vec<IpNet>,
+}
+
+impl RateLimitLayerState {
+    pub fn new(
+        limiter: Arc<RateLimiter>,
+        jwt_issuer: Arc<JwtIssuer>,
+        trusted_proxies: Vec<IpNet>,
+    ) -> Self {
+        Self {
+            limiter,
+            jwt_issuer,
+            trusted_proxies,
+        }
+    }
+}
+
+/// Derive a per-user rate-limit key from a verified JWT's `sub` claim.
+///
+/// Plan 0022 T3: fixes the shared-bucket problem documented as SEC-HIGH
+/// F-03 in the PR #30 security audit. The pre-0022 `extract_rate_limit_key`
+/// used the first 8 chars of the Bearer token as the bucket key; all
+/// HS256 JWTs issued by the same `JwtIssuer` share the same header
+/// segment (`eyJhbGci...`), so every authenticated caller collided on
+/// one bucket. This function decodes + verifies the HMAC and returns
+/// `jwt-sub:{uuid}` — a real per-user key.
+///
+/// Returns `None` when the `Authorization` header is absent, malformed,
+/// or the signature / expiration check fails. Callers decide the fallback
+/// (typically IP-keyed via `real_client_ip`).
+///
+/// **Double-verify trade-off (v1 accepted):** this function calls
+/// `JwtIssuer::verify_access` in the rate-limit middleware, and the
+/// `Principal` extractor downstream calls it again to materialize the
+/// handler's `Principal`. HMAC-SHA256 on a compact JWT is ~µs, negligible
+/// vs the handler itself (~ms for a DB tx + audit INSERT), so the
+/// duplicate cost is acceptable in v1. Optimization path — stash the
+/// decoded claims in `Request::extensions()` so the extractor can reuse
+/// them — is deferred to plan 0023+ if p95 monitoring shows >5% regression.
+pub fn extract_authenticated_key(headers: &HeaderMap, jwt: &JwtIssuer) -> Option<String> {
+    let auth = headers.get("authorization")?.to_str().ok()?;
+    let token = auth.strip_prefix("Bearer ")?;
+    let claims = jwt.verify_access(token).ok()?;
+    Some(format!("jwt-sub:{}", claims.sub))
+}
+
+/// Extract the best client identifier for an **authenticated** rate-limit
+/// bucket, with a trusted-proxy-aware IP fallback.
+///
+/// Priority:
+/// 1. Verified JWT `sub` claim ⇒ `jwt-sub:{uuid}` (real per-user bucket).
+/// 2. API key prefix ⇒ `apikey:{prefix}` (same as the unauthenticated
+///    extractor; preserved so machine-to-machine callers are not demoted
+///    to an IP bucket when they happen to miss a bearer).
+/// 3. Real client IP via [`real_client_ip`] ⇒ `ip:{addr}`.
+/// 4. Sentinel `ip:unknown`.
+fn extract_authenticated_rate_limit_key(
+    headers: &HeaderMap,
+    jwt: &JwtIssuer,
+    peer_addr: Option<std::net::IpAddr>,
+    trusted_proxies: &[IpNet],
+) -> String {
+    if let Some(key) = extract_authenticated_key(headers, jwt) {
+        return key;
+    }
+    if let Some(api_key) = headers.get("x-api-key").and_then(|v| v.to_str().ok()) {
+        let prefix = &api_key[..api_key.len().min(16)];
+        return format!("apikey:{prefix}");
+    }
+    if let Some(peer) = peer_addr {
+        let real = real_client_ip(headers, peer, trusted_proxies);
+        return format!("ip:{real}");
+    }
+    "ip:unknown".to_string()
+}
+
+/// Axum middleware layer for **authenticated** rate limiting.
+///
+/// Uses [`extract_authenticated_rate_limit_key`] so each JWT-authenticated
+/// caller gets an isolated bucket keyed by the verified `sub` claim.
+/// Unauthenticated callers fall through to API-key prefix or IP keying
+/// (see function docstring for the priority order).
+///
+/// Wire with `axum::middleware::from_fn_with_state`:
+///
+/// ```ignore
+/// let state = RateLimitLayerState::new(limiter, jwt, trusted);
+/// Router::new()
+///     .route("/v1/...", post(handler))
+///     .layer(axum::middleware::from_fn_with_state(
+///         state,
+///         rate_limit_layer_authenticated,
+///     ))
+/// ```
+pub async fn rate_limit_layer_authenticated(
+    axum::extract::State(state): axum::extract::State<RateLimitLayerState>,
+    req: Request,
+    next: Next,
+) -> Response {
+    // Pull ConnectInfo + headers from the Request instead of listing them
+    // as separate middleware extractors. axum's `from_fn_with_state`
+    // caps the total param count including State/Request/Next, and
+    // splitting headers/peer_info into dedicated params hit that cap.
+    let peer_addr = req
+        .extensions()
+        .get::<ConnectInfo<std::net::SocketAddr>>()
+        .map(|ConnectInfo(sa)| sa.ip());
+    let key = extract_authenticated_rate_limit_key(
+        req.headers(),
+        &state.jwt_issuer,
+        peer_addr,
+        &state.trusted_proxies,
+    );
+    let decision = state.limiter.check(&key);
+
+    if !decision.allowed {
+        warn!("rate limit exceeded for key={}", &key[..key.len().min(32)]);
+        return rate_limit_response(&decision);
+    }
+
+    let mut response = next.run(req).await;
+    apply_rate_limit_headers(response.headers_mut(), &decision);
+    response
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/crates/garraia-gateway/src/rate_limiter.rs
+++ b/crates/garraia-gateway/src/rate_limiter.rs
@@ -8,6 +8,7 @@
 //! `DashMap<String, WindowState>`. A background task periodically evicts
 //! expired keys to prevent unbounded memory growth.
 
+use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -17,6 +18,7 @@ use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::middleware::Next;
 use axum::response::Response;
 use dashmap::DashMap;
+use ipnet::IpNet;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
@@ -351,6 +353,90 @@ pub fn extract_rate_limit_key(headers: &HeaderMap) -> String {
     "ip:unknown".to_string()
 }
 
+// ── Trusted-proxy handling (plan 0022 T2 / GAR-426) ───────────────────────────
+
+/// Environment variable that configures which upstream proxies are allowed to
+/// set `X-Forwarded-For` on our behalf. Comma-separated list of IPs or CIDRs.
+///
+/// Examples:
+///   `GARRAIA_TRUSTED_PROXIES=127.0.0.1,10.0.0.0/8`
+///   `GARRAIA_TRUSTED_PROXIES=::1,fc00::/7`
+///
+/// **Fail-closed default:** when the variable is unset OR empty, no proxy is
+/// trusted and `X-Forwarded-For` is ignored entirely. The `peer_addr` (from the
+/// TCP socket) becomes the sole client identifier. This is safer than the
+/// pre-0022 behavior (header accepted unconditionally), at the cost of
+/// requiring deployments behind real proxies to set the var explicitly.
+pub const TRUSTED_PROXIES_ENV: &str = "GARRAIA_TRUSTED_PROXIES";
+
+/// Parse `GARRAIA_TRUSTED_PROXIES` into a `Vec<IpNet>`. Bare IPs are promoted
+/// to `/32` (IPv4) or `/128` (IPv6) CIDRs automatically.
+///
+/// Malformed entries are skipped with a tracing warning — the goal is best-
+/// effort (a typo in one entry should not disable trust for the others) while
+/// preserving the fail-closed semantics (empty / all-invalid ⇒ empty Vec ⇒
+/// XFF ignored).
+pub fn parse_trusted_proxies(value: &str) -> Vec<IpNet> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .filter_map(|s| match s.parse::<IpNet>() {
+            Ok(net) => Some(net),
+            Err(_) => match s.parse::<IpAddr>() {
+                Ok(ip) => Some(IpNet::from(ip)),
+                Err(e) => {
+                    warn!(
+                        entry = s,
+                        error = %e,
+                        "ignoring malformed entry in {TRUSTED_PROXIES_ENV}"
+                    );
+                    None
+                }
+            },
+        })
+        .collect()
+}
+
+/// Derive the real client IP, honoring `X-Forwarded-For` **only** when the
+/// immediate peer is in the `trusted_proxies` allowlist.
+///
+/// Rules (plan 0022 T2 / GAR-426):
+/// 1. If `trusted_proxies` is empty (env unset or all-invalid) ⇒ return
+///    `peer_addr` unconditionally. XFF is ignored (fail-closed).
+/// 2. If `peer_addr` is NOT in any entry of `trusted_proxies` ⇒ return
+///    `peer_addr`. The peer is not an authorized proxy, so its XFF header is
+///    untrusted.
+/// 3. If `peer_addr` IS in `trusted_proxies` ⇒ try to parse the first IP from
+///    `X-Forwarded-For`. If present and valid ⇒ return that. If absent or
+///    malformed ⇒ fall back to `peer_addr`.
+///
+/// **Note:** this helper is currently used only by the rate-limiter's fallback
+/// key-extractor branch (unauthenticated / no-JWT requests). The other two
+/// gateway sites that read `X-Forwarded-For` (`api.rs:71` session token IP
+/// stamp, `admin/middleware.rs:168` admin extract_ip) are intentionally out
+/// of scope for plan 0022 — see GAR-426 description. A later plan (0023+)
+/// should consolidate all three through this helper.
+pub fn real_client_ip(
+    headers: &HeaderMap,
+    peer_addr: IpAddr,
+    trusted_proxies: &[IpNet],
+) -> IpAddr {
+    if trusted_proxies.is_empty() {
+        return peer_addr;
+    }
+    if !trusted_proxies.iter().any(|net| net.contains(&peer_addr)) {
+        return peer_addr;
+    }
+    // Peer is a trusted proxy — honor XFF.
+    headers
+        .get("x-forwarded-for")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.split(',').next())
+        .and_then(|s| s.trim().parse::<IpAddr>().ok())
+        .unwrap_or(peer_addr)
+}
+
 /// Axum middleware that applies a shared `RateLimiter` to every request.
 ///
 /// On limit exceeded: returns 429 with X-RateLimit-* headers.
@@ -404,6 +490,109 @@ mod tests {
             requests_per_hour: 1000,
             burst_size: 1,
         })
+    }
+
+    // ── Plan 0022 T2: TRUSTED_PROXIES + real_client_ip tests ────────────────
+
+    fn peer_v4() -> IpAddr {
+        "10.0.0.5".parse().unwrap()
+    }
+
+    fn peer_v6() -> IpAddr {
+        "fc00::1".parse().unwrap()
+    }
+
+    fn xff_header(value: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert("x-forwarded-for", HeaderValue::from_str(value).unwrap());
+        h
+    }
+
+    #[test]
+    fn trusted_proxies_empty_env_ignores_xff() {
+        // Fail-closed: when GARRAIA_TRUSTED_PROXIES is unset or empty, no
+        // proxy is trusted and X-Forwarded-For is ignored. `peer_addr`
+        // becomes the sole source of truth.
+        let trusted = parse_trusted_proxies("");
+        assert!(trusted.is_empty(), "empty env must produce empty Vec");
+
+        let headers = xff_header("203.0.113.99"); // forged upstream IP
+        let resolved = real_client_ip(&headers, peer_v4(), &trusted);
+        assert_eq!(
+            resolved,
+            peer_v4(),
+            "empty trusted list ⇒ XFF is ignored, peer_addr wins"
+        );
+    }
+
+    #[test]
+    fn trusted_proxies_peer_in_allowlist_accepts_xff() {
+        // Peer is a listed proxy ⇒ XFF is honored. Exact-IP form `/32`
+        // and CIDR form `10.0.0.0/8` both match `peer_v4() = 10.0.0.5`.
+        let trusted = parse_trusted_proxies("10.0.0.0/8, ::1");
+        assert_eq!(trusted.len(), 2);
+
+        let headers = xff_header("203.0.113.99");
+        let resolved = real_client_ip(&headers, peer_v4(), &trusted);
+        assert_eq!(
+            resolved.to_string(),
+            "203.0.113.99",
+            "trusted proxy peer ⇒ XFF.first_hop wins"
+        );
+    }
+
+    #[test]
+    fn trusted_proxies_peer_outside_allowlist_ignores_xff() {
+        // Only a different CIDR listed; peer_v4 = 10.0.0.5 is NOT inside it.
+        // ⇒ peer is not a trusted proxy ⇒ XFF ignored, peer_addr returned.
+        let trusted = parse_trusted_proxies("172.16.0.0/12");
+        assert_eq!(trusted.len(), 1);
+
+        let headers = xff_header("203.0.113.99");
+        let resolved = real_client_ip(&headers, peer_v4(), &trusted);
+        assert_eq!(
+            resolved,
+            peer_v4(),
+            "untrusted peer ⇒ XFF ignored, peer_addr wins (spoofing defense)"
+        );
+    }
+
+    #[test]
+    fn trusted_proxies_cidr_ipv4_and_ipv6_parse() {
+        // Exercises (a) bare IPv4 → /32 promotion, (b) IPv4 CIDR,
+        // (c) bare IPv6 → /128 promotion, (d) IPv6 CIDR,
+        // (e) malformed entry skipped silently.
+        let trusted = parse_trusted_proxies(
+            "127.0.0.1, 10.0.0.0/8, ::1, fc00::/7, not-an-ip, , 999.999.999.999",
+        );
+        assert_eq!(
+            trusted.len(),
+            4,
+            "exactly 4 valid CIDRs (bare IPv4+IPv6 + 2 CIDRs); malformed/empty dropped. got: {trusted:?}"
+        );
+
+        // IPv6 peer inside fc00::/7.
+        let headers = xff_header("2001:db8::1");
+        let resolved = real_client_ip(&headers, peer_v6(), &trusted);
+        assert_eq!(
+            resolved.to_string(),
+            "2001:db8::1",
+            "IPv6 peer inside fc00::/7 ⇒ XFF honored"
+        );
+    }
+
+    #[test]
+    fn trusted_proxies_malformed_xff_falls_back_to_peer() {
+        // Peer IS trusted, but XFF body is unparseable ⇒ fallback to peer.
+        // Guards against a trusted proxy sending garbage XFF.
+        let trusted = parse_trusted_proxies("10.0.0.0/8");
+        let headers = xff_header("not-an-ip");
+        let resolved = real_client_ip(&headers, peer_v4(), &trusted);
+        assert_eq!(
+            resolved,
+            peer_v4(),
+            "malformed XFF ⇒ fallback to peer_addr"
+        );
     }
 
     #[test]

--- a/crates/garraia-gateway/src/rate_limiter.rs
+++ b/crates/garraia-gateway/src/rate_limiter.rs
@@ -116,9 +116,17 @@ impl WindowState {
     }
 
     /// Count requests in the last `window_secs` seconds.
+    ///
+    /// Plan 0022 T5: returns `u32` via `try_from` saturated at `u32::MAX`.
+    /// The cap is defensive only — `prune(3600)` bounds `timestamps.len()`
+    /// to the number of requests observed in the last hour, which even
+    /// at 100k req/s would saturate `Vec<u64>` memory long before
+    /// overflowing `u32`. Previously cast `as u32`, which would silently
+    /// truncate in the unreachable overflow case.
     fn count_in_window(&self, window_secs: u64) -> u32 {
         let cutoff = now_secs().saturating_sub(window_secs);
-        self.timestamps.iter().filter(|&&t| t >= cutoff).count() as u32
+        let count = self.timestamps.iter().filter(|&&t| t >= cutoff).count();
+        u32::try_from(count).unwrap_or(u32::MAX)
     }
 
     /// Record a new request timestamp.
@@ -187,28 +195,60 @@ impl RateLimiter {
     ///
     /// Returns a `RateLimitDecision` — the caller must check `allowed` and
     /// return 429 if it is `false`.
+    ///
+    /// ## Lock discipline (plan 0022 T4, addressing code-review HIGH of PR #30)
+    ///
+    /// The method is split into two phases to avoid holding a write lock on
+    /// the DashMap shard for the entire window-count computation:
+    ///
+    /// 1. **Read phase:** probe via `get()`, clone the `WindowState`, drop
+    ///    the read guard immediately. Prune + count happen on the clone —
+    ///    the shard lock is not held across those loops.
+    /// 2. **Write phase (only when `allowed`):** re-acquire via `entry()`
+    ///    or `get_mut()` to record the new timestamp. Brief write lock.
+    ///
+    /// The split accepts a benign race: two callers can both observe
+    /// `allowed = true` in phase 1 and both record in phase 2, producing
+    /// one extra request above the nominal ceiling per race window. For
+    /// the soft-limit semantics of a sliding-window rate limiter this is
+    /// acceptable — the alternative (locking the shard around the full
+    /// compute+write path, pre-0022 behavior) serialized all throughput
+    /// to the rate of a single `count_in_window` loop even for unrelated
+    /// keys sharing a DashMap shard.
     pub fn check(&self, key: &str) -> RateLimitDecision {
-        let mut entry = self
-            .windows
-            .entry(key.to_string())
-            .or_insert_with(WindowState::new);
-        entry.prune(3600); // keep at most 1 hour of history
+        let now = now_secs();
 
-        let per_minute = entry.count_in_window(60);
-        let per_hour = entry.count_in_window(3600);
+        // Phase 1: read-only snapshot. Cloning the WindowState limits the
+        // read guard to a single shard-touch and lets us prune/count on
+        // our local copy.
+        let (per_minute, per_hour) = match self.windows.get(key) {
+            Some(entry) => {
+                let mut snapshot = entry.clone();
+                drop(entry);
+                snapshot.prune(3600);
+                (snapshot.count_in_window(60), snapshot.count_in_window(3600))
+            }
+            None => (0, 0),
+        };
 
         let allowed = per_minute < self.config.requests_per_minute
             && per_hour < self.config.requests_per_hour;
 
+        // Phase 2: brief write if allowed.
         if allowed {
+            let mut entry = self
+                .windows
+                .entry(key.to_string())
+                .or_insert_with(WindowState::new);
+            entry.prune(3600);
             entry.record();
         }
 
         let remaining = self
             .config
             .requests_per_minute
-            .saturating_sub(per_minute + 1);
-        let reset_at = now_secs() + 60 - (now_secs() % 60);
+            .saturating_sub(u32::try_from(per_minute.saturating_add(1)).unwrap_or(u32::MAX));
+        let reset_at = now + 60 - (now % 60);
 
         RateLimitDecision {
             allowed,

--- a/crates/garraia-gateway/src/rate_limiter.rs
+++ b/crates/garraia-gateway/src/rate_limiter.rs
@@ -468,11 +468,7 @@ pub fn parse_trusted_proxies(value: &str) -> Vec<IpNet> {
 /// stamp, `admin/middleware.rs:168` admin extract_ip) are intentionally out
 /// of scope for plan 0022 — see GAR-426 description. A later plan (0023+)
 /// should consolidate all three through this helper.
-pub fn real_client_ip(
-    headers: &HeaderMap,
-    peer_addr: IpAddr,
-    trusted_proxies: &[IpNet],
-) -> IpAddr {
+pub fn real_client_ip(headers: &HeaderMap, peer_addr: IpAddr, trusted_proxies: &[IpNet]) -> IpAddr {
     if trusted_proxies.is_empty() {
         return peer_addr;
     }
@@ -777,11 +773,7 @@ mod tests {
         let trusted = parse_trusted_proxies("10.0.0.0/8");
         let headers = xff_header("not-an-ip");
         let resolved = real_client_ip(&headers, peer_v4(), &trusted);
-        assert_eq!(
-            resolved,
-            peer_v4(),
-            "malformed XFF ⇒ fallback to peer_addr"
-        );
+        assert_eq!(resolved, peer_v4(), "malformed XFF ⇒ fallback to peer_addr");
     }
 
     #[test]

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -44,7 +44,9 @@ use garraia_auth::{AppPool, JwtIssuer, LoginPool};
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
-use crate::rate_limiter::{RateLimiter, rate_limit_layer};
+use crate::rate_limiter::{
+    RateLimitLayerState, RateLimiter, parse_trusted_proxies, rate_limit_layer_authenticated,
+};
 use crate::state::AppState;
 
 use self::openapi::ApiDoc;
@@ -156,13 +158,25 @@ pub fn router(app_state: Arc<AppState>) -> Router {
             // real handlers (`groups::create_group` + `groups::get_group`).
             // Modes 2 and 3 still answer 503 via `unconfigured_handler`
             // because they lack `Arc<AppPool>` in state.
-            // Plan 0021: dedicated rate-limit (20/min, burst 5) on the
-            // 3 privileged members-management endpoints. Separate
-            // sub-router so the layer applies only to these routes;
-            // read/create endpoints keep the global governor. Key
-            // extractor (`extract_rate_limit_key`) prefers JWT
-            // token-prefix over IP so NAT-bucketing is avoided.
+            // Plan 0022 T3 (GAR-426): per-user authenticated rate-limit
+            // (20/min, burst 5) on the 3 privileged endpoints. Replaces
+            // the pre-0022 `rate_limit_layer` that keyed by JWT token-
+            // prefix (all HS256 tokens collided on `jwt:eyJhbGci`). The
+            // new `rate_limit_layer_authenticated` verifies the JWT and
+            // keys by the `sub` claim (`jwt-sub:{uuid}`), giving each
+            // user an isolated bucket. Unauthenticated fallback uses
+            // `real_client_ip` with trusted-proxy stripping (plan 0022
+            // T2, env `GARRAIA_TRUSTED_PROXIES`).
             let members_manage_rl = RateLimiter::members_manage_limiter();
+            let trusted_proxies = std::env::var("GARRAIA_TRUSTED_PROXIES")
+                .ok()
+                .map(|v| parse_trusted_proxies(&v))
+                .unwrap_or_default();
+            let rate_limit_state = RateLimitLayerState::new(
+                members_manage_rl,
+                full.auth.jwt_issuer.clone(),
+                trusted_proxies,
+            );
             let rate_limited_routes = Router::new()
                 .route(
                     "/v1/groups/{id}/members/{user_id}/setRole",
@@ -174,8 +188,8 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 )
                 .route("/v1/invites/{token}/accept", post(invites::accept_invite))
                 .layer(axum::middleware::from_fn_with_state(
-                    members_manage_rl,
-                    rate_limit_layer,
+                    rate_limit_state,
+                    rate_limit_layer_authenticated,
                 ));
 
             Router::new()

--- a/crates/garraia-gateway/src/router.rs
+++ b/crates/garraia-gateway/src/router.rs
@@ -160,10 +160,18 @@ pub fn build_router(
         //     get(runtime_handler::list_tools_handler),
         // )
         // GAR-335/339: Mobile Cloud Alpha — auth + chat endpoints
-        // Auth routes with strict rate limiting (10 req/min, burst 3)
+        // Auth routes with strict rate limiting (10 req/min, burst 3).
+        //
+        // TODO(plan-0023+): migrate these routes from the deprecated
+        // `rate_limit_layer` to `rate_limit_layer_authenticated` once
+        // the `/auth/*` handlers reliably have a Bearer token on the
+        // request (register/login today don't — they MINT the token).
+        // For now the #[allow(deprecated)] is the compatibility shim.
         .merge({
+            #[allow(deprecated)]
             let auth_limiter = crate::rate_limiter::RateLimiter::auth_limiter();
-            Router::new()
+            #[allow(deprecated)]
+            let router = Router::new()
                 .route("/auth/register", post(mobile_auth::register))
                 .route("/auth/login", post(mobile_auth::login))
                 .route("/auth/oauth/providers", get(oauth::list_oauth_providers))
@@ -179,7 +187,8 @@ pub fn build_router(
                     auth_limiter,
                     crate::rate_limiter::rate_limit_layer,
                 ))
-                .with_state(state.clone())
+                .with_state(state.clone());
+            router
         })
         .route("/me", get(mobile_auth::me))
         .route("/chat", post(mobile_chat::chat))

--- a/crates/garraia-gateway/tests/audit_workspace_branch_two.rs
+++ b/crates/garraia-gateway/tests/audit_workspace_branch_two.rs
@@ -1,0 +1,101 @@
+//! Plan 0022 T7 (GAR-426) — regression guard for the policy branch 2
+//! of `audit_events_group_or_self`.
+//!
+//! The policy (migration 007:161, tightened with `WITH CHECK` in
+//! migration 013) has two branches:
+//!
+//! ```sql
+//! (group_id IS NOT NULL
+//!  AND group_id = current_setting('app.current_group_id')::uuid)
+//! OR
+//! (group_id IS NULL
+//!  AND actor_user_id = current_setting('app.current_user_id')::uuid)
+//! ```
+//!
+//! Branch 1 (group audit) is exercised by plan 0021's `accept_invite`,
+//! `set_member_role`, `delete_member` integration tests — all three
+//! set `app.current_group_id` before calling `audit_workspace_event`
+//! (plan 0021 T3/T4/T5).
+//!
+//! Branch 2 (user audit, group_id IS NULL) is **unreachable by the
+//! current workspace audit helpers** because `audit_workspace_event`
+//! signature requires `group_id: Uuid` (non-optional). But the policy
+//! branch is still load-bearing for any future user-scoped audit
+//! (e.g. global self-export events). Without `app.current_user_id`
+//! set, the WITH CHECK must reject the INSERT with SQLSTATE 42501
+//! (RLS policy violation on row-level security).
+//!
+//! This test pokes the policy directly by opening a tx on the
+//! `garraia_app` pool, deliberately NOT setting `app.current_user_id`,
+//! and attempting a raw `INSERT INTO audit_events` with
+//! `group_id = NULL`. The INSERT must fail.
+//!
+//! This is a REGRESSION GUARD — if a future migration accidentally
+//! relaxes the policy (for example by changing `WITH CHECK` to `TRUE`
+//! under a misguided "permissive" refactor), this test catches it.
+//! The test lives outside `audit_workspace_event` by design: exercising
+//! the helper would require wrapping its `group_id: Uuid` signature
+//! (or adding an Option<Uuid> variant) which is out-of-scope for plan
+//! 0022. Raw INSERT is the minimal viable regression guard.
+
+mod common;
+
+use common::Harness;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn audit_events_insert_without_current_user_id_is_rejected_by_rls() {
+    let h = Harness::get().await;
+    let pool = h.app_pool.pool_for_handlers();
+
+    // Open a tx on the `garraia_app` pool and DELIBERATELY skip
+    // `SET LOCAL app.current_user_id`. The policy branch 2
+    // (`group_id IS NULL ...`) then has no matching user_id and
+    // the WITH CHECK (migration 013) rejects the INSERT.
+    let mut tx = pool
+        .begin()
+        .await
+        .expect("F-05: begin tx on app_pool");
+
+    let actor = Uuid::new_v4();
+
+    // Raw INSERT with group_id = NULL → exercises policy branch 2.
+    // Any `actor_user_id` value works here because the predicate
+    // compares against `current_setting('app.current_user_id')`,
+    // which is empty → NULLIF returns NULL → comparison is NULL →
+    // the OR branch 2 evaluates to NULL → treated as false → the
+    // WITH CHECK denies the INSERT.
+    let result = sqlx::query(
+        "INSERT INTO audit_events \
+             (group_id, actor_user_id, action, resource_type, resource_id, metadata) \
+         VALUES (NULL, $1, 'test.branch_two_guard', 'test_resource', $2, '{}'::jsonb)",
+    )
+    .bind(actor)
+    .bind(actor.to_string())
+    .execute(&mut *tx)
+    .await;
+
+    // The expected failure mode is `sqlx::Error::Database` with
+    // SQLSTATE 42501 (`insufficient_privilege` — how Postgres
+    // reports RLS WITH CHECK rejections).
+    match result {
+        Err(sqlx::Error::Database(db_err))
+            if db_err.code().as_deref() == Some("42501") =>
+        {
+            // Expected — WITH CHECK denies the INSERT because no
+            // branch of the policy matches.
+        }
+        Err(other) => panic!(
+            "F-05: expected SQLSTATE 42501 (RLS WITH CHECK rejection), got a different error: {other:?}"
+        ),
+        Ok(_) => panic!(
+            "F-05 REGRESSION: INSERT into audit_events with group_id=NULL and NO \
+             app.current_user_id set should be rejected by the RLS policy \
+             (migration 013 added explicit WITH CHECK). Accepting this INSERT \
+             means the policy was accidentally relaxed — investigate recent \
+             changes to migration 007/013 or the RLS setup in garraia-workspace."
+        ),
+    }
+
+    // Tx is dropped without commit regardless.
+}

--- a/crates/garraia-gateway/tests/audit_workspace_branch_two.rs
+++ b/crates/garraia-gateway/tests/audit_workspace_branch_two.rs
@@ -52,10 +52,7 @@ async fn audit_events_insert_without_current_user_id_is_rejected_by_rls() {
     // `SET LOCAL app.current_user_id`. The policy branch 2
     // (`group_id IS NULL ...`) then has no matching user_id and
     // the WITH CHECK (migration 013) rejects the INSERT.
-    let mut tx = pool
-        .begin()
-        .await
-        .expect("F-05: begin tx on app_pool");
+    let mut tx = pool.begin().await.expect("F-05: begin tx on app_pool");
 
     let actor = Uuid::new_v4();
 
@@ -79,9 +76,7 @@ async fn audit_events_insert_without_current_user_id_is_rejected_by_rls() {
     // SQLSTATE 42501 (`insufficient_privilege` — how Postgres
     // reports RLS WITH CHECK rejections).
     match result {
-        Err(sqlx::Error::Database(db_err))
-            if db_err.code().as_deref() == Some("42501") =>
-        {
+        Err(sqlx::Error::Database(db_err)) if db_err.code().as_deref() == Some("42501") => {
             // Expected — WITH CHECK denies the INSERT because no
             // branch of the policy matches.
         }

--- a/crates/garraia-gateway/tests/audit_workspace_branch_two.rs
+++ b/crates/garraia-gateway/tests/audit_workspace_branch_two.rs
@@ -72,16 +72,34 @@ async fn audit_events_insert_without_current_user_id_is_rejected_by_rls() {
     .execute(&mut *tx)
     .await;
 
-    // The expected failure mode is `sqlx::Error::Database` with
-    // SQLSTATE 42501 (`insufficient_privilege` — how Postgres
-    // reports RLS WITH CHECK rejections).
+    // The **expected** failure mode is `sqlx::Error::Database` with
+    // SQLSTATE 42501 (`insufficient_privilege` — how Postgres reports
+    // RLS WITH CHECK rejections). The current policy (migration 007:
+    // 161-168, hardened by migration 013) uses `NULLIF(current_setting(
+    // 'app.current_user_id', true), '')::uuid` so an unset session var
+    // evaluates cleanly to NULL and the WITH CHECK denies the write
+    // with 42501.
+    //
+    // A policy refactor that drops the `NULLIF` would instead surface
+    // SQLSTATE 22P02 (`invalid_text_representation`) from the empty-
+    // string → uuid coercion failure BEFORE the policy's WITH CHECK
+    // runs. That is also a failure — the INSERT is still rejected —
+    // so we accept 22P02 as a valid failure code here, but the test
+    // panics loudly on any OTHER error so a less-defensive refactor
+    // is caught in review.
     match result {
-        Err(sqlx::Error::Database(db_err)) if db_err.code().as_deref() == Some("42501") => {
-            // Expected — WITH CHECK denies the INSERT because no
-            // branch of the policy matches.
+        Err(sqlx::Error::Database(db_err))
+            if matches!(db_err.code().as_deref(), Some("42501") | Some("22P02")) =>
+        {
+            // Expected — either the policy's WITH CHECK denies the
+            // INSERT (42501) or the NULLIF was dropped and the
+            // empty-string cast fails first (22P02). Both are
+            // equivalent from the regression-guard standpoint:
+            // the INSERT is rejected.
         }
         Err(other) => panic!(
-            "F-05: expected SQLSTATE 42501 (RLS WITH CHECK rejection), got a different error: {other:?}"
+            "F-05: expected SQLSTATE 42501 (RLS WITH CHECK rejection) \
+             or 22P02 (empty-string cast if NULLIF removed), got: {other:?}"
         ),
         Ok(_) => panic!(
             "F-05 REGRESSION: INSERT into audit_events with group_id=NULL and NO \

--- a/crates/garraia-gateway/tests/rest_v1_invites.rs
+++ b/crates/garraia-gateway/tests/rest_v1_invites.rs
@@ -399,80 +399,88 @@ async fn v1_invites_accept_scenarios() {
         );
     }
 
-    // ─── A7: rate-limit 429 is reachable on /accept (plan 0021) ───
+    // ─── A7: rate-limit deterministic 429 on /accept (plan 0022 T6) ───
     //
-    // Smoke-tests that the members_manage rate-limit middleware is
-    // actually wired on `POST /v1/invites/{token}/accept`. A regression
-    // that removed the `.layer(rate_limit_layer)` would make this test
-    // fail by exhausting a 1000+ loop without ever seeing 429.
+    // Verifies that `rate_limit_layer_authenticated` (plan 0022 T3)
+    // keys by the verified JWT `sub` claim, giving each user an
+    // isolated bucket. With the per-user key in place this test can
+    // assert **deterministically** that the 21st request returns 429
+    // (vs the plan 0021 version that had to loop up to 40 times and
+    // accept "eventually" because all JWT tokens collided on one
+    // bucket — SEC-HIGH F-03 in the plan 0021 security review).
     //
-    // **Key-extractor caveat (plan 0021 follow-up):** the current
-    // `extract_rate_limit_key` (rate_limiter.rs:265-289) uses the first
-    // 8 chars of the Bearer token as the bucket key. Every HS256 JWT
-    // starts with the same header segment (`eyJhbGci...`) → all JWT-
-    // authenticated callers in this test binary share ONE rate-limit
-    // bucket for `/accept`. Our plan 0021 invariant 3 said "JWT
-    // user_id > IP", but the existing extractor does NOT decode the
-    // JWT — it uses the token prefix. Fixing the extractor to decode
-    // the `sub` claim (or take a later slice of the token payload) is
-    // deferred to a dedicated plan (candidate for 0022+). For the test
-    // we therefore don't assert an exact budget (A1-A6 and internal
-    // fixture requests already consumed part of the window); we just
-    // assert that rate-limiting IS enforced — i.e. at least one 429
-    // appears within a small number of rapid-fire requests.
-    //
-    // If the middleware were missing, this loop would return 404 every
-    // time (handler runs with bogus token) and the assertion at the
-    // bottom would fail with zero 429s observed.
+    // Regression guards:
+    // 1. First 20 requests must ALL return 404 (bogus token, handler
+    //    ran under-limit). Any 429 inside the first 20 proves the
+    //    bucket is still shared — plan 0022 T3 regressed.
+    // 2. The 21st request must return 429 exactly. Any other status
+    //    proves the middleware is missing.
+    // 3. The 429 must carry `Retry-After` + `X-RateLimit-Limit` +
+    //    `X-RateLimit-Remaining`, but MUST NOT carry `X-RateLimit-
+    //    Reset` (plan 0022 T5 removed it — timing leak).
     {
-        let (_burster_id, burster_token) = seed_user_without_group(&h, "a7-burster@0021.test")
+        let (_burster_id, burster_token) = seed_user_without_group(&h, "a7-burster@0022.test")
             .await
             .expect("A7: seed burster");
-        // Reuse any bogus token — the handler never reaches token
-        // resolution under rate-limit pressure (the middleware returns
-        // early). Using a known-bogus value also makes the 404 path
-        // deterministic for under-limit requests.
+        // 43-char bogus token so TOKEN_LEN_CHARS guard inside
+        // accept_invite passes; the handler then fails hash match
+        // and returns 404. This makes the under-limit behavior
+        // deterministic (always 404) when the rate-limit is off.
         let bogus = "a7-bogus-token-len43-chars-aaaaaaaaaaaaaaaaa";
 
-        let mut observed_429: Option<axum::response::Response> = None;
-        // Cap the loop at 40 — generous margin over the 20/min budget
-        // so even if the earlier scenarios consumed part of the window
-        // the 429 should arrive well within this count.
-        for i in 0..40 {
+        // 20 under-limit requests MUST all be 404 (members_manage
+        // preset = 20/min).
+        for i in 0..20 {
             let resp = h
                 .router
                 .clone()
                 .oneshot(post_accept(Some(&burster_token), bogus))
                 .await
                 .expect("A7: oneshot");
-            if resp.status() == StatusCode::TOO_MANY_REQUESTS {
-                observed_429 = Some(resp);
-                break;
-            }
-            // Non-429 responses should be 404 (bogus token, handler ran).
             assert_eq!(
                 resp.status(),
                 StatusCode::NOT_FOUND,
-                "A7 req {i}: expected 404 (bogus token) or 429 (limit); got {}",
-                resp.status()
+                "A7 req {i} (zero-indexed, so 1-{n}-th under-limit): expected 404 (bogus token); \
+                 got {}. Likely regression: per-user bucket not working — check plan 0022 T3.",
+                resp.status(),
+                n = i + 1
             );
         }
 
-        let resp = observed_429.expect(
-            "A7: rate-limit middleware MUST be wired on /accept — saw no 429 in 40 requests",
+        // 21st request: MUST be 429.
+        let resp = h
+            .router
+            .clone()
+            .oneshot(post_accept(Some(&burster_token), bogus))
+            .await
+            .expect("A7: 21st oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "A7: 21st request MUST return 429 (members_manage preset = 20/min \
+             per jwt-sub bucket). Got {}. Likely regression: middleware \
+             unwired or bucket still shared.",
+            resp.status()
         );
-        // Verify the IETF rate-limit headers are present on 429.
+        let headers = resp.headers();
         assert!(
-            resp.headers().contains_key("x-ratelimit-limit"),
+            headers.contains_key("retry-after"),
+            "A7: 429 must carry Retry-After (IETF canonical)"
+        );
+        assert!(
+            headers.contains_key("x-ratelimit-limit"),
             "A7: 429 must carry X-RateLimit-Limit"
         );
         assert!(
-            resp.headers().contains_key("x-ratelimit-remaining"),
+            headers.contains_key("x-ratelimit-remaining"),
             "A7: 429 must carry X-RateLimit-Remaining"
         );
+        // Plan 0022 T5: X-RateLimit-Reset intentionally removed
+        // (timing leak). Retry-After covers the signal in a
+        // relative-duration form that does not leak absolute time.
         assert!(
-            resp.headers().contains_key("retry-after"),
-            "A7: 429 must carry Retry-After"
+            !headers.contains_key("x-ratelimit-reset"),
+            "A7: X-RateLimit-Reset MUST NOT be emitted (plan 0022 T5 removed it)"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Closes the 9 follow-ups explicitly deferred from plan 0021 reviews (PR #30):
  - **Per-user rate-limit key** via JWT `sub` decoding (SEC-HIGH F-03 fix).
  - **`GARRAIA_TRUSTED_PROXIES`** env var + `real_client_ip` helper with fail-closed default (SEC-HIGH F-02 fix).
  - **DashMap lock split** in `RateLimiter::check()` (code-review HIGH).
  - **NIT sweep** — `reset_at` single-call, `count_in_window` try_from, remove duplicated headers, **remove `X-RateLimit-Reset`** (SEC-LOW F-06).
  - **F-05 regression guard** — integration test for RLS policy branch 2 (SEC-LOW).
  - **`WorkspaceAuditAction::Display`** impl (code-review NIT).
  - **A7 burst test deterministic** — 21st request = 429 exact.
- 9 commits: T1–T8 + 1 review follow-ups commit.

## Linear

- Issue: [GAR-426](https://linear.app/chatgpt25/issue/GAR-426) — In Progress.
- Plan draft PR #32 (merged as `4f4088f`).

## Design invariants (all enforced + tested)

1. **Fail-closed TRUSTED_PROXIES** — empty env ⇒ XFF ignored entirely.
2. **Per-user bucket** — `jwt-sub:{uuid}` after HMAC-verified `verify_access`; no token-prefix fallback.
3. **DashMap split** — read-phase via `get().clone()` → drop guard → compute → brief write only if allowed. Benign race bounded at +1 overshoot documented in comment.
4. **`X-RateLimit-Reset` removed** — timing leak closed. `Retry-After` remains canonical.
5. **Double-verify trade-off (v1 accepted)** — middleware + extractor both call `verify_access` (~µs cost, negligible vs handler ms). Optimization path via `request.extensions()` deferred to plan 0023+.
6. **Deprecated legacy surface** — `extract_rate_limit_key`, `rate_limit_middleware`, `rate_limit_layer` marked `#[deprecated]` to prevent accidental re-wiring of F-02/F-03 bugs. Internal call-sites use `#[allow(deprecated)]` + `TODO(plan-0023+)`.
7. **Test isolation** — A7 deterministic works because each seed_user_* gets a unique JWT `sub` = unique bucket.

## Commits

| # | Commit | What |
|---|---|---|
| T1 | `c3c4988` | `WorkspaceAuditAction::Display` impl + unit test |
| T2 | `d993e03` | `GARRAIA_TRUSTED_PROXIES` env + `real_client_ip` + 5 unit tests + `ipnet` dep |
| T4 | `94ec498` | DashMap lock split in `check()` + `u32::try_from` in `count_in_window` |
| T5 | `94e3971` | Remove `X-RateLimit-Reset` + consolidate `rate_limit_response` headers |
| T3 | `78f2874` | `RateLimitLayerState` + `rate_limit_layer_authenticated` (per-user JWT sub keying) + wire mode 1 |
| T6 | `91ff5d5` | A7 burst test upgraded to deterministic (21st = 429 exact) |
| T7 | `cbf6f38` | F-05 integration test `audit_workspace_branch_two.rs` (RLS policy branch 2 guard) |
| T8 | `63c1bcd` | `cargo fmt` + Cargo.lock |
| FU | `4712513` | **Review follow-ups** — stale docstring, `#[deprecated]`, 5 fallback-ladder tests, axum-cap doc, F-05 widen match, remaining-invariant comment, XFF TODOs in api.rs+admin/middleware.rs |

## Review results (pre-PR, two-agent)

### Code review (`@code-reviewer`) — **APPROVE WITH NITS, 0 blockers**
- 0 HIGH (any HIGH from plan 0021 carried over was already addressed in the commits above).
- 0 MEDIUM.
- 5 NITs (S-01 to S-05): **all addressed** in commit `4712513` — the remaining-invariant comment, fallback ladder tests, axum-cap doc, F-05 widen match, deprecation signals.

### Security audit (`@security-auditor`) — **8.5/10 APPROVE**
- 0 BLOCKER / 0 SEC-HIGH.
- 2 SEC-LOWs: **addressed** (stale docstring line 4; `#[deprecated]` on legacy extractors).
- 1 SEC-LOW (XFF in api.rs/admin/middleware.rs): kept out-of-scope per GAR-426 description; added `TODO(plan-0023+)` markers inline.
- 3 INFO findings (DashMap race bounded, double-verify cost, accept_invite scan): all documented and accepted for v1.
- Key sign-off: "Plan 0022 fecha corretamente os 9 follow-ups identificados na revisão do plan 0021. O fix central — per-user rate-limit com JWT `sub` como chave — é implementado de forma correta e defensiva."

## Acceptance criteria

- [x] A7 test returns 429 **exactly** on the 21st request.
- [x] `rate_limit_layer_authenticated` keys by verified JWT `sub` UUID.
- [x] `GARRAIA_TRUSTED_PROXIES` documented + 5 unit tests (4 MUSTs + malformed XFF fallback).
- [x] `X-RateLimit-Reset` absent from all response headers (regression guards in `headers_populated`, `rate_limit_response_has_retry_after_but_not_reset`, and A7).
- [x] `WorkspaceAuditAction::Display` + unit test pass.
- [x] F-05 integration test passes (accepts SQLSTATE 42501 + defensive 22P02).
- [x] Legacy `extract_rate_limit_key` + `rate_limit_layer` marked `#[deprecated]`.
- [x] Full test matrix green (9 binaries): **199 gateway lib + 44 auth lib + 8 integrations**.
- [x] cargo fmt --check clean.
- [x] cargo clippy zero warnings in plan 0022 files.
- [ ] CI 9/9 green on this PR.

## Rollback

All additive + forward-compatible. Revert of the squash commit restores plan 0021 behavior. No migrations. No schema changes.

## Follow-ups (plan 0023+)

Documented explicitly as `TODO(plan-0023+)` in code + out-of-scope in GAR-426:

- Consolidate XFF handling in `api.rs:71` + `admin/middleware.rs:168` via shared `real_client_ip`.
- Migrate `/auth/*` routes from deprecated `rate_limit_layer` to `rate_limit_layer_authenticated` (blocked because register/login MINT the token — the bearer is not yet present when the limiter runs).
- Optimization: cache decoded `AccessClaims` in `request.extensions()` to eliminate the double-verify if p95 monitoring shows >5% regression.
- Drop `extract_rate_limit_key` + `rate_limit_layer` + `rate_limit_middleware` entirely once the `/auth/*` routes are migrated.

## Test plan

- [x] Code review: APPROVE WITH NITS, all 5 NITs addressed.
- [x] Security audit: 8.5/10 APPROVE, 2 SEC-LOWs addressed.
- [x] Local full test matrix: 9 binaries green.
- [ ] CI 9/9 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)