### PR TITLE
chore(deps,security): GAR-457 — quinn-proto 0.11.13 → 0.11.14 (RUSTSEC-2026-0037)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -160,20 +160,11 @@ ignore = [
     # semver-incompatible.
     "RUSTSEC-2026-0097",
 
-    # =========================================================================
-    # GAR-457 — quinn-proto Denial of Service in Quinn endpoints
-    # =========================================================================
-    # Temporary ignore — NOT fixed. Tracked by GAR-457. quinn-proto 0.11.13
-    # present in Cargo.lock via quinn 0.11.9 → reqwest 0.12.28, transitively
-    # used by garraia-gateway, garraia-channels (teloxide, serenity), and
-    # several other crates. Fix available: upgrade to >= 0.11.14. Diagnosis
-    # of the simplest cargo update path TBD (may bump via reqwest or via
-    # `cargo update -p quinn-proto --precise 0.11.14`).
+    # NOTE: RUSTSEC-2026-0037 (quinn-proto DoS in Quinn endpoints) was
+    # closed by GAR-457 (2026-04-27, PR-following-#75). Resolution:
+    # `cargo update -p quinn-proto --precise 0.11.14` lockfile-only patch.
+    # Ignore removed.
     #
-    # Short expiration deliberately forces re-triage well before the
-    # wasmtime/rustls cohort. Expires: 2026-06-15 (~7 weeks).
-    "RUSTSEC-2026-0037",
-
     # NOTE: RUSTSEC-2025-0111 (tokio-tar PAX file smuggling) was closed
     # by plan 0053 PR-3 (GAR-449). Resolution: testcontainers 0.23 →
     # 0.27.3 + testcontainers-modules 0.11 → 0.15.0 replaces tokio-tar

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6742,9 +6742,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/deny.toml
+++ b/deny.toml
@@ -9,11 +9,12 @@
 #     advisories`. Now invoked in CI via `cargo-deny-action` default
 #     `command: check` (since GAR-458 enabled the advisories category).
 #   * **Mandatory sync between the two files: wasmtime IDs (15),
-#     rustls-webpki residuals (4), AND 5 audit.toml mirrors that
-#     cargo-deny ALSO requires (rsa, glib, lru, quinn-proto, rand —
-#     differing severity classification between cargo-deny and
-#     cargo-audit).** When the upstream blockers close, the IDs MUST
-#     be dropped from BOTH files atomically.
+#     rustls-webpki residuals (4), AND 4 audit.toml mirrors that
+#     cargo-deny ALSO requires (rsa, glib, lru, rand — differing
+#     severity classification between cargo-deny and cargo-audit).**
+#     When the upstream blockers close, the IDs MUST be dropped from
+#     BOTH files atomically. (quinn-proto previously here was closed
+#     by GAR-457 on 2026-04-27.)
 #   * The 23 unmaintained-only IDs (8 directly named: daemonize,
 #     derivative, fxhash, instant, paste, proc-macro-error, async-std,
 #     rustls-pemfile + 10× gtk-rs + 5× unic-*) are intentionally NOT
@@ -109,10 +110,9 @@ ignore = [
     # under GAR-437 carve-out. Pulled via aws-sdk-s3 → garraia-storage
     # (feature `storage-s3`). Expires 2026-07-31.
     "RUSTSEC-2026-0002",
-    # quinn-proto 0.11.13 — DoS in Quinn endpoints. Mirror of audit.toml
-    # under GAR-457; will be closed by Phase 3 of this session
-    # (cargo update -p quinn-proto --precise 0.11.14). Expires 2026-06-15.
-    "RUSTSEC-2026-0037",
+    # NOTE: RUSTSEC-2026-0037 (quinn-proto) closed by GAR-457 (2026-04-27)
+    # via lockfile-only `cargo update -p quinn-proto --precise 0.11.14`.
+    # Removed from BOTH audit.toml and deny.toml.
     # rand 0.10.1 — custom logger unsound in rand::rng(). Mirror of
     # audit.toml under GAR-437 carve-out. Used broadly; semver-incompatible
     # bump path under audit. Expires 2026-07-31.


### PR DESCRIPTION
## Summary

Closes **RUSTSEC-2026-0037** (Denial of Service in Quinn endpoints) via lockfile-only `cargo update -p quinn-proto --precise 0.11.14`. Mesma forma cirúrgica do plan 0053 PR-1 (rustls-webpki): zero código tocado, zero Cargo.toml mudado, somente Cargo.lock + cleanup dos ignores em `.cargo/audit.toml` + `deny.toml`.

## Changes

- `Cargo.lock`: bump `quinn-proto 0.11.13 → 0.11.14`. Único direct dependent é `quinn 0.11.9` (reqwest → garraia-gateway). Nenhum API break entre 0.11.13 e 0.11.14.
- `.cargo/audit.toml`: remove `RUSTSEC-2026-0037` do bloco GAR-457 (expirava 2026-06-15). Substitui por NOTE histórico explicando o close.
- `deny.toml`: remove `RUSTSEC-2026-0037` do bloco "audit.toml mirrors" (havia sido adicionado em PR #75/GAR-458 com mesmo NOTE histórico).
- `deny.toml` SYNC NOTE: atualiza contagem de mandatory mirrors de 5 → 4 (rsa, glib, lru, rand).

Diff total: **3 arquivos, +15/-24 LOC** (net -9).

## Evidence

| Gate | Resultado |
|---|---|
| `cargo audit --no-fetch --deny unsound` | ✅ exit 0 |
| `cargo deny check` (default = 4 categories) | ✅ exit 0 (advisories ok, bans ok, licenses ok, sources ok) |
| Diff scope | ✅ 3 files: Cargo.lock, audit.toml, deny.toml |
| Diff size | ✅ +15/-24 LOC (net -9, dentro do budget ≤ 100) |
| `cargo tree -i quinn-proto` (single dependent) | ✅ via `quinn 0.11.x` |

## Why lockfile-only

`quinn-proto 0.11.14` é semver-compatible com `0.11.13` (mesma minor). `cargo update --precise` é o caminho de menor risco — não toca nenhum Cargo.toml, não muda dependency graph, não força rebuilds extras. **Idêntico em forma à PR-1 (GAR-447, rustls-webpki)** que já provou o pattern.

## Local verification

```bash
git checkout gar-457-quinn-proto
cargo audit --no-fetch --deny unsound  # → exit 0
cargo deny check                       # → exit 0
git diff main --stat                   # → 3 files, +15/-24
```

## CI checklist

- [ ] `Security Audit` job verde (sem RUSTSEC-2026-0037)
- [ ] `cargo-deny` job verde (4 categorias, sem RUSTSEC-2026-0037)
- [ ] Outros jobs (fmt, clippy, test×3, e2e, playwright, build) verdes
- [ ] @code-reviewer APPROVE
- [ ] @security-auditor APPROVE

## Rollback

`git revert <merge-sha>` reverte o lockfile + restaura os 2 ignores. Zero risk.

## Out of scope

- wasmtime upgrade (GAR-454)
- rustls-webpki structural fix (GAR-455)
- sqlx → sqlx-postgres (GAR-456)

## Linear

- Closes: GAR-457 (sub-issue de GAR-430 Quality Gates 3.6)
- Phase 3 da sessão `voc-est-retomando-o-bright-snowglobe` (após PR #74 GAR-453 + PR #75 GAR-458 mergeados)

🤖 Generated with [Claude Code](https://claude.com/claude-code)