### PR TITLE
fix(ci): restore fmt, clippy strict, and garra test bin env

### DIFF
--- a/crates/garraia-cli/src/chat.rs
+++ b/crates/garraia-cli/src/chat.rs
@@ -131,28 +131,24 @@ fn scan_directory_context(cwd: &str) -> String {
 
 /// Helper to resolve the API key checking env var, explicit config, and "main" config.
 fn get_api_key(config: &AppConfig, provider_name: &str, env_var: &str) -> Option<String> {
-    if !env_var.is_empty() {
-        if let Ok(key) = std::env::var(env_var) {
-            if !key.is_empty() {
-                return Some(key);
-            }
-        }
+    if !env_var.is_empty()
+        && let Ok(key) = std::env::var(env_var)
+        && !key.is_empty()
+    {
+        return Some(key);
     }
-    if let Some(cfg) = config.llm.get(provider_name) {
-        if let Some(ref k) = cfg.api_key {
-            if !k.is_empty() {
-                return Some(k.clone());
-            }
-        }
+    if let Some(cfg) = config.llm.get(provider_name)
+        && let Some(ref k) = cfg.api_key
+        && !k.is_empty()
+    {
+        return Some(k.clone());
     }
-    if let Some(cfg) = config.llm.get("main") {
-        if cfg.provider == provider_name {
-            if let Some(ref k) = cfg.api_key {
-                if !k.is_empty() {
-                    return Some(k.clone());
-                }
-            }
-        }
+    if let Some(cfg) = config.llm.get("main")
+        && cfg.provider == provider_name
+        && let Some(ref k) = cfg.api_key
+        && !k.is_empty()
+    {
+        return Some(k.clone());
     }
     None
 }
@@ -318,7 +314,9 @@ pub async fn run_chat(
                 provider = Arc::new(op);
             }
             other => {
-                anyhow::bail!("Provider desconhecido: {other}. Use: ollama, anthropic, openai, openrouter");
+                anyhow::bail!(
+                    "Provider desconhecido: {other}. Use: ollama, anthropic, openai, openrouter"
+                );
             }
         }
     } else if let Some(ref m) = model_override {

--- a/crates/garraia-cli/src/wizard.rs
+++ b/crates/garraia-cli/src/wizard.rs
@@ -114,9 +114,7 @@ pub fn run_wizard(config_dir: &Path) -> Result<()> {
         println!();
 
         let token: String = Password::new()
-            .with_prompt(
-                "Enter your Telegram bot token (or set TELEGRAM_BOT_TOKEN env var later)",
-            )
+            .with_prompt("Enter your Telegram bot token (or set TELEGRAM_BOT_TOKEN env var later)")
             .allow_empty_password(true)
             .interact()
             .context("telegram token input cancelled")?;
@@ -183,7 +181,9 @@ pub fn run_wizard(config_dir: &Path) -> Result<()> {
                     Some(vault)
                 }
                 Err(e) => {
-                    println!("  Warning: vault creation failed ({e}), will store in config instead.");
+                    println!(
+                        "  Warning: vault creation failed ({e}), will store in config instead."
+                    );
                     None
                 }
             }
@@ -241,9 +241,7 @@ pub fn run_wizard(config_dir: &Path) -> Result<()> {
                         "  Set TELEGRAM_BOT_TOKEN environment variable before starting the server."
                     );
                 } else {
-                    println!(
-                        "  Telegram enabled. Set TELEGRAM_BOT_TOKEN env var before starting."
-                    );
+                    println!("  Telegram enabled. Set TELEGRAM_BOT_TOKEN env var before starting.");
                 }
             }
         }

--- a/crates/garraia-cli/tests/migrate_workspace_integration.rs
+++ b/crates/garraia-cli/tests/migrate_workspace_integration.rs
@@ -22,6 +22,26 @@ use testcontainers::core::{ImageExt, WaitFor};
 use testcontainers::runners::AsyncRunner;
 use testcontainers::{ContainerAsync, GenericImage};
 
+/// Resolve the path to the integration-test target binary.
+///
+/// The crate's `[[bin]]` is currently named `garra` (see
+/// `crates/garraia-cli/Cargo.toml`), so Cargo exports
+/// `CARGO_BIN_EXE_garra` when building this integration test. We use a
+/// runtime lookup (`std::env::var_os`) instead of the compile-time
+/// `env!` macro so a future bin rename produces a clean runtime panic
+/// rather than a compile-time hard fail.
+///
+/// The `CARGO_BIN_EXE_garraia` fallback is **temporary backward
+/// compatibility** for any local checkouts still on the legacy bin
+/// name; it is dead in CI today and SHOULD be removed once we are
+/// confident no environment depends on it.
+fn garra_bin() -> std::path::PathBuf {
+    std::env::var_os("CARGO_BIN_EXE_garra")
+        .or_else(|| std::env::var_os("CARGO_BIN_EXE_garraia"))
+        .map(std::path::PathBuf::from)
+        .expect("expected Cargo to define CARGO_BIN_EXE_garra for integration tests")
+}
+
 const PBKDF2_ITERATIONS: u32 = 600_000;
 const PBKDF2_OUTPUT_LEN: usize = 32;
 
@@ -194,7 +214,7 @@ async fn stage1_happy_path_and_idempotency() {
 
     // Invoke the migration command via the binary under test.
     // We exec via `cargo run` — simpler than wrangling cli::Parser in-process.
-    let output = std::process::Command::new(env!("CARGO_BIN_EXE_garraia"))
+    let output = std::process::Command::new(garra_bin())
         .args([
             "migrate",
             "workspace",
@@ -240,7 +260,7 @@ async fn stage1_happy_path_and_idempotency() {
     assert_eq!(audit_count, 3, "audit events emitted atomically");
 
     // Re-run must be a no-op (idempotency).
-    let rerun = std::process::Command::new(env!("CARGO_BIN_EXE_garraia"))
+    let rerun = std::process::Command::new(garra_bin())
         .args([
             "migrate",
             "workspace",
@@ -300,7 +320,7 @@ async fn stage3_creates_group_and_members_happy_path() {
         ],
     );
 
-    let output = std::process::Command::new(env!("CARGO_BIN_EXE_garraia"))
+    let output = std::process::Command::new(garra_bin())
         .args([
             "migrate",
             "workspace",
@@ -414,7 +434,7 @@ async fn stage3_idempotent_rerun() {
 
     // First run.
     assert!(
-        std::process::Command::new(env!("CARGO_BIN_EXE_garraia"))
+        std::process::Command::new(garra_bin())
             .args([
                 "migrate",
                 "workspace",
@@ -431,7 +451,7 @@ async fn stage3_idempotent_rerun() {
 
     // Second run with --confirm-backup (users.count > 0 now).
     assert!(
-        std::process::Command::new(env!("CARGO_BIN_EXE_garraia"))
+        std::process::Command::new(garra_bin())
             .args([
                 "migrate",
                 "workspace",
@@ -537,7 +557,7 @@ async fn stage3_resolves_preexisting_group_by_name() {
         ],
     );
 
-    let output = std::process::Command::new(env!("CARGO_BIN_EXE_garraia"))
+    let output = std::process::Command::new(garra_bin())
         .args([
             "migrate",
             "workspace",
@@ -670,7 +690,7 @@ async fn stage3_promotes_first_legacy_user_when_group_has_no_owner() {
         ],
     );
 
-    let output = std::process::Command::new(env!("CARGO_BIN_EXE_garraia"))
+    let output = std::process::Command::new(garra_bin())
         .args([
             "migrate",
             "workspace",
@@ -727,7 +747,7 @@ async fn stage3_skips_when_no_legacy_users() {
     // Empty SQLite — no mobile_users rows, just the table.
     seed_sqlite(&sqlite_path, &[]);
 
-    let output = std::process::Command::new(env!("CARGO_BIN_EXE_garraia"))
+    let output = std::process::Command::new(garra_bin())
         .args([
             "migrate",
             "workspace",
@@ -838,7 +858,7 @@ async fn stage5_happy_path_creates_chats_and_members() {
         r#"{"title":"DMs"}"#,
     );
 
-    let output = std::process::Command::new(env!("CARGO_BIN_EXE_garraia"))
+    let output = std::process::Command::new(garra_bin())
         .args([
             "migrate",
             "workspace",
@@ -978,7 +998,7 @@ async fn stage5_idempotent_rerun() {
 
     // First run.
     assert!(
-        std::process::Command::new(env!("CARGO_BIN_EXE_garraia"))
+        std::process::Command::new(garra_bin())
             .args([
                 "migrate",
                 "workspace",
@@ -1000,7 +1020,7 @@ async fn stage5_idempotent_rerun() {
     assert_eq!(after_first_chats, 2);
 
     // Second run — Postgres has rows already, need --confirm-backup.
-    let rerun = std::process::Command::new(env!("CARGO_BIN_EXE_garraia"))
+    let rerun = std::process::Command::new(garra_bin())
         .args([
             "migrate",
             "workspace",
@@ -1068,7 +1088,7 @@ async fn stage5_skips_when_no_sessions_table() {
     // Only mobile_users — NO sessions table on purpose.
     seed_sqlite(&sqlite_path, &[("u1", "alice@example.com", "pw-a")]);
 
-    let output = std::process::Command::new(env!("CARGO_BIN_EXE_garraia"))
+    let output = std::process::Command::new(garra_bin())
         .args([
             "migrate",
             "workspace",
@@ -1144,7 +1164,7 @@ async fn stage5_skips_sessions_without_migrated_user() {
         r#"{"title":"Ghost"}"#,
     );
 
-    let output = std::process::Command::new(env!("CARGO_BIN_EXE_garraia"))
+    let output = std::process::Command::new(garra_bin())
         .args([
             "migrate",
             "workspace",
@@ -1202,7 +1222,7 @@ async fn stage1_dry_run_does_not_persist() {
         &[("u1", "drake@example.com", "pw-drake-1111")],
     );
 
-    let output = std::process::Command::new(env!("CARGO_BIN_EXE_garraia"))
+    let output = std::process::Command::new(garra_bin())
         .args([
             "migrate",
             "workspace",

--- a/crates/garraia-config/src/check.rs
+++ b/crates/garraia-config/src/check.rs
@@ -475,9 +475,9 @@ fn validate(config: &AppConfig) -> Vec<Finding> {
         if !enabled {
             continue;
         }
-        let has_inline_token = ch.settings.get("bot_token").is_some()
-            || ch.settings.get("access_token").is_some()
-            || ch.settings.get("app_token").is_some();
+        let has_inline_token = ch.settings.contains_key("bot_token")
+            || ch.settings.contains_key("access_token")
+            || ch.settings.contains_key("app_token");
         if has_inline_token {
             continue;
         }
@@ -488,17 +488,17 @@ fn validate(config: &AppConfig) -> Vec<Finding> {
             "whatsapp" => Some("WHATSAPP_ACCESS_TOKEN"),
             _ => None,
         };
-        if let Some(var) = env_var {
-            if std::env::var_os(var).is_none() {
-                push_warn(
-                    &mut findings,
-                    &format!("channels.{name}"),
-                    format!(
-                        "channel '{name}' (type={}) is enabled but no token found in config or env var {var}",
-                        ch.channel_type
-                    ),
-                );
-            }
+        if let Some(var) = env_var
+            && std::env::var_os(var).is_none()
+        {
+            push_warn(
+                &mut findings,
+                &format!("channels.{name}"),
+                format!(
+                    "channel '{name}' (type={}) is enabled but no token found in config or env var {var}",
+                    ch.channel_type
+                ),
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes the green-CI regression on `main` introduced by the recent `maria/main` merges. Run [25295421391](https://github.com/michelbr84/GarraRUST/actions/runs/25295421391) was red on **six** jobs sharing the same root cause: code merged without running `cargo fmt` or `cargo clippy` locally.

Six red jobs, one PR:

| Job | Before | After |
|---|---|---|
| Format Check | ❌ fmt drift in `chat.rs` / `wizard.rs` | ✅ |
| Test (windows-latest) | ❌ `env!("CARGO_BIN_EXE_garraia")` compile fail | ✅ |
| Test (ubuntu-latest) | ❌ same `env!` compile fail | ✅ |
| Test (macos-latest) | ❌ same `env!` compile fail | ✅ |
| Coverage (cargo-llvm-cov) | ❌ cascades from test compile fail | ✅ |
| Clippy Linting | ❌ 11 lints in 2 files (rust-clippy 1.92) | ✅ |

## What changed (4 files, all mechanical)

- **`crates/garraia-cli/src/chat.rs`** — `cargo fmt` regen + 3 collapsible-if pyramids in `get_api_key()` flattened to let-chains. Behavior preserved.
- **`crates/garraia-cli/src/wizard.rs`** — `cargo fmt` regen only.
- **`crates/garraia-cli/tests/migrate_workspace_integration.rs`** — new `garra_bin()` helper using `std::env::var_os`; the 14 call sites that used `env!("CARGO_BIN_EXE_garraia")` now route through it. Cargo exports `CARGO_BIN_EXE_garra` since the bin rename in `a1c56e8`; the legacy `CARGO_BIN_EXE_garraia` lookup inside `or_else()` is **temporary backward compatibility** for any local checkouts still on the legacy bin name — it is dead in CI today and SHOULD be removed in a follow-up once we are confident no environment depends on it.
- **`crates/garraia-config/src/check.rs`** — 3x `.get(...).is_some()` → `.contains_key(...)`; one nested `if` collapsed to a let-chain. Verified by `cargo test -p garraia-config --lib` (49/49).

## Validations (local, rustc/clippy 1.92.0 — same as CI `dtolnay/rust-toolchain@stable`)

- ✅ `cargo fmt --check --all`
- ✅ `cargo test -p garraia --test migrate_workspace_integration --no-run`
- ✅ `cargo test -p garraia --no-run`
- ✅ `cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings` (exact CI flags)
- ✅ `cargo test --workspace --exclude garraia-desktop --no-run`
- ✅ `cargo test -p garraia-config --lib` (49 passed, 0 failed)

**Skipped:** `cargo test --workspace --all-features` full execution. The only test surface that adds is Docker-gated (testcontainers Postgres / MinIO) and runs identically on the CI runner. Compile parity above is the meaningful CI-parity gate.

## Risk

Low. Zero product-logic changes:
- Both `chat.rs` and `wizard.rs` source edits are either fmt regen or `if A { if B { … } }` → `if A && B { … }` flattenings (semantically identical in let-chain stable Rust 1.88+, and we are on edition 2024 + rustc 1.92).
- `check.rs`: `HashMap::get(k).is_some()` and `HashMap::contains_key(k)` are observationally equivalent.
- Test file: compile-time `env!` replaced by runtime `var_os` — Cargo always sets `CARGO_BIN_EXE_garra` before running integration tests.

## Out of scope (intentional)

- CodeQL config, Dependabot alerts, security suppressions.
- `ROADMAP.md`, `.claude/`, GarraMaxPower, agent tooling.
- Workflow YAML.
- Any feature work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)