### PR TITLE
chore(deps,security): plan 0053 PR-3 — testcontainers 0.27.3 (GAR-449)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -38,9 +38,13 @@ ignore = [
     # WITH security-auditor review of plugin isolation surface.
     "RUSTSEC-2025-0046",
 
-    # tokio-tar — PAX extended header file smuggling. Pulled by wasmtime
-    # toolchain; bump in B-2.
-    "RUSTSEC-2025-0111",
+    # NOTE: RUSTSEC-2025-0111 (tokio-tar PAX file smuggling) was closed by
+    # plan 0053 PR-3 (GAR-449). Resolution path: testcontainers 0.23 → 0.27.3
+    # + testcontainers-modules 0.11 → 0.15.0, which replaces tokio-tar 0.3.1
+    # with astral-tokio-tar 0.6.0 (the *fixed* version of the replacement —
+    # plan-pivot doc'd in plans/0053 §Amendment 2026-04-25 because the
+    # intermediate path 0.25/0.13 pulled astral-tokio-tar 0.5.6 which had its
+    # own RUSTSEC-2026-0066). tokio-tar absent from Cargo.lock; ignore removed.
 
     # wasmtime 28 — unsound shared linear memory API. Same bump as
     # RUSTSEC-2025-0046; same security review gate.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "astral-tokio-tar"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,11 +1261,14 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.18.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ccca1260af6a459d75994ad5acc1651bcabcbdbc41467cc9786519ab854c30"
+checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
+ "async-stream",
  "base64 0.22.1",
+ "bitflags 2.11.0",
+ "bollard-buildkit-proto",
  "bollard-stubs",
  "bytes",
  "futures-core",
@@ -1264,33 +1283,54 @@ dependencies = [
  "hyper-util",
  "hyperlocal",
  "log",
+ "num",
  "pin-project-lite",
+ "rand 0.9.2",
  "rustls 0.23.36",
  "rustls-native-certs",
- "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_derive",
  "serde_json",
- "serde_repr",
  "serde_urlencoded",
  "thiserror 2.0.18",
+ "time",
  "tokio",
+ "tokio-stream",
  "tokio-util",
+ "tonic 0.14.4",
  "tower-service",
  "url",
  "winapi",
 ]
 
 [[package]]
-name = "bollard-stubs"
-version = "1.47.1-rc.27.3.1"
+name = "bollard-buildkit-proto"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f179cfbddb6e77a5472703d4b30436bff32929c0aa8a9008ecf23d1d3cdd0da"
+checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
 dependencies = [
+ "prost 0.14.3",
+ "prost-types",
+ "tonic 0.14.4",
+ "tonic-prost",
+ "ureq",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.52.1-rc.29.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-buildkit-proto",
+ "bytes",
+ "prost 0.14.3",
  "serde",
+ "serde_json",
  "serde_repr",
- "serde_with",
+ "time",
 ]
 
 [[package]]
@@ -1586,6 +1626,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -2781,6 +2832,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2878,6 +2939,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "ferroid"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee93edf3c501f0035bbeffeccfed0b79e14c311f12195ec0e661e114a0f60da4"
+dependencies = [
+ "portable-atomic",
+ "rand 0.10.1",
+ "web-time",
 ]
 
 [[package]]
@@ -3815,6 +3887,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -6110,7 +6183,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.13.5",
  "thiserror 1.0.69",
  "tokio",
  "tonic 0.12.3",
@@ -6124,7 +6197,7 @@ checksum = "c9d3968ce3aefdcca5c27e3c4ea4391b37547726a70893aab52d3de95d5f8b34"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.13.5",
  "tonic 0.12.3",
 ]
 
@@ -6872,7 +6945,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive 0.14.3",
 ]
 
 [[package]]
@@ -6886,6 +6969,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.116",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost 0.14.3",
 ]
 
 [[package]]
@@ -7083,6 +7188,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7138,6 +7254,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -7271,15 +7393,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897fecc9fac6febd4408f9e935e86df739b0023b625e610e0357535b9c8adad0"
 dependencies = [
  "erasable",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -8746,7 +8859,7 @@ dependencies = [
  "chrono",
  "crc",
  "dotenvy",
- "etcetera",
+ "etcetera 0.8.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -9566,18 +9679,21 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.23.3"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a4f01f39bb10fc2a5ab23eb0d888b1e2bb168c157f61a1b98e6c501c639c74"
+checksum = "bfd5785b5483672915ed5fe3cddf9f546802779fc1eceff0a6fb7321fac81c1e"
 dependencies = [
+ "astral-tokio-tar",
  "async-trait",
  "bollard",
- "bollard-stubs",
  "bytes",
  "docker_credential",
  "either",
- "etcetera",
+ "etcetera 0.11.0",
+ "ferroid",
  "futures",
+ "http 1.4.0",
+ "itertools 0.14.0",
  "log",
  "memchr",
  "parse-display",
@@ -9588,16 +9704,15 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tokio-tar",
  "tokio-util",
  "url",
 ]
 
 [[package]]
 name = "testcontainers-modules"
-version = "0.11.6"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d43ed4e8f58424c3a2c6c56dbea6643c3c23e8666a34df13c54f0a184e6c707"
+checksum = "e5985fde5befe4ffa77a052e035e16c2da86e8bae301baa9f9904ad3c494d357"
 dependencies = [
  "testcontainers",
 ]
@@ -9802,21 +9917,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tar"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75"
-dependencies = [
- "filetime",
- "futures-core",
- "libc",
- "redox_syscall 0.3.5",
- "tokio",
- "tokio-stream",
- "xattr",
-]
-
-[[package]]
 name = "tokio-tungstenite"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10016,7 +10116,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.13.5",
  "socket2 0.5.10",
  "tokio",
  "tokio-stream",
@@ -10053,6 +10153,17 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost 0.14.3",
+ "tonic 0.14.4",
 ]
 
 [[package]]
@@ -10539,6 +10650,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "percent-encoding",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.4.0",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10574,6 +10712,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"

--- a/benches/database-poc/Cargo.toml
+++ b/benches/database-poc/Cargo.toml
@@ -23,8 +23,8 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 # Postgres
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "uuid", "chrono", "migrate"] }
-testcontainers = "0.23"
-testcontainers-modules = { version = "0.11", features = ["postgres"] }
+testcontainers = "0.27"
+testcontainers-modules = { version = "0.15", features = ["postgres"] }
 pgvector = { version = "0.4", features = ["sqlx"] }
 # SQLite
 rusqlite = { version = "0.32", features = ["bundled", "vtab", "functions", "blob"] }

--- a/crates/garraia-auth/Cargo.toml
+++ b/crates/garraia-auth/Cargo.toml
@@ -85,8 +85,8 @@ password-hash = { version = "0.5", features = ["getrandom"] }
 static_assertions = "1"
 # Integration tests spin their own pgvector container so garraia-auth stays
 # independently testable. Shared fixture optimization deferred to GAR-391c.
-testcontainers = "0.23"
-testcontainers-modules = { version = "0.11", features = ["postgres"] }
+testcontainers = "0.27"
+testcontainers-modules = { version = "0.15", features = ["postgres"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
 anyhow = "1"
 # Used by the smoke test to apply migrations 001..008 before exercising the

--- a/crates/garraia-cli/Cargo.toml
+++ b/crates/garraia-cli/Cargo.toml
@@ -59,7 +59,7 @@ dev-echo-provider = ["garraia-gateway/dev-echo-provider"]
 
 [dev-dependencies]
 tempfile = "3"
-testcontainers = "0.23"
+testcontainers = "0.27"
 # Integration tests run as their own bin crates, so they need explicit
 # access to some deps from the test file. Reuse workspace pins.
 sqlx = { workspace = true, features = ["runtime-tokio-native-tls", "postgres", "uuid", "chrono"] }

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -230,8 +230,8 @@ tower = { workspace = true, features = ["util"] }
 # `auth-v1` removed in 391c). Tests boot a pgvector container, apply workspace
 # migrations 001..010, and validate happy paths + byte-identical 401 anti-
 # enumeration. Plan reference: plans/0012-gar-391c-extractor-and-wiring.md.
-testcontainers = "0.23"
-testcontainers-modules = { version = "0.11", features = ["postgres"] }
+testcontainers = "0.27"
+testcontainers-modules = { version = "0.15", features = ["postgres"] }
 secrecy = "0.10"
 garraia-workspace = { path = "../garraia-workspace" }
 garraia-auth = { workspace = true }

--- a/crates/garraia-storage/Cargo.toml
+++ b/crates/garraia-storage/Cargo.toml
@@ -43,6 +43,6 @@ base64 = { version = "0.22", optional = true }
 [dev-dependencies]
 tempfile = "3"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-testcontainers = "0.23"
-testcontainers-modules = { version = "0.11", features = ["minio"] }
+testcontainers = "0.27"
+testcontainers-modules = { version = "0.15", features = ["minio"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }

--- a/crates/garraia-workspace/Cargo.toml
+++ b/crates/garraia-workspace/Cargo.toml
@@ -35,8 +35,8 @@ validator = { version = "0.20", features = ["derive"] }
 pgvector = { version = "0.4", features = ["sqlx"] }
 
 [dev-dependencies]
-testcontainers = "0.23"
-testcontainers-modules = { version = "0.11", features = ["postgres"] }
+testcontainers = "0.27"
+testcontainers-modules = { version = "0.15", features = ["postgres"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
 anyhow = "1"
 rand = "0.8"


### PR DESCRIPTION
## Summary

Bump `testcontainers 0.23 → 0.27.3` + `testcontainers-modules 0.11 → 0.15.0` em 6 declarações dev-dependencies. **Closes RUSTSEC-2025-0111** (`tokio-tar 0.3.1` PAX file smuggling) ao remover `tokio-tar` do `Cargo.lock`. Caminho 0.25/0.13 foi rejeitado por trocar uma advisory ignorada por outra equivalente (RUSTSEC-2026-0066 em `astral-tokio-tar 0.5.6`).

## Changes

8 arquivos, 205+/57- (Cargo.lock = 230 linhas, código = ~30 linhas):

| Arquivo | Antes | Depois |
|---|---|---|
| `crates/garraia-auth/Cargo.toml:88-89` | `0.23` / `0.11` | `0.27` / `0.15` |
| `crates/garraia-gateway/Cargo.toml:233-234` | `0.23` / `0.11` | `0.27` / `0.15` |
| `crates/garraia-storage/Cargo.toml:46-47` | `0.23` / `0.11` | `0.27` / `0.15` |
| `crates/garraia-workspace/Cargo.toml:38-39` | `0.23` / `0.11` | `0.27` / `0.15` |
| `crates/garraia-cli/Cargo.toml:62` | `0.23` (testcontainers) | `0.27` |
| `benches/database-poc/Cargo.toml:26-27` (não-workspace) | `0.23` / `0.11` | `0.27` / `0.15` |
| `.cargo/audit.toml` | RUSTSEC-2025-0111 ignored | nota explicativa, ignore removido |
| `Cargo.lock` | tokio-tar 0.3.1 | astral-tokio-tar 0.6.0 (fixed version) |

Zero mudanças em runtime code. Todas as edições em \`[dev-dependencies]\` ou lockfile.

## Why 0.27.3, not 0.25.2

Diagnóstico empírico em worktree mostrou que `testcontainers 0.25.2` puxa `astral-tokio-tar 0.5.6`, que tem **RUSTSEC-2026-0066** (Insufficient validation of PAX extensions, severity 1.7 low, fix em \`>=0.6.0\`). Trocar uma ignored PAX advisory por outra equivalente seria \"vitória contábil\" sem ganho real de segurança. Decisão de rota A documentada em \`plans/0053-gar-437-rustsec-triage.md §Amendment 2026-04-25\`.

`testcontainers 0.27.3` arrasta `astral-tokio-tar 0.6.0` e fecha ambas as advisories de uma vez.

## Evidence

### cargo metadata (lockfile state)

\`\`\`
$ cargo metadata --locked --format-version=1 | grep -q '\"name\":\"tokio-tar\"' && echo FAIL || echo \"OK: tokio-tar absent\"
OK: tokio-tar absent

$ cargo metadata --locked --format-version=1 | python -c 'import json,sys; v=[p[\"version\"] for p in json.load(sys.stdin)[\"packages\"] if p[\"name\"]==\"astral-tokio-tar\"]; print(f\"astral-tokio-tar={v[0] if v else \\\"absent\\\"}\")'
astral-tokio-tar=0.6.0
\`\`\`

### cargo audit before/after

| | Before (main) | After (this PR) |
|---|---|---|
| RUSTSEC-2025-0111 in output | yes (then ignored) | **absent (tokio-tar gone)** |
| RUSTSEC-2026-0066 in output | n/a (no astral-tokio-tar yet) | **absent (astral-tokio-tar=0.6.0 fixed)** |
| Total non-ignored vulns | 14 (wasmtime ×12 + quinn-proto + 1 other) | 14 (same — no new advisory) |
| Total ID count | 37 | 37 |

\`\`\`
$ cargo audit --no-fetch 2>&1 | grep -E \"RUSTSEC-2025-0111|RUSTSEC-2026-0066\" || echo \"OK: both absent\"
OK: both absent
\`\`\`

### Local gates (all green)

- \`cargo fmt --all -- --check\` ✓
- \`cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings\` ✓
- \`cargo build --workspace --tests --exclude garraia-desktop\` ✓ (4m14s, **zero API drift** from 0.23 → 0.27)
- \`cargo test --no-run -p garraia-auth -p garraia-gateway --features test-helpers -p garraia-storage -p garraia-workspace\` ✓
- \`cargo deny check bans licenses sources\` ✓
- \`cargo audit --no-fetch\`: RUSTSEC-2025-0111 + RUSTSEC-2026-0066 ausentes (delta zero em vulns não-ignoradas vs main)

## CI checklist

- [ ] Format
- [ ] Clippy strict
- [ ] Test (ubuntu)
- [ ] Test (windows)
- [ ] Test (macos)
- [ ] Build
- [ ] E2E
- [ ] Playwright
- [ ] Security — cargo audit (informativo até PR-7 / GAR-453)

## Rollback

\`git revert <merge-sha>\` — toca apenas \`Cargo.toml\`, \`Cargo.lock\`, \`.cargo/audit.toml\`. Sem migrations, sem schema, sem runtime code.

## Out of scope (registrado, NÃO tocado neste PR)

Diagnóstico revelou 13 advisories novas que apareceram no DB cargo-audit após plan 0053 ser escrito. Tratamento decidido pelo usuário 2026-04-25:

- **Wasmtime ×12** (RUSTSEC-2026-0020/0021/0085/0086/0087/0088/0089/0091/0092/0093/0094/0095/0096) → **GAR-454 Q7b** (já carve-out, plan 0050.4)
- **\`quinn-proto\` RUSTSEC-2026-0037** (DoS em Quinn endpoints) → **GAR-456** a criar na Fase D do plan immutable-parnas

Nenhum entra neste PR. Disciplina train mode preservada.

## Linear

- Sub-issue: [GAR-449](https://linear.app/chatgpt25/issue/GAR-449/gar-437c-rustsec-tokio-tar-bump-via-testcontainers) — In Progress
- Epic: [GAR-437](https://linear.app/chatgpt25/issue/GAR-437) — Q7 RUSTSEC triage
- Parent epic: [GAR-430](https://linear.app/chatgpt25/issue/GAR-430) — Quality Gates Phase 3.6
- Plans: \`plans/0053-gar-437-rustsec-triage.md\` (canônico) + \`~/.claude/plans/retomar-o-garrarust-em-immutable-parnas.md\` (espelho operacional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)