### PR TITLE
test(auth): GAR-468 Q6.6 — kill 3 Debug-redaction mutation bypasses (tests-only)

### DIFF
--- a/crates/garraia-auth/src/jwt.rs
+++ b/crates/garraia-auth/src/jwt.rs
@@ -411,6 +411,59 @@ mod tests {
         assert_eq!(recomputed, pair.hmac_hash);
     }
 
+    /// GAR-468 Q6.6 — kills mutant `jwt.rs:63` (`Debug for JwtConfig`
+    /// → `Ok(Default::default())`). The `Debug` impl is hand-rolled to
+    /// redact both secrets; this test asserts the redaction is observable
+    /// (the mutant produces empty output that lacks `[REDACTED]` markers).
+    #[test]
+    fn debug_for_jwt_config_redacts_both_secrets() {
+        let cfg = JwtConfig {
+            jwt_secret: SecretString::from("jwt-super-secret-32-bytes-AAAA!!".to_owned()),
+            refresh_hmac_secret: SecretString::from("refresh-hmac-32-bytes-BBBBBBBBB!!".to_owned()),
+        };
+        let dbg = format!("{cfg:?}");
+        assert!(
+            !dbg.contains("jwt-super-secret"),
+            "Debug must not leak jwt_secret: {dbg}"
+        );
+        assert!(
+            !dbg.contains("refresh-hmac"),
+            "Debug must not leak refresh_hmac_secret: {dbg}"
+        );
+        assert!(
+            dbg.contains("[REDACTED]"),
+            "redaction marker missing: {dbg}"
+        );
+    }
+
+    /// GAR-468 Q6.6 — kills mutant `jwt.rs:81` (`Debug for RefreshTokenPair`
+    /// → `Ok(Default::default())`). Asserts the plaintext is masked and
+    /// the hmac_hash is hex-redacted, regardless of input.
+    #[test]
+    fn debug_for_refresh_token_pair_redacts_plaintext_and_hash() {
+        let pair = RefreshTokenPair {
+            plaintext: SecretString::from("super-secret-token-plaintext-XYZ".to_owned()),
+            hmac_hash: "deadbeefcafebabe1234567890abcdef".to_owned(),
+        };
+        let dbg = format!("{pair:?}");
+        assert!(
+            !dbg.contains("super-secret-token"),
+            "Debug must not leak plaintext: {dbg}"
+        );
+        assert!(
+            !dbg.contains("deadbeefcafebabe"),
+            "Debug must not leak hmac_hash: {dbg}"
+        );
+        assert!(
+            dbg.contains("[REDACTED]"),
+            "plaintext marker missing: {dbg}"
+        );
+        assert!(
+            dbg.contains("[HEX_REDACTED]"),
+            "hmac_hash marker missing: {dbg}"
+        );
+    }
+
     #[test]
     fn new_for_test_and_issue_access_for_test_roundtrip() {
         // Short secret: padded to 32 bytes internally.

--- a/crates/garraia-auth/src/types.rs
+++ b/crates/garraia-auth/src/types.rs
@@ -105,3 +105,41 @@ pub struct LoginOutcome {
     pub refresh_token: SecretString,
     pub expires_at: DateTime<Utc>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// GAR-468 Q6.6 — kills mutant `types.rs:47` (`Debug for Credential`
+    /// → `Ok(Default::default())`). Asserts the password is masked while
+    /// the email is preserved (emails are non-secret identifiers; passwords
+    /// are SecretString and must never reach `Debug` output).
+    #[test]
+    fn debug_for_credential_internal_redacts_password() {
+        let cred = Credential::Internal {
+            email: "alice@example.invalid".to_owned(),
+            password: SecretString::from("super-secret-password-XYZ".to_owned()),
+        };
+        let dbg = format!("{cred:?}");
+        assert!(
+            !dbg.contains("super-secret-password"),
+            "Debug must not leak password: {dbg}"
+        );
+        assert!(
+            dbg.contains("[REDACTED]"),
+            "redaction marker missing: {dbg}"
+        );
+        // Email is intentionally preserved — it is a non-secret identifier
+        // and is allowed to surface in structured logs.
+        assert!(
+            dbg.contains("alice@example.invalid"),
+            "email should be visible (it is not a secret): {dbg}"
+        );
+        // Variant tag should be present — confirms structured output (the
+        // mutant `Ok(Default::default())` produces an empty `()` instead).
+        assert!(
+            dbg.contains("Credential::Internal"),
+            "variant tag missing: {dbg}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Tests-only PR adding 3 unit tests for hand-rolled Debug impls in \`garraia-auth\`. Kills 3 of the 5 Debug-redaction mutants flagged in the complete mutation run [25116031135](https://github.com/michelbr84/GarraRUST/actions/runs/25116031135) (mapped to Q6.6 in PR #94 baseline doc update).

Closes Q6.6 ([GAR-468](https://linear.app/chatgpt25/issue/GAR-468/q66-mutation-testing-debug-impl-skip-annotations)) — 3 of 5 caught here, 2 explicitly deferred to follow-up Q6.6.b (see "Out of scope" below).

## Mutants killed

| File:Line | Mutant | Test |
|-----------|--------|------|
| \`jwt.rs:63\` | \`Debug for JwtConfig → Ok(Default::default())\` | \`debug_for_jwt_config_redacts_both_secrets\` |
| \`jwt.rs:81\` | \`Debug for RefreshTokenPair → Ok(Default::default())\` | \`debug_for_refresh_token_pair_redacts_plaintext_and_hash\` |
| \`types.rs:47\` | \`Debug for Credential → Ok(Default::default())\` | \`debug_for_credential_internal_redacts_password\` (in new \`mod tests\` block) |

Each test asserts:
1. The plaintext secret/PII is **not** present in the formatted output.
2. The redaction marker (\`[REDACTED]\` / \`[HEX_REDACTED]\`) **is** present.
3. Variant tags / non-secret identifiers are preserved (mutant produces empty output and fails these).

## Out of scope (Q6.6.b follow-up)

The remaining 2 Debug mutants — \`signup_pool.rs:153\` (\`Debug for SignupPool\`) and \`app_pool.rs:218\` (\`Debug for AppPool\`) — could not be killed within the rules of this PR:

- **Strategy A** (\`#[cfg_attr(test, mutants::skip)]\`): requires \`mutants\` as dev-dependency, which would change \`Cargo.toml\` (forbidden by spec).
- **Strategy B** (test-only constructor): would need a feature-gated \`for_test\` factory taking a raw \`PgPool\`, which is production-touch scope creep.
- **Strategy C** (testcontainer-backed integration test): valid path, but doubles the integration-test budget and exceeds the "tiny PR" intent.

**Both Debug impls print only hardcoded literal strings** (\`"<PgPool[garraia_signup]>"\` / \`"<PgPool[garraia_app]>"\`) and do not include the inner \`PgPool\`'s connection URL — so the mutant \`Ok(Default::default())\` is benign by construction. Will be filed as Q6.6.b for testcontainer coverage.

## Tests-only

- 2 files modified, +91 LOC (under the user's 100 LOC ideal cap).
- \`git diff origin/main -- Cargo.toml Cargo.lock\` → empty.
- Production runtime untouched.

## Local commands run

- \`cargo fmt --check --all\` ✓
- \`cargo check -p garraia-auth --locked --tests\` ✓
- \`cargo +1.92 check --workspace --exclude garraia-desktop --locked\` ✓ (MSRV)
- \`cargo clippy -p garraia-auth --all-targets -- -D warnings\` ✓ (zero warnings)
- \`cargo test -p garraia-auth --lib\` ✓ (51 tests pass, +3 new)

## Risks & rollback

- **Zero risk to production**: tests-only.
- **Test fixtures**: synthetic public strings only (\`"jwt-super-secret-..."\`, xkcd-936-style, no real secrets), \`@example.invalid\` per RFC 2606.
- **Rollback**: trivial \`git revert <merge-sha>\`.

## Expected mutation score impact

- Before: 90.78% (128/141 killed)
- After: ~92.91% (131/141 killed = +2.13 p.p.)
- Path to 94.33% target: kill the remaining 2 Debug mutants in Q6.6.b follow-up.

## Linear

- GAR-468 (Q6.6, this PR): https://linear.app/chatgpt25/issue/GAR-468
- Parent: [GAR-436](https://linear.app/chatgpt25/issue/GAR-436) (Q6 baseline)
- Epic: [GAR-430](https://linear.app/chatgpt25/issue/GAR-430) (Quality Gates Phase 3.6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)