### PR TITLE
chore(deps,security): plan 0053 PR-1 — rustls-webpki 0.103.x hot path patch (GAR-447)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -50,17 +50,55 @@ ignore = [
     # RUSTSEC-2025-0046; same security review gate.
     "RUSTSEC-2025-0118",
 
-    # rustls-webpki — CRL matching logic; bump to >=0.103.10 (or
-    # 0.104-alpha.x if on rustls 0.23 alpha chain) in B-2.
+    # --- rustls-webpki residuals (GAR-447 PR-1, plan 0053) ---
+    #
+    # PR-1 (commit landing this comment block) applied the lockfile-only
+    # patch `cargo update -p rustls-webpki@0.103.9 --precise 0.103.13`,
+    # closing the 4 advisories below on the **production hot path**
+    # (rustls 0.23 chain: reqwest, hyper-rustls, tokio-rustls 0.26).
+    #
+    # The 4 IDs REMAIN ignored here because two legacy chains in
+    # Cargo.lock still trigger them and have no upstream fix:
+    #
+    #   A) rustls-webpki 0.102.8 (all 4 IDs)
+    #      via: serenity 0.12.5 → tokio-tungstenite 0.21
+    #           → rustls 0.22 → rustls-webpki 0.102.8
+    #      blocker: serenity 0.12.5 is the latest stable on crates.io;
+    #               line rustls-webpki 0.102.x is EOL (no 0.102.10+).
+    #
+    #   B) rustls-webpki 0.101.7 (3 of 4 IDs: 0098, 0099, 0104)
+    #      via: aws-smithy-http-client 1.1.12 → rustls 0.21
+    #           → rustls-webpki 0.101.7
+    #      blocker: aws-smithy-http-client 1.1.12 is the latest stable
+    #               on crates.io; feature-gated behind `storage-s3`.
+    #
+    # `cargo-audit` 0.22.x does NOT support per-(advisory, version)
+    # ignore — only per advisory ID. Aggressive `[patch.crates-io]`
+    # overrides for tokio-tungstenite/serenity/aws-smithy were
+    # rejected as too risky for a security PR (would force semver-
+    # incompatible bumps that could break Discord and S3 paths).
+    #
+    # Residual tracking: GAR-455 (Q7c) under GAR-430.
+    # Expiration target for these 4 IDs: 2026-07-31 (will be refreshed
+    # in PR-6 / GAR-452 once the lote-wide audit.toml cleanup lands).
+    #
+    # If a future advisory affects ONLY the 0.103.x line, this block
+    # MUST be revisited: the ignore would silence a real prod regression.
+
+    # rustls-webpki — CRL matching logic. Patched in 0.103.10. Hot path
+    # 0.103.13 is fixed. Residual: 0.102.8 only (serenity chain).
     "RUSTSEC-2026-0049",
 
-    # rustls-webpki — URI name constraints; same bump family as above.
+    # rustls-webpki — URI name constraints. Patched in 0.103.12. Hot
+    # path 0.103.13 is fixed. Residual: 0.102.8 + 0.101.7 chains.
     "RUSTSEC-2026-0098",
 
-    # rustls-webpki — wildcard in name-constrained certs; same bump.
+    # rustls-webpki — wildcard in name-constrained certs. Patched in
+    # 0.103.12. Hot path 0.103.13 is fixed. Residual: 0.102.8 + 0.101.7.
     "RUSTSEC-2026-0099",
 
-    # rustls-webpki — reachable panic in CRL parsing; same bump.
+    # rustls-webpki — reachable panic in CRL parsing. Patched in
+    # 0.103.13. Hot path 0.103.13 is fixed. Residual: 0.102.8 + 0.101.7.
     "RUSTSEC-2026-0104",
 
     # --- Unsound warnings (deny due to --deny unsound) — 3 unique IDs ---

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7731,7 +7731,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -7781,7 +7781,7 @@ dependencies = [
  "rustls 0.23.36",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.13",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -7817,9 +7817,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

Lockfile-only patch `cargo update -p rustls-webpki@0.103.9 --precise 0.103.13` closing the 4 advisories (RUSTSEC-2026-{0049, 0098, 0099, 0104}) **on the production hot path** (rustls 0.23 chain: `reqwest`, `hyper-rustls`, `tokio-rustls 0.26`).

**This PR is partial honest mitigation, not closure of the 4 advisories.** Two legacy chains continue to trigger the same IDs without upstream fix; residual tracked in [GAR-455 (Q7c)](https://linear.app/chatgpt25/issue/GAR-455).

## Acceptance criteria (revised)

| | |
|---|---|
| `Cargo.lock` shows `rustls-webpki 0.103.13` (was 0.103.9) | ✅ |
| Production hot path TLS 0.23 clean of the 4 IDs | ✅ |
| `.cargo/audit.toml` keeps 4 IDs ignored with explicit comments linking GAR-455 | ✅ |
| PR body does NOT promise "closes 4 advisories" | ✅ (this section) |
| No `[patch.crates-io]` aggressive override | ✅ |
| No serenity fork | ✅ |
| No semver-incompatible tokio-tungstenite bump | ✅ |

## Why partial?

After the patch, `cargo audit` still triggers the 4 IDs because two chains in `Cargo.lock` use legacy `rustls-webpki` versions with **no upstream fix available**:

### Residual chain A — serenity 0.12.5 (Discord)
```
rustls-webpki 0.102.8 ← rustls 0.22 ← tokio-rustls 0.25 ← tokio-tungstenite 0.21 ← serenity 0.12.5
```
Triggers all 4 IDs. Line `rustls-webpki 0.102.x` is EOL — no `0.102.10+` published. `serenity 0.12.5` is the latest stable on crates.io; nenhum upgrade disponível.

### Residual chain B — aws-smithy-http-client 1.1.12 (`storage-s3` feature-gated)
```
rustls-webpki 0.101.7 ← rustls 0.21 ← tokio-rustls 0.24 + hyper-rustls 0.24 ← aws-smithy-http-client 1.1.12 ← aws-sdk-s3
```
Triggers 3 of the 4 IDs (0098, 0099, 0104; 0049 doesn't affect 0.101.x line). `aws-smithy-http-client 1.1.12` is the latest stable; sem upgrade disponível.

### Why we cannot drop the IDs from `audit.toml`

`cargo-audit` 0.22.x does **not** support per-(advisory ID, package version) ignore — only per advisory ID. Removing the 4 IDs would silence the prod fix when it lands, AND keep the legacy chains noisy. Keeping them with explicit scoped comments is the honest choice.

### Why we did NOT use aggressive overrides

Considered and rejected:
- `[patch.crates-io] tokio-tungstenite = "0.26"` to force serenity onto rustls 0.23 → semver-incompatible API breaks across `WebSocketStream` and trait bounds; high risk of breaking Discord channel.
- Fork of `serenity` to bump rustls → out of scope for a security triage PR; large refactor.
- `[patch.crates-io] aws-smithy-http-client` → no public alternative crate.

The user explicitly approved Opção 3 (mitigação parcial honesta + Q7c residual tracking) — see plan `plans/0053-gar-437-rustsec-triage.md` and complete plan in `~/.claude/plans/estamos-retomando-o-projeto-serialized-karp.md`.

## Evidence

### `Cargo.lock` diff (8 lines)
```
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.13",
   ... (3 references updated)

- name = "rustls-webpki"
- version = "0.103.9"
- checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+ name = "rustls-webpki"
+ version = "0.103.13"
+ checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
```

### Advisory DB ground truth
| Advisory | Patched in | 0.103.13 fixed? |
|---|---|---|
| RUSTSEC-2026-0049 | `>= 0.103.10` | ✅ |
| RUSTSEC-2026-0098 | `>= 0.103.12` | ✅ |
| RUSTSEC-2026-0099 | `>= 0.103.12` | ✅ |
| RUSTSEC-2026-0104 | `>= 0.103.13` | ✅ |

### Verification

- ✅ `cargo check --workspace --exclude garraia-desktop` passou em 1m47s.
- ✅ `cargo audit` mostra as 4 IDs **apenas** nas chains residuais (0.102.8 + 0.101.7), nunca em 0.103.13. Reprodutível removendo temporariamente os 4 IDs do `audit.toml` e re-rodando `cargo audit`.
- ✅ `Cargo.lock` ainda contém `rustls-webpki 0.103.13` (verificado via `cargo tree -i rustls-webpki@0.103.13`).
- ⚠️ `cargo audit` continua reportando outros advisories pré-existentes (wasmtime → Q7b/GAR-454, quinn-proto, etc.) — **fora do escopo deste PR**.

## Files changed

- `Cargo.lock` (+4/-4): rustls-webpki version bump.
- `.cargo/audit.toml` (+43/-5): expanded comment block on the 4 IDs explaining residuals + GAR-455 cross-link.

## Linear cross-references

- [GAR-447](https://linear.app/chatgpt25/issue/GAR-447) — this PR (acceptance revised).
- [GAR-455 (Q7c)](https://linear.app/chatgpt25/issue/GAR-455) — residual upstream blockers, exp 2026-07-31.
- [GAR-437](https://linear.app/chatgpt25/issue/GAR-437) — parent (Q7 RUSTSEC triage).
- [GAR-430](https://linear.app/chatgpt25/issue/GAR-430) — epic (Quality Gates Phase 3.6).

## Reviewers requested

- @code-reviewer — overall review.
- @security-auditor — TLS surface review (mandatory per plan §8 quality gates).

## Test plan

- [x] `cargo check --workspace --exclude garraia-desktop` — passou.
- [ ] CI checks (cargo-deny, dependency-review, gitleaks, fmt, clippy strict, tests, e2e, playwright, security-audit informativo) — pending workflow run.
- [ ] @security-auditor APPROVE on TLS surface (no API/runtime change, lockfile-only).
- [ ] @code-reviewer APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)