### PR TITLE
refactor(gateway): GAR-439 slice 9.a — extract admin/shared.rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,24 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Plan abundant-thimble (GAR-439 slice 9.a, 2026-04-28): the default
+      # GHA `ubuntu-latest` runner ships with ~14 GB free disk. The combo of
+      # (cache restore ~3.2 GB target + cargo install --force rebuild +
+      # `cargo llvm-cov` instrumented rebuild of target/) crosses 14 GB and
+      # the runner crashes with `No space left on device` mid-job (verified
+      # empirically on PR #90 retry — same failure twice). Pruning the
+      # default runner image saves ~12 GB before any rust step touches disk.
+      # Inline `rm -rf` instead of an external action to keep supply-chain
+      # surface zero (same posture as `cargo-deny`/`cargo-audit` jobs).
+      - name: Free up disk space (GHA runner default ~14 GB → ~26 GB)
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force || true
+          df -h
+
       - name: Install Rust + llvm-tools-preview
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/crates/garraia-gateway/src/admin/handlers.rs
+++ b/crates/garraia-gateway/src/admin/handlers.rs
@@ -1,26 +1,18 @@
-use std::sync::Arc;
-
 use axum::Json;
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 use ring::aead::{AES_256_GCM, Aad, LessSafeKey, Nonce, UnboundKey};
 use ring::rand::{SecureRandom, SystemRandom};
-use tokio::sync::Mutex;
 
 use super::middleware::{AuthenticatedAdmin, build_clear_cookie, build_session_cookie, extract_ip};
 use super::rbac::{Action, Resource, Role, check_permission};
-use super::store::AdminStore;
-use crate::state::SharedState;
 
-/// Shared state for admin API handlers.
-#[derive(Clone)]
-pub struct AdminState {
-    pub store: Arc<Mutex<AdminStore>>,
-    pub app_state: SharedState,
-    /// Master encryption key (derived or loaded at startup) for secrets encryption.
-    pub encryption_key: Arc<Vec<u8>>,
-}
+// Slice 9.a (GAR-439): `AdminState` and `derive_encryption_key` extracted to
+// `admin::shared`. Re-exported here so external paths
+// `super::handlers::AdminState` and `super::handlers::derive_encryption_key`
+// (consumed by `admin/routes.rs`) keep resolving without changes.
+pub use super::shared::{AdminState, derive_encryption_key};
 
 // ── Auth endpoints ──────────────────────────────────────────────────
 
@@ -1075,58 +1067,6 @@ fn redact_config_secrets(config: &mut garraia_config::AppConfig) {
             }
         }
     }
-}
-
-/// Derive or generate a master encryption key for the admin secrets store.
-pub fn derive_encryption_key() -> Vec<u8> {
-    if let Ok(passphrase) = std::env::var("GARRAIA_ADMIN_KEY") {
-        let salt = b"garraia-admin-secrets-v1";
-        let iterations = std::num::NonZeroU32::new(100_000).unwrap();
-        let mut key = vec![0u8; 32];
-        ring::pbkdf2::derive(
-            ring::pbkdf2::PBKDF2_HMAC_SHA256,
-            iterations,
-            salt,
-            passphrase.as_bytes(),
-            &mut key,
-        );
-        return key;
-    }
-
-    if let Ok(passphrase) = std::env::var("GARRAIA_VAULT_PASSPHRASE") {
-        let salt = b"garraia-admin-secrets-v1";
-        let iterations = std::num::NonZeroU32::new(100_000).unwrap();
-        let mut key = vec![0u8; 32];
-        ring::pbkdf2::derive(
-            ring::pbkdf2::PBKDF2_HMAC_SHA256,
-            iterations,
-            salt,
-            passphrase.as_bytes(),
-            &mut key,
-        );
-        return key;
-    }
-
-    let key_path = garraia_config::ConfigLoader::default_config_dir()
-        .join("admin")
-        .join("master.key");
-
-    if let Ok(data) = std::fs::read(&key_path)
-        && data.len() == 32
-    {
-        return data;
-    }
-
-    let rng = SystemRandom::new();
-    let mut key = vec![0u8; 32];
-    rng.fill(&mut key).expect("failed to generate master key");
-
-    if let Some(parent) = key_path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    let _ = std::fs::write(&key_path, &key);
-
-    key
 }
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/crates/garraia-gateway/src/admin/mod.rs
+++ b/crates/garraia-gateway/src/admin/mod.rs
@@ -3,4 +3,5 @@ pub mod handlers;
 pub mod middleware;
 pub mod rbac;
 pub mod routes;
+pub mod shared;
 pub mod store;

--- a/crates/garraia-gateway/src/admin/shared.rs
+++ b/crates/garraia-gateway/src/admin/shared.rs
@@ -1,0 +1,81 @@
+//! Shared admin infrastructure.
+//!
+//! Slice 9.a of GAR-439 (Q9 of EPIC GAR-430 Quality Gates Phase 3.6).
+//! Extracted from `admin/handlers.rs` (3300 LOC) without behavior change.
+//! Holds the cross-family `AdminState` value object and the master-key
+//! derivation primitive (`derive_encryption_key`) used by the admin
+//! sub-router during construction.
+//!
+//! Future slices (9.b..9.f) will extract per-family handler modules
+//! (projects, credentials, channels, mcp_registry, agents) and may
+//! later promote response-builder helpers into this module once they
+//! have at least one caller migrated.
+
+use std::sync::Arc;
+
+use ring::rand::{SecureRandom, SystemRandom};
+use tokio::sync::Mutex;
+
+use super::store::AdminStore;
+use crate::state::SharedState;
+
+/// Shared state for admin API handlers.
+#[derive(Clone)]
+pub struct AdminState {
+    pub store: Arc<Mutex<AdminStore>>,
+    pub app_state: SharedState,
+    /// Master encryption key (derived or loaded at startup) for secrets encryption.
+    pub encryption_key: Arc<Vec<u8>>,
+}
+
+/// Derive or generate a master encryption key for the admin secrets store.
+pub fn derive_encryption_key() -> Vec<u8> {
+    if let Ok(passphrase) = std::env::var("GARRAIA_ADMIN_KEY") {
+        let salt = b"garraia-admin-secrets-v1";
+        let iterations = std::num::NonZeroU32::new(100_000).unwrap();
+        let mut key = vec![0u8; 32];
+        ring::pbkdf2::derive(
+            ring::pbkdf2::PBKDF2_HMAC_SHA256,
+            iterations,
+            salt,
+            passphrase.as_bytes(),
+            &mut key,
+        );
+        return key;
+    }
+
+    if let Ok(passphrase) = std::env::var("GARRAIA_VAULT_PASSPHRASE") {
+        let salt = b"garraia-admin-secrets-v1";
+        let iterations = std::num::NonZeroU32::new(100_000).unwrap();
+        let mut key = vec![0u8; 32];
+        ring::pbkdf2::derive(
+            ring::pbkdf2::PBKDF2_HMAC_SHA256,
+            iterations,
+            salt,
+            passphrase.as_bytes(),
+            &mut key,
+        );
+        return key;
+    }
+
+    let key_path = garraia_config::ConfigLoader::default_config_dir()
+        .join("admin")
+        .join("master.key");
+
+    if let Ok(data) = std::fs::read(&key_path)
+        && data.len() == 32
+    {
+        return data;
+    }
+
+    let rng = SystemRandom::new();
+    let mut key = vec![0u8; 32];
+    rng.fill(&mut key).expect("failed to generate master key");
+
+    if let Some(parent) = key_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(&key_path, &key);
+
+    key
+}


### PR DESCRIPTION
## Resumo

TDD REFACTOR puro (zero behavior change). Slice **9.a** do epic GAR-430 / Q9 (Quality Gates Phase 3.6). Primeira extração do refactor de `admin/handlers.rs` (3300 LOC) em 6+ PRs pequenos. Linear: [GAR-439](https://linear.app/chatgpt25/issue/GAR-439).

Sequencial após PR #89 (GAR-440 slice 10.a) — mesmo padrão de slice fino, mesma sessão `abundant-thimble`.

## Mudança

| Antes | Depois |
|---|---|
| `crates/garraia-gateway/src/admin/handlers.rs` (3300 LOC) | `handlers.rs` (3245 LOC) |
| `pub struct AdminState` inline (linhas 16-23) | Extraído para `admin/shared.rs` |
| `pub fn derive_encryption_key()` inline (linhas 1077-1127) | Extraído para `admin/shared.rs` |
| — | Novo `admin/shared.rs` (81 LOC) |

Re-export em `handlers.rs`:

```rust
pub use super::shared::{AdminState, derive_encryption_key};
```

preserva os paths externos `super::handlers::AdminState` e `super::handlers::derive_encryption_key` consumidos por `admin/routes.rs:9,16`. Zero alteração em `routes.rs`.

## Imports limpos em `handlers.rs`

| Removidos (eram usados só pelo `AdminState`) | `std::sync::Arc`, `tokio::sync::Mutex`, `super::store::AdminStore`, `crate::state::SharedState` |
| Mantidos (ainda usados por `encrypt_value`/`decrypt_value` em handlers.rs) | `ring::rand::{SecureRandom, SystemRandom}` |

`encrypt_value`/`decrypt_value` ficam em `handlers.rs` até slice **9.c** (`admin/credentials.rs`).

## Validação local

| Check | Resultado |
|---|---|
| `cargo fmt --check --all` | OK |
| `cargo check -p garraia-gateway --locked` | OK |
| `cargo +1.92 check --workspace --exclude garraia-desktop --locked` (MSRV) | OK |
| `cargo clippy -p garraia-gateway --all-targets -- -D warnings` | OK |
| `cargo test -p garraia-gateway --lib admin::` | **23/23 passed** (rbac/store/audit) |

## Diff stats

```
crates/garraia-gateway/src/admin/handlers.rs | 70 ++----------------------
crates/garraia-gateway/src/admin/mod.rs      |  1 +
crates/garraia-gateway/src/admin/shared.rs   | 81 ++++++++++++++++++++++++++++
3 files changed, 87 insertions(+), 65 deletions(-)
```

Total movido: ~140 LOC. Bem dentro do orçamento ≤500 LOC do epic.

## Reviews internos (4 paralelos)

| Reviewer | Veredicto |
|---|---|
| `code-reviewer` (oficial) | APPROVED. 0 blockers, 0 importantes. 1 LOW herdada do código original (`NonZeroU32::new(100_000).unwrap()` — fora de escopo) |
| `security-auditor` (oficial) | PASS no slice. **Bytes idênticos**, zero risco introduzido. **2 MEDIUM PRE-EXISTENTES** (salt PBKDF2 fixo `b"garraia-admin-secrets-v1"` sem diversificação por instalação; iterações 100k < 210k NIST SP 800-132 rev 2023). **2 LOW**: dual public path via re-export pode ser tightened para `pub(crate)` em slice futuro; `master.key` sem `chmod 0600` no write. **Sub-issue de hardening será aberta como follow-up.** |
| `rust-refactor-engineer` (general-purpose, papel atribuído) | PASS. Byte-equivalence confirmada |
| `privacy-hygiene-reviewer` (general-purpose, papel atribuído) | CLEAN. Zero PII / secrets / paths privados |

## Por que `admin/shared.rs` primeiro

GAR-439 Linear especifica 6+ slices: **9.a shared**, 9.b projects, 9.c credentials, 9.d channels, 9.e mcp_registry, 9.f agents, 9.g (opcional) mod.rs. `shared.rs` é pré-requisito porque:

1. **AdminState é consumido por todas as 5 famílias** — extrair primeiro permite que cada slice subsequente importe `use super::shared::AdminState;` em vez de duplicar.
2. **Zero acoplamento** com handlers de família — apenas struct + 1 fn de bootstrap.
3. **Tests existentes (23 admin lib tests) cobrem** a refactor transitivamente — qualquer regressão de path quebraria a compilação de `routes.rs`.

## Próximos slices (não nesta PR)

- 9.b — `admin/projects.rs` (~180 LOC)
- 9.c — `admin/credentials.rs` (~270 LOC, inclui `encrypt_value`/`decrypt_value`)
- 9.d — `admin/channels.rs` (~100 LOC)
- 9.e — `admin/mcp_registry.rs` (~380 LOC)
- 9.f — `admin/agents.rs` (~380 LOC)
- 9.g (opcional) — fechamento `admin/mod.rs` < 300 LOC

Depois das 6 famílias movidas, abrir slice de hardening cobrindo os 2 MEDIUM pre-existentes (salt diversification + PBKDF2 iterations bump) — tracked como sub-issue dedicada.

## Rollback

`git revert <SHA>` simples. Re-exports revertidos automaticamente.

## Refs

- Linear: [GAR-439](https://linear.app/chatgpt25/issue/GAR-439), parent [GAR-430 EPIC](https://linear.app/chatgpt25/issue/GAR-430).
- Plan: `C:/Users/miche/.claude/plans/voc-est-no-reposit-rio-abundant-thimble.md`.
- PR antecessor da mesma sessão: #89 (GAR-440 slice 10.a, mergeado em `3c94964`).