### PR TITLE
refactor(gateway): GAR-440 slice 10.a — extract bootstrap/config.rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,18 @@ jobs:
         # for supply-chain hygiene. `^0.6` allows minor bumps within the 0.6.x
         # line (current 0.6.16 as of 2026-04-28); breaking-change bumps require
         # a deliberate edit.
-        run: cargo install --locked --version '^0.6' cargo-llvm-cov
+        #
+        # `--force` is required because the cache step above restores
+        # `~/.cargo/bin/` whenever the same Cargo.lock hash hits (which is
+        # always for refactor PRs that don't touch the lockfile). On a cache
+        # hit, the cargo-llvm-cov binary is already present and `cargo
+        # install` refuses to overwrite without `--force`. Discovered on
+        # PR-1 of plan abundant-thimble (GAR-440 slice 10.a, 2026-04-28):
+        # 1st CI run installed clean, 2nd run (after fmt fixup commit) hit
+        # cache and failed with `error: binary cargo-llvm-cov already
+        # exists in destination`. `--force` makes the step idempotent
+        # without sacrificing the supply-chain pin.
+        run: cargo install --locked --force --version '^0.6' cargo-llvm-cov
 
       - name: Generate lcov coverage
         run: |

--- a/crates/garraia-gateway/src/bootstrap/config.rs
+++ b/crates/garraia-gateway/src/bootstrap/config.rs
@@ -1,0 +1,79 @@
+//! Bootstrap configuration helpers.
+//!
+//! Slice 10.a of GAR-440 (Q10 of EPIC GAR-430 Quality Gates Phase 3.6).
+//! Extracted from `bootstrap.rs` without behavior change — holds the path
+//! resolvers and the API-key precedence chain (vault → config → env) that
+//! every downstream pipeline (agents, channels, state, router, admin)
+//! consumes via `crate::bootstrap::{default_vault_path, resolve_api_key}`.
+
+use std::path::PathBuf;
+
+/// Default vault path under the user's home directory.
+pub(crate) fn default_vault_path() -> Option<PathBuf> {
+    Some(
+        garraia_config::ConfigLoader::default_config_dir()
+            .join("credentials")
+            .join("vault.json"),
+    )
+}
+
+pub(super) fn default_allowlist_path() -> PathBuf {
+    garraia_config::ConfigLoader::default_config_dir().join("allowlist.json")
+}
+
+/// Resolve an API key using the priority chain: vault -> config -> env var.
+pub(crate) fn resolve_api_key(
+    config_key: Option<&str>,
+    vault_credential_key: &str,
+    env_var: &str,
+) -> Option<String> {
+    // 1. Try credential vault (only works when GARRAIA_VAULT_PASSPHRASE is set)
+    if let Some(vault_path) = default_vault_path()
+        && let Some(val) = garraia_security::try_vault_get(&vault_path, vault_credential_key)
+    {
+        return Some(val);
+    }
+
+    // 2. Config file value
+    if let Some(key) = config_key
+        && !key.is_empty()
+    {
+        return Some(key.to_string());
+    }
+
+    // 3. Environment variable
+    std::env::var(env_var).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_api_key_prefers_config_over_env() {
+        // Config value should win when present
+        let result = resolve_api_key(
+            Some("from-config"),
+            "NONEXISTENT_VAULT_KEY",
+            "NONEXISTENT_ENV_VAR_12345",
+        );
+        assert_eq!(result, Some("from-config".to_string()));
+    }
+
+    #[test]
+    fn resolve_api_key_falls_back_to_env() {
+        // Set a unique env var for this test
+        let var_name = "GARRAIA_TEST_API_KEY_BOOTSTRAP_72";
+        // SAFETY: this test is single-threaded and uses a unique env var name.
+        unsafe { std::env::set_var(var_name, "from-env") };
+        let result = resolve_api_key(None, "NONEXISTENT_VAULT_KEY", var_name);
+        assert_eq!(result, Some("from-env".to_string()));
+        unsafe { std::env::remove_var(var_name) };
+    }
+
+    #[test]
+    fn resolve_api_key_returns_none_when_all_missing() {
+        let result = resolve_api_key(None, "NONEXISTENT_VAULT_KEY", "NONEXISTENT_ENV_VAR_99999");
+        assert_eq!(result, None);
+    }
+}

--- a/crates/garraia-gateway/src/bootstrap/mod.rs
+++ b/crates/garraia-gateway/src/bootstrap/mod.rs
@@ -22,42 +22,14 @@ use tracing::{error, info, warn};
 
 use crate::state::SharedState;
 
-/// Default vault path under the user's home directory.
-pub(crate) fn default_vault_path() -> Option<PathBuf> {
-    Some(
-        garraia_config::ConfigLoader::default_config_dir()
-            .join("credentials")
-            .join("vault.json"),
-    )
-}
+mod config;
 
-fn default_allowlist_path() -> PathBuf {
-    garraia_config::ConfigLoader::default_config_dir().join("allowlist.json")
-}
-
-/// Resolve an API key using the priority chain: vault -> config -> env var.
-pub(crate) fn resolve_api_key(
-    config_key: Option<&str>,
-    vault_credential_key: &str,
-    env_var: &str,
-) -> Option<String> {
-    // 1. Try credential vault (only works when GARRAIA_VAULT_PASSPHRASE is set)
-    if let Some(vault_path) = default_vault_path()
-        && let Some(val) = garraia_security::try_vault_get(&vault_path, vault_credential_key)
-    {
-        return Some(val);
-    }
-
-    // 2. Config file value
-    if let Some(key) = config_key
-        && !key.is_empty()
-    {
-        return Some(key.to_string());
-    }
-
-    // 3. Environment variable
-    std::env::var(env_var).ok()
-}
+// Slice 10.a (GAR-440): path resolvers and API-key precedence chain extracted
+// to `bootstrap::config`. Re-exported at this level so external paths
+// `crate::bootstrap::default_vault_path` and `crate::bootstrap::resolve_api_key`
+// stay valid (consumed by `admin::handlers`, `router`, `state`).
+pub(crate) use config::{default_vault_path, resolve_api_key};
+use config::default_allowlist_path;
 
 /// Build a fully-configured `AgentRuntime` from the application config.
 pub fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
@@ -2385,31 +2357,4 @@ mod tests {
         let _runtime = build_agent_runtime(&config);
     }
 
-    #[test]
-    fn resolve_api_key_prefers_config_over_env() {
-        // Config value should win when present
-        let result = resolve_api_key(
-            Some("from-config"),
-            "NONEXISTENT_VAULT_KEY",
-            "NONEXISTENT_ENV_VAR_12345",
-        );
-        assert_eq!(result, Some("from-config".to_string()));
-    }
-
-    #[test]
-    fn resolve_api_key_falls_back_to_env() {
-        // Set a unique env var for this test
-        let var_name = "GARRAIA_TEST_API_KEY_BOOTSTRAP_72";
-        // SAFETY: this test is single-threaded and uses a unique env var name.
-        unsafe { std::env::set_var(var_name, "from-env") };
-        let result = resolve_api_key(None, "NONEXISTENT_VAULT_KEY", var_name);
-        assert_eq!(result, Some("from-env".to_string()));
-        unsafe { std::env::remove_var(var_name) };
-    }
-
-    #[test]
-    fn resolve_api_key_returns_none_when_all_missing() {
-        let result = resolve_api_key(None, "NONEXISTENT_VAULT_KEY", "NONEXISTENT_ENV_VAR_99999");
-        assert_eq!(result, None);
-    }
 }

--- a/crates/garraia-gateway/src/bootstrap/mod.rs
+++ b/crates/garraia-gateway/src/bootstrap/mod.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use garraia_agents::tools::Tool;
@@ -28,8 +27,8 @@ mod config;
 // to `bootstrap::config`. Re-exported at this level so external paths
 // `crate::bootstrap::default_vault_path` and `crate::bootstrap::resolve_api_key`
 // stay valid (consumed by `admin::handlers`, `router`, `state`).
-pub(crate) use config::{default_vault_path, resolve_api_key};
 use config::default_allowlist_path;
+pub(crate) use config::{default_vault_path, resolve_api_key};
 
 /// Build a fully-configured `AgentRuntime` from the application config.
 pub fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
@@ -2356,5 +2355,4 @@ mod tests {
         // Should not panic — unknown providers are logged and skipped
         let _runtime = build_agent_runtime(&config);
     }
-
 }


### PR DESCRIPTION
## Resumo

TDD REFACTOR puro (zero behavior change). Slice **10.a** do epic GAR-430 / Q10 (Quality Gates Phase 3.6). Primeira extração do refactor de `bootstrap.rs` (2415 LOC) em 6 PRs pequenos. Linear: [GAR-440](https://linear.app/chatgpt25/issue/GAR-440).

## Mudança

| Antes | Depois |
|---|---|
| `crates/garraia-gateway/src/bootstrap.rs` (2415 LOC) | `crates/garraia-gateway/src/bootstrap/mod.rs` (2353 LOC) |
| 3 fns `default_vault_path` / `default_allowlist_path` / `resolve_api_key` inline | Extraídas para `bootstrap/config.rs` (novo, 79 LOC) |
| 3 unit tests `resolve_api_key_*` em `mod tests` inline | Movidos para `bootstrap::config::tests` |

`bootstrap.rs` foi renomeado para `bootstrap/mod.rs` via `git mv` para acomodar o submódulo `config`. Re-exports em `mod.rs`:

```rust
mod config;

use config::default_allowlist_path;
pub(crate) use config::{default_vault_path, resolve_api_key};
```

preservam os paths externos `crate::bootstrap::default_vault_path` e `crate::bootstrap::resolve_api_key` consumidos por `admin/handlers.rs`, `router.rs`, `state.rs`. Path inalterado para callers externos.

## Visibilidade

| Símbolo | Antes | Depois | Razão |
|---|---|---|---|
| `default_vault_path` | `pub(crate)` | `pub(crate)` em `config`, `pub(crate) use` em `mod.rs` | preservar `crate::bootstrap::default_vault_path` |
| `default_allowlist_path` | `fn` privada | `pub(super)` em `config` | só `bootstrap` acessa; `pub(super)` é o equivalente semântico exato |
| `resolve_api_key` | `pub(crate)` | `pub(crate)` em `config`, `pub(crate) use` em `mod.rs` | preservar `crate::bootstrap::resolve_api_key` |

## Validação local

| Check | Resultado |
|---|---|
| `cargo fmt --check --all` | OK |
| `cargo check -p garraia-gateway --locked` | OK |
| `cargo +1.92 check --workspace --exclude garraia-desktop --locked` (MSRV) | OK |
| `cargo clippy -p garraia-gateway --all-targets -- -D warnings` | OK |
| `cargo test -p garraia-gateway --lib bootstrap::` | **5/5 passed** (3 movidos + 2 mantidos) |

## Diff stats

```
crates/garraia-gateway/src/bootstrap/config.rs     | 79 ++++++++++++++++++++++
.../src/{bootstrap.rs => bootstrap/mod.rs}         | 71 ++-----------------
2 files changed, 86 insertions(+), 64 deletions(-)
```

Net diff: **+22 LOC** em `mod.rs` (mod declaration + re-exports), **+79 LOC** novos em `config.rs`. Total ~150 LOC tocados, dentro do orçamento ≤500 LOC do epic.

## Por que `bootstrap/config.rs` primeiro

GAR-440 Linear especifica 6 slices: **10.a config**, 10.b storage, 10.c agents, 10.d channels, 10.e telemetry, 10.f slim orchestrator. `config.rs` é o slice mais seguro para começar porque:

1. **Zero acoplamento com `AppState` mutável** — funções puras de path resolution e env var fallback.
2. **Tests inline já cobrem** os 3 caminhos (`config wins`, `env fallback`, `none when all missing`).
3. **Não depende de ordem de inicialização** — pode ser chamada de qualquer ponto.

## Próximos slices (não nesta PR)

- 10.b — `bootstrap/storage.rs` (ObjectStore wiring)
- 10.c — `bootstrap/agents.rs` (974 LOC; provavelmente exige sub-divisão)
- 10.d — `bootstrap/channels.rs` (1210 LOC; sub-divisão obrigatória)
- 10.e — `bootstrap/telemetry.rs` (escopo a confirmar; Explore agent não localizou OTel/Prometheus em `bootstrap.rs` — possivelmente já mora em outro crate)
- 10.f — slim final < 500 LOC

## Reviews internos

| Reviewer | Veredicto |
|---|---|
| `code-reviewer` (oficial) | APROVADO. 0 blockers, 0 importantes. 2 LOW (test rename / serial_test guard) — cobrem código pré-existente, ficam para PR de melhoria futura |
| `rust-refactor-engineer` (general-purpose com prompt de papel) | PASS. Byte-equivalence confirmada |
| `privacy-hygiene-reviewer` (general-purpose com prompt de papel) | CLEAN. Zero PII / secrets / paths privados / emails |

## Rollback

`git revert` simples. Renomeação reversa é trivial via `git mv bootstrap/mod.rs bootstrap.rs && rm bootstrap/config.rs && git checkout bootstrap.rs` (mas `git revert <SHA>` faz isso automaticamente).

## Refs

- Linear: [GAR-440](https://linear.app/chatgpt25/issue/GAR-440), parent [GAR-430 EPIC](https://linear.app/chatgpt25/issue/GAR-430).
- Plan: `C:/Users/miche/.claude/plans/voc-est-no-reposit-rio-abundant-thimble.md`.