### PR TITLE
security(deps): GAR-484 — close 5 Dependabot advisories via lockfile-only updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1164,7 +1164,7 @@ dependencies = [
  "log",
  "num",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rustls 0.23.36",
  "rustls-native-certs",
  "rustls-pki-types",
@@ -1368,7 +1368,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
 dependencies = [
  "ambient-authority",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1947,7 +1947,7 @@ checksum = "6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3"
 dependencies = [
  "crc",
  "digest 0.10.7",
- "rand 0.9.2",
+ "rand 0.9.3",
  "regex",
  "rustversion",
 ]
@@ -3199,8 +3199,8 @@ dependencies = [
  "jsonwebtoken",
  "password-hash",
  "pbkdf2",
- "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.8.6",
+ "rand 0.9.3",
  "secrecy 0.10.3",
  "serde",
  "serde_json",
@@ -3449,7 +3449,7 @@ version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
  "garraia-common",
- "rand 0.9.2",
+ "rand 0.9.3",
  "regex",
  "ring",
  "serde",
@@ -3556,7 +3556,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "pgvector",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "scopeguard",
  "serde",
@@ -3907,7 +3907,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.3",
  "smallvec",
  "spinning_top",
  "web-time",
@@ -3930,7 +3930,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.3",
  "smallvec",
  "spinning_top",
  "web-time",
@@ -5558,7 +5558,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -5947,7 +5947,7 @@ dependencies = [
  "once_cell",
  "opentelemetry",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
@@ -6225,7 +6225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -6235,7 +6235,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -6809,7 +6809,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls 0.23.36",
@@ -6866,9 +6866,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -6877,9 +6877,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -8418,7 +8418,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1",
@@ -8459,7 +8459,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -8989,7 +8989,7 @@ checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
 dependencies = [
  "log",
  "notify-rust",
- "rand 0.9.2",
+ "rand 0.9.3",
  "serde",
  "serde_json",
  "serde_repr",
@@ -9755,7 +9755,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -10014,7 +10014,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustls 0.22.4",
  "rustls-pki-types",
  "sha1",
@@ -10034,7 +10034,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rustls 0.23.36",
  "rustls-pki-types",
  "sha1",
@@ -10053,7 +10053,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.3",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",

--- a/benches/database-poc/Cargo.lock
+++ b/benches/database-poc/Cargo.lock
@@ -755,7 +755,7 @@ dependencies = [
  "chrono",
  "deunicode",
  "dummy",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -955,7 +955,7 @@ dependencies = [
  "fake",
  "hdrhistogram",
  "pgvector",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rusqlite",
  "serde",
@@ -1672,7 +1672,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -1992,9 +1992,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2238,9 +2238,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2648,7 +2648,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1",
@@ -2688,7 +2688,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",


### PR DESCRIPTION
## Summary

Manual follow-up to Dependabot PRs #97 (time + bench lockfile refresh) and #99 (openssl bump), closing the **residual lockfile-only advisories** that were not covered by either Dependabot PR. Zero production runtime change. MSRV 1.92 preserved.

Tracks under [GAR-484](https://linear.app/chatgpt25/issue/GAR-484/q10-dependabot-triage-2026-04-29-sessao-snuggly-pillow) (Q10 Dependabot triage 2026-04-29, sessão snuggly-pillow).

## Alerts closed (6)

| # | Sev | Pkg | Lockfile | Mechanism |
|---|-----|-----|----------|-----------|
| 24 | Low  | rand 0.9.2 → 0.9.3 | `Cargo.lock` | `cargo update -p rand@0.9.2 --precise 0.9.3` |
| 25 | Low  | rand 0.8.5 → 0.8.6 | `Cargo.lock` | `cargo update -p rand@0.8.5 --precise 0.8.6` |
| 33 | Low  | rustls-webpki 0.103.11 → 0.103.13 (RUSTSEC-2026-0098) | `benches/database-poc/Cargo.lock` | `cargo update -p rustls-webpki --precise 0.103.13` |
| 34 | Low  | rustls-webpki 0.103.11 → 0.103.13 (RUSTSEC-2026-0099) | bench | same bump |
| 35 | Low  | rand 0.8.5 → 0.8.6 | bench | `cargo update -p rand@0.8.5 --precise 0.8.6` |
| 38 | High | rustls-webpki 0.103.11 → 0.103.13 (RUSTSEC-2026-0104) | bench | same bump as #33/#34 |

(Three rustls-webpki alerts are distinct advisory IDs that all happen to be fixed by the same 0.103.13 bump.)

## Alerts already closed by #97 / #99 (7)

| # | Sev | Pkg | Closed by |
|---|-----|-----|-----------|
| 26, 27, 28, 30 | High | openssl 0.10.75 → 0.10.78 | PR #99 |
| 29 | Low  | openssl | PR #99 |
| 31 | High | tokio-tar → astral-tokio-tar | PR #97 (testcontainers 0.23 → 0.27.3 lockfile refresh) |
| 32 | Med  | time 0.3.45 → 0.3.47 | PR #97 |

## Alerts deferred to dedicated Linear (7)

| # | Pkg | Tracked by |
|---|-----|------------|
| 7 | jsonwebtoken | [GAR-485](https://linear.app/chatgpt25/issue/GAR-485) (Q10.a, major bump 9 → 10, dedicated impact analysis) |
| 11, 22, 23, 37 | rustls-webpki 0.102.x residual via serenity 0.12.5 | [GAR-455](https://linear.app/chatgpt25/issue/GAR-455) (no upstream fix; allowlisted in `.cargo/audit.toml`) |
| 2 | glib | [GAR-430](https://linear.app/chatgpt25/issue/GAR-430) (desktop-only via Tauri/gtk-rs, allowlisted) |
| 5 | lru | [GAR-437](https://linear.app/chatgpt25/issue/GAR-437) (transitive via aws-sdk-s3, allowlisted) |

Final state: **20 → 7** open Dependabot alerts (13 closed: 6 by this PR, 7 by prior #97/#99). All 7 remaining have explicit upstream-blocked or major-bump Linear ownership.

## Validation

- `cargo fmt --check --all` ✅
- `cargo check --workspace --exclude garraia-desktop --locked` ✅
- `(cd benches/database-poc && cargo check --locked)` ✅
- `cargo audit` (root) ✅ — 22 allowed warnings, 0 vulnerabilities (unchanged from main)
- `cargo deny check` ✅ — `advisories ok, bans ok, licenses ok, sources ok`
- `cargo audit` (bench) — 1 vulnerability remaining: `rsa 0.9.10` RUSTSEC-2023-0071, **already allowlisted** in `.cargo/audit.toml` line 57 under [GAR-456](https://linear.app/chatgpt25/issue/GAR-456) (sqlx-mysql lockfile leak, defense-in-depth via `default-features = false` on sqlx)

## MSRV impact

None. All target versions (`rand 0.8.6`, `rand 0.9.3`, `rustls-webpki 0.103.13`) ship with MSRV ≤ 1.85 — well under the workspace pin of 1.92.

## Runtime impact

None. All updates are semver-patch upgrades within the already-pinned minor version. No `Cargo.toml` was touched; only `Cargo.lock` and `benches/database-poc/Cargo.lock`.

## Diff size

68 LOC across 2 lockfiles (50 root + 18 bench). Well below the 200-LOC stop condition.

## Rollback

`git revert <sha>` on `main`. Two-file lockfile-only diff makes triage trivial.

## Capability traceability (sessão snuggly-pillow)

- ClaudeMaxPower: hooks ativos (`session-start`, `pre-tool-use`, `post-tool-use`, `stop`) + `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`.
- Superpowers skills: `using-superpowers`, `writing-plans`, `using-worktrees`.
- Real agents: `security-auditor` (PR #99 review), `general-purpose` as `dependency-analyst` (PR #97 review), `general-purpose` as `privacy-hygiene-reviewer` (PR #102 scan), `code-reviewer` (PR #102 GO).
- Linear MCP: `mcp__linear-server__save_issue` (created [GAR-484](https://linear.app/chatgpt25/issue/GAR-484), [GAR-485](https://linear.app/chatgpt25/issue/GAR-485)) + `save_comment` (GAR-455, GAR-430, GAR-437, GAR-484).
- GitHub Actions: PR-level CI gating this merge.
- **awesome-claude-token-stack**: NOT INSTALLED (verified `~/.claude/plugins/`, `~/.claude/skills/`, `~/.claude/cmp-skills/`); capability gap registered honestly.

🤖 Plan: `voc-est-no-reposit-rio-snuggly-pillow.md`. Generated with [Claude Code](https://claude.com/claude-code).