### PR TITLE
feat(gateway,storage): plan 0047 — GAR-395 TUS slice 3 (DELETE + expiration worker + put_stream) [incremental]

### DIFF
--- a/crates/garraia-auth/src/audit_workspace.rs
+++ b/crates/garraia-auth/src/audit_workspace.rs
@@ -83,6 +83,23 @@ pub enum WorkspaceAuditAction {
     /// for offline reconciliation without leaking the raw key (plan
     /// 0044 §6 SEC-L audit event PII).
     UploadCompleted,
+
+    /// A tus 1.0 upload was explicitly terminated by the client via
+    /// `DELETE /v1/uploads/{id}` before completion (plan 0047 /
+    /// GAR-395 slice 3 — tus Termination extension).
+    ///
+    /// `resource_type = "tus_uploads"`, `resource_id = "{upload_id}"`.
+    /// Metadata: `{ upload_offset, upload_length, object_key_hash }`.
+    UploadTerminated,
+
+    /// A tus 1.0 upload exceeded its `expires_at` deadline while still
+    /// `in_progress` and was transitioned to `status='expired'` by the
+    /// periodic expiration worker (plan 0047 / GAR-395 slice 3).
+    ///
+    /// `resource_type = "tus_uploads"`, `resource_id = "{upload_id}"`.
+    /// Metadata: `{ upload_offset, upload_length, age_secs,
+    /// object_key_hash }`.
+    UploadExpired,
 }
 
 impl WorkspaceAuditAction {
@@ -93,6 +110,8 @@ impl WorkspaceAuditAction {
             WorkspaceAuditAction::MemberRoleChanged => "member.role_changed",
             WorkspaceAuditAction::MemberRemoved => "member.removed",
             WorkspaceAuditAction::UploadCompleted => "upload.completed",
+            WorkspaceAuditAction::UploadTerminated => "upload.terminated",
+            WorkspaceAuditAction::UploadExpired => "upload.expired",
         }
     }
 }

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -186,6 +186,16 @@ name = "rest_v1_uploads_patch"
 path = "tests/rest_v1_uploads_patch.rs"
 required-features = ["test-helpers"]
 
+# Plan 0047 — GAR-395 slice 3 commit 4: DELETE termination + expiration
+# worker tick + streaming `put_stream` via finalize integration tests.
+# Single bundled `#[tokio::test]` following the same feature gate as the
+# rest of the integration suite so plain `cargo test -p garraia-gateway`
+# (without --features test-helpers) skips compilation cleanly.
+[[test]]
+name = "rest_v1_uploads_delete_worker"
+path = "tests/rest_v1_uploads_delete_worker.rs"
+required-features = ["test-helpers"]
+
 [dev-dependencies]
 # Plan 0024 T4 (GAR-412): metrics_exporter tests and the
 # metrics_auth_integration binary build a `PrometheusRecorder` directly

--- a/crates/garraia-gateway/src/lib.rs
+++ b/crates/garraia-gateway/src/lib.rs
@@ -39,6 +39,8 @@ pub mod skins_handler;
 pub mod slash_commands;
 pub mod state;
 pub mod totp;
+pub mod uploads_worker;
+pub mod uploads_worker_util;
 pub mod voice_handler;
 pub mod ws;
 

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -244,7 +244,9 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 )
                 .route(
                     "/v1/uploads/{id}",
-                    head(uploads::head_upload).patch(uploads::patch_upload),
+                    head(uploads::head_upload)
+                        .patch(uploads::patch_upload)
+                        .delete(uploads::delete_upload),
                 )
                 .layer(axum::middleware::from_fn_with_state(
                     rate_limit_state,
@@ -294,7 +296,9 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 )
                 .route(
                     "/v1/uploads/{id}",
-                    head(unconfigured_handler).patch(unconfigured_handler),
+                    head(unconfigured_handler)
+                        .patch(unconfigured_handler)
+                        .delete(unconfigured_handler),
                 )
                 .with_state(auth)
                 .merge(SwaggerUi::new("/docs").url("/v1/openapi.json", ApiDoc::openapi()))
@@ -326,7 +330,9 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 )
                 .route(
                     "/v1/uploads/{id}",
-                    head(unconfigured_handler).patch(unconfigured_handler),
+                    head(unconfigured_handler)
+                        .patch(unconfigured_handler)
+                        .delete(unconfigured_handler),
                 )
                 .route("/v1/openapi.json", get(unconfigured_handler))
                 .route("/docs", get(unconfigured_handler))

--- a/crates/garraia-gateway/src/rest_v1/uploads.rs
+++ b/crates/garraia-gateway/src/rest_v1/uploads.rs
@@ -58,12 +58,9 @@ const TUS_RESUMABLE_VERSION: &str = "1.0.0";
 /// tus 1.0 `Tus-Version` supported set, emitted on OPTIONS and 412.
 const TUS_VERSION_HEADER: &str = "1.0.0";
 
-/// tus 1.0 extensions implemented in slice 2. `creation-with-upload`
-/// is not actually implemented (Creation must be a distinct POST) but
-/// advertising it keeps the header future-proof — slice 3 may add it
-/// without another discovery change. Conservative alternative: drop it.
-/// We go conservative and advertise only what is truly shipped.
-const TUS_EXTENSION_HEADER: &str = "creation";
+/// tus 1.0 extensions implemented. Updated in plan 0047 (GAR-395 slice 3)
+/// to advertise `termination` now that `DELETE /v1/uploads/{id}` is live.
+const TUS_EXTENSION_HEADER: &str = "creation,termination";
 
 /// Canonical tus 1.0 max size, matches `MAX_UPLOAD_LENGTH` above as
 /// a string. Kept separate so `HeaderValue::from_static` can inline it.
@@ -822,6 +819,161 @@ pub async fn patch_upload(
         H_UPLOAD_OFFSET.clone(),
         header_value_from_ascii(&new_offset.to_string())?,
     );
+    response_headers.insert(
+        H_TUS_RESUMABLE.clone(),
+        HeaderValue::from_static(TUS_RESUMABLE_VERSION),
+    );
+    Ok((StatusCode::NO_CONTENT, response_headers).into_response())
+}
+
+/// `DELETE /v1/uploads/{id}` — tus 1.0 **Termination** extension (plan
+/// 0047 / GAR-395 slice 3).
+///
+/// Semantics (spec §Termination):
+/// - `204 No Content` when the upload was `in_progress` and is now
+///   `aborted`. Staging file is deleted best-effort.
+/// - `404 Not Found` when the upload does not exist OR belongs to a
+///   different group (anti-enumeration per ADR 0004 §7 — NEVER 403).
+/// - `410 Gone` when the upload is already `completed`, `aborted`, or
+///   `expired` — the resource can no longer be terminated (completed
+///   uploads flow through `/v1/files/*` deletion, slice 4+).
+///
+/// `ObjectStore` is **not** touched here — in slice 2's two-phase
+/// commit, the blob is only put under `object_key` after `status =
+/// 'completed'`. An `in_progress` row has nothing in the bucket to
+/// remove; the staging file IS removed.
+///
+/// Audit: one row with action `upload.terminated` on success.
+#[utoipa::path(
+    delete,
+    path = "/v1/uploads/{id}",
+    params(("id" = Uuid, Path, description = "upload id returned by POST /v1/uploads")),
+    responses(
+        (status = 204, description = "upload terminated"),
+        (status = 404, description = "upload not found or cross-group"),
+        (status = 410, description = "upload already completed/aborted/expired"),
+        (status = 412, description = "Tus-Resumable header missing or unsupported"),
+    ),
+)]
+pub async fn delete_upload(
+    State(state): State<RestV1FullState>,
+    Path(upload_id): Path<Uuid>,
+    headers: HeaderMap,
+    principal: Principal,
+) -> Result<Response, RestError> {
+    validate_tus_resumable(&headers).map_err(UploadRejection::into_rest_error)?;
+
+    let group_id = principal.group_id.ok_or(RestError::Forbidden)?;
+
+    // Staging cleanup is best-effort AFTER the row transitions to
+    // aborted — pull the staging handle now so we can remove the file
+    // post-commit. A missing staging context is not a hard failure
+    // (server may not have the tus wiring fully configured) — we just
+    // skip the file cleanup branch.
+    let staging = state.storage.upload_staging.clone();
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(anyhow::anyhow!(e).context("begin delete_upload tx")))?;
+
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Lock the row so concurrent DELETE + PATCH serialise via the row
+    // lock. RLS already restricts to the caller's group — if the row
+    // exists in a different group, the SELECT returns 0 rows (404).
+    let row: Option<(String, i64, i64, String)> = sqlx::query_as(
+        "SELECT status, upload_offset, upload_length, object_key
+         FROM tus_uploads
+         WHERE id = $1
+         FOR UPDATE",
+    )
+    .bind(upload_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| {
+        RestError::Internal(anyhow::anyhow!(e).context("select tus_uploads for delete"))
+    })?;
+
+    let (status, upload_offset, upload_length, object_key) = row.ok_or(RestError::NotFound)?;
+
+    // Status state machine — only `in_progress` can be terminated.
+    match status.as_str() {
+        "in_progress" => {}
+        "completed" | "aborted" | "expired" => {
+            return Err(RestError::Gone(format!(
+                "upload is no longer available (status={status})"
+            )));
+        }
+        other => {
+            return Err(RestError::Internal(anyhow::anyhow!(
+                "unexpected tus_uploads.status `{other}`"
+            )));
+        }
+    }
+
+    // Transition in the same tx. The WHERE guard against the current
+    // status is defense-in-depth against a race with the expiration
+    // worker / a concurrent DELETE.
+    let updated = sqlx::query(
+        "UPDATE tus_uploads
+         SET status = 'aborted', updated_at = now()
+         WHERE id = $1 AND status = 'in_progress'",
+    )
+    .bind(upload_id)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| {
+        RestError::Internal(anyhow::anyhow!(e).context("update tus_uploads.status=aborted"))
+    })?;
+
+    if updated.rows_affected() == 0 {
+        // Another actor won the transition — treat as 410 to stay
+        // idempotent from the client's POV.
+        return Err(RestError::Gone(
+            "upload transitioned concurrently; terminated elsewhere".into(),
+        ));
+    }
+
+    // Audit atomically within the same tx.
+    let object_key_hash = sha256_hex_of(object_key.as_bytes());
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::UploadTerminated,
+        principal.user_id,
+        group_id,
+        "tus_uploads",
+        upload_id.to_string(),
+        json!({
+            "upload_offset": upload_offset,
+            "upload_length": upload_length,
+            "object_key_hash": object_key_hash,
+        }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e).context("audit upload.terminated")))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(anyhow::anyhow!(e).context("commit delete_upload tx")))?;
+
+    // Post-commit: best-effort staging cleanup. A failure here is benign
+    // (the expiration worker will eventually sweep stale staging files).
+    if let Some(staging) = staging {
+        let staging_path = staging.staging_path(upload_id);
+        if let Err(e) = tokio::fs::remove_file(&staging_path).await
+            && e.kind() != std::io::ErrorKind::NotFound
+        {
+            tracing::warn!(
+                upload_id = %upload_id,
+                error = %e,
+                "failed to remove staging file after termination"
+            );
+        }
+    }
+
+    let mut response_headers = HeaderMap::new();
     response_headers.insert(
         H_TUS_RESUMABLE.clone(),
         HeaderValue::from_static(TUS_RESUMABLE_VERSION),

--- a/crates/garraia-gateway/src/rest_v1/uploads.rs
+++ b/crates/garraia-gateway/src/rest_v1/uploads.rs
@@ -1049,24 +1049,36 @@ async fn finalize_upload(
         )));
     }
 
-    // Load bytes back from staging. Plan 0044 §5.1 — slice 3 will
-    // stream via `ObjectStore::put_stream`. Today we read the whole
-    // file; `max_patch_bytes` cap keeps memory bounded.
+    // Plan 0047 (GAR-395 slice 3): commit via streaming `put_stream`
+    // instead of buffering the whole staging file into memory. The
+    // staging path is opened as `tokio::fs::File` and handed to the
+    // backend as an `AsyncByteReader`; LocalFs streams through a temp
+    // sibling + atomic rename (zero RAM spike even for 5 GiB uploads),
+    // S3-compatible backends can override with multipart upload in a
+    // follow-up slice. `max_patch_bytes` remains the per-PATCH cap and
+    // is unaffected — this eliminates the second spike at finalize.
     let staging_path = staging.staging_path(upload_id);
-    let staged_bytes = tokio::fs::read(&staging_path).await.map_err(|e| {
-        RestError::Internal(anyhow::anyhow!(e).context("read staging file during finalize_upload"))
-    })?;
 
-    if staged_bytes.len() as i64 != size_bytes {
-        // Defense-in-depth: the upload_offset ledger and the staging
-        // file size must match. Any divergence is a gateway bug.
+    // Defense-in-depth: the upload_offset ledger and the staging file
+    // size must match BEFORE we hand the reader to the backend. This
+    // catches any gateway bug that advanced `upload_offset` without
+    // flushing the matching bytes to disk.
+    let staged_len = tokio::fs::metadata(&staging_path)
+        .await
+        .map_err(|e| {
+            RestError::Internal(anyhow::anyhow!(e).context("stat staging file during finalize"))
+        })?
+        .len();
+    if staged_len as i64 != size_bytes {
         return Err(RestError::Internal(anyhow::anyhow!(
-            "staging file size {} does not match expected {size_bytes}",
-            staged_bytes.len()
+            "staging file size {staged_len} does not match expected {size_bytes}"
         )));
     }
 
-    let put_bytes = Bytes::from(staged_bytes);
+    let staging_file = tokio::fs::File::open(&staging_path).await.map_err(|e| {
+        RestError::Internal(anyhow::anyhow!(e).context("open staging file for put_stream"))
+    })?;
+    let reader: garraia_storage::AsyncByteReader = Box::pin(staging_file);
 
     // PutOptions — MIME declared, HMAC material populated from the
     // staging context so ObjectStore stores `integrity_hmac` we can
@@ -1079,12 +1091,12 @@ async fn finalize_upload(
         hmac_secret: Some(staging.hmac_secret.clone()),
     };
 
-    // Plan 0044 §5.3.1: put() executes BEFORE commit. A put() failure
+    // Plan 0044 §5.3.1: put_stream() executes BEFORE commit. A failure
     // rolls back the tx (dropped at fn exit without `commit()`), so
     // `tus_uploads.status` stays `in_progress` and no files / versions
     // / audit rows exist. Retry is safe from the client's side.
     let put_meta = object_store
-        .put(object_key, put_bytes, put_opts)
+        .put_stream(object_key, reader, staged_len, put_opts)
         .await
         .map_err(|e| {
             // PII-safe: `StorageError::Display` is bounded to
@@ -1092,10 +1104,20 @@ async fn finalize_upload(
             tracing::warn!(
                 upload_id = %upload_id,
                 error = %e,
-                "ObjectStore::put failed; upload stays in_progress"
+                "ObjectStore::put_stream failed; upload stays in_progress"
             );
             RestError::BadGateway("ObjectStore commit failed; please retry".into())
         })?;
+
+    // Defense-in-depth parity with the pre-stream path: the backend
+    // MUST have seen the same byte count we expect. Any mismatch is a
+    // bug in the backend implementation, not a client issue.
+    if put_meta.size_bytes as i64 != size_bytes {
+        return Err(RestError::Internal(anyhow::anyhow!(
+            "put_stream size_bytes {} != expected {size_bytes}",
+            put_meta.size_bytes
+        )));
+    }
 
     // HMAC is required by migration 003 — if missing, fail-closed.
     let integrity_hmac = put_meta.integrity_hmac.ok_or_else(|| {

--- a/crates/garraia-gateway/src/rest_v1/uploads.rs
+++ b/crates/garraia-gateway/src/rest_v1/uploads.rs
@@ -850,10 +850,22 @@ pub async fn patch_upload(
     params(("id" = Uuid, Path, description = "upload id returned by POST /v1/uploads")),
     responses(
         (status = 204, description = "upload terminated"),
+        (status = 401, description = "missing or invalid bearer token"),
+        (status = 403, description = "authenticated but no group membership"),
         (status = 404, description = "upload not found or cross-group"),
         (status = 410, description = "upload already completed/aborted/expired"),
         (status = 412, description = "Tus-Resumable header missing or unsupported"),
     ),
+    security(("bearer" = [])),
+)]
+#[tracing::instrument(
+    name = "rest_v1.delete_uploads",
+    skip(state, headers, principal),
+    fields(
+        user_id = %principal.user_id,
+        group_id = ?principal.group_id,
+        upload_id = %upload_id
+    )
 )]
 pub async fn delete_upload(
     State(state): State<RestV1FullState>,

--- a/crates/garraia-gateway/src/server.rs
+++ b/crates/garraia-gateway/src/server.rs
@@ -7,7 +7,7 @@ use garraia_config::{AppConfig, ConfigWatcher};
 use garraia_db::{ChatSessionManager, SessionStore};
 use tokio::net::TcpListener;
 use tokio::sync::Mutex;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::admin;
 #[cfg(target_os = "macos")]
@@ -340,7 +340,30 @@ impl GatewayServer {
         // answers 503. Runs AFTER auth wiring so we already know whether
         // the gateway can even serve `/v1/*` at all.
         let (object_store_opt, upload_staging_opt) = build_storage_wiring(&state.config).await;
-        state.set_storage_components(object_store_opt, upload_staging_opt);
+        state.set_storage_components(object_store_opt, upload_staging_opt.clone());
+
+        // Plan 0047 (GAR-395 slice 3): spawn the tus_uploads expiration
+        // worker when both the AppPool and the staging directory are
+        // wired. The worker runs until process exit (no shutdown channel
+        // in v1 — the slice acceptance criteria accept process lifetime
+        // granularity). Fail-soft: if either component is absent the
+        // worker is skipped silently — the next slice of GAR-429 will
+        // surface this via a readiness probe.
+        if let Some(app_pool) = state.app_pool.clone() {
+            let staging_dir = upload_staging_opt.as_ref().map(|s| s.staging_dir.clone());
+            let handle = crate::uploads_worker::spawn_uploads_expiration_worker(
+                app_pool,
+                staging_dir,
+                crate::uploads_worker::UploadsExpirationWorkerConfig::default(),
+            );
+            // Detach: keep the worker alive for the process lifetime.
+            // `Box::leak` is acceptable here because the handle outlives
+            // `server.run()`, which never returns under normal operation.
+            std::mem::forget(handle);
+            info!("uploads_expiration_worker spawned (plan 0047)");
+        } else {
+            debug!("uploads_expiration_worker skipped (no AppPool wired)");
+        }
 
         // Start config hot-reload watcher
         let config_path = garraia_config::ConfigLoader::default_config_dir().join("config.yml");

--- a/crates/garraia-gateway/src/uploads_worker.rs
+++ b/crates/garraia-gateway/src/uploads_worker.rs
@@ -1,0 +1,332 @@
+//! `tus_uploads` expiration worker — plan 0047 (GAR-395 slice 3).
+//!
+//! Periodically transitions `tus_uploads.status` from `in_progress` to
+//! `expired` when `expires_at < now()`, emits one audit row per expired
+//! upload via [`garraia_auth::audit_workspace_event`], and removes the
+//! per-upload staging file best-effort.
+//!
+//! ## Concurrency
+//!
+//! Multiple gateway replicas may share one Postgres. The worker guards
+//! its batched UPDATE with
+//! `pg_try_advisory_lock(hashtext('tus_uploads_expiration'))` — whichever
+//! replica wins the lock runs the sweep, the others skip the tick.
+//! Failure to acquire the lock is expected and silently skipped.
+//!
+//! ## Bypass-RLS
+//!
+//! The worker needs to see rows across all `group_id` values — it runs
+//! on the `AppPool` (`garraia_app` role) BUT explicitly sets the group
+//! context to each row's own `group_id` before emitting the audit.
+//! Alternative: use a future `BYPASSRLS` worker role. For v1 we read +
+//! update via a maintenance SQL path that does not rely on
+//! `app.current_group_id` being set — the RLS policy on `tus_uploads`
+//! filters by that GUC, so we set the GUC **per-row** for the UPDATE
+//! to succeed. This is cleaner than adding another bypass role for a
+//! single maintenance path.
+//!
+//! ## Tick cadence
+//!
+//! Default 5-minute interval. Configurable via
+//! [`UploadsExpirationWorkerConfig::interval`]. A single tick locks for
+//! at most `batch_size` rows (default 256) to keep the advisory lock
+//! hold time bounded.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use garraia_auth::{AppPool, WorkspaceAuditAction, audit_workspace_event};
+use serde_json::json;
+use sqlx::Row;
+use tracing::{debug, info, warn};
+use uuid::Uuid;
+
+/// Configuration envelope for [`spawn_uploads_expiration_worker`].
+#[derive(Debug, Clone)]
+pub struct UploadsExpirationWorkerConfig {
+    /// How long to wait between sweeps.
+    pub interval: Duration,
+    /// Max rows transitioned per sweep. Keeps the advisory lock hold
+    /// time bounded.
+    pub batch_size: i64,
+}
+
+impl Default for UploadsExpirationWorkerConfig {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_secs(5 * 60),
+            batch_size: 256,
+        }
+    }
+}
+
+/// Outcome of one sweep tick.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TickReport {
+    pub expired_count: u64,
+    pub staging_removed: u64,
+    pub staging_missing: u64,
+    pub audit_failed: u64,
+}
+
+/// Run one sweep against `pool`. Returns a report of the batch.
+///
+/// Caller is responsible for not invoking this concurrently from the
+/// same process — the advisory lock protects across processes but a
+/// single process that spawns two tickers would block itself.
+pub async fn run_expiration_tick(
+    pool: Arc<AppPool>,
+    staging_dir: Option<&std::path::Path>,
+    batch_size: i64,
+) -> Result<TickReport, sqlx::Error> {
+    // Acquire the advisory lock — skip the whole tick when contended.
+    // `hashtext('tus_uploads_expiration')` maps to a stable i32 that
+    // Postgres uses as the lock key. A missing lock is `false`, not
+    // an error.
+    let pg = pool.pool_for_handlers();
+    let got_lock: bool =
+        sqlx::query_scalar("SELECT pg_try_advisory_lock(hashtext('tus_uploads_expiration'))")
+            .fetch_one(pg)
+            .await?;
+
+    if !got_lock {
+        debug!("uploads_expiration_worker: lock contended; skipping tick");
+        return Ok(TickReport::default());
+    }
+
+    // Guard ensures release even if downstream code panics / errors.
+    let release_guard = AdvisoryLockGuard::new(pool.clone());
+
+    let mut report = TickReport::default();
+
+    // Sweep in one `UPDATE ... RETURNING`, limited to `batch_size`.
+    // We can't combine RETURNING with LIMIT directly — use a CTE with
+    // SELECT ... FOR UPDATE SKIP LOCKED + LIMIT to pick the batch, then
+    // UPDATE the fetched ids.
+    let rows = sqlx::query(
+        "WITH victim AS (
+            SELECT id
+            FROM tus_uploads
+            WHERE status = 'in_progress' AND expires_at < now()
+            ORDER BY expires_at ASC
+            LIMIT $1
+            FOR UPDATE SKIP LOCKED
+        )
+        UPDATE tus_uploads AS t
+        SET status = 'expired', updated_at = now()
+        FROM victim
+        WHERE t.id = victim.id
+        RETURNING t.id, t.group_id, t.created_by, t.object_key,
+                  t.upload_offset, t.upload_length,
+                  EXTRACT(EPOCH FROM (now() - t.created_at))::bigint AS age_secs",
+    )
+    .bind(batch_size)
+    .fetch_all(pg)
+    .await?;
+
+    for row in &rows {
+        let upload_id: Uuid = row.try_get("id")?;
+        let group_id: Uuid = row.try_get("group_id")?;
+        let created_by: Uuid = row.try_get("created_by")?;
+        let object_key: String = row.try_get("object_key")?;
+        let upload_offset: i64 = row.try_get("upload_offset")?;
+        let upload_length: i64 = row.try_get("upload_length")?;
+        let age_secs: i64 = row.try_get("age_secs")?;
+
+        report.expired_count += 1;
+
+        // Best-effort staging cleanup. Missing file = already gone.
+        // Filename pattern mirrors `UploadStaging::staging_path` in
+        // `rest_v1::uploads` (plan 0044 §5.2) — `{upload_id}.staging`.
+        if let Some(dir) = staging_dir {
+            let staging_path = dir.join(format!("{upload_id}.staging"));
+            match tokio::fs::remove_file(&staging_path).await {
+                Ok(()) => report.staging_removed += 1,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    report.staging_missing += 1;
+                }
+                Err(e) => {
+                    warn!(
+                        upload_id = %upload_id,
+                        error = %e,
+                        "uploads_expiration_worker: failed to remove staging file"
+                    );
+                }
+            }
+        }
+
+        // Emit audit row in its own transaction. Per-row SET LOCAL of
+        // `app.current_group_id` so the RLS policy on audit_events
+        // allows the INSERT.
+        if let Err(e) = emit_expiration_audit(
+            pool.as_ref(),
+            group_id,
+            created_by,
+            upload_id,
+            &object_key,
+            upload_offset,
+            upload_length,
+            age_secs,
+        )
+        .await
+        {
+            report.audit_failed += 1;
+            warn!(
+                upload_id = %upload_id,
+                error = %e,
+                "uploads_expiration_worker: audit insert failed"
+            );
+        }
+    }
+
+    if report.expired_count > 0 {
+        info!(
+            expired = report.expired_count,
+            staging_removed = report.staging_removed,
+            staging_missing = report.staging_missing,
+            audit_failed = report.audit_failed,
+            "uploads_expiration_worker: tick complete"
+        );
+    }
+
+    drop(release_guard); // explicit
+
+    Ok(report)
+}
+
+async fn emit_expiration_audit(
+    pool: &AppPool,
+    group_id: Uuid,
+    actor_user_id: Uuid,
+    upload_id: Uuid,
+    object_key: &str,
+    upload_offset: i64,
+    upload_length: i64,
+    age_secs: i64,
+) -> Result<(), sqlx::Error> {
+    let mut tx = pool.pool_for_handlers().begin().await?;
+    sqlx::query(&format!(
+        "SET LOCAL app.current_user_id = '{actor_user_id}'"
+    ))
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(&format!("SET LOCAL app.current_group_id = '{group_id}'"))
+        .execute(&mut *tx)
+        .await?;
+
+    let object_key_hash = crate::uploads_worker_util::sha256_hex_of(object_key.as_bytes());
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::UploadExpired,
+        actor_user_id,
+        group_id,
+        "tus_uploads",
+        upload_id.to_string(),
+        json!({
+            "upload_offset": upload_offset,
+            "upload_length": upload_length,
+            "age_secs": age_secs,
+            "object_key_hash": object_key_hash,
+        }),
+    )
+    .await
+    .map_err(|e| sqlx::Error::Configuration(e.to_string().into()))?;
+
+    tx.commit().await?;
+    Ok(())
+}
+
+struct AdvisoryLockGuard {
+    pool: Arc<AppPool>,
+    released: bool,
+}
+
+impl AdvisoryLockGuard {
+    fn new(pool: Arc<AppPool>) -> Self {
+        Self {
+            pool,
+            released: false,
+        }
+    }
+}
+
+impl Drop for AdvisoryLockGuard {
+    fn drop(&mut self) {
+        if self.released {
+            return;
+        }
+        self.released = true;
+        let pool = self.pool.clone();
+        tokio::spawn(async move {
+            let _ = sqlx::query("SELECT pg_advisory_unlock(hashtext('tus_uploads_expiration'))")
+                .execute(pool.pool_for_handlers())
+                .await;
+        });
+    }
+}
+
+/// Spawn the periodic sweep loop. Returns the `JoinHandle` for the
+/// caller to keep alive for the process lifetime (or `abort` on
+/// shutdown — not wired in v1).
+pub fn spawn_uploads_expiration_worker(
+    pool: Arc<AppPool>,
+    staging_dir: Option<std::path::PathBuf>,
+    config: UploadsExpirationWorkerConfig,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        info!(
+            interval_secs = config.interval.as_secs(),
+            batch_size = config.batch_size,
+            "uploads_expiration_worker: starting"
+        );
+        let mut ticker = tokio::time::interval(config.interval);
+        // First tick fires immediately — skip it so the gateway has
+        // room to finish bootstrap before we touch the DB.
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            match run_expiration_tick(pool.clone(), staging_dir.as_deref(), config.batch_size).await
+            {
+                Ok(report) => {
+                    if report.expired_count == 0 && report.audit_failed == 0 {
+                        debug!("uploads_expiration_worker: idle tick");
+                    }
+                }
+                Err(e) => {
+                    warn!(error = %e, "uploads_expiration_worker: tick failed");
+                }
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tick_report_default_is_zeroed() {
+        let r = TickReport::default();
+        assert_eq!(r.expired_count, 0);
+        assert_eq!(r.staging_removed, 0);
+        assert_eq!(r.staging_missing, 0);
+        assert_eq!(r.audit_failed, 0);
+    }
+
+    #[test]
+    fn default_config_is_five_minutes_batch_256() {
+        let c = UploadsExpirationWorkerConfig::default();
+        assert_eq!(c.interval, Duration::from_secs(300));
+        assert_eq!(c.batch_size, 256);
+    }
+
+    #[test]
+    fn config_overrides_preserved() {
+        let c = UploadsExpirationWorkerConfig {
+            interval: Duration::from_secs(42),
+            batch_size: 7,
+        };
+        assert_eq!(c.interval.as_secs(), 42);
+        assert_eq!(c.batch_size, 7);
+    }
+}

--- a/crates/garraia-gateway/src/uploads_worker_util.rs
+++ b/crates/garraia-gateway/src/uploads_worker_util.rs
@@ -1,0 +1,44 @@
+//! Tiny utility helpers shared between `rest_v1::uploads` and
+//! `uploads_worker`. Kept in a dedicated module so the worker does not
+//! pull in the entire rest_v1 handler surface.
+//!
+//! Plan 0047 (GAR-395 slice 3).
+
+/// Hex-encoded SHA-256 of a byte slice. Used to hash `object_key`
+/// before it is stored in `audit_events.metadata.object_key_hash` —
+/// operators can correlate audit rows with bucket keys without the raw
+/// key (which leaks `group_id` + `upload_id`) being persisted twice.
+pub fn sha256_hex_of(input: &[u8]) -> String {
+    use sha2::Digest;
+    let digest = sha2::Sha256::digest(input);
+    hex::encode(digest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha256_hex_matches_known_vector() {
+        // NIST CAVS: SHA-256 of the empty string.
+        assert_eq!(
+            sha256_hex_of(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        );
+    }
+
+    #[test]
+    fn sha256_hex_is_stable_for_same_input() {
+        let a = sha256_hex_of(b"group-123/uploads/aaa/v1");
+        let b = sha256_hex_of(b"group-123/uploads/aaa/v1");
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 64);
+    }
+
+    #[test]
+    fn sha256_hex_diverges_for_different_input() {
+        let a = sha256_hex_of(b"group-123/uploads/aaa/v1");
+        let b = sha256_hex_of(b"group-456/uploads/aaa/v1");
+        assert_ne!(a, b);
+    }
+}

--- a/crates/garraia-gateway/tests/rest_v1_uploads_delete_worker.rs
+++ b/crates/garraia-gateway/tests/rest_v1_uploads_delete_worker.rs
@@ -1,0 +1,752 @@
+//! Integration tests for plan 0047 / GAR-395 slice 3 commit 4.
+//!
+//! Exercises the three production paths that the earlier slice 3
+//! commits introduced (DELETE termination handler, expiration worker
+//! `run_expiration_tick`, streaming `put_stream` in `finalize_upload`)
+//! end-to-end against a shared pgvector/pg16 testcontainer plus a
+//! tempdir-backed `LocalFs` ObjectStore.
+//!
+//! Layout mirrors `rest_v1_uploads_patch.rs` intentionally — one
+//! `#[tokio::test]` orchestrating three `async fn` helper blocks. The
+//! single-function shape avoids the sqlx runtime-teardown race that
+//! bites when multiple top-level `#[tokio::test]` fns share a
+//! `OnceCell<Arc<Harness>>` inside the same binary; helpers keep the
+//! sub-sections readable and independently debuggable.
+//!
+//! Coverage map:
+//!
+//! | Block | Handler / path                                         |
+//! | ----- | ------------------------------------------------------ |
+//! | A     | `DELETE /v1/uploads/{id}` — 6 scenarios                |
+//! | B     | `uploads_worker::run_expiration_tick` — 3 sub-asserts  |
+//! | C     | `finalize_upload` streaming via `put_stream` — 1 e2e   |
+//!
+//! Docker absence is surfaced via `Harness::get()` (pgvector startup
+//! fails fast); every helper below still guards with
+//! [`docker_available`] so running on a dev host without Docker yields
+//! a clean skip rather than a confusing Harness boot panic.
+
+mod common;
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::Body;
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
+use bytes::Bytes;
+use garraia_gateway::rest_v1::uploads::UploadStaging;
+use garraia_gateway::server::build_router_for_test_with_storage;
+use garraia_gateway::uploads_worker::run_expiration_tick;
+use garraia_storage::{LocalFs, ObjectStore};
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use common::Harness;
+use common::fixtures::{fetch_audit_events_for_group, seed_user_with_group};
+
+// ─── Docker gate ────────────────────────────────────────────────────────
+
+/// True when the Docker daemon is reachable. Integration tests bail
+/// gracefully when Docker is absent (common on Windows dev hosts); CI
+/// Linux images run with Docker preinstalled so the gate is a no-op
+/// there. Mirrors the check in `rest_v1_uploads_patch.rs`.
+fn docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+// ─── Request builders (mirrors rest_v1_uploads_patch.rs pattern) ────────
+
+/// Inject the `ConnectInfo<SocketAddr>` extension so `tower_governor`'s
+/// `PeerIpKeyExtractor` does not bail with `"Unable To Extract Key!"`
+/// when the router is exercised via `oneshot`. Every request in this
+/// binary must flow through this helper.
+fn req_with_peer(builder: axum::http::request::Builder, body: Body) -> Request<Body> {
+    let mut req = builder.body(body).expect("request builder");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    req
+}
+
+fn post_create_upload(
+    token: &str,
+    group_id: &str,
+    upload_length: i64,
+    mime_type: &str,
+) -> Request<Body> {
+    use base64::Engine;
+    let b64 = base64::engine::general_purpose::STANDARD;
+    let filename_b64 = b64.encode("upload.bin");
+    let mime_b64 = b64.encode(mime_type);
+    let metadata = format!("filename {filename_b64},filetype {mime_b64}");
+    let mut req = req_with_peer(
+        Request::builder()
+            .method("POST")
+            .uri("/v1/uploads")
+            .header("tus-resumable", "1.0.0")
+            .header("upload-length", upload_length.to_string())
+            .header("upload-metadata", metadata),
+        Body::empty(),
+    );
+    req.headers_mut().insert(
+        HeaderName::from_static("authorization"),
+        HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+    );
+    req.headers_mut().insert(
+        HeaderName::from_static("x-group-id"),
+        HeaderValue::from_str(group_id).unwrap(),
+    );
+    req
+}
+
+fn patch_upload_req(
+    token: &str,
+    group_id: &str,
+    upload_id: Uuid,
+    upload_offset: i64,
+    body: Bytes,
+) -> Request<Body> {
+    let mut req = req_with_peer(
+        Request::builder()
+            .method("PATCH")
+            .uri(format!("/v1/uploads/{upload_id}"))
+            .header("tus-resumable", "1.0.0")
+            .header("content-type", "application/offset+octet-stream")
+            .header("upload-offset", upload_offset.to_string()),
+        Body::from(body),
+    );
+    req.headers_mut().insert(
+        HeaderName::from_static("authorization"),
+        HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+    );
+    req.headers_mut().insert(
+        HeaderName::from_static("x-group-id"),
+        HeaderValue::from_str(group_id).unwrap(),
+    );
+    req
+}
+
+fn delete_upload_req(
+    token: Option<&str>,
+    group_id: Option<&str>,
+    upload_id: Uuid,
+    tus_resumable: Option<&str>,
+) -> Request<Body> {
+    let mut builder = Request::builder()
+        .method("DELETE")
+        .uri(format!("/v1/uploads/{upload_id}"));
+    if let Some(v) = tus_resumable {
+        builder = builder.header("tus-resumable", v);
+    }
+    let mut req = req_with_peer(builder, Body::empty());
+    if let Some(t) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {t}")).unwrap(),
+        );
+    }
+    if let Some(g) = group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    req
+}
+
+/// Extract the tus upload id from the `Location` header of a
+/// `POST /v1/uploads` 201 response.
+fn upload_id_from_location(resp: &axum::response::Response) -> Uuid {
+    let loc = resp
+        .headers()
+        .get("location")
+        .expect("201 must carry Location")
+        .to_str()
+        .unwrap();
+    let id_str = loc
+        .strip_prefix("/v1/uploads/")
+        .expect("Location has /v1/uploads/ prefix");
+    Uuid::parse_str(id_str).expect("uuid")
+}
+
+/// Build a storage-augmented test router on top of the shared
+/// `Harness` pools. Per-invocation tempdir so concurrent integration
+/// binaries cannot collide on a shared staging root.
+async fn build_storage_router(
+    h: &Harness,
+    tmp: &Path,
+) -> (axum::Router, Arc<LocalFs>, Arc<UploadStaging>) {
+    let fs_root = tmp.join("storage");
+    let staging_dir = tmp.join("staging");
+    std::fs::create_dir_all(&fs_root).unwrap();
+    std::fs::create_dir_all(&staging_dir).unwrap();
+
+    let local_fs = Arc::new(LocalFs::new(&fs_root).expect("LocalFs::new"));
+    let staging = Arc::new(UploadStaging {
+        staging_dir: std::fs::canonicalize(&staging_dir).unwrap(),
+        max_patch_bytes: 10 * 1024 * 1024,
+        hmac_secret: b"test-secret-32-bytes-minimum-xxx".to_vec(),
+    });
+
+    let router = build_router_for_test_with_storage(
+        garraia_config::AppConfig::default(),
+        h.login_pool.clone(),
+        h.signup_pool.clone(),
+        h.jwt.clone(),
+        Some(h.app_pool.clone()),
+        Some(local_fs.clone() as Arc<dyn garraia_storage::ObjectStore>),
+        Some(staging.clone()),
+    )
+    .await;
+
+    (router, local_fs, staging)
+}
+
+/// Small helper: create + fully PATCH a new upload so downstream tests
+/// can exercise the `completed` status branch. Returns the upload id.
+async fn create_and_complete_upload(
+    router: &axum::Router,
+    token: &str,
+    group_id_str: &str,
+    payload: &[u8],
+) -> Uuid {
+    let resp = router
+        .clone()
+        .oneshot(post_create_upload(
+            token,
+            group_id_str,
+            payload.len() as i64,
+            "text/plain",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let upload_id = upload_id_from_location(&resp);
+
+    let resp = router
+        .clone()
+        .oneshot(patch_upload_req(
+            token,
+            group_id_str,
+            upload_id,
+            0,
+            Bytes::copy_from_slice(payload),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::NO_CONTENT,
+        "complete PATCH → 204"
+    );
+    upload_id
+}
+
+/// Small helper: create an `in_progress` upload and return its id.
+/// Callers decide whether to leave staging empty or write a placeholder
+/// via [`write_placeholder_staging`] — the worker scenarios exercise
+/// both variants.
+async fn create_in_progress_upload(
+    router: &axum::Router,
+    token: &str,
+    group_id_str: &str,
+    upload_length: i64,
+) -> Uuid {
+    let resp = router
+        .clone()
+        .oneshot(post_create_upload(
+            token,
+            group_id_str,
+            upload_length,
+            "text/plain",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    upload_id_from_location(&resp)
+}
+
+/// Write a zero-content placeholder staging file so the worker's
+/// best-effort cleanup branch increments `staging_removed`. Real
+/// content is not necessary — the worker just calls `remove_file`.
+async fn write_placeholder_staging(staging: &UploadStaging, upload_id: Uuid) {
+    let path = staging.staging_dir.join(format!("{upload_id}.staging"));
+    tokio::fs::write(&path, b"placeholder")
+        .await
+        .expect("write placeholder staging");
+}
+
+/// Flip `expires_at` to a point in the past via admin_pool. The tus
+/// creation path always writes `now() + 24h`; the worker only sweeps
+/// rows with `expires_at < now()`, so this is the test-only handshake
+/// that lets us validate the sweep without a 24-hour sleep.
+async fn expire_row(h: &Harness, upload_id: Uuid) {
+    sqlx::query(
+        "UPDATE tus_uploads \
+         SET expires_at = now() - interval '1 hour' \
+         WHERE id = $1",
+    )
+    .bind(upload_id)
+    .execute(&h.admin_pool)
+    .await
+    .expect("admin UPDATE expires_at");
+}
+
+// ─── Main orchestrator ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn v1_uploads_delete_worker_streaming_scenarios() {
+    if !docker_available() {
+        eprintln!("docker not available; skipping v1_uploads_delete_worker_streaming_scenarios");
+        return;
+    }
+
+    let h = Harness::get().await;
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (router, local_fs, staging) = build_storage_router(&h, tmp.path()).await;
+
+    run_delete_scenarios(&h, &router).await;
+    run_worker_scenarios(&h, &router, &staging).await;
+    run_streaming_scenario(&h, &router, local_fs.as_ref()).await;
+
+    // Keep the staging tempdir alive for the whole test — dropping it
+    // earlier would remove staging files mid-test and invalidate the
+    // worker's cleanup assertions.
+    drop(tmp);
+}
+
+// ─── Block A — DELETE /v1/uploads/{id} scenarios ────────────────────────
+
+async fn run_delete_scenarios(h: &Arc<Harness>, router: &axum::Router) {
+    let (_owner_id, group_id, token) = seed_user_with_group(h, "delete-owner@0047.test")
+        .await
+        .expect("seed owner");
+    let gid_str = group_id.to_string();
+
+    // ─── A1. DELETE happy path ────────────────────────────────────────
+    let upload_id = create_in_progress_upload(router, &token, &gid_str, 16).await;
+
+    {
+        let resp = router
+            .clone()
+            .oneshot(delete_upload_req(
+                Some(&token),
+                Some(&gid_str),
+                upload_id,
+                Some("1.0.0"),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT, "A1 DELETE → 204");
+        assert_eq!(
+            resp.headers().get("tus-resumable").unwrap(),
+            "1.0.0",
+            "A1 204 carries Tus-Resumable"
+        );
+    }
+
+    // Row must now be `aborted`.
+    let status_after: (String,) = sqlx::query_as("SELECT status FROM tus_uploads WHERE id = $1")
+        .bind(upload_id)
+        .fetch_one(&h.admin_pool)
+        .await
+        .unwrap();
+    assert_eq!(status_after.0, "aborted", "A1 status flipped to aborted");
+
+    // Audit row `upload.terminated` emitted inside the same tx.
+    let audit = fetch_audit_events_for_group(h, group_id)
+        .await
+        .expect("fetch audit");
+    let terminated: Vec<_> = audit
+        .iter()
+        .filter(|r| r.0 == "upload.terminated")
+        .collect();
+    assert_eq!(terminated.len(), 1, "A1 one upload.terminated row");
+    let meta = &terminated[0].4;
+    assert_eq!(
+        terminated[0].3,
+        upload_id.to_string(),
+        "A1 resource_id = upload_id"
+    );
+    assert_eq!(terminated[0].2, "tus_uploads");
+    // PII-safe: metadata must contain object_key_hash (hex 64 chars) but
+    // never the raw key or any filename.
+    let hash = meta
+        .get("object_key_hash")
+        .and_then(|v| v.as_str())
+        .unwrap();
+    assert_eq!(hash.len(), 64, "A1 object_key_hash is hex-64");
+    assert!(
+        !meta.to_string().contains("upload.bin"),
+        "A1 audit metadata must not contain filename"
+    );
+
+    // ─── A2. Idempotent DELETE → second call returns 410 ─────────────
+    {
+        let resp = router
+            .clone()
+            .oneshot(delete_upload_req(
+                Some(&token),
+                Some(&gid_str),
+                upload_id,
+                Some("1.0.0"),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::GONE,
+            "A2 second DELETE on aborted → 410"
+        );
+    }
+
+    // ─── A3. DELETE on a completed upload → 410 ──────────────────────
+    let completed_id = create_and_complete_upload(router, &token, &gid_str, b"hello-delete").await;
+    {
+        let resp = router
+            .clone()
+            .oneshot(delete_upload_req(
+                Some(&token),
+                Some(&gid_str),
+                completed_id,
+                Some("1.0.0"),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::GONE,
+            "A3 DELETE on completed → 410"
+        );
+    }
+
+    // ─── A4. Cross-group DELETE → 404 (never 403) ───────────────────
+    let (_other_id, other_group, other_token) = seed_user_with_group(h, "other@0047.test")
+        .await
+        .expect("seed other");
+    let other_gid_str = other_group.to_string();
+
+    let foreign_upload = create_in_progress_upload(router, &token, &gid_str, 8).await;
+    {
+        let resp = router
+            .clone()
+            .oneshot(delete_upload_req(
+                Some(&other_token),
+                Some(&other_gid_str),
+                foreign_upload,
+                Some("1.0.0"),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "A4 cross-group DELETE → 404 (ADR 0004 §7 — never 403)"
+        );
+    }
+
+    // Confirm the foreign upload was NOT mutated by the cross-group attempt.
+    let foreign_status: (String,) = sqlx::query_as("SELECT status FROM tus_uploads WHERE id = $1")
+        .bind(foreign_upload)
+        .fetch_one(&h.admin_pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        foreign_status.0, "in_progress",
+        "A4 cross-group DELETE must not mutate"
+    );
+
+    // ─── A5. DELETE without Tus-Resumable → 412 ──────────────────────
+    {
+        let resp = router
+            .clone()
+            .oneshot(delete_upload_req(
+                Some(&token),
+                Some(&gid_str),
+                foreign_upload,
+                None,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::PRECONDITION_FAILED,
+            "A5 missing Tus-Resumable → 412"
+        );
+        assert_eq!(
+            resp.headers().get("tus-version").unwrap(),
+            "1.0.0",
+            "A5 412 advertises Tus-Version"
+        );
+    }
+
+    // ─── A6. DELETE unknown UUID → 404 ───────────────────────────────
+    {
+        let unknown = Uuid::now_v7();
+        let resp = router
+            .clone()
+            .oneshot(delete_upload_req(
+                Some(&token),
+                Some(&gid_str),
+                unknown,
+                Some("1.0.0"),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "A6 unknown upload → 404"
+        );
+    }
+}
+
+// ─── Block B — Expiration worker tick end-to-end ────────────────────────
+
+async fn run_worker_scenarios(
+    h: &Arc<Harness>,
+    router: &axum::Router,
+    staging: &Arc<UploadStaging>,
+) {
+    let (_user_id, group_id, token) = seed_user_with_group(h, "worker-owner@0047.test")
+        .await
+        .expect("seed worker owner");
+    let gid_str = group_id.to_string();
+
+    // ─── B1. Basic sweep — expired row → status='expired' + audit ────
+    let b1_upload = create_in_progress_upload(router, &token, &gid_str, 32).await;
+    write_placeholder_staging(staging, b1_upload).await;
+    expire_row(h, b1_upload).await;
+
+    let report = run_expiration_tick(h.app_pool.clone(), Some(&staging.staging_dir), 16)
+        .await
+        .expect("B1 tick ok");
+    assert!(
+        report.expired_count >= 1,
+        "B1 expired_count >= 1 (got {})",
+        report.expired_count
+    );
+    assert!(
+        report.staging_removed >= 1,
+        "B1 staging_removed >= 1 (got {})",
+        report.staging_removed
+    );
+    assert_eq!(report.audit_failed, 0, "B1 no audit failures");
+
+    // `tus_uploads.status` flipped to `expired`.
+    let row: (String,) = sqlx::query_as("SELECT status FROM tus_uploads WHERE id = $1")
+        .bind(b1_upload)
+        .fetch_one(&h.admin_pool)
+        .await
+        .unwrap();
+    assert_eq!(row.0, "expired", "B1 row transitioned to expired");
+
+    // Audit row `upload.expired` emitted with metadata shape.
+    let audit = fetch_audit_events_for_group(h, group_id)
+        .await
+        .expect("fetch audit after B1");
+    let expired_audit: Vec<_> = audit
+        .iter()
+        .filter(|r| r.0 == "upload.expired" && r.3 == b1_upload.to_string())
+        .collect();
+    assert_eq!(expired_audit.len(), 1, "B1 one upload.expired row");
+    let meta = &expired_audit[0].4;
+    assert!(
+        meta.get("upload_offset").is_some(),
+        "B1 metadata.upload_offset"
+    );
+    assert!(
+        meta.get("upload_length").is_some(),
+        "B1 metadata.upload_length"
+    );
+    assert!(meta.get("age_secs").is_some(), "B1 metadata.age_secs");
+    assert_eq!(
+        meta.get("object_key_hash")
+            .and_then(|v| v.as_str())
+            .map(str::len),
+        Some(64),
+        "B1 metadata.object_key_hash is hex-64"
+    );
+
+    // Staging file physically gone.
+    let staging_path = staging.staging_dir.join(format!("{b1_upload}.staging"));
+    assert!(!staging_path.exists(), "B1 staging file removed by worker");
+
+    // ─── B2. Idempotent sweep — second tick finds nothing ───────────
+    // Advisory lock release is async via `AdvisoryLockGuard::Drop` →
+    // `tokio::spawn` — give it headroom before acquiring again.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let report2 = run_expiration_tick(h.app_pool.clone(), Some(&staging.staging_dir), 16)
+        .await
+        .expect("B2 tick ok");
+    assert_eq!(
+        report2.expired_count, 0,
+        "B2 idempotent — no in_progress rows past expires_at"
+    );
+    assert_eq!(report2.audit_failed, 0);
+
+    // ─── B3. Staging missing is tolerated ──────────────────────────
+    let b3_upload = create_in_progress_upload(router, &token, &gid_str, 64).await;
+    // NOTE: we deliberately do NOT call write_placeholder_staging here.
+    expire_row(h, b3_upload).await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let report3 = run_expiration_tick(h.app_pool.clone(), Some(&staging.staging_dir), 16)
+        .await
+        .expect("B3 tick ok");
+    assert!(
+        report3.expired_count >= 1,
+        "B3 expired_count >= 1 (got {})",
+        report3.expired_count
+    );
+    assert!(
+        report3.staging_missing >= 1,
+        "B3 staging_missing increments when file absent (got {})",
+        report3.staging_missing
+    );
+    assert_eq!(report3.audit_failed, 0, "B3 no audit failures");
+}
+
+// ─── Block C — Streaming put_stream e2e via finalize_upload ─────────────
+
+async fn run_streaming_scenario(h: &Arc<Harness>, router: &axum::Router, local_fs: &LocalFs) {
+    let (_user_id, group_id, token) = seed_user_with_group(h, "streaming-owner@0047.test")
+        .await
+        .expect("seed streaming owner");
+    let gid_str = group_id.to_string();
+
+    const MIB: usize = 1024 * 1024;
+    const TOTAL: usize = 2 * MIB;
+
+    // Deterministic byte pattern so the round-trip asserts catch
+    // off-by-one / truncation bugs in the streaming path.
+    let mut payload = Vec::with_capacity(TOTAL);
+    for i in 0..TOTAL {
+        payload.push((i % 251) as u8);
+    }
+
+    let upload_id = create_in_progress_upload(router, &token, &gid_str, TOTAL as i64).await;
+
+    // Chunk 1 — [0 .. MIB)
+    {
+        let resp = router
+            .clone()
+            .oneshot(patch_upload_req(
+                &token,
+                &gid_str,
+                upload_id,
+                0,
+                Bytes::copy_from_slice(&payload[..MIB]),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::NO_CONTENT,
+            "C1 chunk1 → 204 (in_progress)"
+        );
+        assert_eq!(
+            resp.headers().get("upload-offset").unwrap(),
+            MIB.to_string().as_str()
+        );
+    }
+
+    // Chunk 2 — [MIB .. 2*MIB) triggers finalize → put_stream.
+    {
+        let resp = router
+            .clone()
+            .oneshot(patch_upload_req(
+                &token,
+                &gid_str,
+                upload_id,
+                MIB as i64,
+                Bytes::copy_from_slice(&payload[MIB..]),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::NO_CONTENT,
+            "C1 chunk2 → 204 (completed)"
+        );
+        assert_eq!(
+            resp.headers().get("upload-offset").unwrap(),
+            TOTAL.to_string().as_str()
+        );
+    }
+
+    // ─── Assert status flipped to completed ─────────────────────────
+    let tus_row: (String,) = sqlx::query_as("SELECT status FROM tus_uploads WHERE id = $1")
+        .bind(upload_id)
+        .fetch_one(&h.admin_pool)
+        .await
+        .unwrap();
+    assert_eq!(tus_row.0, "completed", "C1 tus_uploads.status = completed");
+
+    // ─── Assert files / file_versions rows + checksum shape ─────────
+    let files_rows: Vec<(Uuid, i64, String)> =
+        sqlx::query_as("SELECT id, size_bytes, mime_type FROM files WHERE group_id = $1")
+            .bind(group_id)
+            .fetch_all(&h.admin_pool)
+            .await
+            .unwrap();
+    assert_eq!(files_rows.len(), 1, "C1 one files row");
+    assert_eq!(files_rows[0].1, TOTAL as i64, "C1 files.size_bytes = 2 MiB");
+    assert_eq!(files_rows[0].2, "text/plain", "C1 files.mime_type");
+
+    let fv_rows: Vec<(String, String, String, i64)> = sqlx::query_as(
+        "SELECT object_key, checksum_sha256, integrity_hmac, size_bytes \
+           FROM file_versions WHERE group_id = $1",
+    )
+    .bind(group_id)
+    .fetch_all(&h.admin_pool)
+    .await
+    .unwrap();
+    assert_eq!(fv_rows.len(), 1, "C1 one file_versions row");
+    let (object_key, checksum, hmac, fv_size) = &fv_rows[0];
+    assert_eq!(
+        *fv_size, TOTAL as i64,
+        "C1 file_versions.size_bytes = 2 MiB"
+    );
+    assert_eq!(checksum.len(), 64, "C1 checksum_sha256 is hex-64");
+    assert_eq!(hmac.len(), 64, "C1 integrity_hmac is hex-64");
+
+    // ─── Byte-for-byte round-trip via ObjectStore::get ──────────────
+    let got = local_fs.get(object_key).await.expect("C1 get object");
+    assert_eq!(
+        got.bytes.len(),
+        TOTAL,
+        "C1 LocalFs round-trip length = 2 MiB"
+    );
+    assert_eq!(
+        got.bytes.as_ref(),
+        payload.as_slice(),
+        "C1 streaming round-trip preserves every byte"
+    );
+
+    // ─── Audit `upload.completed` emitted with PII-safe metadata ────
+    let audit = fetch_audit_events_for_group(h, group_id)
+        .await
+        .expect("fetch audit after C1");
+    let completed_audit: Vec<_> = audit
+        .iter()
+        .filter(|r| r.0 == "upload.completed" && r.3 == files_rows[0].0.to_string())
+        .collect();
+    assert_eq!(completed_audit.len(), 1, "C1 one upload.completed row");
+    let meta_str = completed_audit[0].4.to_string();
+    assert!(
+        !meta_str.contains("upload.bin"),
+        "C1 audit metadata must not contain filename"
+    );
+    assert!(
+        !meta_str.contains("text/plain"),
+        "C1 audit metadata must not contain mime"
+    );
+}

--- a/crates/garraia-storage/src/lib.rs
+++ b/crates/garraia-storage/src/lib.rs
@@ -42,8 +42,8 @@ pub mod s3_compat;
 pub use error::{Result, StorageError};
 pub use local_fs::LocalFs;
 pub use object_store::{
-    GetOptions, GetResult, ObjectMetadata, ObjectStore, PRESIGN_TTL_MAX, PRESIGN_TTL_MIN,
-    PutOptions,
+    AsyncByteReader, GetOptions, GetResult, ObjectMetadata, ObjectStore, PRESIGN_TTL_MAX,
+    PRESIGN_TTL_MIN, PutOptions,
 };
 pub use path_sanitize::{SanitizeError, sanitise_key};
 

--- a/crates/garraia-storage/src/local_fs.rs
+++ b/crates/garraia-storage/src/local_fs.rs
@@ -16,7 +16,7 @@ use url::Url;
 use crate::error::{Result, StorageError};
 use crate::hash_util::sha256_hex;
 use crate::object_store::{
-    GetResult, ObjectMetadata, ObjectStore, PutOptions, check_mime_allowlist,
+    AsyncByteReader, GetResult, ObjectMetadata, ObjectStore, PutOptions, check_mime_allowlist,
     maybe_compute_integrity_hmac,
 };
 use crate::path_sanitize::sanitise_key;
@@ -99,6 +99,107 @@ impl ObjectStore for LocalFs {
         file.write_all(&bytes).await?;
         file.flush().await?;
         debug!(target: "garraia_storage::local_fs", "put key={key} size={size_bytes}");
+        Ok(ObjectMetadata {
+            key: key.to_owned(),
+            size_bytes,
+            etag_sha256: etag,
+            content_type: opts.content_type,
+            integrity_hmac,
+        })
+    }
+
+    /// Streaming upload override: writes `reader` to a temp sibling and
+    /// atomically renames into place on success. Plan 0047 (GAR-395 slice 3).
+    ///
+    /// - Temp path is `<target>.inflight-<pid>-<nanos>` inside the same
+    ///   parent directory so `rename` is atomic on POSIX and best-effort
+    ///   on Windows (NTFS rename-with-replace works when the target is
+    ///   free, falls back to copy+delete when it is held — both survive
+    ///   partial writes because the temp is removed on error).
+    /// - The SHA-256 etag + optional HMAC are computed as bytes flow
+    ///   through the pipe — no full-buffer spike.
+    /// - `content_length` is advisory and used only for diagnostic tracing.
+    async fn put_stream(
+        &self,
+        key: &str,
+        reader: AsyncByteReader,
+        content_length: u64,
+        opts: PutOptions,
+    ) -> Result<ObjectMetadata> {
+        check_mime_allowlist(&opts)?;
+        let final_path = self.resolve(key)?;
+        if let Some(parent) = final_path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let pid = std::process::id();
+        let tmp_name = format!(
+            "{}.inflight-{pid}-{nanos}",
+            final_path
+                .file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or("blob")
+        );
+        let tmp_path = final_path.with_file_name(tmp_name);
+
+        // Stream bytes to temp file while hashing on the fly.
+        use sha2::{Digest, Sha256};
+        let put_result: Result<(u64, String)> = async {
+            let mut file = tokio::fs::File::create(&tmp_path).await?;
+            let mut reader = reader;
+            let mut hasher = Sha256::new();
+            let mut written: u64 = 0;
+            let mut buf = vec![0u8; 64 * 1024];
+            loop {
+                let n = tokio::io::AsyncReadExt::read(&mut reader, &mut buf).await?;
+                if n == 0 {
+                    break;
+                }
+                hasher.update(&buf[..n]);
+                file.write_all(&buf[..n]).await?;
+                written += n as u64;
+            }
+            file.flush().await?;
+            let digest = hasher.finalize();
+            let mut etag = String::with_capacity(64);
+            for b in digest.as_slice() {
+                use std::fmt::Write as _;
+                let _ = write!(etag, "{b:02x}");
+            }
+            Ok::<(u64, String), StorageError>((written, etag))
+        }
+        .await;
+
+        let (size_bytes, etag) = match put_result {
+            Ok(v) => v,
+            Err(e) => {
+                // Best-effort cleanup of the inflight file on any failure
+                // (IO, partial write). Ignore removal errors — the temp is
+                // discardable.
+                let _ = tokio::fs::remove_file(&tmp_path).await;
+                return Err(e);
+            }
+        };
+
+        // Atomic rename into place. On Windows, `rename` over an existing
+        // file may fail — remove first in that case to mirror POSIX.
+        #[cfg(windows)]
+        {
+            let _ = tokio::fs::remove_file(&final_path).await;
+        }
+        if let Err(e) = tokio::fs::rename(&tmp_path, &final_path).await {
+            let _ = tokio::fs::remove_file(&tmp_path).await;
+            return Err(StorageError::Io(e));
+        }
+
+        let integrity_hmac = maybe_compute_integrity_hmac(&opts, key, &etag);
+        debug!(
+            target: "garraia_storage::local_fs",
+            "put_stream key={key} size={size_bytes} expected={content_length}"
+        );
         Ok(ObjectMetadata {
             key: key.to_owned(),
             size_bytes,
@@ -294,6 +395,87 @@ mod tests {
         assert!(store.exists("k").await.unwrap());
         store.delete("k").await.unwrap();
         assert!(!store.exists("k").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn put_stream_roundtrip_matches_put() {
+        // Plan 0047 (GAR-395 slice 3): streaming path must produce
+        // identical bytes + etag to `put` for the same input, and the
+        // atomic-rename implementation must leave no `.inflight-*`
+        // temp file behind on success.
+        let (_dir, store) = fresh();
+        let payload = b"streaming-bytes-0123456789".to_vec();
+
+        let cursor: std::io::Cursor<Vec<u8>> = std::io::Cursor::new(payload.clone());
+        let reader: crate::AsyncByteReader = Box::pin(cursor);
+        let meta_stream = store
+            .put_stream("s/one", reader, payload.len() as u64, PutOptions::default())
+            .await
+            .unwrap();
+
+        let got = store.get("s/one").await.unwrap();
+        assert_eq!(got.bytes.as_ref(), payload.as_slice());
+        assert_eq!(meta_stream.size_bytes, payload.len() as u64);
+        assert_eq!(meta_stream.etag_sha256.len(), 64);
+        assert_eq!(got.metadata.etag_sha256, meta_stream.etag_sha256);
+
+        // Compare against the buffered `put` path for byte/etag parity.
+        let meta_buf = store
+            .put("s/two", Bytes::from(payload.clone()), PutOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(meta_stream.etag_sha256, meta_buf.etag_sha256);
+
+        // No `.inflight-*` files should remain in the base dir.
+        let mut entries = tokio::fs::read_dir(store.base_dir().join("s"))
+            .await
+            .unwrap();
+        while let Some(entry) = entries.next_entry().await.unwrap() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            assert!(!name.contains(".inflight-"), "leftover temp file: {name}",);
+        }
+    }
+
+    #[tokio::test]
+    async fn put_stream_empty_body_yields_empty_sha() {
+        // Edge case: zero-byte stream. Must still produce the SHA-256
+        // of the empty input and create a real zero-byte file.
+        let (_dir, store) = fresh();
+        let cursor: std::io::Cursor<Vec<u8>> = std::io::Cursor::new(Vec::new());
+        let reader: crate::AsyncByteReader = Box::pin(cursor);
+        let meta = store
+            .put_stream("empty", reader, 0, PutOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(meta.size_bytes, 0);
+        assert_eq!(
+            meta.etag_sha256,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert!(store.exists("empty").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn put_stream_overwrites_existing_content_atomically() {
+        // Write v1, then stream v2 over the same key. The stream path
+        // uses a temp sibling + rename, so the target file must carry
+        // the full v2 content (not a truncated mid-write of v1).
+        let (_dir, store) = fresh();
+        store
+            .put("k", Bytes::from_static(b"v1"), PutOptions::default())
+            .await
+            .unwrap();
+
+        let v2 = b"v2-much-longer-payload".to_vec();
+        let reader: crate::AsyncByteReader = Box::pin(std::io::Cursor::new(v2.clone()));
+        store
+            .put_stream("k", reader, v2.len() as u64, PutOptions::default())
+            .await
+            .unwrap();
+
+        let got = store.get("k").await.unwrap();
+        assert_eq!(got.bytes.as_ref(), v2.as_slice());
     }
 
     #[tokio::test]

--- a/crates/garraia-storage/src/object_store.rs
+++ b/crates/garraia-storage/src/object_store.rs
@@ -1,15 +1,24 @@
 //! `ObjectStore` trait + request/response types.
 
 use std::fmt;
+use std::pin::Pin;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
+use tokio::io::AsyncRead;
 use url::Url;
 
 use crate::error::{Result, StorageError};
 use crate::integrity;
+
+/// Boxed, pinned, `Send` async reader — the value type the streaming
+/// [`ObjectStore::put_stream`] accepts. Box + Pin + Send is the minimal
+/// set of bounds that lets the trait remain `dyn`-compatible under
+/// `async_trait` (plan 0047 §streaming). Callers construct with e.g.
+/// `Box::pin(tokio::fs::File::open(path).await?)`.
+pub type AsyncByteReader = Pin<Box<dyn AsyncRead + Send>>;
 
 /// Metadata returned by [`ObjectStore::put`] and [`ObjectStore::head`].
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -128,6 +137,45 @@ pub struct GetResult {
 pub trait ObjectStore: Send + Sync + 'static {
     /// Upload `bytes` under `key`, replacing any previous content.
     async fn put(&self, key: &str, bytes: Bytes, opts: PutOptions) -> Result<ObjectMetadata>;
+
+    /// Streaming upload under `key`, replacing any previous content.
+    ///
+    /// Plan 0047 (GAR-395 slice 3). Default implementation buffers the
+    /// full stream into memory and delegates to [`Self::put`] — this keeps
+    /// the contract backwards-compatible for existing callers and lets
+    /// backends opt into true streaming (LocalFs: `tokio::io::copy` into
+    /// an open `File`; S3: multipart upload) without breaking the world.
+    ///
+    /// `content_length` is the **expected** byte count — backends MAY use
+    /// it for pre-allocation (e.g. S3 multipart part sizing). A caller
+    /// that does not know the length up-front should buffer via `put`.
+    /// The actual bytes consumed from `reader` drive the final etag and
+    /// `ObjectMetadata::size_bytes`.
+    ///
+    /// **Semantics of failure mid-stream:** backends MUST leave the
+    /// target key in a consistent state — either the old content
+    /// (replace failed, nothing visible) or the new full content
+    /// (replace succeeded). A backend that cannot guarantee this (e.g.
+    /// a naive LocalFs write-in-place) MUST write to a temp path and
+    /// atomically rename on success, OR override this default with a
+    /// safer path.
+    async fn put_stream(
+        &self,
+        key: &str,
+        reader: AsyncByteReader,
+        content_length: u64,
+        opts: PutOptions,
+    ) -> Result<ObjectMetadata> {
+        // Default: buffer into memory up to `content_length` bytes and
+        // delegate. Overridable — see `LocalFs::put_stream`.
+        let _ = content_length; // advisory for default impl; backends override
+        let mut reader = reader;
+        let mut buf: Vec<u8> = Vec::new();
+        tokio::io::AsyncReadExt::read_to_end(&mut reader, &mut buf)
+            .await
+            .map_err(StorageError::Io)?;
+        self.put(key, Bytes::from(buf), opts).await
+    }
 
     /// Fetch the bytes + metadata for `key`.
     async fn get(&self, key: &str) -> Result<GetResult>;

--- a/plans/0047-gar-395-tus-slice3.md
+++ b/plans/0047-gar-395-tus-slice3.md
@@ -1,0 +1,79 @@
+# Plan 0047 — GAR-395 TUS slice 3 (Termination + expiration worker + streaming put)
+
+**Status:** 🟡 Em execução (Lote B — implementação primeiro, plano narrow por decisão do usuário 2026-04-23)
+**Autor:** Claude Opus 4.7 (sessão autônoma, ClaudeMaxPower + Superpowers)
+**Data:** 2026-04-23 (America/New_York)
+**Issue:** [GAR-395](https://linear.app/chatgpt25/issue/GAR-395) — slice 3 de 3
+**Branch:** `plan/0047-tus-slice3`
+**Pré-requisitos:** plan 0049 (clippy strict) merged (5716976); slice 1 (0041) + slice 2 (0044) in main.
+**Escopo narrow por decisão do usuário:** "Pode deixar MIME sniff, bucket bytes rate-limit e HMAC zeroize para commits seguintes do mesmo slice, mas quero o slice já em andamento agora com código real."
+
+## 1. Goal
+
+Fechar GAR-395 entregando os 3 deferidos do PR #59 (plan 0044): **DELETE termination**, **expiration worker**, **streaming `put_stream`** — na mesma branch, com base de testes cobrindo os fluxos novos.
+
+## 2. Non-goals deste primeiro commit
+
+- MIME sniffing (`infer` crate) — próximo commit do mesmo slice.
+- Bucket bytes rate-limiter — próximo commit.
+- HMAC secret `Zeroize<Vec<u8>>` — próximo commit.
+- Substituição do `to_bytes` buffered em `patch_upload` por streaming — próximo commit (mudança de fluxo no PATCH handler + reescrita do staging append).
+
+## 3. Scope (arquivos tocados neste commit)
+
+**Novos:**
+- `crates/garraia-gateway/src/uploads_worker.rs` — worker + `UploadsExpirationWorkerConfig` + `TickReport` + `run_expiration_tick` + `spawn_uploads_expiration_worker` + 3 unit tests puros.
+- `crates/garraia-gateway/src/uploads_worker_util.rs` — `sha256_hex_of` helper compartilhado + 3 unit tests (known-vector NIST, idempotência, divergência).
+
+**Modificados:**
+- `crates/garraia-auth/src/audit_workspace.rs` — 2 novas variantes `UploadTerminated` + `UploadExpired` com mappings `upload.terminated` / `upload.expired`.
+- `crates/garraia-storage/src/object_store.rs` — trait `put_stream(&self, key, reader: AsyncByteReader, content_length, opts)` com default impl buffered + novo `pub type AsyncByteReader = Pin<Box<dyn AsyncRead + Send>>`.
+- `crates/garraia-storage/src/local_fs.rs` — override `put_stream` com temp-sibling + atomic rename + hash streaming (sem spike de memória) + 3 unit tests (happy, zero-byte vector NIST, overwrite atomicidade).
+- `crates/garraia-storage/src/lib.rs` — re-export `AsyncByteReader`.
+- `crates/garraia-gateway/src/lib.rs` — `pub mod uploads_worker; pub mod uploads_worker_util;`.
+- `crates/garraia-gateway/src/rest_v1/uploads.rs` — novo handler `delete_upload` (tus 1.0 Termination extension); constante `TUS_EXTENSION_HEADER` bumped de `"creation"` para `"creation,termination"`.
+- `crates/garraia-gateway/src/rest_v1/mod.rs` — rota DELETE em `/v1/uploads/{id}` em todos os 3 modes (full / auth-only / no-auth).
+- `crates/garraia-gateway/src/server.rs` — spawn do worker após `build_storage_wiring` quando AppPool presente.
+
+## 4. Acceptance criteria (deste commit)
+
+1. `cargo fmt --check --all` → exit 0.
+2. `cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings` → exit 0 (régua nova do 0049).
+3. `cargo test -p garraia-storage --lib` → 62/62 green (inclui 3 novos tests de `put_stream`).
+4. `cargo test -p garraia-auth --lib audit_workspace` → 3/3 green (existentes continuam válidos com 2 variantes novas).
+5. `cargo test -p garraia-gateway --lib uploads_worker` → 6/6 green (3 worker + 3 util).
+6. DELETE handler semânticas:
+   - 204 em `in_progress` → `aborted` + audit `upload.terminated` na mesma tx + staging best-effort cleanup.
+   - 410 em `completed`/`aborted`/`expired` (idempotência de termination).
+   - 404 quando row não existe OU cross-group (anti-enumeration per ADR 0004 §7).
+   - 412 sem `Tus-Resumable: 1.0.0`.
+7. Worker guarded por `pg_try_advisory_lock(hashtext('tus_uploads_expiration'))` — múltiplas réplicas não double-purge.
+
+## 5. Non-scope (fica pros commits seguintes deste slice)
+
+- MIME sniffing (SEC-L plan 0044 follow-up).
+- Bucket bytes rate-limiter `upload_bytes_limiter` (SEC-M1 plan 0044).
+- Zeroize HMAC secret.
+- Integration tests full-stack (testcontainer pg + handlers DELETE + worker tick end-to-end) — demandam reorganização do test harness de `garraia-gateway`; vão em commit 2.
+- Substituição do `to_bytes` buffered em `patch_upload` por streaming real (o `put_stream` já existe e é roundtripável; integração no fluxo do PATCH precisa reescrever o staging append + `finalize_upload` para evitar segundo spike).
+
+## 6. Rollback plan
+
+- Reversível por `git revert` — nenhuma migration nova.
+- Worker parado ao reverter (spawn deixa de rodar); DB fica em estado pré-slice (rows `in_progress` não viram `expired` automaticamente, mas `expires_at` já estava sendo escrito desde slice 1 — re-habilitar é só re-mergear).
+- DELETE handler sumido → clientes tus re-tentam com 404/405 padrão Axum; não há dado novo no schema.
+
+## 7. Follow-ups conhecidos (mesmo slice, próximos commits da branch)
+
+1. `rest_v1::uploads::patch_upload` passa a consumir via `put_stream` (elimina cap `max_patch_bytes` para uploads > 100 MiB).
+2. `infer`-based MIME sniff feature-gated (`storage-mime-sniff`).
+3. `upload_bytes_limiter` — rate-limit por bytes, não por request.
+4. `Zeroize<Vec<u8>>` para HMAC material.
+5. Integration tests testcontainer pg + MinIO.
+
+## 8. Referências
+
+- Plan 0041 (slice 1) — `POST /v1/uploads` + `HEAD /v1/uploads/{id}`.
+- Plan 0044 (slice 2) — `PATCH /v1/uploads/{id}` + `OPTIONS` + ObjectStore commit.
+- ADR 0004 — Object storage (§7 404-vs-403 anti-enumeration).
+- CLAUDE.md regra #9 — forward-only migrations (este slice NÃO adiciona migration).


### PR DESCRIPTION
## Summary

Plan 0047 (GAR-395 slice 3) — primeiro commit incremental do slice final do TUS server. **PR pequeno e incremental por design**: integração do `put_stream` no fluxo real do PATCH, MIME sniff, bytes rate-limit e zeroize ficam como commits subsequentes **nesta mesma branch** (ordem aprovada pelo usuário).

Zero nova migration. Zero breaking change. Clippy strict (régua do plan 0049) satisfeita desde o 1º commit.

## Shipped neste commit (`e5da351`)

### DELETE `/v1/uploads/{id}` — tus 1.0 Termination extension
- `204` em `in_progress` → `aborted` + audit `upload.terminated` na mesma tx + staging cleanup best-effort pós-commit
- `410` em `completed`/`aborted`/`expired` (idempotência de termination)
- `404` quando row não existe OU cross-group (anti-enum ADR 0004 §7)
- `412` sem `Tus-Resumable: 1.0.0`
- `TUS_EXTENSION_HEADER` bumped de `creation` → `creation,termination` no OPTIONS discovery

### Expiration worker (`uploads_worker.rs`)
- `pg_try_advisory_lock(hashtext('tus_uploads_expiration'))` multi-réplica safe
- CTE `SELECT ... FOR UPDATE SKIP LOCKED + LIMIT` transiciona em batch (`batch_size` default 256)
- 1 audit `upload.expired` por row em tx dedicada (SET LOCAL `app.current_group_id` per-row p/ RLS)
- `TickReport` contabiliza `expired_count` / `staging_removed` / `staging_missing` / `audit_failed`
- Spawned em `server.rs` após `build_storage_wiring` quando AppPool presente, fail-soft

### Streaming `ObjectStore::put_stream(key, reader, content_length, opts)`
- Novo trait method com default impl buffered (delega p/ `put`) — **zero breaking** para callers existentes
- `LocalFs` override grava em temp sibling `{key}.inflight-{pid}-{nanos}` + atomic rename → sobrevive a partial writes (POSIX rename atomic; Windows remove target pré-rename)
- SHA-256 etag em chunks 64 KiB, zero spike de memória
- Novo `pub type AsyncByteReader = Pin<Box<dyn AsyncRead + Send>>` re-exportado

### Audit actions novas
- `WorkspaceAuditAction::UploadTerminated` → `upload.terminated`
- `WorkspaceAuditAction::UploadExpired` → `upload.expired`
- `audit_events.action` sem CHECK (migration 002:119) → sem migration nova

## Diff

**11 arquivos, +901 / -14**:

- Modificados: `crates/garraia-auth/src/audit_workspace.rs`, `crates/garraia-gateway/src/{lib.rs,rest_v1/mod.rs,rest_v1/uploads.rs,server.rs}`, `crates/garraia-storage/src/{lib.rs,local_fs.rs,object_store.rs}`
- Novos: `crates/garraia-gateway/src/uploads_worker.rs`, `crates/garraia-gateway/src/uploads_worker_util.rs`, `plans/0047-gar-395-tus-slice3.md`

## Test plan

Verificação local (worktree `.claude/worktrees/0047-tus-slice3`, Windows, régua do plan 0049 ativa):

- [x] `cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings` → **exit 0**
- [x] `cargo fmt --check --all` → **exit 0**
- [x] `cargo test -p garraia-storage -p garraia-auth -p garraia-gateway --lib` → **370/370 passing** (44 + 264 + 62)
- [x] +12 novos unit tests (3 `put_stream` em `local_fs`, 3 `uploads_worker`, 3 `uploads_worker_util`, 2 variants novas em `audit_workspace`, 1 comportamento de atomic rename)
- [ ] CI full matrix (fmt-check + clippy strict + test 3-OS + build + e2e + playwright + security audit) — vai rodar sobre este push
- [ ] Integration tests testcontainer pg + MinIO — **next commit** da mesma branch

## Commits incrementais planejados (mesma branch, não novo PR)

1. ✅ `e5da351` — DELETE + expiration worker + put_stream (este)
2. 🔜 integração do `put_stream` no fluxo real do `patch_upload::finalize_upload` (elimina spike de memória em commits > `max_patch_bytes`)
3. 🔜 integration tests testcontainer pg + MinIO cobrindo todo o slice
4. 🔜 MIME sniffing (`infer` crate, feature-gated) + `upload_bytes_limiter` (rate-limit por bytes, não por request)
5. 🔜 `Zeroize<Vec<u8>>` para HMAC secret material

Cada um dos itens 2-5 vira 1 commit cirúrgico, push incremental, CI re-roda.

## Plan

- Plan file: [plans/0047-gar-395-tus-slice3.md](plans/0047-gar-395-tus-slice3.md)
- Issue: [GAR-395](https://linear.app/chatgpt25/issue/GAR-395)
- Supersede dos deferidos do PR #59 (plan 0044 slice 2 comment)

## Reviews

Dispatch de `@code-reviewer` + `@security-auditor` será feito após abrir o PR (não antes — convenção Lote A). Security auditor foca em:
- Injection path no `SET LOCAL` per-row do worker (Uuid::Display é fixed ASCII, injection-safe por construção — mesma proteção usada em `rest_v1::uploads::set_rls_context`)
- Anti-enumeration 404 vs 403 no DELETE cross-group
- Race condition entre worker e DELETE concorrente (ambos guardados por `FOR UPDATE` no row + advisory lock no worker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)