### PR TITLE
ci(security): bump cargo-audit ^0.22 + astral-tokio-tar 0.6.1 (GAR-462)

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -12,26 +12,28 @@ name: Security — cargo audit
 # no SARIF upload to the GitHub Security tab; failure visibility is
 # limited to the Actions tab + default notification channel.
 #
-# Plan 0043 (2026-04-22): the scheduled run went red with
-#   `error loading advisory database: TOML parse error at line N, column 8`
-# because `rustsec 0.30.x` cannot deserialize CVSS v4 advisories
-# (`cvss = "CVSS:4.0/..."`). Verification showed 39+ such entries in the
-# current HEAD of advisory-db (the earliest is deno/RUSTSEC-2025-0138
-# from 2025-12-29), so a SHA pin pre-dating v4 would require going back
-# 4+ months and losing all recent advisories. The adopted strategy is
-# instead to **strip** the CVSS v4 files after fetching HEAD. This keeps
-# full coverage of the CVSS v3 advisory corpus at the price of an
-# explicit, logged coverage gap on the v4-annotated crates.
+# Plan 0043 (2026-04-22) added a temporary CVSS v4 strip workaround to keep
+# `cargo audit` working against advisory-db HEAD when rustsec 0.30.x choked
+# on `cvss = "CVSS:4.0/..."` entries (see GAR-428).
 #
-# Crates in our Cargo.lock that intersect the stripped set as of the
-# pinning date: cap-primitives, cmov, quinn-proto, tar, time, wasmtime.
-# Manual review of these is tracked as follow-up to Lote B-2 (see plan
-# `synchronous-baking-hippo.md` §13).
+# GAR-462 (2026-04-28) supersedes that workaround. cargo-audit 0.22.1
+# (released 2026-02-04) ships rustsec >= 0.31 which (a) tolerates CVSS v4
+# entries natively and (b) tolerates non-canonical advisory filenames such
+# as `RUSTSEC-0000-0000.<N>.md` (the placeholder convention used by
+# advisory-db contributors for advisories awaiting permanent ID assignment).
+# Empirically verified locally against advisory-db HEAD `3562fa0`:
+# `cargo-audit 0.22.1 audit --deny unsound` loads the DB without error.
 #
-# EXPIRES 2026-05-20 (4 weeks). At expiration either rustsec has shipped
-# CVSS v4 support (remove the strip step) or we re-triage.
-# Safety net: the strip step aborts the job if the stripped count
-# exceeds 50 — forces triage when upstream does a bulk migration.
+# Consequence: this workflow no longer needs the manual fetch + strip step.
+# Pin bumped from `^0.21` to `^0.22` and the manual advisory-db management
+# is handed back to cargo-audit itself.
+#
+# Note on coverage: cargo-audit (any version) does NOT match advisories
+# filed under the placeholder ID `RUSTSEC-0000-0000`. The companion
+# `cargo-deny` job in `ci.yml` does match them — it caught the
+# `astral-tokio-tar 0.6.0` PAX header / chmod-via-symlink advisories in
+# GAR-462. Until upstream RustSec assigns permanent IDs, cargo-deny is
+# the authoritative gate for placeholder-ID advisories.
 
 on:
   schedule:
@@ -57,13 +59,6 @@ concurrency:
   # who may simply be testing the workflow).
   cancel-in-progress: false
 
-env:
-  # Plan 0043: hard ceiling on CVSS v4 advisories that may be stripped.
-  # If the real count at HEAD exceeds this, the job aborts so we can
-  # re-triage upstream schema state instead of silently losing coverage.
-  # Current count (2026-04-22): 39. EXPIRES 2026-05-20.
-  MAX_STRIPPED_CVSS_V4: 50
-
 jobs:
   audit:
     name: cargo audit
@@ -79,55 +74,20 @@ jobs:
       - name: Install cargo-audit
         # `--locked` pins the transitive deps of cargo-audit itself so
         # this job doesn't silently drift when a new cargo-audit release
-        # lands. Version range `^0.21` tracks the 0.21.x line; bump
-        # deliberately when upstream breaks the CLI contract (flags,
-        # exit codes, report format).
-        run: cargo install --locked --version '^0.21' cargo-audit
+        # lands. Version range `^0.22` tracks the 0.22.x line (bumped
+        # from `^0.21` in GAR-462). 0.22.1 ships rustsec >= 0.31 with
+        # native CVSS v4 support and tolerance for non-canonical
+        # advisory filenames — both fixes that previously required the
+        # manual strip workaround removed by GAR-462. Bump the range
+        # deliberately when upstream breaks the CLI contract.
+        run: cargo install --locked --version '^0.22' cargo-audit
 
       - name: Prime crates.io index for workspace deps
-        # cargo-audit --no-fetch disables the crates.io index refresh
-        # that cargo-audit uses for metadata lookups (yanked status
-        # and crate existence checks). Even without --deny yanked,
-        # yanked crates appear as yellow warnings which require the
-        # index. Pre-populate the local sparse index via
-        # `cargo fetch --locked` so the audit can resolve every dep
-        # in our lockfile without re-fetching. Plan 0043 §5.6.
+        # cargo-audit performs metadata lookups (yanked status, crate
+        # existence) against the crates.io index. Pre-populating via
+        # `cargo fetch --locked` keeps those lookups offline-stable
+        # and shortens the audit step. Plan 0043 §5.6.
         run: cargo fetch --locked
-
-      - name: Fetch advisory database and strip CVSS v4 entries
-        # Fetch HEAD of the RustSec advisory database, then remove entries
-        # that use CVSS v4 notation. rustsec 0.30.x fails to load the
-        # entire DB if a single entry is unparseable (by-design strictness
-        # of `rustsec::Database::open`). Stripping is the minimum-cost way
-        # to restore audit coverage without losing 4+ months of recent
-        # CVSS v3 advisories (plan 0043 §5.2). EXPIRES 2026-05-20.
-        run: |
-          set -euo pipefail
-          mkdir -p ~/.cargo/advisory-db
-          cd ~/.cargo/advisory-db
-          git init --quiet
-          git remote add origin https://github.com/rustsec/advisory-db.git
-          git fetch --depth=1 --quiet origin main
-          git checkout --quiet FETCH_HEAD
-          echo "Advisory DB HEAD: $(git rev-parse --short HEAD)"
-          echo "Commit date: $(git log -1 --format=%cd --date=iso-strict)"
-          # Strip CVSS v4 advisories. Anchored to start of line and
-          # tolerant of leading whitespace (`[[:space:]]*`) to cover
-          # TOML-legal indentation variants — rustsec advisory files
-          # today use no indent, but the schema allows leading spaces.
-          # Exact prefix `cvss = "CVSS:4.0/` keeps the match precise —
-          # body mentions of `CVSS:4.0` in prose won't trigger.
-          mapfile -t stripped < <(grep -rlE '^[[:space:]]*cvss = "CVSS:4\.0/' crates/ || true)
-          echo "Stripping ${#stripped[@]} CVSS v4 advisories (threshold ${MAX_STRIPPED_CVSS_V4}):"
-          if [ "${#stripped[@]}" -gt "${MAX_STRIPPED_CVSS_V4}" ]; then
-            echo "::error::Stripped ${#stripped[@]} CVSS v4 advisories exceeds threshold ${MAX_STRIPPED_CVSS_V4}."
-            echo "Re-triage required — rustsec likely needs CVSS v4 support."
-            exit 1
-          fi
-          if [ "${#stripped[@]}" -gt 0 ]; then
-            printf '  %s\n' "${stripped[@]}"
-            rm -- "${stripped[@]}"
-          fi
 
       - name: Run cargo audit
         # `cargo audit` already fails on any advisory (Informational,
@@ -141,11 +101,11 @@ jobs:
         # has "all versions yanked, unmaintained" upstream — no bump
         # possible. Yanked still shows as yellow warning in the log;
         # B-2 will swap core2 out of the dep tree or feature-gate
-        # `garraia-media` for CI-free builds. Removing `--deny yanked`
-        # is scoped: it's the single axis blocking green here, and
-        # leaving it exposed-but-not-fatal matches the existing treatment
-        # of unmaintained warnings in `informational_warnings`.
+        # `garraia-media` for CI-free builds.
         #
-        # `-n / --no-fetch` prevents cargo-audit from trying to refresh
-        # the DB and overriding our CVSS v4 strip.
-        run: cargo audit --no-fetch --deny unsound
+        # GAR-462 dropped `--no-fetch`: the workaround that required
+        # pre-fetching + stripping the advisory-db is gone, so
+        # cargo-audit 0.22 fetches and manages the DB on its own. The
+        # DB SHA appears in the run log as part of cargo-audit's normal
+        # output for traceability.
+        run: cargo audit --deny unsound

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
   # 5 audit.toml mirrors with deny-stricter severity mapping under GAR-437/
   # GAR-456/GAR-457, 23 unmaintained-only spread across GAR-430 ownership).
   # Second-layer gate paired with the now-blocking PR-time `Security Audit`
-  # job (`cargo audit --no-fetch --deny unsound`).
+  # job (`cargo audit --deny unsound`, GAR-462 dropped `--no-fetch`).
   cargo-deny:
     name: cargo-deny
     runs-on: ubuntu-latest
@@ -480,22 +480,22 @@ jobs:
 
   # Security audit — bloqueante desde plan 0053 PR-7 (GAR-453, fecha GAR-437).
   # Espelha o setup do nightly `.github/workflows/cargo-audit.yml` para evitar
-  # drift de decisão entre PR-time e schedule. Quando rustsec >= 0.31 com CVSS
-  # v4 nativo chegar, o strip step abaixo deve sair de AMBOS workflows
-  # atomicamente. Histórico: o `continue-on-error: true` que sobreviveu até
-  # plan 0053 PR-1..PR-6 cobria 6 advisories; PR-1..PR-6 fecharam ou
-  # documentaram cada uma em `.cargo/audit.toml` com Linear owner explícito,
-  # então o gate agora é blocking de fato.
+  # drift de decisão entre PR-time e schedule. Histórico: o `continue-on-error:
+  # true` que sobreviveu até plan 0053 PR-1..PR-6 cobria 6 advisories;
+  # PR-1..PR-6 fecharam ou documentaram cada uma em `.cargo/audit.toml` com
+  # Linear owner explícito, então o gate agora é blocking de fato.
+  #
+  # GAR-462 (2026-04-28): bump cargo-audit pin de `^0.21` para `^0.22` e
+  # remove o strip CVSS v4 do plan 0043. cargo-audit 0.22.1 ships rustsec
+  # >= 0.31 que (a) tolera CVSS v4 nativamente e (b) tolera filenames
+  # não-canônicos como `RUSTSEC-0000-0000.<N>.md` (placeholders pre-ID).
+  # Mudanças aqui devem replicar em cargo-audit.yml.
   security:
     name: Security Audit
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
-    env:
-      # Plan 0043: hard ceiling para CVSS v4 advisories que podem ser
-      # strippadas. Alinhado com cargo-audit.yml. EXPIRES 2026-05-20.
-      MAX_STRIPPED_CVSS_V4: 50
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -504,47 +504,19 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install cargo-audit
-        # `--locked` pina as transitive deps de cargo-audit; range `^0.21`
-        # tracks a linha 0.21.x igual ao nightly. Bump deliberado quando
+        # `--locked` pina as transitive deps de cargo-audit; range `^0.22`
+        # tracks a linha 0.22.x igual ao nightly. Bump deliberado quando
         # upstream quebrar contrato CLI.
-        run: cargo install --locked --version '^0.21' cargo-audit
+        run: cargo install --locked --version '^0.22' cargo-audit
 
       - name: Prime crates.io index for workspace deps
-        # cargo-audit --no-fetch desabilita o refresh do índice — pré-popular
-        # via `cargo fetch --locked` para que metadata lookups (yanked,
-        # existência) funcionem offline. Plan 0043 §5.6.
+        # Pre-popular o sparse index para que metadata lookups (yanked,
+        # existência) de cargo-audit funcionem rápido. Plan 0043 §5.6.
         run: cargo fetch --locked
-
-      - name: Fetch advisory database and strip CVSS v4 entries
-        # Fetch HEAD do RustSec advisory-db, depois strip de entradas com
-        # CVSS v4 (rustsec 0.30.x falha o load inteiro se uma única entrada
-        # for unparseable). Hard-stop em threshold quando upstream fizer bulk
-        # migration. EXPIRES 2026-05-20. Espelha cargo-audit.yml passo-a-passo.
-        run: |
-          set -euo pipefail
-          mkdir -p ~/.cargo/advisory-db
-          cd ~/.cargo/advisory-db
-          git init --quiet
-          git remote add origin https://github.com/rustsec/advisory-db.git
-          git fetch --depth=1 --quiet origin main
-          git checkout --quiet FETCH_HEAD
-          echo "Advisory DB HEAD: $(git rev-parse --short HEAD)"
-          echo "Commit date: $(git log -1 --format=%cd --date=iso-strict)"
-          mapfile -t stripped < <(grep -rlE '^[[:space:]]*cvss = "CVSS:4\.0/' crates/ || true)
-          echo "Stripping ${#stripped[@]} CVSS v4 advisories (threshold ${MAX_STRIPPED_CVSS_V4}):"
-          if [ "${#stripped[@]}" -gt "${MAX_STRIPPED_CVSS_V4}" ]; then
-            echo "::error::Stripped ${#stripped[@]} CVSS v4 advisories exceeds threshold ${MAX_STRIPPED_CVSS_V4}."
-            echo "Re-triage required — rustsec likely needs CVSS v4 support."
-            exit 1
-          fi
-          if [ "${#stripped[@]}" -gt 0 ]; then
-            printf '  %s\n' "${stripped[@]}"
-            rm -- "${stripped[@]}"
-          fi
 
       - name: Run security audit
         # `--deny unsound` widens failure beyond the default vuln set.
-        # `--no-fetch` prevents cargo-audit from refreshing the DB and
-        # overriding the CVSS v4 strip above. Mesmo flag-for-flag que o
-        # nightly cargo-audit.yml — mudanças aqui devem replicar lá.
-        run: cargo audit --no-fetch --deny unsound
+        # GAR-462 dropped `--no-fetch`: cargo-audit 0.22 gerencia o
+        # advisory-db sozinho. Mesmo flag-for-flag que o nightly
+        # cargo-audit.yml.
+        run: cargo audit --deny unsound

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
+checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
 dependencies = [
  "filetime",
  "futures-core",
@@ -1634,7 +1634,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2447,7 +2447,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2687,7 +2687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4383,7 +4383,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4718,7 +4718,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5520,7 +5520,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5977,7 +5977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -6793,7 +6793,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.36",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6830,9 +6830,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7417,7 +7417,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7521,7 +7521,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9246,7 +9246,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11227,7 +11227,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Pivots GAR-462 away from the workflow-strip workaround that v1 of this PR proposed. Two coupled changes:

1. **Bump `astral-tokio-tar 0.6.0 → 0.6.1`** (`Cargo.lock`) — closes two real placeholder-ID advisories that cargo-deny detected on this PR's first CI run.
2. **Bump cargo-audit pin `^0.21 → ^0.22`** in `.github/workflows/cargo-audit.yml` and `.github/workflows/ci.yml`, **drop the CVSS v4 strip workaround** from plan 0043, drop `--no-fetch`. cargo-audit 0.22.1 ships rustsec ≥ 0.31 with native CVSS v4 support and tolerance for non-canonical advisory filenames.

## Why a pivot from v1

v1 of this PR proposed stripping non-canonical filenames (`RUSTSEC-0000-0000.<N>.md`) from the advisory-db at workflow time, on the premise that those files were "withdrawn-advisory placeholders" and stripping them lost no real coverage. **That premise was wrong.** cargo-deny on v1's first CI run flagged:

```
error[vulnerability]: PAX Header Desynchronization in astral-tokio-tar
   ID: RUSTSEC-0000-0000
   astral-tokio-tar v0.6.0
   Solution: Upgrade to >=0.6.1
```

`RUSTSEC-0000-0000.<N>.md` is the **placeholder convention for advisories awaiting permanent RustSec ID assignment**, not a withdrawn-advisory marker. Stripping those files would silence real new advisories from `cargo audit`. Empirically there are **two** such advisories against `astral-tokio-tar 0.6.0` in advisory-db HEAD `3562fa0`:

- GHSA-fp55-jw48-c537 — PAX Header Desynchronization (smuggle files via tar manipulation)
- GHSA-xx64-wwv2-hcqq — `unpack_in` chmod via symlinks

Both are fixed in `astral-tokio-tar 0.6.1`. So the correct fix is to bump the dep, and let upstream cargo-audit 0.22 (which already shipped the parser fixes) handle the DB load gracefully.

## Failing run that motivated the PR

- Scheduled run #14: https://github.com/michelbr84/GarraRUST/actions/runs/25044766005
- Step that failed: `Run cargo audit` — `error: error loading advisory database: ... expected … RUSTSEC-0000-0000.2.md to be named "RUSTSEC-0000-0000.md"`
- cargo-audit version on the failing job: 0.21.2 (rustsec 0.30.x — too strict)

## Local validation (pre-push)

| Gate | Result |
|---|---|
| `cargo tree -i astral-tokio-tar` | shows 0.6.1 only |
| `cargo audit --deny unsound` (cargo-audit 0.22.1, fresh DB) | exit 0, 22 allowed warnings (baseline) |
| `cargo deny check` | `advisories ok, bans ok, licenses ok, sources ok` — astral-tokio-tar vulns gone |
| `cargo check --workspace --exclude garraia-desktop --locked` | exit 0 |
| `cargo fmt --all -- --check` | exit 0 |
| `python -c "yaml.safe_load(...)"` (both workflows) | yaml ok |

## Lockfile cascade — accepted under empirical proof

`cargo update -p astral-tokio-tar --precise 0.6.1` triggered a 32-line cascade across windows-sys (0.45/0.48/0.52/0.59) and socket2 (0.5.10) transitive deps. Diagnosis:

- `astral-tokio-tar 0.6.0` and `0.6.1` have **identical** dep manifests.
- `cargo update --workspace --dry-run` reports **zero** packages would change naturally.
- `--offline` produces an identical 32-line diff (not an index race).
- The cascade is the SAT solver finding a different valid resolution after the version swap.
- All four post-bump gates above pass.

The cascade is benign resolver re-pick on otherwise stable infrastructure versions already present in the lockfile through other consumers.

## Coverage honesty

cargo-audit (any version, including 0.22.1) does **NOT** match advisories filed under the placeholder ID `RUSTSEC-0000-0000` — it silently skips them during the match phase. **cargo-deny IS the authoritative gate** for those, and it caught the astral-tokio-tar advisories on this PR's first run, which is what triggered the strategy pivot. Until upstream RustSec assigns permanent IDs, cargo-deny remains the companion gate. This PR's commit message and the workflow comments document that explicitly.

## Refs

- GAR-428 (closed 2026-04-22; CVSS v4 strip — this PR removes the workaround in keeping with its `EXPIRES 2026-05-20`)
- GAR-462 (this PR — sibling to GAR-428, same upstream-parser-gap family)
- GAR-430 (Q7 RUSTSEC triage epic)
- GAR-453 (security gate blocking)

## Test plan

- [x] Reproduce upstream `cargo-audit 0.21` failure locally against advisory-db `3562fa0`
- [x] Validate `cargo-audit 0.22.1` loads the DB cleanly (exit 0)
- [x] Bump `astral-tokio-tar` to `0.6.1`; confirm `cargo deny check` no longer flags it
- [x] Confirm `cargo check`, `cargo fmt`, both workflows YAML parse cleanly
- [x] Empirically verify the lockfile cascade is deterministic resolver re-pick (identical manifests, `--offline` reproduction)
- [ ] CI green on this PR (incl. `Security Audit` and `cargo-deny` jobs)
- [ ] `@code-reviewer` + `@security-auditor` review the v2 patch
- [ ] Post-merge: rerun `Security — cargo audit` workflow on `main`, confirm green
- [ ] Update Linear (GAR-462) with run URL + merge SHA + evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)