### PR TITLE
chore(ci,security): enable cargo-deny advisories — sync 21 IDs (GAR-458)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -15,22 +15,29 @@
 # concrete Linear issue as owner (not a "Lote" marker), (4) must declare
 # fix availability honestly, (5) must have an expiration date.
 #
-# SYNC NOTE — `audit.toml` vs `deny.toml` (HONEST asymmetry):
+# SYNC NOTE — `audit.toml` vs `deny.toml` (HONEST asymmetry,
+# refreshed 2026-04-27 by GAR-458 PR #75):
 #
 #   * `audit.toml` controls vulnerabilities flagged by `cargo audit`.
 #     It carries every RUSTSEC ID that would otherwise make `cargo audit`
 #     exit non-zero on `Cargo.lock`.
-#   * `deny.toml` controls advisories flagged by `cargo deny`. It carries
-#     the same RUSTSEC wasmtime IDs (mandatory sync) PLUS 5 additional
-#     `unmaintained-only` advisories (daemonize, derivative, fxhash,
-#     instant, paste) that `cargo audit` auto-classifies as "allowed
-#     warnings" and does NOT require explicit ignore.
-#   * **Mandatory sync on wasmtime IDs only.** When GAR-454 (Q7b) bumps
-#     wasmtime to ≥ 40.0.4 / ≥ 41.0.4, ALL 15 wasmtime IDs below MUST be
+#   * `deny.toml` controls advisories flagged by `cargo deny check
+#     advisories` (now invoked in CI via cargo-deny-action default
+#     `command: check`). It carries the same RUSTSEC wasmtime IDs AND
+#     the same 4 rustls-webpki residual IDs (mandatory sync, see below)
+#     PLUS 23 `unmaintained-only` advisories that `cargo audit`
+#     auto-classifies as "allowed warnings" and does NOT require
+#     explicit ignore here.
+#   * **Mandatory sync between the two files: wasmtime IDs (15) AND
+#     rustls-webpki residuals (4).** When GAR-454 (Q7b) bumps wasmtime
+#     to ≥ 40.0.4 / ≥ 41.0.4, ALL 15 wasmtime IDs below MUST be dropped
+#     from BOTH files atomically. When GAR-455 closes (serenity 0.13 +
+#     aws-smithy upgrade), ALL 4 rustls-webpki IDs below MUST be
 #     dropped from BOTH files atomically.
-#   * The 5 unmaintained-only IDs in `deny.toml` are intentionally NOT
-#     mirrored here. Do not "fix" the asymmetry by mass-mirroring; that
-#     would change runtime behavior of `cargo audit`.
+#   * The 23 unmaintained-only IDs in `deny.toml` (8 directly named +
+#     10 gtk-rs + 5 unic-*) are intentionally NOT mirrored here. Do not
+#     "fix" the asymmetry by mass-mirroring; that would change runtime
+#     behavior of `cargo audit`.
 
 [advisories]
 ignore = [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,15 +53,15 @@ jobs:
         # scripts/build-installer.ps1.
         run: cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings
 
-  # Supply-chain gate: license allow-list + crate bans + registry source bans.
-  # Uses deny.toml at the repo root (exists since 2026-03, never invoked in CI
-  # until plan 0050 Lote 1 / GAR-431). Runs in parallel with clippy.
-  #
-  # NOTE: `advisories` check is intentionally NOT run here — it is scoped to
-  # Q7 (RUSTSEC triage, GAR-437 / plan 0050 Lote 4a) and already covered by
-  # the nightly `cargo audit` workflow with deferred ignores through
-  # 2026-05-20. Once Q7 closes, flip the `command` below to `check` (default)
-  # and drop this note.
+  # Supply-chain gate: license allow-list + crate bans + registry source bans
+  # + RustSec advisories. Uses deny.toml at the repo root. Runs in parallel
+  # with clippy. Now invokes the `cargo-deny-action` default `command: check`,
+  # which runs all four categories — `advisories` was added in plan 0053
+  # PR-7 followup / GAR-458 after the `audit.toml` train (PR-1..PR-7) closed
+  # the Q7 RUSTSEC triage and `deny.toml` was synced with 21 ignored IDs
+  # (4 rustls-webpki residuals, 12 unmaintained-only crates, 15 wasmtime).
+  # Second-layer gate paired with the now-blocking PR-time `Security Audit`
+  # job (`cargo audit --no-fetch --deny unsound`).
   cargo-deny:
     name: cargo-deny
     runs-on: ubuntu-latest
@@ -69,10 +69,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Run cargo-deny (bans + licenses + sources)
+      - name: Run cargo-deny (advisories + bans + licenses + sources)
         uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          command: check bans licenses sources
 
   # Dependency review — catches new vulnerable/deprecated transitive deps
   # before they land on main. Runs only on pull_request (the action requires

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,11 +58,12 @@ jobs:
   # with clippy. Now invokes the `cargo-deny-action` default `command: check`,
   # which runs all four categories — `advisories` was added in plan 0053
   # PR-7 followup / GAR-458 after the `audit.toml` train (PR-1..PR-7) closed
-  # the Q7 RUSTSEC triage. `deny.toml` ignore list = 42 RUSTSEC IDs total
+  # the Q7 RUSTSEC triage. `deny.toml` ignore list = 47 RUSTSEC IDs total
   # (15 wasmtime under GAR-454, 4 rustls-webpki residuals under GAR-455,
-  # 23 unmaintained-only spread across GAR-430 ownership). Second-layer
-  # gate paired with the now-blocking PR-time `Security Audit` job
-  # (`cargo audit --no-fetch --deny unsound`).
+  # 5 audit.toml mirrors with deny-stricter severity mapping under GAR-437/
+  # GAR-456/GAR-457, 23 unmaintained-only spread across GAR-430 ownership).
+  # Second-layer gate paired with the now-blocking PR-time `Security Audit`
+  # job (`cargo audit --no-fetch --deny unsound`).
   cargo-deny:
     name: cargo-deny
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,10 +58,11 @@ jobs:
   # with clippy. Now invokes the `cargo-deny-action` default `command: check`,
   # which runs all four categories — `advisories` was added in plan 0053
   # PR-7 followup / GAR-458 after the `audit.toml` train (PR-1..PR-7) closed
-  # the Q7 RUSTSEC triage and `deny.toml` was synced with 21 ignored IDs
-  # (4 rustls-webpki residuals, 12 unmaintained-only crates, 15 wasmtime).
-  # Second-layer gate paired with the now-blocking PR-time `Security Audit`
-  # job (`cargo audit --no-fetch --deny unsound`).
+  # the Q7 RUSTSEC triage. `deny.toml` ignore list = 42 RUSTSEC IDs total
+  # (15 wasmtime under GAR-454, 4 rustls-webpki residuals under GAR-455,
+  # 23 unmaintained-only spread across GAR-430 ownership). Second-layer
+  # gate paired with the now-blocking PR-time `Security Audit` job
+  # (`cargo audit --no-fetch --deny unsound`).
   cargo-deny:
     name: cargo-deny
     runs-on: ubuntu-latest

--- a/deny.toml
+++ b/deny.toml
@@ -12,14 +12,15 @@
 #     rustls-webpki residuals (4).** When the upstream blockers close
 #     (GAR-454 wasmtime; GAR-455 serenity/aws-smithy) the IDs MUST be
 #     dropped from BOTH files atomically.
-#   * The 12 unmaintained-only IDs (daemonize, derivative, fxhash,
-#     instant, paste, proc-macro-error, async-std, 10× gtk-rs, 5×
-#     unic-*) are intentionally NOT mirrored in `audit.toml`. `cargo
-#     audit` auto-classifies them as "allowed warnings" and does NOT
-#     require explicit ignore. Mirroring them here in `deny.toml` is
-#     required because `cargo deny` treats them as deny-by-default.
-#     Do not "fix" the asymmetry by mass-mirroring to `audit.toml`;
-#     that would change runtime behavior.
+#   * The 23 unmaintained-only IDs (8 directly named: daemonize,
+#     derivative, fxhash, instant, paste, proc-macro-error, async-std,
+#     rustls-pemfile + 10× gtk-rs + 5× unic-*) are intentionally NOT
+#     mirrored in `audit.toml`. `cargo audit` auto-classifies them as
+#     "allowed warnings" and does NOT require explicit ignore.
+#     Mirroring them here in `deny.toml` is required because `cargo
+#     deny` treats them as deny-by-default. Do not "fix" the asymmetry
+#     by mass-mirroring to `audit.toml`; that would change runtime
+#     behavior.
 version = 2
 yanked = "warn"
 ignore = [
@@ -54,6 +55,12 @@ ignore = [
     #     rustls 0.21 (feature `storage-s3`; latest stable).
     # Neither has an upstream fix today. cargo-deny 0.16.x does not
     # support per-(advisory, version) ignore.
+    #
+    # OPERATIONAL WARNING: enabling the `storage-s3` feature in production
+    # requires manual re-triage of GAR-455 BEFORE deploy. The expiration
+    # date below does not substitute that check — it only forces a
+    # scheduled re-audit. (Security review of PR #75 / GAR-458 flagged
+    # this LOW residual risk explicitly.)
     "RUSTSEC-2026-0049", # CRL matching — patched in 0.103.10
     "RUSTSEC-2026-0098", # URI name constraints — patched in 0.103.12
     "RUSTSEC-2026-0099", # wildcard in name-constrained — patched in 0.103.12
@@ -72,6 +79,11 @@ ignore = [
     "RUSTSEC-2024-0436", # paste (transitive via wasmtime)
     "RUSTSEC-2024-0370", # proc-macro-error (transitive, no maintained alt)
     "RUSTSEC-2025-0052", # async-std (via opentelemetry_sdk 0.26 → garraia-telemetry)
+    # Added 2026-04-27 (PR #75 CI surfaced this — local cache was stale):
+    # rustls-pemfile 2.2.0 archived 2025-08; upstream recommends migrating
+    # to `rustls-pki-types::PemObject`. Pulled via axum-server 0.7.3 →
+    # garraia-gateway. Owner: GAR-430 (Quality Gates 3.6).
+    "RUSTSEC-2025-0134", # rustls-pemfile
 
     # --- gtk-rs unmaintained — desktop-only (10 IDs, expires 2026-07-31) ---
     # Pulled via tauri-runtime-wry → wry 0.54 → gtk 0.18 → atk/gdk/gtk3-macros

--- a/deny.toml
+++ b/deny.toml
@@ -1,21 +1,25 @@
 [advisories]
 # SYNC NOTE — `deny.toml` vs `.cargo/audit.toml` (HONEST asymmetry,
-# refreshed 2026-04-26 by plan 0053 PR-6 / GAR-452):
+# refreshed 2026-04-27 by plan 0053 PR-7 followup / GAR-458):
 #
 #   * `audit.toml` controls vulnerabilities flagged by `cargo audit`
-#     (the nightly Security workflow uses `--deny unsound`).
-#   * `deny.toml` controls advisories flagged by `cargo deny`.
-#   * Mandatory sync between the two files: **only the RUSTSEC wasmtime
-#     IDs.** When GAR-454 (Q7b) bumps wasmtime to >= 40.0.4 / >= 41.0.4,
-#     ALL 15 wasmtime IDs below MUST be dropped from BOTH files
-#     atomically.
-#   * The 5 unmaintained-only IDs at the bottom of this list (daemonize,
-#     derivative, fxhash, instant, paste) are intentionally NOT mirrored
-#     in `audit.toml`. `cargo audit` auto-classifies them as "allowed
-#     warnings" and does NOT require explicit ignore. Mirroring them
-#     here in `deny.toml` is required because `cargo deny` treats them
-#     as deny-by-default. Do not "fix" the asymmetry by mass-mirroring
-#     to `audit.toml`; that would change runtime behavior.
+#     (the PR-time Security job uses `--deny unsound`, mirroring the
+#     nightly `cargo-audit.yml` setup since GAR-453 made it blocking).
+#   * `deny.toml` controls advisories flagged by `cargo deny check
+#     advisories`. Now invoked in CI via `cargo-deny-action` default
+#     `command: check` (since GAR-458 enabled the advisories category).
+#   * **Mandatory sync between the two files: wasmtime IDs (15) AND
+#     rustls-webpki residuals (4).** When the upstream blockers close
+#     (GAR-454 wasmtime; GAR-455 serenity/aws-smithy) the IDs MUST be
+#     dropped from BOTH files atomically.
+#   * The 12 unmaintained-only IDs (daemonize, derivative, fxhash,
+#     instant, paste, proc-macro-error, async-std, 10× gtk-rs, 5×
+#     unic-*) are intentionally NOT mirrored in `audit.toml`. `cargo
+#     audit` auto-classifies them as "allowed warnings" and does NOT
+#     require explicit ignore. Mirroring them here in `deny.toml` is
+#     required because `cargo deny` treats them as deny-by-default.
+#     Do not "fix" the asymmetry by mass-mirroring to `audit.toml`;
+#     that would change runtime behavior.
 version = 2
 yanked = "warn"
 ignore = [
@@ -39,6 +43,22 @@ ignore = [
     "RUSTSEC-2026-0095", # CRITICAL (CVSS 9.0)
     "RUSTSEC-2026-0096", # CRITICAL (CVSS 9.0)
 
+    # --- rustls-webpki residual — 4 IDs (GAR-455, expires 2026-07-31) ---
+    # MIRROR of the same 4 IDs in `.cargo/audit.toml`. Plan 0053 PR-1
+    # (GAR-447) closed the production hot path (rustls 0.23 chain) via
+    # lockfile-only `cargo update`, but `cargo deny` walks the full
+    # lockfile and still sees the legacy chains:
+    #   * `rustls-webpki 0.102.8` via serenity 0.12.5 → tokio-tungstenite
+    #     0.21 → rustls 0.22 (latest stable; 0.102.x line is EOL).
+    #   * `rustls-webpki 0.101.7` via aws-smithy-http-client 1.1.12 →
+    #     rustls 0.21 (feature `storage-s3`; latest stable).
+    # Neither has an upstream fix today. cargo-deny 0.16.x does not
+    # support per-(advisory, version) ignore.
+    "RUSTSEC-2026-0049", # CRL matching — patched in 0.103.10
+    "RUSTSEC-2026-0098", # URI name constraints — patched in 0.103.12
+    "RUSTSEC-2026-0099", # wildcard in name-constrained — patched in 0.103.12
+    "RUSTSEC-2026-0104", # reachable panic in CRL parsing — patched in 0.103.13
+
     # --- Unmaintained-only — deny.toml-exclusive (no audit.toml mirror) ---
     # These crates have RUSTSEC `unmaintained` advisories but no fixed
     # version. `cargo audit` auto-allows them as warnings; `cargo deny`
@@ -50,6 +70,36 @@ ignore = [
     "RUSTSEC-2025-0057", # fxhash (transitive via wasmtime)
     "RUSTSEC-2024-0384", # instant (transitive via notify)
     "RUSTSEC-2024-0436", # paste (transitive via wasmtime)
+    "RUSTSEC-2024-0370", # proc-macro-error (transitive, no maintained alt)
+    "RUSTSEC-2025-0052", # async-std (via opentelemetry_sdk 0.26 → garraia-telemetry)
+
+    # --- gtk-rs unmaintained — desktop-only (10 IDs, expires 2026-07-31) ---
+    # Pulled via tauri-runtime-wry → wry 0.54 → gtk 0.18 → atk/gdk/gtk3-macros
+    # → garraia-desktop. CI excludes garraia-desktop (`--exclude garraia-desktop`)
+    # so runtime risk on Linux server deploys is zero, but `cargo deny` walks
+    # the full lockfile. Upstream gtk-rs GTK3 bindings discontinued; GTK4
+    # migration is a Tauri-side decision. Owner: epic GAR-430.
+    "RUSTSEC-2024-0411", # gdk
+    "RUSTSEC-2024-0412", # gdk-sys
+    "RUSTSEC-2024-0413", # atk
+    "RUSTSEC-2024-0414", # atk-sys
+    "RUSTSEC-2024-0415", # gdkwayland-sys
+    "RUSTSEC-2024-0416", # gdkx11
+    "RUSTSEC-2024-0417", # gdkx11-sys
+    "RUSTSEC-2024-0418", # gtk
+    "RUSTSEC-2024-0419", # gtk-sys
+    "RUSTSEC-2024-0420", # gtk3-macros
+
+    # --- unic-* unmaintained — open-i18n/rust-unic discontinued (5 IDs) ---
+    # Pulled via tauri-utils 2.8 → urlpattern 0.3 → unic-ucd-ident → unic-*.
+    # Tauri 2.x uses urlpattern for permission scope matching; replacement
+    # depends on a Tauri or urlpattern crate update. Owner: GAR-430.
+    # Expires 2026-07-31.
+    "RUSTSEC-2025-0075", # unic-char-property
+    "RUSTSEC-2025-0080", # unic-char-range
+    "RUSTSEC-2025-0081", # unic-common
+    "RUSTSEC-2025-0098", # unic-ucd-ident
+    "RUSTSEC-2025-0100", # unic-ucd-version
 ]
 
 [licenses]

--- a/deny.toml
+++ b/deny.toml
@@ -8,10 +8,12 @@
 #   * `deny.toml` controls advisories flagged by `cargo deny check
 #     advisories`. Now invoked in CI via `cargo-deny-action` default
 #     `command: check` (since GAR-458 enabled the advisories category).
-#   * **Mandatory sync between the two files: wasmtime IDs (15) AND
-#     rustls-webpki residuals (4).** When the upstream blockers close
-#     (GAR-454 wasmtime; GAR-455 serenity/aws-smithy) the IDs MUST be
-#     dropped from BOTH files atomically.
+#   * **Mandatory sync between the two files: wasmtime IDs (15),
+#     rustls-webpki residuals (4), AND 5 audit.toml mirrors that
+#     cargo-deny ALSO requires (rsa, glib, lru, quinn-proto, rand —
+#     differing severity classification between cargo-deny and
+#     cargo-audit).** When the upstream blockers close, the IDs MUST
+#     be dropped from BOTH files atomically.
 #   * The 23 unmaintained-only IDs (8 directly named: daemonize,
 #     derivative, fxhash, instant, paste, proc-macro-error, async-std,
 #     rustls-pemfile + 10× gtk-rs + 5× unic-*) are intentionally NOT
@@ -84,6 +86,37 @@ ignore = [
     # to `rustls-pki-types::PemObject`. Pulled via axum-server 0.7.3 →
     # garraia-gateway. Owner: GAR-430 (Quality Gates 3.6).
     "RUSTSEC-2025-0134", # rustls-pemfile
+
+    # --- audit.toml mirrors that cargo-deny ALSO requires (vuln + unsound) ---
+    # These IDs are in `.cargo/audit.toml` but cargo-deny categorizes them
+    # differently than cargo-audit — `unsound` is deny-by-default in
+    # cargo-deny, so we must mirror them here even though `cargo audit
+    # --deny unsound` already covers them in the PR-time Security gate.
+    # Local `cargo deny --offline check` does NOT reproduce these failures
+    # because the local cargo-deny version's severity mapping differs from
+    # the cargo-deny-action@v2 used in CI; the IDs are added defensively
+    # to cover the empirical CI behavior.
+    #
+    # rsa 0.9.10 — Marvin Attack timing sidechannel. Mirror of audit.toml
+    # under GAR-456. Pulled via sqlx-mysql lockfile leak (defense-in-depth
+    # in PR-4 prevented runtime use). Expires 2026-07-31.
+    "RUSTSEC-2023-0071",
+    # glib 0.18.5 — VariantStrIter unsound iterator impls. Mirror of
+    # audit.toml under GAR-437 carve-out. Desktop-only via Tauri surface.
+    # Expires 2026-07-31.
+    "RUSTSEC-2024-0429",
+    # lru 0.12.5 — IterMut stacked-borrows violation. Mirror of audit.toml
+    # under GAR-437 carve-out. Pulled via aws-sdk-s3 → garraia-storage
+    # (feature `storage-s3`). Expires 2026-07-31.
+    "RUSTSEC-2026-0002",
+    # quinn-proto 0.11.13 — DoS in Quinn endpoints. Mirror of audit.toml
+    # under GAR-457; will be closed by Phase 3 of this session
+    # (cargo update -p quinn-proto --precise 0.11.14). Expires 2026-06-15.
+    "RUSTSEC-2026-0037",
+    # rand 0.10.1 — custom logger unsound in rand::rng(). Mirror of
+    # audit.toml under GAR-437 carve-out. Used broadly; semver-incompatible
+    # bump path under audit. Expires 2026-07-31.
+    "RUSTSEC-2026-0097",
 
     # --- gtk-rs unmaintained — desktop-only (10 IDs, expires 2026-07-31) ---
     # Pulled via tauri-runtime-wry → wry 0.54 → gtk 0.18 → atk/gdk/gtk3-macros


### PR DESCRIPTION
## Summary

Followup do plan 0053 PR-7 (GAR-453, merged d1ff5f5). Flippa o `cargo-deny-action` para o default `command: check` (todas as 4 categorias: advisories + bans + licenses + sources), adicionando uma **segunda camada** de gate RustSec ao lado do `Security Audit` job que ficou blocking ontem.

## Changes

- `deny.toml`: +59/-7 LOC. Adiciona **21 IDs** ignorados, todos empíricamente inventariados via `cargo deny --offline check advisories`:
  - **4× rustls-webpki residuals** (mirror de `.cargo/audit.toml` sob GAR-455). PR-1 fechou o production hot path; cargo-deny ainda walks o lockfile inteiro e vê as cadeias legacy serenity 0.12.5 / aws-smithy-http-client 1.1.12. cargo-deny 0.16.x não suporta ignore por (advisory, version).
  - **10× gtk-rs unmaintained** (atk, atk-sys, gdk, gdk-sys, gdkwayland-sys, gdkx11, gdkx11-sys, gtk, gtk-sys, gtk3-macros). Desktop-only — CI exclui `garraia-desktop`. Owner: epic GAR-430.
  - **5× unic-*** (open-i18n/rust-unic discontinued) via tauri-utils → urlpattern. Owner: GAR-430.
  - **2× extra**: proc-macro-error (RUSTSEC-2024-0370), async-std (RUSTSEC-2025-0052 via opentelemetry_sdk → garraia-telemetry).
- `ci.yml`: +12/-13 LOC. Remove o argumento `command: check bans licenses sources`, deixando o action default `check` (todas as 4 categorias). Comentário datado removido; nova nota explica o pareamento com `Security Audit` blocking.

Diff total: **+74/-26 LOC**, 2 arquivos.

Mantém inalterados: 15 wasmtime IDs (GAR-454, expira 2026-08-31) + 5 unmaintained-only deny.toml-exclusivos (daemonize/derivative/fxhash/instant/paste).

## Evidence

| Gate | Resultado |
|---|---|
| `cargo deny --offline check` | ✅ exit 0 (advisories ok, bans ok, licenses ok, sources ok) |
| Diff scope | ✅ 2 files: deny.toml + ci.yml |
| YAML válido | ✅ `python -c "import yaml; ..."` |
| Diff size | ✅ +74/-26 = 100 LOC net (dentro do budget ≤ 200) |
| Empirical inventory | ✅ 21 IDs descobertos via `cargo deny --offline check advisories` em main pré-PR |

## Why blocking advisories now

Antes: `command: check bans licenses sources` deliberadamente excluía `advisories` enquanto Q7 RUSTSEC triage estava aberto (ci.yml tinha comentário datado apontando isso). Q7 fechou ontem com GAR-453 (PR #74). Agora os 21 IDs remanescentes têm ownership concreto + expiration futura em `deny.toml`, e `cargo deny --offline check` é green pre-merge. Habilitar `advisories` adiciona uma segunda camada independente do `cargo audit` PR-time, com uma vantagem: cargo-deny também flagga `unmaintained` (que cargo-audit auto-allow), mantendo o radar para crates abandonados.

## Local verification

```bash
git checkout gar-458-deny-advisories
cargo deny --offline check 2>&1 | tail -5
# → advisories ok, bans ok, licenses ok, sources ok
# → exit 0
```

## CI checklist

- [ ] `cargo-deny` job (agora rodando 4 categorias) verde
- [ ] `Security Audit` continua verde
- [ ] Demais jobs (fmt, clippy, test×3, e2e, playwright, build) verdes
- [ ] @code-reviewer APPROVE
- [ ] @security-auditor APPROVE

## Rollback

`git revert <merge-sha>` restaura `command: check bans licenses sources` + os 7 comments datados. Zero runtime change.

## Out of scope

- wasmtime upgrade (GAR-454)
- rustls-webpki structural fix (GAR-455)
- sqlx → sqlx-postgres (GAR-456)
- quinn-proto bump (GAR-457)
- Reusable workflow refactor

## Linear

- Closes: GAR-458
- Plan: §11 do session plan `voc-est-retomando-o-bright-snowglobe.md`
- Sibling tracking: 21 IDs adicionados todos têm Linear owner concreto (GAR-455 / GAR-430) com expiration futura (2026-07-31).

🤖 Generated with [Claude Code](https://claude.com/claude-code)