### PR TITLE
test(auth): GAR-463 Q6.1 — kill 5 critical mutation bypasses (tests-only)

### DIFF
--- a/crates/garraia-auth/src/hashing.rs
+++ b/crates/garraia-auth/src/hashing.rs
@@ -165,4 +165,92 @@ mod tests {
         let pw = secret("any input");
         consume_dummy_hash(&pw).expect("dummy hash verify must succeed (boolean discarded)");
     }
+
+    // ───────────────────────────────────────────────────────────────────────
+    // GAR-463 Q6.1 — kill 3 mutation bypasses in this module
+    //
+    // Coverage targets (file:line in src/hashing.rs at PR #91):
+    //   - line 81:  `verify_pbkdf2 → Ok(true)`        (any password verifies)
+    //   - line 107: `consume_dummy_hash → Ok(())`     (no real argon2 work)
+    //
+    // The deterministic PBKDF2 fixture below is generated with a FIXED salt
+    // so the PHC is fully reproducible without bringing OsRng into the test.
+    // No real secret — both salt and password are public test constants.
+    // ───────────────────────────────────────────────────────────────────────
+
+    /// Synthetic PBKDF2-SHA256 PHC fixture for the public test password
+    /// `"correct horse battery staple"` (xkcd 936) with FIXED 16-byte salt
+    /// `"crab-salt-fixed"` (base64 `Y3JhYi1zYWx0LWZpeGVk`) and i=600_000.
+    ///
+    /// Reproduce via `examples/gen_pbkdf2_fixture.rs` (deleted before commit):
+    /// ```ignore
+    /// let salt = SaltString::from_b64("Y3JhYi1zYWx0LWZpeGVk").unwrap();
+    /// Pbkdf2.hash_password_customized(
+    ///     b"correct horse battery staple", None, None,
+    ///     pbkdf2::Params { rounds: 600_000, output_length: 32 }, &salt,
+    /// ).unwrap().to_string()
+    /// ```
+    const PBKDF2_FIXTURE_PHC: &str =
+        "$pbkdf2-sha256$i=600000,l=32$Y3JhYi1zYWx0LWZpeGVk$fJC/CVFjhIg4Ba4mggBBBt9+u5ygVtyQEzEFm7qN+xE";
+
+    #[test]
+    fn pbkdf2_accepts_correct_password() {
+        let pw = secret("correct horse battery staple");
+        assert!(
+            verify_pbkdf2(PBKDF2_FIXTURE_PHC, &pw).expect("verify"),
+            "fixture PHC must verify against the public xkcd-936 password"
+        );
+    }
+
+    #[test]
+    fn pbkdf2_rejects_wrong_password() {
+        // Mutant `verify_pbkdf2 → Ok(true)` makes this assertion FAIL.
+        let wrong = secret("definitely-not-the-password");
+        let result = verify_pbkdf2(PBKDF2_FIXTURE_PHC, &wrong).expect("verify");
+        assert!(
+            !result,
+            "verify_pbkdf2 must return Ok(false) for a wrong password \
+             — mutant `Ok(true)` triggers this assertion failure"
+        );
+    }
+
+    #[test]
+    fn pbkdf2_rejects_argon2id_phc() {
+        let pw = secret("anything");
+        let phc = hash_argon2id(&pw).expect("hash");
+        match verify_pbkdf2(&phc, &pw) {
+            Err(AuthError::Hashing(_)) => {}
+            other => panic!("expected Hashing error for argon2id PHC, got {other:?}"),
+        }
+    }
+
+    /// Kills mutant `consume_dummy_hash → Ok(())` (src/hashing.rs:107).
+    ///
+    /// `consume_dummy_hash` has no observable side-effects — its contract IS
+    /// its execution time (anti-enumeration timing match against a real
+    /// argon2id verify). The only way to detect the `Ok(())` mutant is to
+    /// assert that real argon2id work runs.
+    ///
+    /// Argon2id with RFC 9106 params (m=64MiB, t=3, p=4) takes ≥ 30 ms on
+    /// commodity hardware. Slowest GHA shared runner observed ≥ 10 ms.
+    /// 5 ms threshold gives ~6× headroom over the mutated `Ok(())` path
+    /// (microseconds) and ≥ 3× under the real lower bound — flake-resistant.
+    #[test]
+    fn consume_dummy_hash_performs_real_argon2_work() {
+        use std::time::{Duration, Instant};
+        let pw = secret("any input");
+
+        // Warmup: first call may pay page-fault cost on DUMMY_HASH bytes.
+        consume_dummy_hash(&pw).expect("warmup");
+
+        let start = Instant::now();
+        consume_dummy_hash(&pw).expect("real call");
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed >= Duration::from_millis(5),
+            "consume_dummy_hash returned in {elapsed:?}; expected >= 5ms of \
+             real argon2id work — mutant `Ok(())` returns instantly"
+        );
+    }
 }

--- a/crates/garraia-auth/src/hashing.rs
+++ b/crates/garraia-auth/src/hashing.rs
@@ -190,8 +190,7 @@ mod tests {
     ///     pbkdf2::Params { rounds: 600_000, output_length: 32 }, &salt,
     /// ).unwrap().to_string()
     /// ```
-    const PBKDF2_FIXTURE_PHC: &str =
-        "$pbkdf2-sha256$i=600000,l=32$Y3JhYi1zYWx0LWZpeGVk$fJC/CVFjhIg4Ba4mggBBBt9+u5ygVtyQEzEFm7qN+xE";
+    const PBKDF2_FIXTURE_PHC: &str = "$pbkdf2-sha256$i=600000,l=32$Y3JhYi1zYWx0LWZpeGVk$fJC/CVFjhIg4Ba4mggBBBt9+u5ygVtyQEzEFm7qN+xE";
 
     #[test]
     fn pbkdf2_accepts_correct_password() {

--- a/crates/garraia-auth/src/hashing.rs
+++ b/crates/garraia-auth/src/hashing.rs
@@ -179,7 +179,7 @@ mod tests {
     // ───────────────────────────────────────────────────────────────────────
 
     /// Synthetic PBKDF2-SHA256 PHC fixture for the public test password
-    /// `"correct horse battery staple"` (xkcd 936) with FIXED 16-byte salt
+    /// `"correct horse battery staple"` (xkcd 936) with FIXED 15-byte salt
     /// `"crab-salt-fixed"` (base64 `Y3JhYi1zYWx0LWZpeGVk`) and i=600_000.
     ///
     /// Reproduce via `examples/gen_pbkdf2_fixture.rs` (deleted before commit):
@@ -231,9 +231,16 @@ mod tests {
     /// assert that real argon2id work runs.
     ///
     /// Argon2id with RFC 9106 params (m=64MiB, t=3, p=4) takes ≥ 30 ms on
-    /// commodity hardware. Slowest GHA shared runner observed ≥ 10 ms.
-    /// 5 ms threshold gives ~6× headroom over the mutated `Ok(())` path
-    /// (microseconds) and ≥ 3× under the real lower bound — flake-resistant.
+    /// commodity hardware (~80–250 ms on `windows-latest` GHA runners under
+    /// load per test-engineer review). 8 ms lower bound gives ~1000× over
+    /// the mutated `Ok(())` path (microseconds) while staying ≥ 4× under
+    /// the slowest observed real lower bound — robust against scheduler
+    /// jitter on shared CI without false-positive risk.
+    ///
+    /// The upper bound of 10 s is a sanity check: if the call genuinely
+    /// takes longer than that, the runner is hosed (memory-pressured /
+    /// CPU-starved) and the test result is meaningless — surface it as a
+    /// failure rather than a misleading pass.
     #[test]
     fn consume_dummy_hash_performs_real_argon2_work() {
         use std::time::{Duration, Instant};
@@ -247,9 +254,15 @@ mod tests {
         let elapsed = start.elapsed();
 
         assert!(
-            elapsed >= Duration::from_millis(5),
-            "consume_dummy_hash returned in {elapsed:?}; expected >= 5ms of \
+            elapsed >= Duration::from_millis(8),
+            "consume_dummy_hash returned in {elapsed:?}; expected >= 8ms of \
              real argon2id work — mutant `Ok(())` returns instantly"
+        );
+        assert!(
+            elapsed < Duration::from_secs(10),
+            "consume_dummy_hash took {elapsed:?}; runner is severely \
+             resource-starved — the timing assertion above cannot be \
+             trusted under such conditions"
         );
     }
 }

--- a/crates/garraia-auth/tests/sessions_lifecycle.rs
+++ b/crates/garraia-auth/tests/sessions_lifecycle.rs
@@ -1,0 +1,231 @@
+//! Integration tests for `SessionStore::issue` / `verify_refresh` / `revoke`
+//! against a real Postgres testcontainer (pgvector/pg16).
+//!
+//! GAR-463 Q6.1 (parent GAR-436) — kills these mutants from the
+//! cargo-mutants baseline (run 25072579785, 85.04% killed):
+//!
+//!   - `crates/garraia-auth/src/sessions.rs:115` `verify_refresh → Ok(None)`
+//!   - `crates/garraia-auth/src/sessions.rs:158` `revoke → Ok(())`
+//!
+//! Mirrors the boot pattern from `tests/verify_internal.rs` (per-test
+//! container) rather than the process-wide `tests/common/harness.rs`
+//! (which is feature-gated to `test-support` for the RLS matrix). One test
+//! per mutant + a couple of negative-path companions to keep the audit
+//! trail clean.
+
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use garraia_auth::{
+    JwtConfig, JwtIssuer, LoginConfig, LoginPool, SessionId, SessionStore,
+};
+use garraia_workspace::{Workspace, WorkspaceConfig};
+use secrecy::{ExposeSecret, SecretString};
+use testcontainers::ContainerAsync;
+use testcontainers::ImageExt;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres as PgImage;
+use uuid::Uuid;
+
+/// Per-test fixture: container handle (kept alive for the duration of the
+/// test) + admin pool + the constructed `SessionStore` + a `JwtIssuer`
+/// suitable for issuing/verifying refresh tokens against the store.
+///
+/// Holding `_container` here is what keeps the Postgres instance alive
+/// across the test body — dropping `Fixture` mid-test would tear down the
+/// container and turn every subsequent query into a connection error.
+struct Fixture {
+    _container: ContainerAsync<PgImage>,
+    admin_pool: sqlx::PgPool,
+    store: SessionStore,
+    issuer: JwtIssuer,
+}
+
+async fn boot() -> anyhow::Result<Fixture> {
+    let container = PgImage::default()
+        .with_name("pgvector/pgvector")
+        .with_tag("pg16")
+        .start()
+        .await?;
+    let host = container.get_host().await?;
+    let port = container.get_host_port_ipv4(5432).await?;
+    let postgres_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+    // Apply migrations 001..010 (010 grants SELECT on sessions to garraia_login,
+    // which is required for verify_refresh to return rows).
+    Workspace::connect(WorkspaceConfig {
+        database_url: postgres_url.clone(),
+        max_connections: 5,
+        migrate_on_start: true,
+    })
+    .await?;
+
+    // Promote garraia_login to LOGIN with a known password (test-only).
+    let admin_pool = sqlx::PgPool::connect(&postgres_url).await?;
+    sqlx::query("ALTER ROLE garraia_login WITH LOGIN PASSWORD 'test-password'")
+        .execute(&admin_pool)
+        .await?;
+
+    let login_url = postgres_url.replace("postgres:postgres@", "garraia_login:test-password@");
+    let login_pool = Arc::new(
+        LoginPool::from_dedicated_config(&LoginConfig {
+            database_url: login_url,
+            max_connections: 4,
+        })
+        .await?,
+    );
+
+    let store = SessionStore::new(login_pool);
+    // Build the issuer via the public `JwtConfig` constructor (same pattern
+    // as the unit tests in `src/jwt.rs::tests::cfg`). The `new_for_test`
+    // helper is feature-gated to `test-support` and not visible from
+    // integration tests by default; using the public API keeps this file
+    // free of Cargo.toml feature toggles.
+    let issuer = JwtIssuer::new(JwtConfig {
+        jwt_secret: SecretString::from("q6-1-test-jwt-secret-32-bytes!!!".to_owned()),
+        refresh_hmac_secret: SecretString::from(
+            "q6-1-test-refresh-hmac-32-bytes!".to_owned(),
+        ),
+    })?;
+
+    Ok(Fixture {
+        _container: container,
+        admin_pool,
+        store,
+        issuer,
+    })
+}
+
+/// Insert a `users` row directly via the admin pool (bypassing RLS/grants
+/// the same way `verify_internal.rs::seed_user` does). Returns `user_id`.
+///
+/// Email uses the `.invalid` TLD (RFC 2606) plus a fresh UUID for safe
+/// parallel test execution.
+async fn seed_user(admin: &sqlx::PgPool) -> anyhow::Result<Uuid> {
+    let user_id = Uuid::now_v7();
+    let email = format!("session-test-{}@example.invalid", Uuid::now_v7());
+    sqlx::query(
+        "INSERT INTO users (id, email, display_name, status) \
+         VALUES ($1, $2, $3, 'active')",
+    )
+    .bind(user_id)
+    .bind(&email)
+    .bind(format!("Session Test {user_id}"))
+    .execute(admin)
+    .await?;
+    Ok(user_id)
+}
+
+/// Issue a refresh-token pair via `JwtIssuer`, then persist a `sessions`
+/// row via `SessionStore::issue`. Returns `(plaintext, session_id)`.
+async fn issue_session_for(
+    f: &Fixture,
+    user_id: Uuid,
+) -> anyhow::Result<(String, SessionId, DateTime<Utc>)> {
+    let pair = f.issuer.issue_refresh()?;
+    let (sid, expires_at) = f
+        .store
+        .issue(user_id, &pair.hmac_hash, None)
+        .await?;
+    Ok((pair.plaintext.expose_secret().to_string(), sid, expires_at))
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// verify_refresh — kills sessions.rs:115 `Ok(None)`
+// ───────────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn verify_refresh_returns_none_for_unknown_token() -> anyhow::Result<()> {
+    let f = boot().await?;
+    // No session ever issued → DB lookup returns 0 rows.
+    let result = f
+        .store
+        .verify_refresh("definitely-not-a-real-token", &f.issuer)
+        .await?;
+    assert!(
+        result.is_none(),
+        "verify_refresh must return None for an unknown plaintext"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn verify_refresh_returns_some_for_valid_token() -> anyhow::Result<()> {
+    let f = boot().await?;
+    let user_id = seed_user(&f.admin_pool).await?;
+    let (plaintext, sid, _exp) = issue_session_for(&f, user_id).await?;
+
+    let result = f.store.verify_refresh(&plaintext, &f.issuer).await?;
+    let Some((found_sid, found_uid)) = result else {
+        panic!(
+            "verify_refresh returned Ok(None) for the just-issued token — \
+             mutant `sessions.rs:115 → Ok(None)` triggers this panic"
+        );
+    };
+    assert_eq!(found_sid, sid);
+    assert_eq!(found_uid, user_id);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn verify_refresh_returns_none_for_revoked_session() -> anyhow::Result<()> {
+    let f = boot().await?;
+    let user_id = seed_user(&f.admin_pool).await?;
+    let (plaintext, sid, _exp) = issue_session_for(&f, user_id).await?;
+
+    // Revoke first.
+    f.store.revoke(sid).await?;
+
+    // Then verify must return None — the row has revoked_at set.
+    let result = f.store.verify_refresh(&plaintext, &f.issuer).await?;
+    assert!(
+        result.is_none(),
+        "verify_refresh must return None after revoke — mutant \
+         `sessions.rs:158 revoke → Ok(())` (no-op) leaves revoked_at NULL \
+         and would make this assertion fail"
+    );
+    Ok(())
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// revoke — kills sessions.rs:158 `Ok(())` (also covered above as a chain;
+// this is the focused, narrower test)
+// ───────────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn revoke_is_idempotent_and_persists() -> anyhow::Result<()> {
+    let f = boot().await?;
+    let user_id = seed_user(&f.admin_pool).await?;
+    let (plaintext, sid, _exp) = issue_session_for(&f, user_id).await?;
+
+    // First revoke succeeds and sets revoked_at = now().
+    f.store.revoke(sid).await?;
+
+    // Second revoke is a no-op (UPDATE ... AND revoked_at IS NULL matches 0
+    // rows). Must still return Ok(()) — both the real impl AND the mutant
+    // pass this assertion, BUT...
+    f.store.revoke(sid).await?;
+
+    // ...the verify_refresh below would return Some(...) under the mutant
+    // because revoked_at would still be NULL. The real impl revoked the row
+    // on the first call, so verify_refresh returns None.
+    let result = f.store.verify_refresh(&plaintext, &f.issuer).await?;
+    assert!(
+        result.is_none(),
+        "after revoke + idempotent re-revoke, verify_refresh must return None"
+    );
+
+    // Direct DB observation: revoked_at is non-NULL.
+    let revoked_at: Option<DateTime<Utc>> = sqlx::query_scalar(
+        "SELECT revoked_at FROM sessions WHERE id = $1",
+    )
+    .bind(sid.0)
+    .fetch_one(&f.admin_pool)
+    .await?;
+    assert!(
+        revoked_at.is_some(),
+        "revoked_at must be populated after revoke — mutant `Ok(())` (no-op) \
+         leaves it NULL"
+    );
+    Ok(())
+}

--- a/crates/garraia-auth/tests/sessions_lifecycle.rs
+++ b/crates/garraia-auth/tests/sessions_lifecycle.rs
@@ -16,9 +16,7 @@
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
-use garraia_auth::{
-    JwtConfig, JwtIssuer, LoginConfig, LoginPool, SessionId, SessionStore,
-};
+use garraia_auth::{JwtConfig, JwtIssuer, LoginConfig, LoginPool, SessionId, SessionStore};
 use garraia_workspace::{Workspace, WorkspaceConfig};
 use secrecy::{ExposeSecret, SecretString};
 use testcontainers::ContainerAsync;
@@ -83,9 +81,7 @@ async fn boot() -> anyhow::Result<Fixture> {
     // free of Cargo.toml feature toggles.
     let issuer = JwtIssuer::new(JwtConfig {
         jwt_secret: SecretString::from("q6-1-test-jwt-secret-32-bytes!!!".to_owned()),
-        refresh_hmac_secret: SecretString::from(
-            "q6-1-test-refresh-hmac-32-bytes!".to_owned(),
-        ),
+        refresh_hmac_secret: SecretString::from("q6-1-test-refresh-hmac-32-bytes!".to_owned()),
     })?;
 
     Ok(Fixture {
@@ -123,10 +119,7 @@ async fn issue_session_for(
     user_id: Uuid,
 ) -> anyhow::Result<(String, SessionId, DateTime<Utc>)> {
     let pair = f.issuer.issue_refresh()?;
-    let (sid, expires_at) = f
-        .store
-        .issue(user_id, &pair.hmac_hash, None)
-        .await?;
+    let (sid, expires_at) = f.store.issue(user_id, &pair.hmac_hash, None).await?;
     Ok((pair.plaintext.expose_secret().to_string(), sid, expires_at))
 }
 
@@ -216,12 +209,11 @@ async fn revoke_is_idempotent_and_persists() -> anyhow::Result<()> {
     );
 
     // Direct DB observation: revoked_at is non-NULL.
-    let revoked_at: Option<DateTime<Utc>> = sqlx::query_scalar(
-        "SELECT revoked_at FROM sessions WHERE id = $1",
-    )
-    .bind(sid.0)
-    .fetch_one(&f.admin_pool)
-    .await?;
+    let revoked_at: Option<DateTime<Utc>> =
+        sqlx::query_scalar("SELECT revoked_at FROM sessions WHERE id = $1")
+            .bind(sid.0)
+            .fetch_one(&f.admin_pool)
+            .await?;
     assert!(
         revoked_at.is_some(),
         "revoked_at must be populated after revoke — mutant `Ok(())` (no-op) \

--- a/crates/garraia-auth/tests/sessions_lifecycle.rs
+++ b/crates/garraia-auth/tests/sessions_lifecycle.rs
@@ -98,8 +98,11 @@ async fn boot() -> anyhow::Result<Fixture> {
 /// Email uses the `.invalid` TLD (RFC 2606) plus a fresh UUID for safe
 /// parallel test execution.
 async fn seed_user(admin: &sqlx::PgPool) -> anyhow::Result<Uuid> {
+    // Single UUID drives BOTH the row PK and the email — guarantees the
+    // identifier surfaced in `display_name` matches the inserted PK and
+    // keeps debugging simple when a test fails (one id to grep).
     let user_id = Uuid::now_v7();
-    let email = format!("session-test-{}@example.invalid", Uuid::now_v7());
+    let email = format!("session-test-{user_id}@example.invalid");
     sqlx::query(
         "INSERT INTO users (id, email, display_name, status) \
          VALUES ($1, $2, $3, 'active')",
@@ -196,12 +199,14 @@ async fn revoke_is_idempotent_and_persists() -> anyhow::Result<()> {
 
     // Second revoke is a no-op (UPDATE ... AND revoked_at IS NULL matches 0
     // rows). Must still return Ok(()) — both the real impl AND the mutant
-    // pass this assertion, BUT...
+    // `Ok(())` pass this call. The discrimination between real and mutant
+    // comes from the `verify_refresh` and SELECT assertions below, NOT from
+    // this second `revoke` call.
     f.store.revoke(sid).await?;
 
-    // ...the verify_refresh below would return Some(...) under the mutant
-    // because revoked_at would still be NULL. The real impl revoked the row
-    // on the first call, so verify_refresh returns None.
+    // Under the mutant, `revoked_at` would still be NULL (first revoke was
+    // a no-op), so `verify_refresh` would return Some(...). The real impl
+    // revoked the row on the first call, so `verify_refresh` returns None.
     let result = f.store.verify_refresh(&plaintext, &f.issuer).await?;
     assert!(
         result.is_none(),

--- a/crates/garraia-auth/tests/verify_internal.rs
+++ b/crates/garraia-auth/tests/verify_internal.rs
@@ -440,3 +440,50 @@ async fn create_identity_is_deferred_to_391c() -> anyhow::Result<()> {
         other => panic!("expected NotImplemented (deferred to 391c), got: {other:?}"),
     }
 }
+
+// ───────────────────────────────────────────────────────────────────────────
+// GAR-463 Q6.1 — kill `verify_credential → Ok(None)` (internal.rs:286)
+//
+// All other tests in this file call `verify_credential_with_ctx` directly,
+// leaving the trait-level entry point (`IdentityProvider::verify_credential`)
+// unexercised. cargo-mutants reports the trait method's `Ok(None)` mutant as
+// missed because nothing observes its delegation. This test exercises the
+// trait method via a `&dyn IdentityProvider` and asserts the happy path.
+// ───────────────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn verify_credential_trait_method_happy_path() -> anyhow::Result<()> {
+    let f = boot().await?;
+    let pw = SecretString::from("correct horse battery staple".to_owned());
+    let phc = hash_argon2id(&pw)?;
+
+    // .invalid TLD per RFC 2606 + UUID for safe parallel test execution.
+    let email = format!("trait-method-{}@example.invalid", Uuid::now_v7());
+    let (user_id, _identity_id) = seed_user(&f.admin_pool, &email, Some(&phc), "active").await?;
+
+    // Call THROUGH the IdentityProvider trait, not `_with_ctx` directly.
+    // The trait method is a simple delegation
+    // (`verify_credential_with_ctx(cred, &RequestCtx::default())`); the
+    // mutant `Ok(None)` would skip that call entirely.
+    let provider: &dyn IdentityProvider = f.provider.as_ref();
+    let cred = Credential::Internal {
+        email: email.clone(),
+        password: pw,
+    };
+    let result = provider
+        .verify_credential(&cred)
+        .await
+        .expect("trait verify_credential must not error on a valid credential");
+
+    match result {
+        Some(uid) => assert_eq!(
+            uid, user_id,
+            "trait method must return the same user id as the seeded user"
+        ),
+        None => panic!(
+            "trait method returned Ok(None) for a valid credential — \
+             mutant `internal.rs:286 → Ok(None)` triggers this panic"
+        ),
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Tests-only PR matando os 5 mutantes críticos de segurança escapados do baseline `cargo-mutants` em `garraia-auth` (mutation score 85.04%, run [25072579785](https://github.com/michelbr84/GarraRUST/actions/runs/25072579785), doc `docs/mutation-baseline-2026-04.md` shipped em PR #91).

Closes Q6.1 ([GAR-463](https://linear.app/chatgpt25/issue/GAR-463/q61-mutation-testing-security-verification-bypass-coverage)). Sub-issue de [GAR-436](https://linear.app/chatgpt25/issue/GAR-436/q6-cargo-mutants-piloto-em-garraia-auth) / epic [GAR-430](https://linear.app/chatgpt25/issue/GAR-430/epic-quality-gates-phase-36-plan-foamy-origami).

## Mutants killed

| File:Line | Mutant | Test |
|-----------|--------|------|
| \`crates/garraia-auth/src/hashing.rs:81\` | \`verify_pbkdf2 → Ok(true)\` | \`pbkdf2_rejects_wrong_password\` (+ \`pbkdf2_accepts_correct_password\` baseline + \`pbkdf2_rejects_argon2id_phc\`) |
| \`crates/garraia-auth/src/hashing.rs:107\` | \`consume_dummy_hash → Ok(())\` | \`consume_dummy_hash_performs_real_argon2_work\` (timing assertion ≥ 8 ms with 10 s upper-bound sanity check) |
| \`crates/garraia-auth/src/internal.rs:286\` | \`verify_credential → Ok(None)\` (trait method) | \`verify_credential_trait_method_happy_path\` (calls via \`&dyn IdentityProvider\`) |
| \`crates/garraia-auth/src/sessions.rs:115\` | \`verify_refresh → Ok(None)\` | \`verify_refresh_returns_some_for_valid_token\` + 2 negative paths (unknown / revoked) |
| \`crates/garraia-auth/src/sessions.rs:158\` | \`revoke → Ok(())\` | \`revoke_is_idempotent_and_persists\` (direct DB observation of \`revoked_at\` via admin pool SELECT) |

## Tests-only confirmation

- Diff: 386 LOC adicionadas em 3 arquivos (\`src/hashing.rs::tests\`, \`tests/verify_internal.rs\`, \`tests/sessions_lifecycle.rs\` — novo).
- \`git diff origin/main -- Cargo.toml Cargo.lock crates/garraia-auth/Cargo.toml\` → **empty**.
- Zero produção runtime change.

## Local commands run

- \`cargo fmt --check --all\` ✓
- \`cargo check -p garraia-auth --locked\` ✓
- \`cargo +1.92 check --workspace --exclude garraia-desktop --locked\` ✓ (MSRV)
- \`cargo clippy -p garraia-auth --all-targets -- -D warnings\` ✓
- \`cargo test -p garraia-auth --lib\` ✓ (48 unit tests passing)
- \`cargo test -p garraia-auth --no-run\` ✓ (integration tests compile)
- \`cargo test -p garraia-auth --test sessions_lifecycle\` — **bloqueado localmente** (Docker daemon offline na máquina de dev; same constraint as \`verify_internal.rs\`). CI Linux job tem Docker preinstalado.
- \`cargo mutants --package garraia-auth ...\` — **gap local** (cargo-mutants ausente). Validação via \`gh workflow run mutants.yml --ref main\` agendada após merge.

## Reviews (parallel pass)

- **code-reviewer**: 1 BLOCKER (B-1 dupla \`Uuid::now_v7()\` em seed_user) + 2 improvements ✓ aplicados
- **security-auditor**: 8.5/10, 1 MEDIUM (timing upper-bound) + 2 LOW ✓ aplicados (LOW expired-token deferido para Q6.3)
- **test-engineer**: ship it, <0.1% flake estimate, sem must-fix
- **privacy-hygiene**: APPROVED, sem hits
- **metrics-analyst**: 386 LOC (77% budget), 9 testes novos, 0 deps novas, 11 gates esperados

Fix-forward commit \`1ccc3f9\` aplicou todos os blockers + medium + low actionables.

## Risks & rollback

- **Timing test em CI**: threshold 8 ms tem ~1000× headroom sobre mutante (~µs) e ≥ 4× sob lower bound real (~30 ms commodity, ~80 ms Windows GHA worst-case). Upper bound 10 s detecta runner-starvation. Se flakar mesmo assim, fix-forward trivial: bump threshold para 4 ms ou \`#[ignore]\` no Windows runner.
- **PBKDF2 fixture**: PHC determinístico (salt fixo \`Y3JhYi1zYWx0LWZpeGVk\` = 15 bytes ASCII \"crab-salt-fixed\", senha pública xkcd-936 \"correct horse battery staple\", i=600_000). Reproduzível pelo snippet docstring. Zero PII, zero secret real.
- **JWT test secrets**: literais 32-byte (\`q6-1-test-jwt-secret-32-bytes!!!\` e \`q6-1-test-refresh-hmac-32-bytes!\`) em \`tests/sessions_lifecycle.rs::boot()\`. Nunca tocam env vars de produção.
- **Rollback**: \`git revert <merge-sha>\` — sem produção tocada, rollback é zero-risco.

## Linear

- Q6.1 (this PR): https://linear.app/chatgpt25/issue/GAR-463
- Q6.2 (boundary tests): https://linear.app/chatgpt25/issue/GAR-464
- Q6.3 (TTL / time arithmetic, includes expired-token follow-up): https://linear.app/chatgpt25/issue/GAR-465
- Q6.4 (unique-violation): https://linear.app/chatgpt25/issue/GAR-466
- Q6.5 (audit observability): https://linear.app/chatgpt25/issue/GAR-467
- Q6.6 (Debug skip annotations): https://linear.app/chatgpt25/issue/GAR-468
- Q6.7 (mutants timeout 90→120): https://linear.app/chatgpt25/issue/GAR-469
- Parent: https://linear.app/chatgpt25/issue/GAR-436
- Epic: https://linear.app/chatgpt25/issue/GAR-430

🤖 Generated with [Claude Code](https://claude.com/claude-code)