### PR TITLE
feat(security,plugins): admin auth + SSRF defense em /api/plugins/* (GAR-459)

### DIFF
--- a/crates/garraia-gateway/src/admin/middleware.rs
+++ b/crates/garraia-gateway/src/admin/middleware.rs
@@ -87,7 +87,19 @@ pub async fn require_csrf(
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
 
-    if csrf_from_header.is_empty() || csrf_from_header != admin.csrf_token {
+    // GAR-459 (PR-A of GAR-454, security-auditor finding MEDIUM): use a
+    // constant-time comparison so the CSRF check cannot leak the prefix
+    // length of `admin.csrf_token` via a byte-by-byte short-circuit timing
+    // oracle. Even though the CSRF token is a 32-byte secret never echoed
+    // in responses, the project convention (see `garraia-auth` hashing
+    // module) is to compare any secret-comparison via `subtle`.
+    use subtle::ConstantTimeEq;
+    let header_bytes = csrf_from_header.as_bytes();
+    let stored_bytes = admin.csrf_token.as_bytes();
+    if csrf_from_header.is_empty()
+        || header_bytes.len() != stored_bytes.len()
+        || header_bytes.ct_eq(stored_bytes).unwrap_u8() == 0
+    {
         return Err(StatusCode::FORBIDDEN);
     }
 
@@ -145,17 +157,25 @@ pub fn extract_session_cookie(headers: &HeaderMap) -> Option<String> {
 }
 
 /// Build a Set-Cookie header for admin session.
+///
+/// **`Path=/`** (GAR-459 PR-A of GAR-454, security-auditor finding MEDIUM):
+/// the cookie used to carry `Path=/admin` which prevented browsers from
+/// sending it on requests to `/api/plugins/*` under SameSite=Strict path
+/// scoping. After this PR the admin session cookie also gates the
+/// `/api/plugins/*` sub-router (GAR-459), so the path scope must cover both.
+/// HttpOnly + Secure + SameSite=Strict remain in place.
 pub fn build_session_cookie(token: &str, max_age_secs: i64) -> String {
     format!(
-        "{}={}; HttpOnly; Secure; SameSite=Strict; Path=/admin; Max-Age={}",
+        "{}={}; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age={}",
         SESSION_COOKIE_NAME, token, max_age_secs
     )
 }
 
-/// Build a Set-Cookie header that clears the session.
+/// Build a Set-Cookie header that clears the session. Path matches
+/// `build_session_cookie` so the browser actually clears the right cookie.
 pub fn build_clear_cookie() -> String {
     format!(
-        "{}=; HttpOnly; Secure; SameSite=Strict; Path=/admin; Max-Age=0",
+        "{}=; HttpOnly; Secure; SameSite=Strict; Path=/; Max-Age=0",
         SESSION_COOKIE_NAME
     )
 }
@@ -210,6 +230,22 @@ mod tests {
         assert!(cookie.contains("HttpOnly"));
         assert!(cookie.contains("Secure"));
         assert!(cookie.contains("SameSite=Strict"));
-        assert!(cookie.contains("Path=/admin"));
+        // GAR-459 (PR-A of GAR-454): cookie path widened from `/admin` to
+        // `/` so the same admin session also gates `/api/plugins/*`. The
+        // previous assertion `Path=/admin` would prevent the cookie from
+        // being sent to plugin routes under SameSite=Strict path scoping.
+        assert!(cookie.contains("Path=/"));
+        assert!(!cookie.contains("Path=/admin"));
+    }
+
+    #[test]
+    fn build_clear_cookie_path_matches_session_cookie() {
+        // Path on the clear-cookie MUST match the session cookie path,
+        // otherwise the browser keeps the original cookie around.
+        let clear = build_clear_cookie();
+        assert!(clear.contains("garraia_admin_session="));
+        assert!(clear.contains("Path=/"));
+        assert!(clear.contains("Max-Age=0"));
+        assert!(!clear.contains("Path=/admin"));
     }
 }

--- a/crates/garraia-gateway/src/plugins_handler.rs
+++ b/crates/garraia-gateway/src/plugins_handler.rs
@@ -35,7 +35,9 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use tracing::{info, warn};
 
-use crate::admin::middleware::{AuthenticatedAdmin, require_admin_auth, require_csrf};
+use crate::admin::middleware::{
+    AuthenticatedAdmin, require_admin_auth, require_csrf, security_headers,
+};
 use crate::admin::rbac::{Permission, has_permission};
 use crate::admin::store::AdminStore;
 use crate::state::SharedState;
@@ -147,6 +149,11 @@ pub fn build_plugin_routes(state: SharedState, admin_store: Arc<Mutex<AdminStore
         .layer(axum::middleware::from_fn(require_csrf))
         .layer(axum::middleware::from_fn(require_admin_auth))
         .layer(Extension(admin_store))
+        // Security-auditor LOW finding (GAR-459): mirror the `security_headers`
+        // middleware applied to the /admin nested router so /api/plugins/*
+        // responses also carry CSP, X-Content-Type-Options, X-Frame-Options,
+        // referrer-policy, permissions-policy, cache-control: no-store.
+        .layer(axum::middleware::from_fn(security_headers))
         .with_state(state)
 }
 

--- a/crates/garraia-gateway/src/plugins_handler.rs
+++ b/crates/garraia-gateway/src/plugins_handler.rs
@@ -1,18 +1,43 @@
 //! Plugin Registry API handlers (Phase 3.1).
 //!
-//! Provides CRUD endpoints for managing WASM plugins:
-//! - `POST /api/plugins/install` — install plugin by URL or name
-//! - `GET /api/plugins` — list installed plugins with status
-//! - `GET /api/plugins/{id}` — get plugin details
-//! - `DELETE /api/plugins/{id}` — uninstall plugin
+//! Provides CRUD endpoints for managing WASM plugins, all gated behind
+//! the admin authentication middleware (`require_admin_auth`) +
+//! `Permission::ManagePlugins` permission check:
+//!
+//! - `POST /api/plugins/install` — install plugin by URL (admin only)
+//! - `GET  /api/plugins`         — list installed plugins
+//! - `GET  /api/plugins/{id}`    — get plugin details
+//! - `DELETE /api/plugins/{id}`  — uninstall plugin
 //! - `POST /api/plugins/{id}/toggle` — enable/disable plugin
+//!
+//! GAR-459 (PR-A of GAR-454, plan `purrfect-lantern` 2026-04-27): hardened
+//! the surface as a prerequisite of the wasmtime 28→44 bump (GAR-454/PR-B).
+//! Threat model: anonymous SSRF via `download_and_validate_manifest`
+//! reaching arbitrary URLs (cloud metadata services, RFC1918, link-local,
+//! loopback). Mitigations:
+//!   1. `require_admin_auth` cookie + `Permission::ManagePlugins` gate.
+//!   2. `require_csrf` on POST/DELETE.
+//!   3. Empty-by-default URL allowlist — remote install disabled until
+//!      operator opts into specific domains via `INSTALL_URL_ALLOWLIST`.
+//!   4. HTTPS-only, redirect=none, 10s timeout, 64KiB body cap, blocked
+//!      IPs (loopback/private/link-local/multicast/unspecified) for
+//!      IPv4 + IPv6.
 
-use axum::Json;
-use axum::extract::{Path, State};
+use std::net::{IpAddr, ToSocketAddrs};
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::extract::{Extension, Path, State};
 use axum::http::StatusCode;
+use axum::routing::{get, post};
+use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
 use tracing::{info, warn};
 
+use crate::admin::middleware::{AuthenticatedAdmin, require_admin_auth, require_csrf};
+use crate::admin::rbac::{Permission, has_permission};
+use crate::admin::store::AdminStore;
 use crate::state::SharedState;
 
 // ── Plugin Manifest (JSON format for API) ───────────────────────────────────
@@ -78,13 +103,85 @@ pub struct TogglePluginRequest {
     pub enabled: bool,
 }
 
+// ── SSRF defense constants ──────────────────────────────────────────────────
+
+/// Allowlist of host suffixes from which `install_plugin` may fetch a
+/// manifest URL. **Empty by default** — remote URL installs are refused
+/// until an operator extends this list. Future move to
+/// `AppConfig.plugins.install_url_allowlist` is tracked under
+/// `GAR-454.a.config`. Match is suffix-based (`endswith`) so that a
+/// trailing-dot canonical comparison yields the expected result; entries
+/// SHOULD be lowercase domain strings (e.g. `"plugins.example.com"`).
+const INSTALL_URL_ALLOWLIST: &[&str] = &[];
+
+/// Maximum plugin manifest body size accepted from a remote URL.
+const MANIFEST_BODY_CAP_BYTES: usize = 64 * 1024;
+
+/// Per-request timeout for the manifest download.
+const MANIFEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+// ── Router builder ──────────────────────────────────────────────────────────
+
+/// Build the `/api/plugins/*` sub-router with admin auth + CSRF + admin-store
+/// extension wired exactly like the `/admin` nested router. Mounted via
+/// `.merge(...)` from the main `build_router` in `router.rs`.
+///
+/// Layer order (axum applies in reverse: last `.layer(...)` runs first on
+/// the incoming request, mirroring `tower::ServiceBuilder` semantics):
+///   1. `Extension<Arc<Mutex<AdminStore>>>` — sets the extension consumed by
+///      `require_admin_auth` to validate the session cookie.
+///   2. `require_admin_auth`               — validates cookie, injects
+///      `AuthenticatedAdmin` into request extensions; rejects 401 otherwise.
+///   3. `require_csrf`                     — on POST/DELETE/PUT/PATCH only,
+///      validates `x-csrf-token` matches `AuthenticatedAdmin.csrf_token`;
+///      403 otherwise. (GET/HEAD/OPTIONS pass through.)
+pub fn build_plugin_routes(state: SharedState, admin_store: Arc<Mutex<AdminStore>>) -> Router {
+    Router::new()
+        .route("/api/plugins/install", post(install_plugin))
+        .route("/api/plugins", get(list_plugins))
+        .route(
+            "/api/plugins/{id}",
+            get(get_plugin).delete(uninstall_plugin),
+        )
+        .route("/api/plugins/{id}/toggle", post(toggle_plugin))
+        .layer(axum::middleware::from_fn(require_csrf))
+        .layer(axum::middleware::from_fn(require_admin_auth))
+        .layer(Extension(admin_store))
+        .with_state(state)
+}
+
 // ── Handlers ────────────────────────────────────────────────────────────────
 
-/// POST /api/plugins/install — install a plugin by URL or name.
+/// Permission gate shared by every plugin handler. Returns `Err(403)` if
+/// the caller's role lacks `Permission::ManagePlugins`. `Role::Admin` and
+/// `Role::Operator` carry it; `Role::Viewer` does not. Defined in
+/// `crate::admin::rbac`.
+fn check_manage_plugins(
+    admin: &AuthenticatedAdmin,
+) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
+    if has_permission(admin.role, Permission::ManagePlugins) {
+        Ok(())
+    } else {
+        Err((
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "status": "error",
+                "message": "missing permission: manage_plugins",
+            })),
+        ))
+    }
+}
+
+/// POST /api/plugins/install — install a plugin by URL (admin/operator only).
 pub async fn install_plugin(
     State(_state): State<SharedState>,
+    Extension(admin): Extension<AuthenticatedAdmin>,
     Json(body): Json<InstallPluginRequest>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    if let Err((code, json)) = check_manage_plugins(&admin) {
+        return (code, json);
+    }
+
     let source = match (&body.url, &body.name) {
         (Some(url), _) => url.clone(),
         (_, Some(name)) => name.clone(),
@@ -99,7 +196,6 @@ pub async fn install_plugin(
         }
     };
 
-    // Validate the source looks reasonable
     if source.trim().is_empty() {
         return (
             StatusCode::BAD_REQUEST,
@@ -110,13 +206,13 @@ pub async fn install_plugin(
         );
     }
 
-    info!(source = %source, "installing plugin");
+    info!(actor = %admin.username, source = %source, "installing plugin");
 
-    // For URL-based installs, download and validate manifest
     if let Some(url) = &body.url {
         match download_and_validate_manifest(url).await {
             Ok(manifest) => {
                 info!(
+                    actor = %admin.username,
                     name = %manifest.name,
                     version = %manifest.version,
                     "plugin manifest validated"
@@ -125,7 +221,10 @@ pub async fn install_plugin(
                     StatusCode::CREATED,
                     Json(serde_json::json!({
                         "status": "ok",
-                        "message": format!("plugin '{}' v{} installed", manifest.name, manifest.version),
+                        "message": format!(
+                            "plugin '{}' v{} installed",
+                            manifest.name, manifest.version
+                        ),
                         "plugin": {
                             "id": manifest.name,
                             "name": manifest.name,
@@ -136,20 +235,26 @@ pub async fn install_plugin(
                     })),
                 );
             }
-            Err(e) => {
-                warn!(url = %url, error = %e, "failed to install plugin from URL");
+            Err(InstallError { status, message }) => {
+                warn!(
+                    actor = %admin.username,
+                    url = %url,
+                    status = status.as_u16(),
+                    error = %message,
+                    "remote plugin install rejected"
+                );
                 return (
-                    StatusCode::BAD_REQUEST,
+                    status,
                     Json(serde_json::json!({
                         "status": "error",
-                        "message": format!("failed to install plugin: {e}"),
+                        "message": message,
                     })),
                 );
             }
         }
     }
 
-    // Name-based install (from built-in registry)
+    // Name-based install (from built-in registry) — no remote network call.
     let name = body.name.as_deref().unwrap_or_default();
     (
         StatusCode::CREATED,
@@ -167,22 +272,32 @@ pub async fn install_plugin(
 }
 
 /// GET /api/plugins — list installed plugins with status.
-pub async fn list_plugins(State(_state): State<SharedState>) -> Json<serde_json::Value> {
-    // Query the plugin loader if available, otherwise return empty list
+pub async fn list_plugins(
+    State(_state): State<SharedState>,
+    Extension(admin): Extension<AuthenticatedAdmin>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    if let Err((code, json)) = check_manage_plugins(&admin) {
+        return (code, json);
+    }
     let plugins: Vec<PluginInfo> = Vec::new();
-
-    Json(serde_json::json!({
-        "plugins": plugins,
-        "total": plugins.len(),
-    }))
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "plugins": plugins,
+            "total": plugins.len(),
+        })),
+    )
 }
 
 /// GET /api/plugins/{id} — get plugin details.
 pub async fn get_plugin(
     State(_state): State<SharedState>,
+    Extension(admin): Extension<AuthenticatedAdmin>,
     Path(id): Path<String>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    // Look up plugin by ID
+    if let Err((code, json)) = check_manage_plugins(&admin) {
+        return (code, json);
+    }
     let _ = &id;
     (
         StatusCode::NOT_FOUND,
@@ -196,14 +311,13 @@ pub async fn get_plugin(
 /// DELETE /api/plugins/{id} — uninstall a plugin.
 pub async fn uninstall_plugin(
     State(_state): State<SharedState>,
+    Extension(admin): Extension<AuthenticatedAdmin>,
     Path(id): Path<String>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    info!(plugin = %id, "uninstalling plugin");
-
-    // In a full implementation, this would:
-    // 1. Stop the plugin if running
-    // 2. Remove WASM files from disk
-    // 3. Remove from registry
+    if let Err((code, json)) = check_manage_plugins(&admin) {
+        return (code, json);
+    }
+    info!(actor = %admin.username, plugin = %id, "uninstalling plugin");
     (
         StatusCode::OK,
         Json(serde_json::json!({
@@ -216,12 +330,20 @@ pub async fn uninstall_plugin(
 /// POST /api/plugins/{id}/toggle — enable or disable a plugin.
 pub async fn toggle_plugin(
     State(_state): State<SharedState>,
+    Extension(admin): Extension<AuthenticatedAdmin>,
     Path(id): Path<String>,
     Json(body): Json<TogglePluginRequest>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    if let Err((code, json)) = check_manage_plugins(&admin) {
+        return (code, json);
+    }
     let action = if body.enabled { "enabled" } else { "disabled" };
-    info!(plugin = %id, action, "toggling plugin");
-
+    info!(
+        actor = %admin.username,
+        plugin = %id,
+        action,
+        "toggling plugin"
+    );
     (
         StatusCode::OK,
         Json(serde_json::json!({
@@ -232,43 +354,249 @@ pub async fn toggle_plugin(
     )
 }
 
-// ── Helpers ─────────────────────────────────────────────────────────────────
+// ── SSRF-hardened manifest download ─────────────────────────────────────────
 
-/// Download a plugin manifest from a URL and validate it.
-async fn download_and_validate_manifest(url: &str) -> Result<PluginManifestJson, String> {
-    let response = reqwest::get(url)
+/// Internal install error carrying a precise HTTP status. Layered to keep
+/// the handler call site short and to make the test cases explicit.
+struct InstallError {
+    status: StatusCode,
+    message: String,
+}
+
+impl InstallError {
+    fn forbidden(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::FORBIDDEN,
+            message: message.into(),
+        }
+    }
+    fn bad_request(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            message: message.into(),
+        }
+    }
+    fn upstream(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_GATEWAY,
+            message: message.into(),
+        }
+    }
+}
+
+/// Download a plugin manifest from `url` and validate it. Hardened against
+/// SSRF, redirect amplification, slow-loris, and oversize bodies — see the
+/// crate-level docstring above for the threat model.
+async fn download_and_validate_manifest(url: &str) -> Result<PluginManifestJson, InstallError> {
+    // 1) URL parse + scheme gate. Use reqwest's re-exported `Url` so we
+    //    don't need to add a direct dep on the `url` crate.
+    let parsed = reqwest::Url::parse(url)
+        .map_err(|e| InstallError::bad_request(format!("invalid URL: {e}")))?;
+    if parsed.scheme() != "https" {
+        return Err(InstallError::bad_request(
+            "manifest URL must use https scheme",
+        ));
+    }
+
+    // 2) Allowlist gate (empty by default → remote URL install disabled).
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| InstallError::bad_request("URL is missing host"))?
+        .to_lowercase();
+    if !host_in_allowlist(&host, INSTALL_URL_ALLOWLIST) {
+        return Err(InstallError::forbidden(
+            "remote URL install disabled (host not in allowlist; \
+             empty allowlist == disabled by default)",
+        ));
+    }
+
+    // 3) DNS resolve + IP block gate. Resolves once here to fail-fast on
+    //    private targets BEFORE the reqwest client opens the socket.
+    //    Note: this is not perfect mitigation against DNS rebinding (the
+    //    actual reqwest connect resolves again); the allowlist gate above
+    //    is the primary defense, and the IP block is defense-in-depth.
+    let port = parsed.port_or_known_default().unwrap_or(443);
+    let socket_str = format!("{host}:{port}");
+    let resolved = socket_str
+        .to_socket_addrs()
+        .map_err(|e| InstallError::bad_request(format!("DNS resolve failed: {e}")))?;
+    let mut any_resolved = false;
+    for addr in resolved {
+        any_resolved = true;
+        if is_blocked_ip(&addr.ip()) {
+            return Err(InstallError::forbidden(format!(
+                "host '{host}' resolves to blocked address {} \
+                 (loopback/private/link-local/multicast/unspecified)",
+                addr.ip()
+            )));
+        }
+    }
+    if !any_resolved {
+        return Err(InstallError::bad_request(format!(
+            "host '{host}' resolved to no addresses"
+        )));
+    }
+
+    // 4) HTTP fetch with redirect=none + timeout + bounded body.
+    let client = reqwest::Client::builder()
+        .timeout(MANIFEST_TIMEOUT)
+        .redirect(reqwest::redirect::Policy::none())
+        .https_only(true)
+        .user_agent(concat!(
+            "GarraIA/",
+            env!("CARGO_PKG_VERSION"),
+            " plugin-installer"
+        ))
+        .build()
+        .map_err(|e| InstallError::upstream(format!("client build failed: {e}")))?;
+
+    let response = client
+        .get(parsed)
+        .send()
         .await
-        .map_err(|e| format!("failed to download manifest: {e}"))?;
+        .map_err(|e| InstallError::upstream(format!("download failed: {e}")))?;
 
     if !response.status().is_success() {
-        return Err(format!("HTTP {}", response.status()));
+        return Err(InstallError::upstream(format!(
+            "upstream returned HTTP {}",
+            response.status()
+        )));
     }
 
-    let text = response
-        .text()
-        .await
-        .map_err(|e| format!("failed to read response: {e}"))?;
+    // Optional Content-Length sanity check (some upstreams omit this header).
+    if let Some(len) = response.content_length()
+        && (len as usize) > MANIFEST_BODY_CAP_BYTES
+    {
+        return Err(InstallError::bad_request(format!(
+            "manifest exceeds {} byte cap (declared {} bytes)",
+            MANIFEST_BODY_CAP_BYTES, len
+        )));
+    }
 
-    let manifest: PluginManifestJson =
-        serde_json::from_str(&text).map_err(|e| format!("invalid plugin manifest JSON: {e}"))?;
+    // Bounded read — accumulate up to the cap, refuse if exceeded.
+    let bytes = read_capped(response, MANIFEST_BODY_CAP_BYTES).await?;
 
-    // Validate semver
+    let text = std::str::from_utf8(&bytes)
+        .map_err(|e| InstallError::bad_request(format!("non-utf8 manifest body: {e}")))?;
+
+    let manifest: PluginManifestJson = serde_json::from_str(text)
+        .map_err(|e| InstallError::bad_request(format!("invalid plugin manifest JSON: {e}")))?;
+
     if !is_valid_semver(&manifest.version) {
-        return Err(format!("invalid semver version: {}", manifest.version));
+        return Err(InstallError::bad_request(format!(
+            "invalid semver version: {}",
+            manifest.version
+        )));
     }
-
-    // Validate name (alphanumeric + hyphens)
     if manifest.name.is_empty()
         || !manifest
             .name
             .chars()
             .all(|c| c.is_alphanumeric() || c == '-')
     {
-        return Err(format!("invalid plugin name: {}", manifest.name));
+        return Err(InstallError::bad_request(format!(
+            "invalid plugin name: {}",
+            manifest.name
+        )));
     }
 
     Ok(manifest)
 }
+
+/// Read at most `cap` bytes from a response body, aborting with a 400 if
+/// the body would exceed the cap. Streams the body to keep peak memory
+/// bounded even on misbehaving upstreams that lie about Content-Length.
+async fn read_capped(response: reqwest::Response, cap: usize) -> Result<Vec<u8>, InstallError> {
+    use futures::StreamExt;
+
+    let mut buf: Vec<u8> = Vec::with_capacity(cap.min(8192));
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| InstallError::upstream(format!("body stream error: {e}")))?;
+        if buf.len() + chunk.len() > cap {
+            return Err(InstallError::bad_request(format!(
+                "manifest exceeds {cap} byte cap (streamed)"
+            )));
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    Ok(buf)
+}
+
+// ── SSRF helpers (kept defensive duplicates; see crate docstring) ──────────
+
+/// Returns `true` if `ip` is loopback, private, link-local, multicast,
+/// unspecified, or otherwise unsafe to use as an HTTP target from the
+/// gateway (SSRF defense). Covers IPv4 + IPv6.
+///
+/// IPv4 ranges blocked:
+///   * 127.0.0.0/8       (loopback)
+///   * 10.0.0.0/8        (RFC 1918)
+///   * 172.16.0.0/12     (RFC 1918)
+///   * 192.168.0.0/16    (RFC 1918)
+///   * 169.254.0.0/16    (link-local incl. AWS/GCP IMDS at 169.254.169.254)
+///   * 0.0.0.0/8         (unspecified / "this network")
+///   * 224.0.0.0/4       (multicast)
+///   * 100.64.0.0/10     (CGNAT)
+///
+/// IPv6 ranges blocked:
+///   * ::1/128           (loopback)
+///   * ::/128            (unspecified)
+///   * fc00::/7          (unique local)
+///   * fe80::/10         (link-local)
+///   * ff00::/8          (multicast)
+///   * ::ffff:0:0/96     (IPv4-mapped — inspect inner v4)
+fn is_blocked_ip(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            let o = v4.octets();
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_unspecified()
+                || v4.is_multicast()
+                || o[0] == 0                  // 0.0.0.0/8
+                || (o[0] == 100 && (64..=127).contains(&o[1])) // 100.64.0.0/10 CGNAT
+        }
+        IpAddr::V6(v6) => {
+            if v6.is_loopback() || v6.is_unspecified() || v6.is_multicast() {
+                return true;
+            }
+            let segs = v6.segments();
+            // fc00::/7 (unique local).
+            if segs[0] & 0xfe00 == 0xfc00 {
+                return true;
+            }
+            // fe80::/10 (link-local).
+            if segs[0] & 0xffc0 == 0xfe80 {
+                return true;
+            }
+            // IPv4-mapped IPv6 (::ffff:0:0/96): inspect the inner v4.
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return is_blocked_ip(&IpAddr::V4(v4));
+            }
+            false
+        }
+    }
+}
+
+/// Suffix-match a host against an allowlist of host suffixes. An empty
+/// allowlist returns `false` (the empty-by-default disabled state).
+/// Suffixes match either the full host or a `.suffix` boundary — so
+/// `"plugins.example.com"` matches `"plugins.example.com"` and
+/// `"v2.plugins.example.com"`, but NOT `"evilplugins.example.com"`.
+fn host_in_allowlist(host: &str, allowlist: &[&str]) -> bool {
+    if allowlist.is_empty() {
+        return false;
+    }
+    let host = host.trim_end_matches('.').to_lowercase();
+    allowlist.iter().any(|allowed| {
+        let allowed = allowed.trim_end_matches('.').to_lowercase();
+        host == allowed || host.ends_with(&format!(".{allowed}"))
+    })
+}
+
+// ── Manifest helpers (unchanged from pre-PR-A) ──────────────────────────────
 
 /// Basic semver validation (major.minor.patch).
 fn is_valid_semver(version: &str) -> bool {
@@ -320,5 +648,132 @@ mod tests {
         assert!(!is_valid_semver("1.0"));
         assert!(!is_valid_semver("abc"));
         assert!(!is_valid_semver("1.0.0-beta"));
+    }
+
+    // ── SSRF defense — IP block ────────────────────────────────────────────
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().expect("test ip parse")
+    }
+
+    #[test]
+    fn is_blocked_ip_loopback_v4() {
+        assert!(is_blocked_ip(&ip("127.0.0.1")));
+        assert!(is_blocked_ip(&ip("127.255.255.254")));
+    }
+
+    #[test]
+    fn is_blocked_ip_rfc1918_v4() {
+        assert!(is_blocked_ip(&ip("10.0.0.1")));
+        assert!(is_blocked_ip(&ip("10.255.255.255")));
+        assert!(is_blocked_ip(&ip("172.16.0.1")));
+        assert!(is_blocked_ip(&ip("172.31.255.255")));
+        assert!(is_blocked_ip(&ip("192.168.0.1")));
+        assert!(is_blocked_ip(&ip("192.168.255.255")));
+    }
+
+    #[test]
+    fn is_blocked_ip_link_local_and_imds_v4() {
+        assert!(is_blocked_ip(&ip("169.254.0.1")));
+        // AWS / GCP / Azure IMDS endpoint.
+        assert!(is_blocked_ip(&ip("169.254.169.254")));
+    }
+
+    #[test]
+    fn is_blocked_ip_unspecified_and_multicast_and_cgnat_v4() {
+        assert!(is_blocked_ip(&ip("0.0.0.0")));
+        assert!(is_blocked_ip(&ip("0.1.2.3")));
+        assert!(is_blocked_ip(&ip("224.0.0.1")));
+        assert!(is_blocked_ip(&ip("239.255.255.255")));
+        // CGNAT 100.64.0.0/10.
+        assert!(is_blocked_ip(&ip("100.64.0.1")));
+        assert!(is_blocked_ip(&ip("100.127.255.254")));
+    }
+
+    #[test]
+    fn is_blocked_ip_ipv6_loopback_and_unspecified() {
+        assert!(is_blocked_ip(&ip("::1")));
+        assert!(is_blocked_ip(&ip("::")));
+    }
+
+    #[test]
+    fn is_blocked_ip_ipv6_unique_local_and_link_local() {
+        assert!(is_blocked_ip(&ip("fc00::1")));
+        assert!(is_blocked_ip(&ip("fd00::1")));
+        assert!(is_blocked_ip(&ip("fe80::1")));
+        assert!(is_blocked_ip(&ip("febf::1")));
+    }
+
+    #[test]
+    fn is_blocked_ip_ipv6_multicast_and_v4_mapped() {
+        assert!(is_blocked_ip(&ip("ff02::1")));
+        // ::ffff:127.0.0.1 — IPv4-mapped IPv6 of loopback.
+        assert!(is_blocked_ip(&ip("::ffff:127.0.0.1")));
+        // ::ffff:169.254.169.254 — IPv4-mapped IPv6 of IMDS.
+        assert!(is_blocked_ip(&ip("::ffff:169.254.169.254")));
+    }
+
+    #[test]
+    fn is_blocked_ip_allows_public_addresses() {
+        assert!(!is_blocked_ip(&ip("8.8.8.8")));
+        assert!(!is_blocked_ip(&ip("1.1.1.1")));
+        assert!(!is_blocked_ip(&ip("203.0.113.1"))); // documentation prefix, but not blocked
+        assert!(!is_blocked_ip(&ip("2606:4700::1111"))); // Cloudflare public
+        assert!(!is_blocked_ip(&ip("2001:4860:4860::8888"))); // Google public
+    }
+
+    // ── SSRF defense — host allowlist ──────────────────────────────────────
+
+    #[test]
+    fn empty_allowlist_blocks_everything() {
+        assert!(!host_in_allowlist("example.com", &[]));
+        assert!(!host_in_allowlist("plugins.example.com", &[]));
+    }
+
+    #[test]
+    fn allowlist_exact_match_only_when_no_subdomain_left() {
+        let list = &["plugins.example.com"];
+        assert!(host_in_allowlist("plugins.example.com", list));
+        assert!(host_in_allowlist("v2.plugins.example.com", list));
+        // Boundary check: no trailing-substring spoofing.
+        assert!(!host_in_allowlist("evilplugins.example.com", list));
+        assert!(!host_in_allowlist("example.com", list));
+    }
+
+    #[test]
+    fn allowlist_is_case_insensitive_and_trims_trailing_dot() {
+        let list = &["Plugins.Example.Com"];
+        assert!(host_in_allowlist("plugins.example.com", list));
+        assert!(host_in_allowlist("PLUGINS.EXAMPLE.COM", list));
+        assert!(host_in_allowlist("plugins.example.com.", list));
+    }
+
+    // ── End-to-end: scheme + allowlist gates ───────────────────────────────
+
+    #[tokio::test]
+    async fn download_rejects_http_scheme() {
+        let err = download_and_validate_manifest("http://plugins.example.com/m.json")
+            .await
+            .expect_err("http should be rejected");
+        assert_eq!(err.status, StatusCode::BAD_REQUEST);
+        assert!(err.message.contains("https"));
+    }
+
+    #[tokio::test]
+    async fn download_rejects_when_allowlist_empty() {
+        // INSTALL_URL_ALLOWLIST is empty by default; any host must be 403.
+        let err = download_and_validate_manifest("https://plugins.example.com/m.json")
+            .await
+            .expect_err("empty allowlist should reject");
+        assert_eq!(err.status, StatusCode::FORBIDDEN);
+        assert!(err.message.contains("allowlist"));
+    }
+
+    #[tokio::test]
+    async fn download_rejects_invalid_url() {
+        let err = download_and_validate_manifest("not a url at all")
+            .await
+            .expect_err("invalid URL should be 400");
+        assert_eq!(err.status, StatusCode::BAD_REQUEST);
     }
 }

--- a/crates/garraia-gateway/src/router.rs
+++ b/crates/garraia-gateway/src/router.rs
@@ -210,21 +210,12 @@ pub fn build_router(
             "/api/openclaw/channels",
             get(crate::openclaw_handler::openclaw_channels),
         )
-        // Phase 3.1: Plugin Registry
-        .route(
-            "/api/plugins/install",
-            post(crate::plugins_handler::install_plugin),
-        )
-        .route("/api/plugins", get(crate::plugins_handler::list_plugins))
-        .route(
-            "/api/plugins/{id}",
-            get(crate::plugins_handler::get_plugin)
-                .delete(crate::plugins_handler::uninstall_plugin),
-        )
-        .route(
-            "/api/plugins/{id}/toggle",
-            post(crate::plugins_handler::toggle_plugin),
-        )
+        // Phase 3.1: Plugin Registry — GAR-459 (PR-A of GAR-454):
+        // mounted as a sub-router with `require_admin_auth` + `require_csrf`
+        // + admin-store extension applied to the 5 routes (mirrors the
+        // /admin nested router's wiring). Handlers also enforce
+        // `Permission::ManagePlugins`. See plugins_handler::build_plugin_routes
+        // for layer ordering rationale.
         // Phase 3.2: MCP Marketplace
         .route(
             "/api/mcp/marketplace",
@@ -323,6 +314,14 @@ pub fn build_router(
         // /v1/openapi.json and /docs. Fail-soft: when AuthConfig env
         // vars are missing, every /v1 route answers 503 Problem Details.
         .merge(crate::rest_v1::router(state.clone()))
+        // GAR-459 (PR-A of GAR-454): /api/plugins/* protected sub-router.
+        // Must merge BEFORE the /admin nest because the nest call moves
+        // `admin_store`. The clone keeps the Arc<Mutex<AdminStore>> live
+        // for both consumers — same admin store, two mounting points.
+        .merge(crate::plugins_handler::build_plugin_routes(
+            state.clone(),
+            admin_store.clone(),
+        ))
         .nest(
             "/admin",
             admin::routes::build_admin_router(state, admin_store),

--- a/crates/garraia-gateway/tests/plugins_auth_ssrf.rs
+++ b/crates/garraia-gateway/tests/plugins_auth_ssrf.rs
@@ -1,0 +1,129 @@
+//! Integration tests for `/api/plugins/*` admin auth gating
+//! (GAR-459 / PR-A of GAR-454).
+//!
+//! Unit-level coverage of `is_blocked_ip`, `host_in_allowlist`, and the
+//! `download_and_validate_manifest` reject paths (HTTPS-only, empty
+//! allowlist, malformed URL) lives next to the helpers in
+//! `crates/garraia-gateway/src/plugins_handler.rs::tests`. This file
+//! covers the router-level gate: anonymous requests without an admin
+//! session cookie MUST receive 401 from every plugin route, before the
+//! handler logic runs.
+//!
+//! Why integration over unit: `require_admin_auth` is wired via
+//! `axum::middleware::from_fn` on the sub-router, so the only honest
+//! way to verify "no cookie → 401" is to drive the router through Tower
+//! and inspect the response status — exactly mirroring how production
+//! traffic flows.
+
+use std::sync::Arc;
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use garraia_agents::AgentRuntime;
+use garraia_channels::ChannelRegistry;
+use garraia_config::AppConfig;
+use garraia_gateway::admin::store::AdminStore;
+use garraia_gateway::plugins_handler::build_plugin_routes;
+use garraia_gateway::state::AppState;
+use http_body_util::BodyExt;
+use tokio::sync::Mutex;
+use tower::ServiceExt;
+
+fn build_test_router() -> Router {
+    let state = Arc::new(AppState::new(
+        AppConfig::default(),
+        AgentRuntime::new(),
+        ChannelRegistry::new(),
+    ));
+    let admin_store = Arc::new(Mutex::new(
+        AdminStore::in_memory().expect("in-memory admin store"),
+    ));
+    build_plugin_routes(state, admin_store)
+}
+
+async fn unauthenticated_request(method: &str, uri: &str, body: Body) -> StatusCode {
+    let req = Request::builder()
+        .uri(uri)
+        .method(method)
+        .header("content-type", "application/json")
+        .body(body)
+        .expect("request build");
+    let router = build_test_router();
+    let resp = router.oneshot(req).await.expect("oneshot");
+    let status = resp.status();
+    // Drain the body so the connection completes cleanly even if test
+    // assertions fail later — the body is irrelevant for the 401 contract.
+    let _ = resp.into_body().collect().await;
+    status
+}
+
+#[tokio::test]
+async fn install_without_cookie_returns_401() {
+    let body = Body::from(r#"{"url":"https://plugins.example.com/m.json"}"#);
+    let status = unauthenticated_request("POST", "/api/plugins/install", body).await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "POST /api/plugins/install must reject anonymous callers"
+    );
+}
+
+#[tokio::test]
+async fn list_without_cookie_returns_401() {
+    let status = unauthenticated_request("GET", "/api/plugins", Body::empty()).await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "GET /api/plugins must reject anonymous callers"
+    );
+}
+
+#[tokio::test]
+async fn get_by_id_without_cookie_returns_401() {
+    let status = unauthenticated_request("GET", "/api/plugins/some-id", Body::empty()).await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "GET /api/plugins/{{id}} must reject anonymous callers"
+    );
+}
+
+#[tokio::test]
+async fn delete_without_cookie_returns_401() {
+    let status = unauthenticated_request("DELETE", "/api/plugins/some-id", Body::empty()).await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "DELETE /api/plugins/{{id}} must reject anonymous callers"
+    );
+}
+
+#[tokio::test]
+async fn toggle_without_cookie_returns_401() {
+    let body = Body::from(r#"{"enabled":true}"#);
+    let status = unauthenticated_request("POST", "/api/plugins/some-id/toggle", body).await;
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "POST /api/plugins/{{id}}/toggle must reject anonymous callers"
+    );
+}
+
+#[tokio::test]
+async fn install_with_garbage_cookie_returns_401() {
+    // A cookie with an unknown session token must still be rejected — the
+    // middleware validates against the AdminStore, not just presence.
+    let req = Request::builder()
+        .uri("/api/plugins/install")
+        .method("POST")
+        .header("content-type", "application/json")
+        .header("cookie", "garraia_admin_session=not-a-valid-token")
+        .body(Body::from(
+            r#"{"url":"https://plugins.example.com/m.json"}"#,
+        ))
+        .expect("request build");
+    let router = build_test_router();
+    let resp = router.oneshot(req).await.expect("oneshot");
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}


### PR DESCRIPTION
## Summary

- **Pré-requisito de segurança** do bump wasmtime (GAR-454/PR-B). Diagnóstico empírico em sessão `purrfect-lantern` (2026-04-27) revelou que `install_plugin` **NÃO era stub puro** — chamava `reqwest::get(url)` em URL atacante-controlada sem auth, allowlist, timeout, body cap, redirect block ou IP block. Reclassificação de `EXPOSED_TO_PROD_INPUT`: `uncertain (low-medium)` → **`yes — SSRF live`**.
- Aplica `require_admin_auth` + `require_csrf` middleware às 5 rotas `/api/plugins/*` via novo `build_plugin_routes(state, admin_store) -> Router`. Espelha o wiring do `/admin` nest.
- Cada handler exige `Permission::ManagePlugins` (Operator + Admin OK; Viewer 403).
- `download_and_validate_manifest` blindado: HTTPS-only, allowlist vazia por default (remote install desabilitado), `Client::builder().timeout(10s).redirect(none).https_only(true)`, body cap 64 KiB streamado, DNS-resolve com IP block (loopback/RFC1918/link-local/IMDS 169.254.169.254/multicast/CGNAT/unspec) em IPv4 + IPv6 incluindo IPv4-mapped IPv6.
- 21 testes novos (15 unit + 6 integration); 278 lib tests passing total (no regression).

## Changes

| Arquivo | Mudança |
|---|---|
| `crates/garraia-gateway/src/plugins_handler.rs` | rewrite cirúrgico: handlers + helpers SSRF + `build_plugin_routes` |
| `crates/garraia-gateway/src/router.rs` | remove block inline; merge `build_plugin_routes` ANTES do `.nest(\"/admin\", ...)` |
| `crates/garraia-gateway/tests/plugins_auth_ssrf.rs` (NOVO) | 6 integration tests (401 sem cookie em todas as 5 rotas + cookie inválido) |

## Evidence

```
$ cd worktrees/gar-454a-plugins-auth
$ cargo check -p garraia-gateway
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 11.96s

$ cargo clippy -p garraia-gateway --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 02s
    (zero warnings)

$ cargo test -p garraia-gateway --lib
    test result: ok. 278 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo test -p garraia-gateway --test plugins_auth_ssrf
    running 6 tests
    test toggle_without_cookie_returns_401 ... ok
    test get_by_id_without_cookie_returns_401 ... ok
    test delete_without_cookie_returns_401 ... ok
    test install_without_cookie_returns_401 ... ok
    test list_without_cookie_returns_401 ... ok
    test install_with_garbage_cookie_returns_401 ... ok
    test result: ok. 6 passed; 0 failed

$ cargo fmt --all -- --check
    (clean)

$ cargo audit --no-fetch --deny unsound
    (warnings only — esperado: ignores documentados)
```

## Local verification

- [x] cargo check
- [x] cargo clippy `-D warnings`
- [x] cargo test --lib (278 passing)
- [x] cargo test integration (6 passing)
- [x] cargo fmt --check
- [x] cargo audit no novas advisories

## Risk

**Médio-baixo**. PR é estritamente aditivo no sentido security (nenhuma rota perde proteção; 5 rotas ganham). Risco material:
- `webchat.html:2044` chama `/api/plugins` (anônimo) → vai receber 401 daqui em diante. Aceitável: webchat não deveria expor registry de plugins para usuário anônimo. Tratável em follow-up cosmético se causar UX issue (collapse da seção em 401).
- `INSTALL_URL_ALLOWLIST` vazia por default = remote URL install **desabilitado** até operador configurar. Operadores que dependiam do flow remoto (não-stub) precisam adicionar host à constante (futuro: `AppConfig.plugins.install_url_allowlist` via `GAR-454.a.config`).

## Rollback

`git revert <sha>` restaura handlers anônimos + SSRF aberto (estado conhecido). Trigger: regressão UX inexorável em webchat ou breakage de operador legítimo.

## Out of scope (follow-ups)

- `GAR-454.a.config` — mover allowlist para `AppConfig.plugins.install_url_allowlist: Vec<String>`.
- JS handler em `webchat.html` para 401 da seção plugins (cosmético).
- Smoke e2e WASM no `garraia-plugins` runtime (separado, virá no PR-B se necessário).

## Linear links

- Sub-issue desta PR: [GAR-459](https://linear.app/chatgpt25/issue/GAR-459/gar-454a-plugin-admin-auth-ssrf-defense-pre-req-do-bump-wasmtime)
- Parent epic: [GAR-454](https://linear.app/chatgpt25/issue/GAR-454/q7b-wasmtime-28-latest-upgrade-closes-15-rustsec-plan-00504) (Q7b wasmtime upgrade — bloqueado por este PR)
- Grandparent: [GAR-430](https://linear.app/chatgpt25/issue/GAR-430/epic-quality-gates-phase-36-plan-foamy-origami) (epic Quality Gates 3.6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)