### PR TITLE
security(deps): PR B — jsonwebtoken 10 (rust_crypto) + getrandom RNG decoupling

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -50,9 +50,24 @@ ignore = [
     # todas as 5 declarações de sqlx, removendo `mysql` feature do active
     # tree. Mas o meta-crate upstream `sqlx 0.8.6` declara `sqlx-mysql`
     # como `optional = true` na sua dep section, então `cargo audit` walks
-    # `Cargo.lock` e continua vendo `rsa 0.9.10` (transitivo). JWT paths
-    # do GarraRUST usam HS256 via `ring` — Marvin code path NÃO reachable.
-    # Fix estrutural: refactor para `sqlx-postgres` direto OU sqlx 0.9.
+    # `Cargo.lock` e continua vendo `rsa 0.9.10` (transitivo).
+    #
+    # AMENDMENT 2026-04-30 (plan personal-api-key-revogada-vectorized-
+    # matsumoto §Step 3): `jsonwebtoken 10 + rust_crypto` foi adotado para
+    # destravar Dependabot PR #103. O backend `rust_crypto` traz `rsa
+    # 0.9.10` para a árvore de produção do `garraia-auth` (segundo path de
+    # entrada além do sqlx). A invariante de segurança permanece: o
+    # GarraRUST emite e verifica APENAS HS256 (`Algorithm::HS256` em
+    # crates/garraia-auth/src/jwt.rs), que usa hmac+sha2 do RustCrypto e
+    # NÃO chama nenhum código RSA — o Marvin code path continua
+    # não-reachable. Antes era "HS256 via ring"; agora é "HS256 via
+    # hmac+sha2 RustCrypto". Mesma invariante, novo backend.
+    #
+    # Fix estrutural (em ordem de preferência):
+    #   1. `jsonwebtoken` upstream isolar `rsa` atrás de uma feature
+    #      "asymmetric" (não-default) — emitir issue lá quando relevante.
+    #   2. Refactor para `sqlx-postgres` direto OU sqlx 0.9 (fecha o path
+    #      sqlx-mysql).
     # Tracked by: GAR-456. Expires: 2026-07-31.
     "RUSTSEC-2023-0071",
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,6 +1047,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1634,7 +1640,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2047,6 +2053,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2109,6 +2127,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -2447,7 +2492,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2571,12 +2616,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2687,7 +2791,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2795,6 +2899,22 @@ dependencies = [
  "rand 0.10.1",
  "web-time",
 ]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "field-offset"
@@ -3195,12 +3315,12 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "garraia-workspace",
+ "getrandom 0.3.4",
  "hmac 0.12.1",
  "jsonwebtoken",
  "password-hash",
  "pbkdf2",
  "rand 0.8.6",
- "rand 0.9.3",
  "secrecy 0.10.3",
  "serde",
  "serde_json",
@@ -3678,6 +3798,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -3934,6 +4055,17 @@ dependencies = [
  "smallvec",
  "spinning_top",
  "web-time",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -4383,7 +4515,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -4718,7 +4850,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4870,17 +5002,23 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
+version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
  "base64 0.22.1",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "hmac 0.12.1",
  "js-sys",
- "pem",
- "ring",
+ "p256",
+ "p384",
+ "rand 0.8.6",
+ "rsa",
  "serde",
  "serde_json",
- "simple_asn1",
+ "sha2 0.10.9",
+ "signature",
 ]
 
 [[package]]
@@ -5520,7 +5658,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5977,7 +6115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5999,6 +6137,30 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "pango"
@@ -6112,16 +6274,6 @@ dependencies = [
  "hmac 0.12.1",
  "password-hash",
  "sha2 0.10.9",
-]
-
-[[package]]
-name = "pem"
-version = "3.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
-dependencies = [
- "base64 0.22.1",
- "serde_core",
 ]
 
 [[package]]
@@ -6531,6 +6683,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6793,7 +6954,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.36",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6830,9 +6991,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7219,6 +7380,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
+]
+
+[[package]]
 name = "rfd"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7417,7 +7588,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7521,7 +7692,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7688,6 +7859,20 @@ name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "secrecy"
@@ -8133,18 +8318,6 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
-
-[[package]]
-name = "simple_asn1"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
-dependencies = [
- "num-bigint",
- "num-traits",
- "thiserror 2.0.18",
- "time",
-]
 
 [[package]]
 name = "siphasher"
@@ -9246,7 +9419,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11227,7 +11400,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,12 @@ ring = "0.17"
 base64 = "0.22"
 uuid = { version = "1", features = ["v4"] }
 rand = "0.9"
-jsonwebtoken = "9"
+# Plan personal-api-key-revogada-vectorized-matsumoto §Step 3 / Decisões §2:
+# `jsonwebtoken 10` requires explicit backend selection. We pick `rust_crypto`
+# because the workspace already depends on `password-hash`/`argon2`/`pbkdf2`/
+# `hmac`/`sha2` (RustCrypto stack); no FIPS requirement justifies the
+# operational cost of the alternative `aws_lc_rs` (cmake + C toolchain).
+jsonwebtoken = { version = "10", default-features = false, features = ["rust_crypto"] }
 
 # Plugin system — bumped from 28 → 44 in GAR-454 (sessão `purrfect-lantern`),
 # closing 15 RUSTSEC IDs incluindo 2 CRITICAL (RUSTSEC-2026-0095 / 0096).

--- a/crates/garraia-auth/Cargo.toml
+++ b/crates/garraia-auth/Cargo.toml
@@ -58,8 +58,11 @@ sha2 = "0.10"
 secrecy = { version = "0.10", features = ["serde"] }
 # JWT issuance + verification (HS256). Pinned via the workspace.
 jsonwebtoken = { workspace = true }
-# Cryptographic randomness for refresh tokens.
-rand = { workspace = true }
+# Cryptographic randomness for refresh tokens. We call `getrandom::fill`
+# directly to decouple this crate from the rand 0.9 -> 0.10 transitive
+# churn that broke Dependabot PR #103. See plan
+# personal-api-key-revogada-vectorized-matsumoto §Decisões §3.
+getrandom = "0.3"
 # Base64 URL-safe encoding for refresh tokens.
 base64 = { workspace = true }
 # Axum extractor support (GAR-391c).

--- a/crates/garraia-auth/src/jwt.rs
+++ b/crates/garraia-auth/src/jwt.rs
@@ -19,8 +19,6 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use chrono::{DateTime, Duration, Utc};
 use hmac::{Hmac, Mac};
 use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation, decode, encode};
-use rand::TryRngCore;
-use rand::rngs::OsRng;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
@@ -201,12 +199,16 @@ impl JwtIssuer {
     }
 
     /// Generate a fresh opaque refresh token and its HMAC-SHA256 hash.
-    /// 32 random bytes from `OsRng`, URL-safe base64 (no padding).
+    /// 32 random bytes via `getrandom::fill` (direct OS RNG syscall),
+    /// URL-safe base64 (no padding). Plan
+    /// personal-api-key-revogada-vectorized-matsumoto §Decisões §3 moved
+    /// from `rand::rngs::OsRng + TryRngCore::try_fill_bytes` to
+    /// `getrandom::fill` to decouple this crate from the rand 0.9/0.10
+    /// transitive-resolution churn that broke Dependabot PR #103.
     pub fn issue_refresh(&self) -> Result<RefreshTokenPair, AuthError> {
         let mut bytes = [0u8; 32];
-        OsRng
-            .try_fill_bytes(&mut bytes)
-            .map_err(|e| AuthError::Config(format!("OsRng failure: {e}")))?;
+        getrandom::fill(&mut bytes)
+            .map_err(|e| AuthError::Config(format!("getrandom failure: {e}")))?;
         let plaintext = URL_SAFE_NO_PAD.encode(bytes);
         let hmac_hash = self.hmac_refresh(&plaintext)?;
         Ok(RefreshTokenPair {


### PR DESCRIPTION
## Summary

- **PR B of 3** for the Green Security Baseline sprint. Replaces broken Dependabot **PR #103** with a manual migration that fixes `unresolved import rand::TryRngCore` / `rand::rngs::OsRng` errors in `crates/garraia-auth/src/jwt.rs:22-23`.
- Selects `jsonwebtoken 10 + rust_crypto` backend (no aws-lc-rs C toolchain).
- Replaces `OsRng.try_fill_bytes` with `getrandom::fill` direct, decoupling the crate from the rand 0.9 → 0.10 transitive churn (Cargo.lock currently has rand 0.7/0.8/0.9/0.10 co-existing).

## Why not PR #103 as-is

PR #103 lockfile bump caused 9 of 16 CI checks to fail (Build, Clippy, Coverage, E2E, MSRV, Playwright, Test×3) all cascading from compile errors at jwt.rs:22-23. The transitive `rand` resolution shifted away from the API the code was using. This PR fixes the underlying coupling, not just the symptom.

## Changes

| File | What |
|---|---|
| `Cargo.toml` (workspace, L76) | `jsonwebtoken = "9"` → `{ version = "10", default-features = false, features = ["rust_crypto"] }` |
| `crates/garraia-auth/Cargo.toml` | Remove runtime `rand`, add `getrandom = "0.3"` direct |
| `crates/garraia-auth/src/jwt.rs` | Drop `use rand::*` imports; `OsRng.try_fill_bytes(&mut bytes)` → `getrandom::fill(&mut bytes)` |
| `Cargo.lock` | `cargo update -p jsonwebtoken --precise 10.3.0` (surgical, not workspace-wide) |
| `.cargo/audit.toml` | Amendment block under GAR-456 documenting that `rust_crypto` backend pulls `rsa 0.9.10` into `garraia-auth` prod tree as a second entry path beyond `sqlx-mysql` |

## RUSTSEC-2023-0071 (Marvin Attack) honesty

`rust_crypto` backend brings `rsa 0.9.10` into the production tree of `garraia-auth`. Same advisory `RUSTSEC-2023-0071` that was already allowlisted workspace-wide (GAR-456). The invariant **stays valid**:

- GarraRUST emits and verifies **HS256 only** (`Algorithm::HS256` in `jwt.rs`).
- HS256 in `rust_crypto` uses `hmac` + `sha2` RustCrypto crates — **no RSA call site exists** in our code path.
- Marvin Attack code path is therefore non-reachable.

The audit.toml comment was updated from "via ring" to "via hmac+sha2 RustCrypto" so the next reviewer can re-validate the invariant from scratch.

## Verification (local)

- [x] `cargo fmt --all -- --check` → pass
- [x] `cargo check --workspace --exclude garraia-desktop --locked` → pass
- [x] `cargo clippy --workspace --exclude garraia-desktop --all-targets --locked -- -D warnings` → pass (0 warnings)
- [x] `cargo +1.92 check --workspace --exclude garraia-desktop --locked` → pass
- [x] `cargo test -p garraia-auth --lib --locked` → **51 passed, 0 failed** (includes all 9 jwt.rs unit tests + GAR-468 Q6.6 mutation killers at jwt.rs:418-465)
- [x] `cargo test --workspace --exclude garraia-desktop --lib --locked` → exit 0
- [x] `cargo audit` → 0 vulns (22 allowed warnings, all pre-existing)
- [x] `cargo deny check` → exit 0
- [x] `cargo tree -p garraia-auth -i rsa` → confirmed rsa 0.9.10 enters via jsonwebtoken 10 path (documented in audit.toml amendment)
- [x] runtime grep for `rand::` in `crates/garraia-auth/src/` → only one hit, in a doc comment; `hashing.rs:47` uses `password_hash::rand_core::OsRng` (transitive via password-hash 0.5, untouched)

## Test plan (CI)

- [ ] Format Check, Build Check, Clippy Linting, Test (×3 OS), Coverage, MSRV (1.92), E2E, Playwright, Security Audit, cargo-deny, Dependency Review, Secret Scan all green.
- [ ] Reviewer skims the `.cargo/audit.toml` amendment for the new "via hmac+sha2 RustCrypto" justification.

## Closes

- Replaces #103 (will auto-close when this PR merges and Dependabot detects the lockfile already at 10.3.0; alternatively comment `@dependabot close` after merge).

## Follow-up (out of scope)

- **PR C**: `.github/workflows/codeql.yml` + `.github/codeql-config.yml` — advanced CodeQL setup excluding `garraia-desktop` (Tauri) to fix the GitHub-native default-setup autobuild banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)