### PR TITLE
ci(mutation): GAR-469 Q6.7 — bump mutants.yml timeout 90→150 min

### DIFF
--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -55,7 +55,14 @@ jobs:
   mutants:
     name: cargo-mutants (garraia-auth pilot)
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    # 150 min based on empirical evidence from run 25109221846 (GAR-469 Q6.7):
+    # 154 of 179 mutants processed in the 90-min window before cancellation
+    # (~35s per outcome with build overhead included). Completing all 179 needs
+    # ~105 min wall-clock; 150 leaves ~45 min (~43%) headroom for future test
+    # growth and slow shared-runner conditions. If the suite ever exceeds this
+    # again, the next step is shard/parallel (open a follow-up issue), not a
+    # blind bump to 180+.
+    timeout-minutes: 150
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Surgical bump of `.github/workflows/mutants.yml` `timeout-minutes` from `90` to `150` based on empirical evidence from the post-Q6.1 rerun (run [25109221846](https://github.com/michelbr84/GarraRUST/actions/runs/25109221846), cancelled at 1h30m).

Closes Q6.7 ([GAR-469](https://linear.app/chatgpt25/issue/GAR-469/q67-mutation-workflow-timeout-90150-min)). Sub-issue of [GAR-436](https://linear.app/chatgpt25/issue/GAR-436) / epic [GAR-430](https://linear.app/chatgpt25/issue/GAR-430).

## Empirical justification

The cancelled rerun **already validated Q6.1's 5 critical mutants as CAUGHT** (see artifact `mutants-report-25109221846`):

| Q6.1 target | Status |
|-------------|--------|
| `hashing.rs:81 verify_pbkdf2 → Ok(true)` | ✅ CAUGHT |
| `hashing.rs:107 consume_dummy_hash → Ok(())` | ✅ CAUGHT |
| `internal.rs:286 verify_credential → Ok(None)` | ✅ CAUGHT |
| `sessions.rs:115 verify_refresh → Ok(None)` | ✅ CAUGHT |
| `sessions.rs:158 revoke → Ok(())` | ✅ CAUGHT |

Bonus: 3 sessions.rs mutants from Q6.3 scope (lines 81, 136, 147) also CAUGHT.

The cancellation cost us only the score-publication step, not security validation.

### Why 150 (not 120, not 180)

- Run processed **154 of 179 mutants in 90 min** = ~35s per outcome (build overhead included).
- 25 remaining × ~35s = ~15 min more → **~105 min** to complete all 179.
- 150 min leaves **~45 min (~43%) headroom** for future test growth and slow shared-runner conditions.
- The original Q6.7 proposal (120 min) was written before the new 179-mutant baseline; 120 would still risk cancellation under jitter.
- 180 would be conservatism without evidence.

If the suite ever exceeds 150 min, the right answer is shard/parallel (open a follow-up), not a blind bump.

## Diff

1 file changed, +8/-1 lines:

```yaml
# .github/workflows/mutants.yml
-    timeout-minutes: 90
+    # 150 min based on empirical evidence from run 25109221846 (GAR-469 Q6.7):
+    # 154 of 179 mutants processed in the 90-min window before cancellation
+    # (~35s per outcome with build overhead included). Completing all 179 needs
+    # ~105 min wall-clock; 150 leaves ~45 min (~43%) headroom for future test
+    # growth and slow shared-runner conditions. If the suite ever exceeds this
+    # again, the next step is shard/parallel (open a follow-up issue), not a
+    # blind bump to 180+.
+    timeout-minutes: 150
```

## Out of scope (deferred follow-ups)

- **Node 24 migration** for `actions/checkout`, `actions/cache`, `actions/upload-artifact`. Repo is 100% v4 today with no prior v5 pattern; GHA forced-switch deadline is 2026-06-02 (~34 days lead time). Will open a separate issue.
- **Shard / parallel** mutants — only if 150 min ever proves insufficient.

## Validation

- yaml-only change, no Rust, no Cargo.toml/Cargo.lock touched (`git diff origin/main -- Cargo.toml Cargo.lock` empty).
- Workflow is `schedule + workflow_dispatch` only; PR doesn't trigger it.
- Post-merge plan: `gh workflow run mutants.yml --ref main` to validate end-to-end with the new timeout.

## Risks & rollback

- **Zero risk to production**: yaml infra-only, schedule-only workflow, never blocks main.
- **Rollback**: trivial `git revert <merge-sha>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)