### PR TITLE
ci(actions): GAR-481 Q6.8 — migrate workflows to Node 24 (v4 → latest)

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -66,7 +66,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install stable Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -39,7 +39,7 @@ jobs:
     # qualquer warning novo em crates ativos falha CI.
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run cargo-deny (advisories + bans + licenses + sources)
         uses: EmbarkStudios/cargo-deny-action@v2
@@ -85,7 +85,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Dependency Review
         uses: actions/dependency-review-action@v4
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Gitleaks needs the full history to scan commits reachable from
           # the PR tip — shallow clones miss the diff baseline on push.
@@ -128,13 +128,13 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -215,7 +215,7 @@ jobs:
       pull-requests: write   # required for gh pr comment
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Plan abundant-thimble (GAR-439 slice 9.a, 2026-04-28): the default
       # GHA `ubuntu-latest` runner ships with ~14 GB free disk. The combo of
@@ -241,7 +241,7 @@ jobs:
           components: llvm-tools-preview
 
       - name: Cache cargo registry + target
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -284,7 +284,7 @@ jobs:
         run: cargo llvm-cov report --summary-only > coverage-summary.txt
 
       - name: Upload lcov artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-lcov-${{ github.run_id }}
           path: lcov.info
@@ -292,7 +292,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload textual summary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-summary-${{ github.run_id }}
           path: coverage-summary.txt
@@ -330,7 +330,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -356,7 +356,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust 1.92
         uses: dtolnay/rust-toolchain@1.92
@@ -408,7 +408,7 @@ jobs:
       GARRAIA_SIGNUP_DATABASE_URL: "postgres://postgres:postgres@localhost:5432/garraia_workspace_test"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Fake CI-only secrets are still printed in logs by default. Mask them
       # so the pattern doesn't become a precedent for real secrets later.
@@ -427,7 +427,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry/index/
@@ -539,7 +539,7 @@ jobs:
         working-directory: tests
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # See `e2e` job for rationale — mask CI-only fake secrets.
       - name: Mask CI-only fake secrets
@@ -553,7 +553,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry/index/
@@ -567,9 +567,9 @@ jobs:
         run: cargo build --bin garraia --release
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: tests/package-lock.json
 
@@ -626,7 +626,7 @@ jobs:
 
       - name: Upload test report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: tests/playwright-report/
@@ -652,7 +652,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install stable Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -65,7 +65,7 @@ jobs:
     timeout-minutes: 150
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -73,7 +73,7 @@ jobs:
       - name: Cache cargo registry + target
         # Isolated prefix to avoid collision with the main `ci.yml` job
         # caches (which compile without mutation instrumentation).
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -122,7 +122,7 @@ jobs:
         # logs, and the summary. 30d retention is enough to compare across
         # ~4 weekly runs.
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mutants-report-${{ github.run_id }}
           path: mutants.out/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -37,7 +37,7 @@ jobs:
           chmod +x release/garraia-linux-x86_64
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: garraia-linux-x86_64
           path: release/garraia-linux-x86_64
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -66,7 +66,7 @@ jobs:
           chmod +x release/garraia-linux-arm64
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: garraia-linux-arm64
           path: release/garraia-linux-arm64
@@ -77,7 +77,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -92,7 +92,7 @@ jobs:
           cp target/release/garraia.exe release/garraia-windows-x86_64.exe
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: garraia-windows-x86_64
           path: release/garraia-windows-x86_64.exe
@@ -103,7 +103,7 @@ jobs:
     runs-on: macos-13
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -118,7 +118,7 @@ jobs:
           chmod +x release/garraia-macos-x86_64
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: garraia-macos-x86_64
           path: release/garraia-macos-x86_64
@@ -129,7 +129,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -144,7 +144,7 @@ jobs:
           chmod +x release/garraia-macos-arm64
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: garraia-macos-arm64
           path: release/garraia-macos-arm64
@@ -158,12 +158,12 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: artifacts
 


### PR DESCRIPTION
## Summary

Bumps GitHub-native `actions/*` JavaScript actions used across the 5 workflows (`ci.yml`, `mutants.yml`, `cargo-audit.yml`, `deploy.yml`, `release.yml`) from v4 to the latest stable major. All targets ship with Node 24 to avoid the **2026-06-02 forced-switch deadline** flagged on run [25109221846](https://github.com/michelbr84/GarraRUST/actions/runs/25109221846).

Closes Q6.8 ([GAR-481](https://linear.app/chatgpt25/issue/GAR-481/q68-migrate-github-actions-to-node-24-before-2026-06-02-forced-switch)). Sibling of [GAR-469](https://linear.app/chatgpt25/issue/GAR-469) (Q6.7 timeout, merged in PR #93).

## Changes — Option A (version bumps, not env-var workaround)

| Action | Before | After | Rationale |
|--------|--------|-------|-----------|
| \`actions/checkout\` | v4 | **v6** | latest v6.0.2 (2026-01-09); first major with Node 24 |
| \`actions/cache\` | v4 | **v5** | latest v5.0.5 (2026-04-13); Node 24 |
| \`actions/upload-artifact\` | v4 | **v7** | latest v7.0.1 (2026-04-10); Node 24 + ESM, includes optional direct uploads |
| \`actions/download-artifact\` | v4 | **v7** | paired with upload v7 — v8 exists but cross-major upload/download has historically been risky |
| \`actions/setup-node\` | v4 | **v6** | latest v6.4.0 (2026-04-20); Node 24. Also bumps \`node-version: '20'\` → \`'24'\` in \`ci.yml:572\` |

## Out of scope (intentionally untouched)

- \`actions/dependency-review-action@v4\` (\`ci.yml:91\`) — latest is v4.9.0 from 2026-03-03; **no v5 published yet**. Will be addressed in a follow-up if/when v5 lands or if GHA forced-switches it.
- Third-party actions: \`dtolnay/rust-toolchain\`, \`docker/*\`, \`softprops/action-gh-release\`, \`EmbarkStudios/cargo-deny-action\`, \`aws-actions/configure-aws-credentials\`, \`taiki-e/install-action\` — out of scope per "official \`actions/*\` only" guidance from the user. Each has its own deprecation cadence.

## Diff

5 files changed, +39/-39 lines (all mechanical \`uses:\` line bumps + 1 \`node-version\` change).

```
.github/workflows/cargo-audit.yml |  2 +-
.github/workflows/ci.yml          | 42 +++++++++++++++++++--------------------
.github/workflows/deploy.yml      |  4 ++--
.github/workflows/mutants.yml     |  6 +++---
.github/workflows/release.yml     | 24 +++++++++++-----------
```

## Validation

**This PR:**
- 14 CI gates run on PR (the upgraded \`ci.yml\` itself is exercised). If checkout/cache/upload-artifact/setup-node v6/v5/v7/v6 fail, this PR catches it.
- yaml-only change, no Rust touched, no Cargo.toml/Cargo.lock.

**Post-merge:**
- Run \`mutants.yml\` via \`workflow_dispatch\` → expect Node 20 deprecation warning **gone**, run completes within 150-min budget (validated empirically by PR #93/run 25116031135).
- \`cargo-audit.yml\` runs on schedule (daily 07:00 UTC) → first warning-free run within 24h.
- \`deploy.yml\` and \`release.yml\` run on tag push only → not exercised in this PR; tag-safe per construction (only \`checkout\` + \`upload-artifact\`/\`download-artifact\` swaps, no behavior changes).

## Risks & rollback

- **`upload-artifact@v7` ESM**: previously CommonJS. Should be transparent to user-facing config; flagged here for transparency.
- **`setup-node@v6` cache change**: v6 release notes say "Limit automatic caching to npm". Our config explicitly passes `cache: 'npm'` so no behavior change expected.
- **`download-artifact@v7` paired with `upload-artifact@v7`**: matched majors, GitHub's documented compatibility surface.
- **Rollback**: trivial \`git revert <merge-sha>\`. No production code touched.

## Risk classification: LOW

Mechanical version bump on Github-native infra actions only. No third-party action surface change. No application logic.

## Linear

- GAR-481 (Q6.8, this PR): https://linear.app/chatgpt25/issue/GAR-481
- Sibling GAR-469 (Q6.7, Done): https://linear.app/chatgpt25/issue/GAR-469
- Epic: GAR-430 (Quality Gates Phase 3.6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)