### PR TITLE
security(secret-scan): PR A — gitleaks ignore + pre-commit + revoked-secret runbook

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,32 @@
+# gitleaks ignore file — historical findings already mitigated.
+#
+# Format: <commit_sha>:<file>:<rule_id>:<line>
+# Reference: https://github.com/gitleaks/gitleaks#gitleaksignore
+#
+# Policy: GarraRUST does not perform git-history rewrites for tokens that
+# have already been revoked upstream. We add the fingerprint here, document
+# the mitigation in docs/security/secret-scanning-runbook.md, and close the
+# corresponding GitHub secret-scanning alert as `resolved/revoked`.
+
+# -----------------------------------------------------------------------
+# Linear API Key — REVOKED 2026-04-30 (GitHub secret-scanning alert #1).
+# Token appeared in 4 internal Linear-automation .ps1 scripts in commit
+# da29936 (2026-02-27, "Atualizei dependências e integração do Whisper STT").
+# Files were removed from git tracking in commit b7d1e73 (2026-03-07) and
+# the .gitignore /*.ps1 rule (line 116) keeps any future variant out of
+# the repo. Token has zero live exposure since the Linear-side revocation.
+da29936565b324d73d6a87f32e77ef73021f6a6c:mark_done_more.ps1:linear-api-key:4
+da29936565b324d73d6a87f32e77ef73021f6a6c:mark_177_done.ps1:linear-api-key:4
+da29936565b324d73d6a87f32e77ef73021f6a6c:mark_179_done.ps1:linear-api-key:4
+da29936565b324d73d6a87f32e77ef73021f6a6c:mark_done_roadmap.ps1:linear-api-key:4
+
+# -----------------------------------------------------------------------
+# False positives — test fixtures inside crates/garraia-security/src/redaction.rs
+# (commit f8374996, 2026-02-22). Lines 71 and 77 are inside `#[cfg(test)]
+# mod tests` and use synthetic patterns (`key=sk-1234...`, `token=xoxb-...`)
+# as INPUT to verify the redact_secrets() function actually redacts them.
+# They are not real secrets. The .gitleaks.toml allowlist already covers
+# `crates/.*/tests/` paths but not `*/src/*.rs` test modules — these two
+# fingerprints close that gap explicitly without weakening the regex.
+f8374996ecd2fcb7b6acadace7be464bffe4d6d7:crates/garraia-security/src/redaction.rs:generic-api-key:71
+f8374996ecd2fcb7b6acadace7be464bffe4d6d7:crates/garraia-security/src/redaction.rs:generic-api-key:77

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+# Pre-commit hooks for GarraRUST.
+#
+# Plan: personal-api-key-revogada-vectorized-matsumoto §Step 1.
+# Linear: GAR-XXX (Green Security Baseline 2026-04-30, sub-issue 1).
+#
+# Local installation (one-time per developer):
+#   pip install pre-commit
+#   pre-commit install
+#
+# Manual run (full repo):
+#   pre-commit run --all-files
+#
+# CI parity: .github/workflows/ci.yml has a `Secret Scan (gitleaks)` job
+# (gitleaks-action@v2) that runs on every push/PR — pre-commit is the
+# local mirror, not the source of truth.
+
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+        # gitleaks reads .gitleaks.toml + .gitleaksignore from repo root.
+        # Documented historical revoked findings live in .gitleaksignore.

--- a/docs/security/secret-scanning-runbook.md
+++ b/docs/security/secret-scanning-runbook.md
@@ -1,0 +1,144 @@
+# Secret Scanning Runbook
+
+> Status: established 2026-04-30 as part of the Green Security Baseline
+> sprint (plan `personal-api-key-revogada-vectorized-matsumoto`,
+> Linear umbrella GAR-XXX).
+> Scope: how GarraRUST detects, prevents, mitigates, and documents secret
+> leaks across the working tree, commits, and historical patches.
+
+## Layered defenses
+
+GarraRUST relies on four overlapping checks — failure in any one gets
+caught by the others:
+
+| Layer | Where | Tool | What it catches |
+|---|---|---|---|
+| **L1** | Local working tree, before commit | `pre-commit` + `gitleaks` (`.pre-commit-config.yaml`) | New secrets a developer is about to commit |
+| **L2** | Local working tree, anytime | `gitleaks detect --no-git --redact --source .` | Currently-staged secrets in working tree files |
+| **L3** | GitHub Actions (every push/PR) | `gitleaks-action@v2` (job `Secret Scan (gitleaks)` in `.github/workflows/ci.yml`) | Secrets in PR diffs that escaped local hooks |
+| **L4** | GitHub-native (continuous) | Secret scanning + push protection (`secret_scanning_push_protection: enabled` per repo `security_and_analysis`) | Token-shaped strings in pushed commits, with provider-side validation when supported |
+
+## Configuration files (repo root)
+
+- **`.gitleaks.toml`** — extends gitleaks default rules with an allow-list
+  for known-safe paths and placeholder strings (test fixtures, example
+  env files, doc snippets). See file header for line-by-line rationale.
+- **`.gitleaksignore`** — lists fingerprints of historical findings that
+  have been revoked upstream and are documented here. Each entry has a
+  comment with the revocation date, the GitHub alert number (if any), and
+  why it stays in history.
+- **`.pre-commit-config.yaml`** — pinned `gitleaks` hook version. Match
+  the `rev:` to the gitleaks-action version used in CI when bumping.
+
+## Policy: do we rewrite history when a secret leaks?
+
+**No, by default.** Once a credential is revoked upstream, the only
+remaining harm is scanner noise. We optimize for operational stability:
+
+| Trade-off | Why we choose "no rewrite" |
+|---|---|
+| Force-push clobbers all clones, forks, and open PR refs | High operational cost |
+| `git-filter-repo` requires re-running on every fork that ever cloned us | Expensive coordination |
+| Any subsequent leak in an old patch puts us right back where we started | Doesn't actually prevent recurrence |
+| Token revocation has already neutralized the risk | The actual security posture is already restored |
+
+Exceptions where we **would** rewrite history:
+
+- Token has not been revoked AND cannot be revoked upstream (rare).
+- Material is regulatory-sensitive (PII/PHI) and legal counsel requires
+  it gone from objects, not just from view.
+- Pre-public release: we have not pushed the repo yet, no clones exist.
+
+For all other cases, the canonical mitigation is the 5-step procedure
+below.
+
+## Standard mitigation procedure (revoked-secret playbook)
+
+When a secret-scanning alert fires (or you discover one yourself):
+
+1. **Revoke the credential upstream** *immediately*. The alert is the
+   trigger; revocation is the action. Do this BEFORE filing tickets,
+   pushing fixes, or messaging the team. For Linear PATs:
+   `https://linear.app/settings/api`. Anthropic, OpenAI, AWS — same
+   pattern: provider settings page first.
+2. **Confirm revocation** by attempting an authenticated request with
+   the old token. If it returns 401/403, you're done with step 1.
+3. **Remove the live token from working tree** (`rm` the file or
+   replace the string with an env-var lookup). Stage the change.
+4. **Capture the gitleaks fingerprint** for historical commits where
+   the token still lives in patches:
+   ```bash
+   gitleaks detect --redact --report-format json \
+     --report-path /tmp/leaks.json --source .
+   ```
+   Each finding has a `Fingerprint: <commit>:<file>:<rule>:<line>` —
+   copy each into `.gitleaksignore` with a `#`-comment block above
+   that includes:
+   - revocation date,
+   - GitHub alert number (if applicable),
+   - why this stays in history (link to this runbook).
+5. **Open a PR with**: `.gitleaksignore` updates + working-tree fix +
+   any pre-commit/runbook adjustments. Do NOT include the token in
+   the PR body, commit messages, or comments.
+6. **After PR merge**, close the GitHub alert as `revoked`:
+   ```bash
+   gh api -X PATCH \
+     repos/michelbr84/GarraRUST/secret-scanning/alerts/<NUMBER> \
+     -f state=resolved -f resolution=revoked \
+     -f resolution_comment="Revoked upstream YYYY-MM-DD; fingerprint in .gitleaksignore."
+   ```
+
+## Local developer setup (one-time)
+
+```bash
+# Install gitleaks (Windows: choco install gitleaks  /  macOS: brew install gitleaks)
+# Or grab a release directly: https://github.com/gitleaks/gitleaks/releases
+
+# Wire up pre-commit
+pip install pre-commit
+pre-commit install
+
+# Verify
+pre-commit run --all-files
+```
+
+If `pre-commit` is missing, `gitleaks detect --no-git` still works as a
+manual check before pushing. Match the version pinned in
+`.pre-commit-config.yaml` to keep behavior identical to CI.
+
+## When CI gitleaks fails on a PR
+
+If `Secret Scan (gitleaks)` fails on a PR you authored:
+
+1. Pull the report from the failing job logs (job's "Run gitleaks" step).
+2. Determine: is it a real new secret OR a historical revoked one
+   surfacing for the first time?
+3. **Real new secret**: revoke upstream, follow the 5-step procedure,
+   re-push.
+4. **Historical revoked**: only allowed if you can show the token is
+   already revoked. Add the fingerprint to `.gitleaksignore` with the
+   comment block, link the alert number, and re-push.
+
+Never `--no-verify` past the gate. Never edit `.gitleaks.toml` to
+allow-list a real secret.
+
+## Open improvements (tracked separately)
+
+- Enable `secret_scanning_validity_checks` (currently `disabled`) once
+  GitHub stabilizes provider validation for our active provider mix.
+- Enable `secret_scanning_non_provider_patterns` (currently `disabled`)
+  to catch high-entropy strings outside known provider formats. Trade-off:
+  more false positives. Worth a follow-up sub-issue under the umbrella.
+- Consider GitHub Advanced Security custom patterns for project-internal
+  token formats (e.g., `GARRAIA_*` env vars) once we're past the green
+  baseline. See `docs/security/threat-model.md` for the broader context.
+
+## See also
+
+- `.gitleaks.toml` — extension rules + allow-list.
+- `.gitleaksignore` — fingerprint exemptions with rationale.
+- `.pre-commit-config.yaml` — local hook pinning.
+- `.github/workflows/ci.yml` job `Secret Scan (gitleaks)` (~L101–119).
+- `docs/security/threat-model.md` — overall security model.
+- `docs/security/codeql-setup.md` *(coming in PR C)* — companion CodeQL
+  configuration runbook.


### PR DESCRIPTION
## Summary

- **PR A of 3** for the Green Security Baseline sprint (plan: `personal-api-key-revogada-vectorized-matsumoto`). Establishes the secret-scanning baseline.
- Closes GitHub secret-scanning alert **#1** (Linear API Key, revoked upstream 2026-04-30) once merged + gh api PATCH executed.
- Adds `.gitleaksignore` (6 fingerprints), `.pre-commit-config.yaml` (gitleaks v8.30.1), and `docs/security/secret-scanning-runbook.md` (5-step playbook).

## What & why

GitHub secret-scanning fired on commit `da29936` (2026-02-27) where four internal `.ps1` Linear-automation scripts hardcoded a Linear PAT. The token has been **revoked upstream** by the user (zero live exposure). Project policy is to NOT rewrite git history for revoked tokens — instead we document historical findings via `.gitleaksignore`, prevent local recurrence via pre-commit, and close the alert as `resolved/revoked` via API.

## Verification

- `gitleaks detect` (full history, 352 commits, 9.19 MB) → **0 leaks** after `.gitleaksignore` covers the 6 historical fingerprints.
- `gitleaks detect --no-git` on the 3 new files → **0 leaks**.
- `mark_done_roadmap.ps1` is already untracked (`.gitignore` line 116 covers `/*.ps1`); no working-tree diff needed.
- Push protection (`secret_scanning_push_protection: enabled`) accepted the push — confirms no novel token-shaped strings were introduced.

## Test plan

- [ ] CI `Secret Scan (gitleaks)` job passes on this PR.
- [ ] CI `Format Check`, `Build Check`, `Clippy`, `Test (×3)`, `MSRV`, `Coverage`, `cargo-deny`, `Security Audit`, `Dependency Review` all pass (no Rust changes, should be green).
- [ ] Reviewer skims `docs/security/secret-scanning-runbook.md` for the 5-step playbook.
- [ ] After merge: `gh api -X PATCH repos/michelbr84/GarraRUST/secret-scanning/alerts/1 -f state=resolved -f resolution=revoked`.

## Follow-ups (not in this PR)

- **PR B**: `jsonwebtoken 9 → 10` migration with `rust_crypto` backend + `getrandom` direct (replaces broken Dependabot PR #103).
- **PR C**: CodeQL advanced setup (`.github/workflows/codeql.yml` + config) to fix the "Code scanning configuration error" banner caused by default-setup autobuild on `garraia-desktop` (Tauri).

🤖 Generated with [Claude Code](https://claude.com/claude-code)