### PR TITLE
feat(security,plugins): is_blocked_ip cobre IPv4-compatible IPv6 (GAR-460)

### DIFF
--- a/crates/garraia-gateway/src/plugins_handler.rs
+++ b/crates/garraia-gateway/src/plugins_handler.rs
@@ -23,7 +23,7 @@
 //!      IPs (loopback/private/link-local/multicast/unspecified) for
 //!      IPv4 + IPv6.
 
-use std::net::{IpAddr, ToSocketAddrs};
+use std::net::{IpAddr, Ipv4Addr, ToSocketAddrs};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -553,6 +553,7 @@ async fn read_capped(response: reqwest::Response, cap: usize) -> Result<Vec<u8>,
 ///   * fe80::/10         (link-local)
 ///   * ff00::/8          (multicast)
 ///   * ::ffff:0:0/96     (IPv4-mapped — inspect inner v4)
+///   * ::a.b.c.d         (IPv4-compatible legacy RFC 4291 §2.5.5.1 — inspect inner v4)
 fn is_blocked_ip(ip: &IpAddr) -> bool {
     match ip {
         IpAddr::V4(v4) => {
@@ -580,6 +581,22 @@ fn is_blocked_ip(ip: &IpAddr) -> bool {
             }
             // IPv4-mapped IPv6 (::ffff:0:0/96): inspect the inner v4.
             if let Some(v4) = v6.to_ipv4_mapped() {
+                return is_blocked_ip(&IpAddr::V4(v4));
+            }
+            // IPv4-compatible IPv6 (RFC 4291 §2.5.5.1, deprecated):
+            // ::a.b.c.d where the high 96 bits are zero and the low 32
+            // bits encode an IPv4 address. Distinguished from v4-mapped
+            // (::ffff:a.b.c.d, handled above by to_ipv4_mapped) and from
+            // pure ::1/:: (caught by is_loopback/is_unspecified guards
+            // ABOVE this branch — those guards run first, so the cases
+            // segs[6] == 0 && segs[7] in (0, 1) never reach here). GAR-460.
+            if segs[0..6] == [0, 0, 0, 0, 0, 0] {
+                let v4 = Ipv4Addr::new(
+                    (segs[6] >> 8) as u8,
+                    (segs[6] & 0xff) as u8,
+                    (segs[7] >> 8) as u8,
+                    (segs[7] & 0xff) as u8,
+                );
                 return is_blocked_ip(&IpAddr::V4(v4));
             }
             false
@@ -718,6 +735,28 @@ mod tests {
         assert!(is_blocked_ip(&ip("::ffff:127.0.0.1")));
         // ::ffff:169.254.169.254 — IPv4-mapped IPv6 of IMDS.
         assert!(is_blocked_ip(&ip("::ffff:169.254.169.254")));
+    }
+
+    #[test]
+    fn is_blocked_ip_ipv6_v4_compatible_legacy() {
+        // GAR-460 — IPv4-compatible IPv6 (RFC 4291 §2.5.5.1, deprecated):
+        // ::a.b.c.d. NOT captured by Ipv6Addr::to_ipv4_mapped() (which
+        // only handles ::ffff:a.b.c.d). The new branch in is_blocked_ip
+        // walks segs[0..6] == [0;6] and decodes segs[6..8] as a v4 addr.
+        assert!(is_blocked_ip(&ip("::127.0.0.1"))); // loopback wrapped
+        assert!(is_blocked_ip(&ip("::169.254.169.254"))); // IMDS wrapped
+        assert!(is_blocked_ip(&ip("::10.0.0.1"))); // RFC1918 wrapped
+        assert!(is_blocked_ip(&ip("::192.168.1.1"))); // RFC1918 wrapped
+        // Public v4 wrapped in v4-compatible should NOT be blocked.
+        assert!(!is_blocked_ip(&ip("::8.8.8.8")));
+        assert!(!is_blocked_ip(&ip("::1.1.1.1")));
+        // Boundary: ::1 stays IPv6 loopback (caught by is_loopback BEFORE
+        // the v4-compat branch fires — guards run in declared order).
+        assert!(is_blocked_ip(&ip("::1")));
+        // Boundary: :: stays IPv6 unspecified (caught by is_unspecified
+        // BEFORE the v4-compat branch). Would also collapse to 0.0.0.0
+        // which is blocked, but for the right reason.
+        assert!(is_blocked_ip(&ip("::")));
     }
 
     #[test]


### PR DESCRIPTION
## Resumo

Fecha **GAR-460** — security-auditor follow-up de PR #77 (GAR-459). O branch v6 de `is_blocked_ip` em `crates/garraia-gateway/src/plugins_handler.rs` usava `Ipv6Addr::to_ipv4_mapped()` que captura SÓ \`::ffff:a.b.c.d\`. O formato legacy IPv4-compatible IPv6 \`::a.b.c.d\` (RFC 4291 §2.5.5.1) escapava — \`::127.0.0.1\`, \`::169.254.169.254\` e \`::a.b.c.d\` para RFC1918 não eram bloqueados.

## Correção

Em \`is_blocked_ip\` (linha 556), nova branch APÓS \`to_ipv4_mapped()\` decodifica os 32 bits baixos quando os 96 bits altos são zero, e recursa para o checker v4. **Ordem dos guards é cuidadosa:** \`is_loopback\`, \`is_unspecified\`, \`is_multicast\`, \`fc00::/7\`, \`fe80::/10\` e v4-mapped rodam ANTES — \`::1\` continua sendo loopback IPv6, \`::\` continua sendo unspecified, e a v4-compat só dispara quando o formato realmente é \`::a.b.c.d\` puro (não v4-mapped, não link-local etc.).

## Tests

Novo \`is_blocked_ip_ipv6_v4_compatible_legacy\` (8 asserts) cobrindo:

| Caso | Esperado | Razão |
|------|----------|-------|
| \`::127.0.0.1\` | bloqueado | loopback wrapped em v4-compat |
| \`::169.254.169.254\` | bloqueado | IMDS wrapped |
| \`::10.0.0.1\`, \`::192.168.1.1\` | bloqueados | RFC1918 wrapped |
| \`::8.8.8.8\`, \`::1.1.1.1\` | permitidos | v4 públicos wrapped |
| \`::1\` | bloqueado | loopback IPv6 puro (guard anterior) |
| \`::\` | bloqueado | unspecified IPv6 (guard anterior) |

17/17 testes do \`plugins_handler\` passam (8 SSRF v4 + 4 SSRF v6 prévios + 1 v6 v4-compat novo + 4 allowlist/manifest).

## Validação local

| Gate | Status |
|------|--------|
| \`cargo fmt --all -- --check\` | ✅ |
| \`cargo clippy -p garraia-gateway --all-targets -- -D warnings\` | ✅ |
| \`cargo test -p garraia-gateway plugins_handler\` | ✅ 17/17 |

## Test plan

- [x] CI \`fmt\`, \`clippy\`, \`cargo-deny\`, \`Security Audit\` verdes
- [ ] CI \`test (ubuntu-latest)\` verde com novo teste
- [ ] CI \`Security Audit\` verde

## Linear

Fecha [GAR-460](https://linear.app/chatgpt25/issue/GAR-460). Sub-issue de GAR-459 (PR #77 security-auditor review, severity LOW); também rastreável sob GAR-430 EPIC Quality Gates Phase 3.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)