### PR TITLE
chore(ci,security): plan 0053 PR-7 — security job blocking (GAR-453)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,24 +453,73 @@ jobs:
           path: tests/playwright-report/
           retention-days: 7
 
-  # Security audit (optional but recommended)
+  # Security audit — bloqueante desde plan 0053 PR-7 (GAR-453, fecha GAR-437).
+  # Espelha o setup do nightly `.github/workflows/cargo-audit.yml` para evitar
+  # drift de decisão entre PR-time e schedule. Quando rustsec >= 0.31 com CVSS
+  # v4 nativo chegar, o strip step abaixo deve sair de AMBOS workflows
+  # atomicamente. Histórico: o `continue-on-error: true` que sobreviveu até
+  # plan 0053 PR-1..PR-6 cobria 6 advisories; PR-1..PR-6 fecharam ou
+  # documentaram cada uma em `.cargo/audit.toml` com Linear owner explícito,
+  # então o gate agora é blocking de fato.
   security:
     name: Security Audit
     runs-on: ubuntu-latest
-    # TODO(fix/ci-triage-2026-04-15): six known RUSTSEC advisories are
-    # currently unresolved (idna 0.5.0, quinn-proto 0.11.13, rsa 0.9.10,
-    # rustls-webpki x2, core2 0.4.0 yanked). Bumping these dependencies
-    # touches crypto/TLS surface area and requires review by
-    # security-auditor — deferred to a dedicated PR. Step-level
-    # continue-on-error on the audit command below keeps the log visible
-    # while reporting the job as successful so merges are not blocked.
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    env:
+      # Plan 0043: hard ceiling para CVSS v4 advisories que podem ser
+      # strippadas. Alinhado com cargo-audit.yml. EXPIRES 2026-05-20.
+      MAX_STRIPPED_CVSS_V4: 50
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Install cargo-audit
-        run: cargo install cargo-audit
+        # `--locked` pina as transitive deps de cargo-audit; range `^0.21`
+        # tracks a linha 0.21.x igual ao nightly. Bump deliberado quando
+        # upstream quebrar contrato CLI.
+        run: cargo install --locked --version '^0.21' cargo-audit
+
+      - name: Prime crates.io index for workspace deps
+        # cargo-audit --no-fetch desabilita o refresh do índice — pré-popular
+        # via `cargo fetch --locked` para que metadata lookups (yanked,
+        # existência) funcionem offline. Plan 0043 §5.6.
+        run: cargo fetch --locked
+
+      - name: Fetch advisory database and strip CVSS v4 entries
+        # Fetch HEAD do RustSec advisory-db, depois strip de entradas com
+        # CVSS v4 (rustsec 0.30.x falha o load inteiro se uma única entrada
+        # for unparseable). Hard-stop em threshold quando upstream fizer bulk
+        # migration. EXPIRES 2026-05-20. Espelha cargo-audit.yml passo-a-passo.
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.cargo/advisory-db
+          cd ~/.cargo/advisory-db
+          git init --quiet
+          git remote add origin https://github.com/rustsec/advisory-db.git
+          git fetch --depth=1 --quiet origin main
+          git checkout --quiet FETCH_HEAD
+          echo "Advisory DB HEAD: $(git rev-parse --short HEAD)"
+          echo "Commit date: $(git log -1 --format=%cd --date=iso-strict)"
+          mapfile -t stripped < <(grep -rlE '^[[:space:]]*cvss = "CVSS:4\.0/' crates/ || true)
+          echo "Stripping ${#stripped[@]} CVSS v4 advisories (threshold ${MAX_STRIPPED_CVSS_V4}):"
+          if [ "${#stripped[@]}" -gt "${MAX_STRIPPED_CVSS_V4}" ]; then
+            echo "::error::Stripped ${#stripped[@]} CVSS v4 advisories exceeds threshold ${MAX_STRIPPED_CVSS_V4}."
+            echo "Re-triage required — rustsec likely needs CVSS v4 support."
+            exit 1
+          fi
+          if [ "${#stripped[@]}" -gt 0 ]; then
+            printf '  %s\n' "${stripped[@]}"
+            rm -- "${stripped[@]}"
+          fi
 
       - name: Run security audit
-        continue-on-error: true
-        run: cargo audit
+        # `--deny unsound` widens failure beyond the default vuln set.
+        # `--no-fetch` prevents cargo-audit from refreshing the DB and
+        # overriding the CVSS v4 strip above. Mesmo flag-for-flag que o
+        # nightly cargo-audit.yml — mudanças aqui devem replicar lá.
+        run: cargo audit --no-fetch --deny unsound


### PR DESCRIPTION
## Summary

Fecha o último `continue-on-error: true` do `.github/workflows/ci.yml` (linha 475, job `security`), transformando `cargo audit` em **gate bloqueante real**. Último PR do plan 0053 / GAR-437 (Q7 RUSTSEC triage). Quando este PR mergear com CI verde, GAR-437 fecha.

## Changes

- `.github/workflows/ci.yml`: substitui o job `security` (lines 456-476) por versão que **espelha o setup do nightly `.github/workflows/cargo-audit.yml` flag-for-flag**:
  - `cargo install --locked --version '^0.21' cargo-audit`
  - `cargo fetch --locked` (primes sparse index para `--no-fetch`)
  - fetch advisory-db + strip CVSS v4 com `MAX_STRIPPED_CVSS_V4=50` hard ceiling
  - `cargo audit --no-fetch --deny unsound`
- Remove `continue-on-error: true` da linha 475.
- Substitui o `TODO(fix/ci-triage-2026-04-15)` (lines 460-466) por nota apontando este PR e plan 0053. As 6 advisories que o TODO citava foram fechadas ou documentadas em `.cargo/audit.toml` por PR-1..PR-6.
- Adiciona `permissions: contents: read` (least-privilege) e `timeout-minutes: 15` (alinhado com nightly).

Diff: single file, **+60/-11 LOC** (net +49, dentro do budget ≤ 100).

## Evidence

| Gate | Resultado |
|---|---|
| Único arquivo modificado | ✅ `.github/workflows/ci.yml` |
| `continue-on-error: true` em `.github/workflows/*.yml` | ✅ 0 (era 1 em main) |
| Local `cargo audit --no-fetch --deny unsound` | ✅ exit 0 (23 allowed unmaintained warnings, não-blocking) |
| YAML parse | ✅ válido (`python -c "import yaml; yaml.safe_load(...)"`) |
| Diffstat | ✅ +60/-11 LOC |
| Paridade comandos com `cargo-audit.yml` nightly | ✅ idêntica (install pin, fetch --locked, strip threshold 50, --no-fetch --deny unsound) |
| Nightly verde mais recente | ✅ run de 2026-04-27T09:19Z em HEAD `27499a2` (mesma base deste PR) |

## Why command matches nightly

A escolha de espelhar o nightly cargo-audit.yml passo-a-passo é deliberada:

1. **Mesma decisão verde/vermelho.** Se PR-time roda comando diferente do schedule, é possível PR ficar verde e o nightly do mesmo SHA ficar vermelho — telemetria mente.
2. **Setup robusto já validado.** O nightly resolve o problema de CVSS v4 (rustsec 0.30.x falha load com entradas v4) via fetch manual + strip + threshold. Reusar evita reinventar uma versão paralela.
3. **Quando rustsec ≥ 0.31 com CVSS v4 nativo chegar**, o strip step sai de **AMBOS** workflows atomicamente — comentário explícito no header do job avisa.

## Local verification

```bash
git checkout gar-437g-ci-blocking
grep -cE '^\s*continue-on-error:\s*true\s*$' .github/workflows/ci.yml   # → 0
git diff main --name-only                                                # → .github/workflows/ci.yml
git diff main --stat                                                     # → +60 -11
cargo audit --no-fetch --deny unsound                                    # → exit 0
python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
```

## CI checklist

- [ ] `fmt` job verde
- [ ] `clippy` job verde
- [ ] `cargo-deny` job verde
- [ ] `dependency-review` job verde
- [ ] `gitleaks` job verde
- [ ] `test (ubuntu-latest)` job verde
- [ ] `test (windows-latest)` job verde
- [ ] `test (macos-latest)` job verde
- [ ] `build` job verde
- [ ] `e2e` job verde
- [ ] `playwright` job verde
- [ ] **`security` job verde — sem CoE, exit 0** ← gate primário deste PR
- [ ] @code-reviewer APPROVE
- [ ] @security-auditor APPROVE

## Rollback

Single-commit revert: `git revert <merge-sha>` restaura `continue-on-error: true` + TODO antigo. Zero runtime change, 100% reversível em < 5 min.

## Out of scope

- wasmtime upgrade → GAR-454
- rustls-webpki residual → GAR-455
- sqlx → sqlx-postgres direto → GAR-456
- quinn-proto bump → GAR-457
- cargo-deny advisories sync → GAR-458
- MSRV bump → GAR-441
- Reusable workflow refactor (DRY entre `ci.yml::security` e `cargo-audit.yml::audit`) → futuro follow-up

## Linear

- Closes: GAR-453 (sub-issue, este PR)
- Closes: GAR-437 (epic Q7 RUSTSEC triage) — somente quando CI verde pós-merge confirmar `security` blocking
- Plan source-of-truth: `plans/0053-gar-437-rustsec-triage.md` §5 PR-7
- Sub-issues que continuam em backlog (rastreados em `.cargo/audit.toml` cleanup do PR-6): GAR-454, GAR-455, GAR-456, GAR-457, GAR-458

🤖 Generated with [Claude Code](https://claude.com/claude-code)