### PR TITLE
chore(hooks): cap .garra-estado.md to last 5 entries (root cause)

### DIFF
--- a/.claude/hooks/stop.sh
+++ b/.claude/hooks/stop.sh
@@ -12,6 +12,12 @@ cd "${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 ESTADO_FILE=".garra-estado.md"
 SESSIONS_DIR=".claude/sessions"
 MAX_SESSIONS=10
+# Cap how many "## <timestamp>" entries we retain in $ESTADO_FILE. The new
+# entry is always prepended; the awk filter below drops anything past the
+# Nth historical block. Without this cap the file grew unbounded
+# (~82k chars after several dozen sessions before the 2026-04-27 manual
+# truncation). 5 keeps the active context near ~5-10k chars indefinitely.
+MAX_ESTADO_ENTRIES=5
 
 mkdir -p "$SESSIONS_DIR"
 
@@ -40,14 +46,24 @@ if [ -f "$ESTADO_FILE" ]; then
   # header lines that may have accumulated between entries. Old hook versions
   # prepended a fresh header every session; this idempotent awk keeps exactly
   # one header at the top of the file forever.
-  EXISTING=$(awk '/^## / { capture = 1 } capture && !/^# Estado GarraIA$/' "$ESTADO_FILE")
+  #
+  # The new entry being prepended below counts as #1, so we retain at most
+  # (MAX_ESTADO_ENTRIES - 1) historical blocks here — and exit before any
+  # block past that boundary is printed. Every line of a retained block
+  # reaches the default print action via `capture && !/^# Estado GarraIA$/`.
+  EXISTING=$(awk -v keep="$((MAX_ESTADO_ENTRIES - 1))" '
+    /^## / { count++; if (count > keep) exit; capture = 1 }
+    capture && !/^# Estado GarraIA$/
+  ' "$ESTADO_FILE")
   echo -e "# Estado GarraIA\n\n$ESTADO_ENTRY\n$EXISTING" > "$ESTADO_FILE"
 else
   echo -e "# Estado GarraIA\n\n$ESTADO_ENTRY" > "$ESTADO_FILE"
 fi
 
-# Stage .garra-estado.md (não commita)
-git add "$ESTADO_FILE" 2>/dev/null || true
+# `.garra-estado.md` é local/operacional e está em .gitignore (linha 46) —
+# nunca deve ser stageado. O `git add` anterior falhava silenciosamente
+# por causa do gitignore mas ainda gerava ruído em hooks futuros e poluía
+# `git status -uall`. Removido.
 
 # ── 2. Salvar sessão ──────────────────────────────────────────────────────
 SESSION_FILE="$SESSIONS_DIR/session-$TIMESTAMP.md"


### PR DESCRIPTION
## Resumo

Corrige a causa raiz do crescimento descontrolado do \`.garra-estado.md\`. O hook \`.claude/hooks/stop.sh\` prepende uma nova entrada por sessão e, no estado anterior, preservava o histórico inteiro sem cap. O arquivo cresceu para **82.465 chars / 2.190 linhas** em 2026-04-27 antes do truncamento manual.

## Mudanças

| Linha | Mudança |
|------|---------|
| `stop.sh` (novo `MAX_ESTADO_ENTRIES=5`) | cap explícito, parametrizável |
| `stop.sh` awk filter | conta \`^## \` e \`exit\` antes do (N+1)-ésimo bloco; retém \`MAX_ESTADO_ENTRIES - 1 = 4\` blocos históricos (a entrada nova é prepended por fora do awk) |
| `stop.sh` removido \`git add "$ESTADO_FILE"\` | \`.garra-estado.md\` está em \`.gitignore:46\`; o \`git add\` falhava silenciosamente — limpeza |

Diff: **+19/-3 LOC** em 1 arquivo.

## Test (manual fixture)

Sandbox em \`/tmp/tmp.*/\` com fixture de 8 entradas em layout newest-on-top (mirror do real):

\`\`\`
Entries before: 8
After hook:     5 (1 new + 4 historical)
Headers:        1
Retained:       #8, #7, #6, #5 (newest)
Dropped:        #4, #3, #2, #1 (oldest)
===PROD-LAYOUT CAP TEST PASSED===
\`\`\`

## Validação

| Gate | Status |
|------|--------|
| \`bash -n .claude/hooks/stop.sh\` | ✅ |
| shellcheck | ⚠ não disponível localmente — sintaxe validada via \`bash -n\` |
| Cap test 8 → 5 (newest retained) | ✅ |
| Header count stays at 1 | ✅ |
| \`.garra-estado.md\` não é stageado | ✅ (linha removida) |

## Out of scope

* Rotação do \`.claude/sessions/\` — já tem \`MAX_SESSIONS=10\` cap funcional.
* Telemetry hook (\`acts-log.js\`) — sem alteração.
* O próprio \`.garra-estado.md\` (operacional, ignorado, já truncado manualmente).

## Test plan

- [ ] CI \`fmt\`, \`clippy\`, \`cargo-deny\`, \`Security Audit\` verdes (não-Rust mas devem passar trivialmente).
- [ ] Próxima sessão observa que \`.garra-estado.md\` mantém ≤ 5 entradas após \`stop\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)