### PR TITLE
chore(hooks): use $CLAUDE_PROJECT_DIR + dedupe estado header (GAR-445)

### DIFF
--- a/.claude/hooks/post-tool-use.sh
+++ b/.claude/hooks/post-tool-use.sh
@@ -2,6 +2,10 @@
 # GarraRUST — post-tool-use hook
 # Roda cargo test ou flutter test após edições
 
+# Resolve project root so Cargo / flutter lookups work regardless of CWD
+# (GAR-445).
+cd "${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
 FILE="${CLAUDE_TOOL_INPUT_FILE_PATH:-}"
 [ -z "$FILE" ] && exit 0
 

--- a/.claude/hooks/pre-tool-use.sh
+++ b/.claude/hooks/pre-tool-use.sh
@@ -2,6 +2,9 @@
 # GarraIA SuperPowers — pre-tool-use hook
 # Bloqueia comandos perigosos, detecta segredos e registra audit log
 
+# Resolve project root so AUDIT_LOG resolves regardless of CWD (GAR-445).
+cd "${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
 CMD="${CLAUDE_TOOL_INPUT_COMMAND:-}"
 AUDIT_LOG=".claude/audit.log"
 

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -4,6 +4,10 @@
 
 set -euo pipefail
 
+# Resolve project root so all relative paths below work regardless of CWD
+# (GAR-445).
+cd "${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 CYAN='\033[0;36m'

--- a/.claude/hooks/stop.sh
+++ b/.claude/hooks/stop.sh
@@ -4,6 +4,11 @@
 
 set -euo pipefail
 
+# Resolve project root so all relative paths below work regardless of the CWD
+# Claude Code used to invoke this hook (sessions started from a worktree or
+# subdir used to fail with "No such file or directory" — see GAR-445).
+cd "${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
 ESTADO_FILE=".garra-estado.md"
 SESSIONS_DIR=".claude/sessions"
 MAX_SESSIONS=10
@@ -30,7 +35,12 @@ $LOG
 "
 
 if [ -f "$ESTADO_FILE" ]; then
-  EXISTING=$(cat "$ESTADO_FILE")
+  # Strip any accumulated "# Estado GarraIA" header(s) from $EXISTING — keep
+  # only the content starting at the first "## <timestamp>" entry, and drop
+  # header lines that may have accumulated between entries. Old hook versions
+  # prepended a fresh header every session; this idempotent awk keeps exactly
+  # one header at the top of the file forever.
+  EXISTING=$(awk '/^## / { capture = 1 } capture && !/^# Estado GarraIA$/' "$ESTADO_FILE")
   echo -e "# Estado GarraIA\n\n$ESTADO_ENTRY\n$EXISTING" > "$ESTADO_FILE"
 else
   echo -e "# Estado GarraIA\n\n$ESTADO_ENTRY" > "$ESTADO_FILE"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/session-start.sh"
+            "command": "bash \"${CLAUDE_PROJECT_DIR}/.claude/hooks/session-start.sh\""
           }
         ]
       }
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/pre-tool-use.sh"
+            "command": "bash \"${CLAUDE_PROJECT_DIR}/.claude/hooks/pre-tool-use.sh\""
           }
         ]
       }
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/post-tool-use.sh"
+            "command": "bash \"${CLAUDE_PROJECT_DIR}/.claude/hooks/post-tool-use.sh\""
           }
         ]
       }
@@ -40,7 +40,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/stop.sh"
+            "command": "bash \"${CLAUDE_PROJECT_DIR}/.claude/hooks/stop.sh\""
           }
         ]
       }


### PR DESCRIPTION
## Summary

- `.claude/settings.json`: all 4 hook paths (`SessionStart`, `PreToolUse`, `PostToolUse`, `Stop`) now use `\${CLAUDE_PROJECT_DIR}` so they resolve regardless of the session CWD. Fixes the sporadic `bash: .claude/hooks/stop.sh: No such file or directory` reported after Lote 0 when sessions were started from nested worktrees or subdirs.
- Each hook script (`session-start`, `pre-tool-use`, `post-tool-use`, `stop`) gets a `cd \"\${CLAUDE_PROJECT_DIR:-<BASH_SOURCE-based fallback>}\"` at the top so its internal relative paths (`.garra-estado.md`, `.claude/audit.log`, `.claude/sessions/`, `skills/`, `.claude/agents/`) resolve even when `CLAUDE_PROJECT_DIR` is unset.
- `stop.sh`: `cat \$ESTADO_FILE` → idempotent awk that strips accumulated `# Estado GarraIA` header lines before prepending the new entry. Without this fix each session added another duplicate header (52 headers were observed locally before the fix); `.garra-estado.md` now keeps exactly one header at the top forever.

## Why

Discovered during the checkpoint of plan `inherited-pelican` (2026-04-24) after Lote 2 (GAR-438) merged. Two operational cosmetics were in the way of the next quality-gates lote (GAR-444 — EchoProvider) because that lote will exercise the worktree path heavily. Fixing the hook robustness first, in a tiny separate PR, keeps the GAR-444 PR narrow.

## Evidence

Smoke tests (fixtures in `/tmp/hooks-smoke/`, not in tree):

1. `stop.sh` run 2x with `CLAUDE_PROJECT_DIR` set: `grep -c \"^# Estado GarraIA\$\" .garra-estado.md` = **1**, entries = **2** (idempotent).
2. `stop.sh` with `CLAUDE_PROJECT_DIR` unset and CWD=`/`: BASH_SOURCE fallback resolves correctly, no stray files.
3. `session-start.sh` + `pre-tool-use.sh` + `post-tool-use.sh`: exit 0 with/without `CLAUDE_PROJECT_DIR`.

One-shot local cleanup of the main tree's `.garra-estado.md` (52 duplicate headers → 1, all 53 entries preserved; backup kept at `.garra-estado.md.bak-inherited-pelican`). Not in this PR because `.garra-estado.md` is gitignored (see `.gitignore:46`). The fix is idempotent, so the file self-heals on the next stop hook.

## Test plan

- [x] `stop.sh` smoke: header count collapses from seeded 3 → 1 after first run; stays at 1 on second run.
- [x] `stop.sh` fallback (`CLAUDE_PROJECT_DIR` unset, CWD=`/`): writes to the correct project, zero stray files.
- [x] `session-start.sh` reads the state file correctly under both modes.
- [x] `pre-tool-use.sh` + `post-tool-use.sh` exit 0 with / without `CLAUDE_PROJECT_DIR`.
- [ ] CI fmt/clippy/build/test/cargo-deny/dependency-review/gitleaks/e2e/playwright pass (no Rust code touched — pure regression check).

## Out of scope

- No Rust code touched. No `ci.yml` changes.
- No `CLAUDE.md`, `ROADMAP.md`, ADR, or skills changes.
- `.garra-estado.md` rotation to last-N entries — deferred follow-up.
- GAR-444 (EchoProvider) and GAR-443 (Playwright drift) — separate PRs.

Closes GAR-445. Parent: [GAR-430](https://linear.app/chatgpt25/issue/GAR-430) (EPIC Quality Gates Phase 3.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)