### PR TITLE
docs(plans): retrospective 0050.4 wasmtime upgrade + mark Lote 4b done

### DIFF
--- a/plans/0050-gar-430-quality-gates-phase-3.6.md
+++ b/plans/0050-gar-430-quality-gates-phase-3.6.md
@@ -491,22 +491,24 @@ Sequencialmente, um PR por cluster:
 
 **Lote 4b — wasmtime upgrade (subplano próprio, ref. `plans/0050.4-wasmtime-upgrade.md`):**
 
-Será escrito como sub-plan apartado, contendo:
-* inventário dos pontos de `garraia-plugins` que tocam wasmtime 28 API;
-* matriz de breaking changes 28→29;
-* estratégia de upgrade (one-shot vs. duas etapas 28 → 28.X → 29);
-* plano de teste (testes existentes + novos) — o risco de
-  `RUSTSEC-2025-0118` (unsound shared linear memory) exige cobertura
-  adversarial mínima;
-* rollback plan;
-* aprovação explícita por `@security-auditor`.
+✅ **DONE 2026-04-27** — sessão `purrfect-lantern` (plan
+`C:/Users/miche/.claude/plans/conferi-o-gar-454-no-purrfect-lantern.md`)
+fechou GAR-454 em 2 PRs sequenciais:
+
+* **PR #77** (GAR-459 pré-req de segurança): admin auth + SSRF defense em `/api/plugins/*`. Mergeado em `0ee9595c`.
+* **PR #78** (GAR-454 main): wasmtime 28.0.1 → 44.0.0 + drop atômico de 15 RUSTSEC IDs (incluindo 2 CRITICAL CVSS 9.0). Mergeado em `cb873d59`.
+
+Re-scope vs. plan original: o ticket evoluiu de "bump 28→29 fechando 2 IDs" para "bump 28→44 fechando 15 IDs" após o inventário empírico de GAR-452/PR-6 (2026-04-26). A execução final saltou diretamente para a versão estável mais recente (44.0.0, publicada 2026-04-20) por economia de roundtrips e porque os 15 IDs incluíam CVEs 2026-Q1/Q2 que só fixam em wasmtime 40+.
+
+Retrospectivo + breaking-change matrix em `plans/0050.4-wasmtime-upgrade.md`.
 
 **Saída do Lote 4a:** `cargo audit` verde exceto para o ignore
 explícito de wasmtime com link ao sub-plan 0050.4. Entradas expiradas
 limpas. Jobo `security` passa a falhar em qualquer NOVA advisory.
 
-**Saída do Lote 4b:** wasmtime em 29+, `.cargo/audit.toml` com ≤ 2
-ignores (ou zero), `security` 100% bloqueante.
+**Saída do Lote 4b (atingida):** wasmtime em 44.0.0, `.cargo/audit.toml`
+sem nenhum ignore wasmtime (todos os 15 dropped atomicamente), `security`
+100% bloqueante.
 
 ### Lote 5 — Mutation testing piloto (4h)
 *Depende: Lote 3 (cobertura visível).*

--- a/plans/0050.4-wasmtime-upgrade.md
+++ b/plans/0050.4-wasmtime-upgrade.md
@@ -1,0 +1,199 @@
+# Plan 0050.4 — wasmtime 28 → 44 upgrade (Q7b / GAR-454)
+
+> **Status:** ✅ Retrospectivo — escrito DEPOIS da execução em sessão
+> `purrfect-lantern` (2026-04-27). Documenta o que foi feito, por que,
+> e como reproduzir/reverter. Sub-plan reservado em
+> `plans/0050.gar-430-quality-gates-phase-3.6.md` Lote 4b.
+
+---
+
+## Context
+
+GAR-454 era o último lote pesado da Quality Gates Phase 3.6 (epic
+GAR-430): bump estrutural de wasmtime atrás de 15 RUSTSEC IDs
+acumulados (incluindo 2 CRITICAL CVSS 9.0 emitidos em 2026 Q1/Q2).
+
+A complexidade vinha de duas fontes:
+1. **Major-version delta**: 16 majors entre 28 e 44 — o changelog não
+   é trivial.
+2. **Plugin/WASM surface review obrigatório**: o ticket explicitamente
+   exigia review de isolation antes do bump estrutural.
+
+A sessão `purrfect-lantern` (`C:/Users/miche/.claude/plans/conferi-o-gar-454-no-purrfect-lantern.md`)
+foi aprovada com 5 amendments incluindo a regra de **não terminar a
+sessão após PR-A**.
+
+---
+
+## Achado material durante diagnóstico (Phase 1)
+
+Inspeção empírica de `crates/garraia-gateway/src/plugins_handler.rs`
+mostrou que `install_plugin` **NÃO era stub** como o ticket Linear
+descrevia: o handler chamava `reqwest::get(url)` sem auth, allowlist,
+timeout, body cap, redirect block ou IP block. **SSRF live**.
+
+Reclassificação: `EXPOSED_TO_PROD_INPUT` `uncertain (low-medium)` →
+`yes — SSRF live`.
+
+Decisão: introduzir um **PR-A pré-requisito** (GAR-459) fechando a
+SSRF antes do bump estrutural. Sem isso, o upgrade trocaria um
+sandbox vulnerável por outro com superfície externa ainda exposta.
+
+---
+
+## Sequência de PRs
+
+### PR-A — `/api/plugins/*` admin auth + SSRF defense (GAR-459, PR #77)
+
+**Mergeado em** `0ee9595c` (squash) em 2026-04-27 21:32 UTC.
+
+Mudanças principais:
+- 5 endpoints `/api/plugins/*` movidos para `build_plugin_routes(state, admin_store)`
+  com `require_csrf` + `require_admin_auth` + `Extension(admin_store)` +
+  `security_headers` middleware (espelhando o `/admin` nest).
+- Cada handler exige `Permission::ManagePlugins` (Operator+Admin OK; Viewer 403).
+- `INSTALL_URL_ALLOWLIST: &[&str] = &[]` empty-by-default. Quando
+  `body.url` é fornecido com allowlist vazia → 403.
+- Para o caso de allowlist futura ter entradas: HTTPS-only,
+  redirect=none, timeout 10s, body cap 64 KiB streamado, IP block
+  (loopback/RFC1918/link-local/IMDS/multicast/CGNAT/unspec) IPv4+IPv6.
+- Audit fixes inline: cookie `Path=/admin` → `Path=/`, CSRF compare
+  via `subtle::ConstantTimeEq`, `security_headers` aplicado.
+- 21 testes novos (15 unit + 6 integration). 280 lib tests passing total.
+- Reviews: `code-reviewer` + `security-auditor` ambos APPROVE_WITH_NITS.
+  EXPOSED_TO_PROD_INPUT reclassificado para `no — auth + allowlist enforced`.
+
+Follow-ups Linear: **GAR-460** (LOW, IPv4-compat IPv6), **GAR-461**
+(Med, DNS pinning).
+
+### PR-B — wasmtime 28 → 44 + drop 15 RUSTSEC ignores (GAR-454, PR #78)
+
+Mergeado em `<MERGE_SHA_PR_B>` em `<MERGE_AT_PR_B>`.
+
+Mudanças minimais (6 LOC efetivos no runtime + Cargo.toml + lockfile +
+audit/deny ignores):
+
+| Arquivo | Mudança |
+|---|---|
+| `Cargo.toml` (workspace) | `wasmtime = "28"` → `"44"`; `wasmtime-wasi = { version = "44", features = ["p1"] }` adicionado |
+| `crates/garraia-plugins/Cargo.toml` | `wasmtime-wasi = "28"` → `{ workspace = true }` (corrige drift pré-existente) |
+| `crates/garraia-plugins/src/runtime.rs` | imports: `preview1`→`p1`, `pipe::*`→`p2::pipe::*`, `SocketAddrUse`→`sockets::*`. Removido `Config::async_support(true)` (deprecated em v44, no-op) |
+| `Cargo.lock` | regenerado |
+| `.cargo/audit.toml` | drop atômico do bloco wasmtime (15 IDs) |
+| `deny.toml` | drop atômico do bloco wasmtime (15 IDs) |
+
+Empirical breaking changes encontradas (tabela de change-detection
+entre wasmtime 28 e 44):
+
+| Símbolo | wasmtime 28 | wasmtime 44 | Categoria |
+|---|---|---|---|
+| `wasmtime_wasi::preview1` | `preview1` | `p1` | rename |
+| `wasmtime_wasi::pipe::{MemoryInputPipe, MemoryOutputPipe}` | top-level pipe | `p2::pipe::*` | path move |
+| `wasmtime_wasi::SocketAddrUse` | top-level | `sockets::SocketAddrUse` | path move |
+| `Config::async_support(_)` | required | deprecated, no-op | removal |
+| `WasiCtxBuilder::preopened_dir` | (host, guest, DirPerms, FilePerms) | **idêntico** | nenhuma |
+| `WasiCtxBuilder::socket_addr_check` | `Fn(SocketAddr, SocketAddrUse) -> Pin<Box<...>>` | **idêntico** | nenhuma |
+| `WasiCtxBuilder::build_p1` | always-on | **feature-gated `p1`** | feature gate |
+| `wasmtime_wasi::I32Exit` | top-level | **idêntico** | nenhuma |
+| `wasmtime::*` core (Config, Engine, Linker, Module, Store, StoreLimits, StoreLimitsBuilder) | estável | estável | nenhuma |
+| MSRV | qualquer | **1.92** (já satisfeito) | nenhuma |
+
+Sandbox semantics inalteradas: `epoch_interruption` + `Engine::increment_epoch()`
++ `Store::set_epoch_deadline()` + `StoreLimitsBuilder::memory_size`
++ `WasiCtxBuilder` permission model preservados.
+
+Tests: 13 unit tests em `garraia-plugins` continuam passando (cobrem
+path traversal, IP privado para SSRF, manifest defaults — invariantes
+não-WASM).
+
+Validação local:
+- `cargo build -p garraia-plugins`: 7.54s incremental, OK
+- `cargo test -p garraia-plugins`: 13 passed, 0 failed
+- `cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings`: 1m 47s, OK
+- `cargo fmt --check`: clean
+- `cargo audit --no-fetch --deny unsound`: exit 0
+- `cargo deny check`: advisories+bans+licenses+sources OK
+- `cargo tree -i wasmtime`: única versão `v44.0.0`
+
+`cargo deny` flagged each of the 15 removed IDs as
+`advisory-not-detected: no crate matched advisory criteria` —
+empirical proof of disappearance.
+
+---
+
+## RUSTSEC IDs fechados (15 atomic drop)
+
+Mesma lista em `audit.toml` e `deny.toml` (sync invariant):
+
+* RUSTSEC-2025-0046 — fd_renumber WASIp1 host panic (pre-existing)
+* RUSTSEC-2025-0118 — unsound shared linear memory API (pre-existing)
+* RUSTSEC-2026-0020 — guest-controlled resource exhaustion (WASI) — Med 6.9
+* RUSTSEC-2026-0021 — guest-controlled resource exhaustion (WASI #2) — Med 6.9
+* RUSTSEC-2026-0085 — Med 5.6
+* RUSTSEC-2026-0086 — Low 2.3
+* RUSTSEC-2026-0087 — Med 4.1
+* RUSTSEC-2026-0088 — Low 2.3
+* RUSTSEC-2026-0089 — Med 5.9
+* RUSTSEC-2026-0091 — Med 6.1
+* RUSTSEC-2026-0092 — Med 5.9
+* RUSTSEC-2026-0093 — Med 6.9
+* RUSTSEC-2026-0094 — Med 6.1
+* **RUSTSEC-2026-0095 — CRITICAL CVSS 9.0**
+* **RUSTSEC-2026-0096 — CRITICAL CVSS 9.0**
+
+---
+
+## Out of scope (registrado em follow-ups)
+
+* WebAssembly Component Model migration (escopo separado).
+* Multi-module isolation reform.
+* Smoke e2e WASM em `garraia-plugins` runtime — exige fixture `.wasm`
+  real, registrado para issue futura se PR-B revelar regressão runtime.
+* `RUSTSEC-2025-0057` (fxhash) e `RUSTSEC-2024-0436` (paste) permanecem
+  em `deny.toml` — verificado empiricamente que ainda são pulled (não
+  exclusivamente via wasmtime); separate carve-out tracking.
+
+---
+
+## Lições aprendidas
+
+1. **"Stub" ≠ inert**: o ticket Linear descrevia `install_plugin` como
+   stub mas o handler **realmente fazia network calls**. Inspeção
+   empírica do código-fonte É mais confiável que descrições de tickets,
+   especialmente quando a última edição do código foi há mais de 6 meses.
+2. **Surface reviews antes de bumps estruturais**: GAR-454 explicitamente
+   exigia review de plugin isolation antes do bump. Honrar esse gate
+   produziu um achado material (SSRF live) que teria escapado se PR-B
+   fosse o primeiro commit.
+3. **Diff de 16 majors é menor do que parece**: empiricamente, wasmtime
+   28→44 produziu apenas 4 imports + 1 método deprecated removido em 1
+   arquivo. A maioria das mudanças foi reorganização de namespaces
+   (preview1→p1, pipe→p2::pipe, SocketAddrUse→sockets::), não breaking
+   API contract. Os tests existentes guiaram o refactor sem regressão.
+4. **SYNC invariant audit.toml ↔ deny.toml**: os comentários de header
+   nos próprios arquivos forçaram sync atômico — pattern útil para
+   replicar em outros pares de configs duplicados.
+5. **Empirical proof via cargo deny `advisory-not-detected`**: melhor
+   forma de provar que IDs sumiram do lockfile sem precisar exit-status
+   misleading.
+
+---
+
+## Rollback
+
+`git revert <PR-B sha>` + restore os 15 IDs em audit.toml e deny.toml
+(blocos preservados em git history). Restaura wasmtime 28.0.1 e
+baseline anterior de ignores.
+
+Trigger plausível: regressão de runtime em código WASM real ou
+advisory novo introduzido pelo upgrade.
+
+---
+
+## Cross-references
+
+* Plan principal: `C:/Users/miche/.claude/plans/conferi-o-gar-454-no-purrfect-lantern.md`
+* Epic: GAR-430 (Quality Gates Phase 3.6)
+* Issues fechadas: GAR-454 (este), GAR-459 (PR-A pré-req)
+* Follow-ups: GAR-460 (LOW), GAR-461 (Med)
+* PRs: #77 (GAR-459), #78 (GAR-454)


### PR DESCRIPTION
## Summary

- Adiciona `plans/0050.4-wasmtime-upgrade.md` — retrospectivo completo do bump wasmtime 28 → 44, fechado em PR #78 (`cb873d59`). Documenta breaking-change matrix empírica, sequência PR-A/PR-B, lições aprendidas e procedimento de rollback.
- Atualiza `plans/0050-gar-430-quality-gates-phase-3.6.md` Lote 4b como ✅ DONE com link para o retrospectivo + merge SHAs.

## Changes

| Arquivo | Mudança |
|---|---|
| `plans/0050.4-wasmtime-upgrade.md` (NOVO, 199 LOC) | Retrospectivo completo |
| `plans/0050-gar-430-quality-gates-phase-3.6.md` | §Lote 4b marcado DONE, links para PR #77 + #78 |

## Local verification

- [x] `cargo fmt --check` (n/a — apenas docs)
- [x] Markdown render OK no preview local
- [x] Cross-references válidos (GAR-454, GAR-459, GAR-430, PR #77, PR #78)

## Risk

Nenhum — apenas documentação.

## Rollback

`git revert <sha>` se algum doc-link estiver errado.

## Linear

* [GAR-454](https://linear.app/chatgpt25/issue/GAR-454) — DONE em PR #78
* [GAR-459](https://linear.app/chatgpt25/issue/GAR-459) — DONE em PR #77
* [GAR-430](https://linear.app/chatgpt25/issue/GAR-430) — epic Quality Gates 3.6, Lote 4b agora completo

🤖 Generated with [Claude Code](https://claude.com/claude-code)