### PR TITLE
feat(ci): plan 0050 Lote 2 — reativar e2e + playwright (GAR-438)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,9 +199,14 @@ jobs:
     # Fix: build `--bin garraia`, start via `garraia start`, add Postgres
     # service + minimal auth envs so `AuthConfig::from_env` does not bail.
     services:
+      # Pin to 16.8-alpine (minor+patch) for deterministic CI runs —
+      # full SHA pin would be overkill for an ephemeral test service.
+      # `POSTGRES_USER: postgres` declared explicitly so the connection
+      # strings below remain auditable even if the image default changes.
       postgres:
-        image: postgres:16-alpine
+        image: postgres:16.8-alpine
         env:
+          POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: garraia_workspace_test
         ports:
@@ -225,6 +230,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      # Fake CI-only secrets are still printed in logs by default. Mask them
+      # so the pattern doesn't become a precedent for real secrets later.
+      - name: Mask CI-only fake secrets
+        run: |
+          echo "::add-mask::ci-e2e-jwt-secret-minimum-32-bytes-XXXXXXXX"
+          echo "::add-mask::ci-e2e-refresh-hmac-secret-min-32-bytes-XXXXXXXX"
+          echo "::add-mask::postgres://postgres:postgres@localhost:5432/garraia_workspace_test"
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -284,9 +297,14 @@ jobs:
     # from `garraia-cli`). See the `e2e` job comment for the full causal
     # chain.
     services:
+      # Pin to 16.8-alpine (minor+patch) for deterministic CI runs —
+      # full SHA pin would be overkill for an ephemeral test service.
+      # `POSTGRES_USER: postgres` declared explicitly so the connection
+      # strings below remain auditable even if the image default changes.
       postgres:
-        image: postgres:16-alpine
+        image: postgres:16.8-alpine
         env:
+          POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: garraia_workspace_test
         ports:
@@ -310,6 +328,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      # See `e2e` job for rationale — mask CI-only fake secrets.
+      - name: Mask CI-only fake secrets
+        working-directory: .
+        run: |
+          echo "::add-mask::ci-playwright-jwt-secret-minimum-32-bytes-XXXXXXXX"
+          echo "::add-mask::ci-playwright-refresh-hmac-min-32-bytes-XXXXXXXX"
+          echo "::add-mask::postgres://postgres:postgres@localhost:5432/garraia_workspace_test"
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,17 @@ jobs:
           echo "gateway failed to respond to /health within 30s" >&2
           exit 1
 
+      # TEMPORARY (plan 0050 Lote 2 P2.5, 2026-04-24): tests 3-6 of
+      # tests/e2e_telegram_api.sh exercise POST /v1/chat/completions which
+      # requires a real `LlmProvider` wired into the `AgentRuntime`. CI has
+      # only a fake `ANTHROPIC_API_KEY: sk-ant-test-key-for-ci`, so the
+      # gateway answers "Agent error: no LLM provider configured" and the
+      # script exits 1 on test 3. This is a pre-existing config gap, not a
+      # regression from this Lote. Tracked by GAR-NEW-Q18 (mock/echo LLM
+      # provider for CI); removing this CoE is part of that issue's DoD.
+      # Build / Start gateway / Health probe above stay genuinely blocking.
       - name: Run E2E tests
+        continue-on-error: true
         run: |
           chmod +x tests/e2e_telegram_api.sh
           GARRAIA_BASE_URL=http://localhost:3888 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,7 +380,16 @@ jobs:
           echo "gateway failed to respond to /health within 30s" >&2
           exit 1
 
+      # TEMPORARY (plan 0050 Lote 2, 2026-04-24): 6 of 9 tests in
+      # mcp-manager.spec.ts time out waiting for
+      # `input[placeholder*="Command"]` inside the Add MCP modal. The form
+      # HTML has drifted since the spec was written — this is a pre-existing
+      # UI/test issue, not a regression from this Lote. Tracked by
+      # GAR-NEW-Q17; this `continue-on-error: true` MUST be removed when
+      # that issue lands. The build/start/install/health-probe steps above
+      # stay genuinely blocking — only this one step is temporarily masked.
       - name: Run Playwright tests
+        continue-on-error: true
         run: |
           GARRAIA_BASE_URL=http://localhost:3888 \
           GARRAIA_SKIP_SERVER=1 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,23 +185,43 @@ jobs:
         # See clippy job comment: garraia-desktop excluded on CI.
         run: cargo build --workspace --exclude garraia-desktop --release
 
-  # E2E integration test (GAR-216)
+  # E2E integration test (GAR-216, GAR-438 / plan 0050 Lote 2)
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
-    # TODO(fix/ci-triage-2026-04-15): the gateway release binary compiles
-    # successfully but exits immediately on startup in CI (likely missing
-    # Postgres service / env config since plan 0016 M4 introduced
-    # /v1/groups handlers that require garraia-workspace). This is a
-    # pre-existing failure on main, unrelated to glib/rustfmt. Deferred
-    # to a follow-up PR that will either add a Postgres service container
-    # to this job or gate the gateway startup on a minimal config profile.
-    # Step-level continue-on-error on Build/Start/Run below keeps the log
-    # visible while reporting the job as successful.
+    # Plan 0050 Lote 2 (GAR-438, plan happy-finch 2026-04-24):
+    # The previous "gateway exits immediately" hypothesis was wrong. Root cause
+    # was that `garraia-gateway` is a library crate (no production [[bin]]);
+    # the real binary is `garraia` from `garraia-cli`. The job used to
+    # `cargo build -p garraia-gateway --release` + `./target/release/garraia-gateway`
+    # — that binary never existed, the `&` backgrounded a non-existent
+    # process with exit 0, and `continue-on-error: true` masked the failure.
+    # Fix: build `--bin garraia`, start via `garraia start`, add Postgres
+    # service + minimal auth envs so `AuthConfig::from_env` does not bail.
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: garraia_workspace_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     env:
       # Use a mock/echo LLM — no real API key required for E2E structure tests
       ANTHROPIC_API_KEY: "sk-ant-test-key-for-ci"
       GARRAIA_API_KEY: "ci-test-bearer-token"
+      # Plan 0050 Lote 2: minimal auth envs for `AuthConfig::from_env` (fail-soft
+      # to 503 on /v1/auth/* if any pool role is missing, but `/health` stays
+      # green and the E2E script only hits /health + /api/sessions + /v1/chat).
+      GARRAIA_JWT_SECRET: "ci-e2e-jwt-secret-minimum-32-bytes-XXXXXXXX"
+      GARRAIA_REFRESH_HMAC_SECRET: "ci-e2e-refresh-hmac-secret-min-32-bytes-XXXXXXXX"
+      GARRAIA_LOGIN_DATABASE_URL: "postgres://postgres:postgres@localhost:5432/garraia_workspace_test"
+      GARRAIA_SIGNUP_DATABASE_URL: "postgres://postgres:postgres@localhost:5432/garraia_workspace_test"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -221,22 +241,26 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-e2e-
 
-      - name: Build gateway (release)
-        continue-on-error: true
-        run: cargo build -p garraia-gateway --release
+      - name: Build garraia binary (release)
+        run: cargo build --bin garraia --release
 
       - name: Start gateway in background
-        continue-on-error: true
         run: |
-          ./target/release/garraia-gateway &
+          ./target/release/garraia start --host 0.0.0.0 --port 3888 &
           echo $! > /tmp/garraia.pid
-          # Wait up to 15s for health endpoint to respond
-          for i in $(seq 1 15); do
-            curl -sf http://localhost:3888/health && break || sleep 1
+          # Wait up to 30s for health endpoint to respond
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3888/health; then
+              echo ""
+              echo "gateway responded to /health after ${i}s"
+              exit 0
+            fi
+            sleep 1
           done
+          echo "gateway failed to respond to /health within 30s" >&2
+          exit 1
 
       - name: Run E2E tests
-        continue-on-error: true
         run: |
           chmod +x tests/e2e_telegram_api.sh
           GARRAIA_BASE_URL=http://localhost:3888 \
@@ -250,20 +274,36 @@ jobs:
             kill $(cat /tmp/garraia.pid) 2>/dev/null || true
           fi
 
-  # Playwright E2E Web UI tests (GAR-300)
+  # Playwright E2E Web UI tests (GAR-300, GAR-438 / plan 0050 Lote 2)
   playwright:
     name: Playwright E2E (MCP UI)
     runs-on: ubuntu-latest
-    # TODO(fix/ci-triage-2026-04-15): same root cause as the `e2e` job —
-    # gateway release binary starts but exits immediately on CI. Install
-    # Playwright step is unblocked by the committed package-lock.json, but
-    # the gateway startup cascade still fails. Deferred to the same
-    # follow-up PR as `e2e`. Step-level continue-on-error on Build/Start/Run
-    # below keeps the log visible while reporting the job as successful.
+    # Plan 0050 Lote 2 (GAR-438, plan happy-finch 2026-04-24): same root cause
+    # as the `e2e` job — the previous workflow ran a binary that never existed
+    # (`./target/release/garraia-gateway`, but the real binary is `garraia`
+    # from `garraia-cli`). See the `e2e` job comment for the full causal
+    # chain.
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: garraia_workspace_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     env:
       ANTHROPIC_API_KEY: "sk-ant-test-key-for-ci"
       GARRAIA_ADMIN_USER: "admin"
       GARRAIA_ADMIN_PASS: "admin123ci"
+      GARRAIA_JWT_SECRET: "ci-playwright-jwt-secret-minimum-32-bytes-XXXXXXXX"
+      GARRAIA_REFRESH_HMAC_SECRET: "ci-playwright-refresh-hmac-min-32-bytes-XXXXXXXX"
+      GARRAIA_LOGIN_DATABASE_URL: "postgres://postgres:postgres@localhost:5432/garraia_workspace_test"
+      GARRAIA_SIGNUP_DATABASE_URL: "postgres://postgres:postgres@localhost:5432/garraia_workspace_test"
     defaults:
       run:
         working-directory: tests
@@ -284,10 +324,9 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-playwright-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Build gateway
+      - name: Build garraia binary (release)
         working-directory: .
-        continue-on-error: true
-        run: cargo build -p garraia-gateway --release
+        run: cargo build --bin garraia --release
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -297,22 +336,37 @@ jobs:
           cache-dependency-path: tests/package-lock.json
 
       - name: Install Playwright
-        continue-on-error: true
         run: npm ci && npx playwright install chromium --with-deps
 
       - name: Start gateway
         working-directory: .
-        continue-on-error: true
         run: |
-          ./target/release/garraia-gateway &
-          for i in $(seq 1 20); do curl -sf http://localhost:3888/health && break || sleep 1; done
+          ./target/release/garraia start --host 0.0.0.0 --port 3888 &
+          echo $! > /tmp/garraia.pid
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3888/health; then
+              echo ""
+              echo "gateway responded to /health after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "gateway failed to respond to /health within 30s" >&2
+          exit 1
 
       - name: Run Playwright tests
-        continue-on-error: true
         run: |
           GARRAIA_BASE_URL=http://localhost:3888 \
           GARRAIA_SKIP_SERVER=1 \
           npx playwright test
+
+      - name: Stop gateway
+        if: always()
+        working-directory: .
+        run: |
+          if [ -f /tmp/garraia.pid ]; then
+            kill $(cat /tmp/garraia.pid) 2>/dev/null || true
+          fi
 
       - name: Upload test report
         if: always()

--- a/tests/e2e_telegram_api.sh
+++ b/tests/e2e_telegram_api.sh
@@ -89,10 +89,14 @@ run_test() {
     info "Running: $name"
     if $fn; then
         pass "$name"
-        ((PASS++))
+        # Use assignment form instead of `((PASS++))`: bash post-increment
+        # returns the value BEFORE the increment (0 on first call), which
+        # has exit status 1 and aborts the script under `set -e` (line 22).
+        # Discovered in plan 0050 Lote 2 (GAR-438), 2026-04-24.
+        PASS=$((PASS + 1))
     else
         fail "$name"
-        ((FAIL++))
+        FAIL=$((FAIL + 1))
     fi
 }
 

--- a/tests/playwright/mcp-manager.spec.ts
+++ b/tests/playwright/mcp-manager.spec.ts
@@ -71,8 +71,12 @@ test.describe('MCP Manager Web UI (GAR-300)', () => {
   // ── 1. Page loads ──────────────────────────────────────────────────────────
   test('1. MCP page loads with Add button and template gallery', async ({ page }) => {
     await expect(page.getByRole('button', { name: '+ Add MCP' })).toBeVisible();
-    // Page title
-    await expect(page.locator('#topbar-title, #page-title, h2, h1').first()).toContainText(/MCP/i);
+    // Page title — #page-title is the dynamic span updated by the admin JS
+    // (admin.html:545 + 708). The previous combined selector with `.first()`
+    // picked `<h1>🦜 GarraIA</h1>` from the banner because `.first()` takes
+    // the first DOM-order match of any of the comma-separated selectors, not
+    // the first in the selector list. Fixed in plan 0050 Lote 2 (GAR-438).
+    await expect(page.locator('#page-title')).toContainText(/MCP/i);
     // Template gallery section
     await expect(page.locator('#content-area')).toContainText(/template/i);
   });


### PR DESCRIPTION
## Summary

- Root cause of the masked e2e/playwright jobs was **not** startup failure for lack of Postgres — it was the workflow running `./target/release/garraia-gateway`, a binary that **never existed** (`garraia-gateway` is a library crate; the real binary is `garraia` from `garraia-cli`). Shell returned "No such file or directory", `&` backgrounded a non-existent process with exit 0, `curl /health` timed out, and `continue-on-error: true` reported both jobs as green.
- Primary fix is **CI-only** (build `--bin garraia`, start via `garraia start`, add Postgres service, export minimal auth envs).
- Removing the CoE masks revealed **three pre-existing bugs** in the test fixtures / CI config. Per user decisions across P2 and P2.5 (2026-04-24), the two trivial ones are fixed here and two dedicated issues own the remaining two CoE directives.

## What changed

| Before | After |
|---|---|
| `cargo build -p garraia-gateway --release` | `cargo build --bin garraia --release` |
| `./target/release/garraia-gateway &` (binary never existed) | `./target/release/garraia start --host 0.0.0.0 --port 3888 &` |
| No Postgres service | `postgres:16.8-alpine` + `POSTGRES_USER: postgres` + pg_isready health-check, both jobs |
| Missing auth envs | `GARRAIA_JWT_SECRET`, `GARRAIA_REFRESH_HMAC_SECRET`, `GARRAIA_LOGIN_DATABASE_URL`, `GARRAIA_SIGNUP_DATABASE_URL` (≥32B, XXXXX+ allowlist) + `::add-mask::` step |
| `continue-on-error: true` on 7 steps (e2e 3 + playwright 4) | **4 removed permanently**; **3 remain, all tracked by named issues** |
| `tests/e2e_telegram_api.sh` aborted after test 1 due to `((PASS++))` under `set -e` | `PASS=$((PASS + 1))` / `FAIL=$((FAIL + 1))` |
| `mcp-manager.spec.ts:75` selector picked `<h1>🦜 GarraIA</h1>` instead of page title | Uses `#page-title` directly |
| 15s silent health probe | 30s loop with explicit `exit 1` if `/health` never responds |

## Empirical evidence the primary fix works

From run [24891719307](https://github.com/michelbr84/GarraRUST/actions/runs/24891719307) (commit `8ace7a9`, 11/12 checks green):

- Step `Start gateway in background` executed `./target/release/garraia start --host 0.0.0.0 --port 3888` successfully and exited 0 in ~6s — `curl /health` returned 200.
- Log line: `WARN garraia_gateway::server: garraia-auth wiring partially failed; /v1/auth/* will return 503 login_ok=false signup_ok=false jwt_ok=true` — `AuthConfig::from_env` validated the new env vars (`jwt_ok=true`), pools degraded gracefully because the Postgres container has no `garraia_login`/`garraia_signup` roles (expected; fail-soft).
- **E2E test 1 (Health) PASS, test 2 (Create Telegram session) PASS** — proves gateway boot + SQLite session store are real in CI. Test 3 failed with a real `Agent error: no LLM provider configured` (pre-existing gap, now tracked by GAR-444).
- Playwright: build + start + install + health probe genuinely blocking and all green. Only `Run Playwright tests` step uses CoE (GAR-443 tracks 6 of 9 tests that fail on `input[placeholder*="Command"]` UI drift).

## Exit criterion — final, explicit, time-boxed

Original Lote 2 criterion: `grep -cE "^\s*continue-on-error:\s*true\s*$" .github/workflows/ci.yml` == **1** (only `security`, Lote 4 scope).

**Relaxed to == 3** for this PR, each line fully tracked:

| Line | Step | Lote | Owning issue |
|---|---|---|---|
| L286 (NEW, TEMPORARY) | `e2e` → `Run E2E tests` | 2 | **[GAR-444](https://linear.app/chatgpt25/issue/GAR-444/q18-mockecho-llm-provider-para-ci-destravar-tests-3-6-de-e2e-telegram)** (Q18: mock/echo LLM provider for CI) |
| L402 (NEW, TEMPORARY) | `playwright` → `Run Playwright tests` | 2 | **[GAR-443](https://linear.app/chatgpt25/issue/GAR-443/q17-ui-drift-no-form-add-mcp-timeout-em-inputplaceholdercommand)** (Q17: UI drift in Add MCP form) |
| L443 (PREEXISTING) | `security` → `Run security audit` | 4 | RUSTSEC triage per plan master |

Every CoE line has an in-file comment naming the blocking issue. `security` stays untouched per scope rules. When GAR-443 and GAR-444 land, `grep == 1` again.

## Scope rules (Opção A + P2 + P2.5, approved by user 2026-04-24)

**In scope of PR #64:**
- Workflow edits (`.github/workflows/ci.yml`)
- 2-line bash fix in `tests/e2e_telegram_api.sh`
- 1-line selector fix in `tests/playwright/mcp-manager.spec.ts`

**Explicitly out of scope:**
- No `ci-minimal` profile in production code.
- No mock/echo LLM provider in `garraia-agents` (tracked by GAR-444).
- No UI drift investigation in admin.html (tracked by GAR-443).
- No Rust regression test (`gateway_binary_smoke`) — candidate for follow-up.
- MSRV / RUSTSEC / coverage / mutation / refactors / MCP `acts` wiring — all untouched.

## Test plan

- [ ] Format / Clippy / cargo-deny / Dep Review / gitleaks — stay green (10/10 non-e2e checks).
- [ ] Test Linux / Windows / macOS / Build Check — no Rust changed, stay green.
- [ ] **`E2E Tests`**: build / start gateway / health probe (30s loop) genuinely blocking. `Run E2E tests` step tolerates failure via CoE tracked by GAR-444.
- [ ] **`Playwright E2E (MCP UI)`**: build / start / install Playwright / health probe genuinely blocking. `Run Playwright tests` step tolerates failure via CoE tracked by GAR-443.
- [ ] `Security Audit` stays non-blocking (Lote 4 scope).
- [ ] Post-merge: `grep -cE "^\s*continue-on-error:\s*true\s*$" .github/workflows/ci.yml` on `main` returns exactly **3** (L286 + L402 + L443), each with blocking-issue comments.

## Reviews

- `@code-reviewer` (commit `fc975e1` + `503630f`) → **Approved with nits** — all addressed in `503630f`.
- `@security-auditor` (commit `fc975e1` + `503630f`) → **Approve with nits 8.5/10** — all addressed in `503630f`.
- Subsequent commits (`8ace7a9` P2 + `e57e858` P2.5) are tight follow-ups scoped to test fixtures + 1 CoE line; happy to re-run reviews if preferred.

## Linear

Closes [GAR-438](https://linear.app/chatgpt25/issue/GAR-438/q8-reativar-e2e-playwright-com-postgres-service-container).

Opens [GAR-443](https://linear.app/chatgpt25/issue/GAR-443/q17-ui-drift-no-form-add-mcp-timeout-em-inputplaceholdercommand) (Q17: Playwright UI drift) — exclusive owner of the L402 CoE.

Opens [GAR-444](https://linear.app/chatgpt25/issue/GAR-444/q18-mockecho-llm-provider-para-ci-destravar-tests-3-6-de-e2e-telegram) (Q18: mock/echo LLM provider for CI) — exclusive owner of the L286 CoE.

Tracks EPIC [GAR-430](https://linear.app/chatgpt25/issue/GAR-430/epic-quality-gates-phase-36-plan-foamy-origami).

Plan file: `C:/Users/miche/.claude/plans/ative-o-modo-de-happy-finch.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)