### PR TITLE
docs(roadmap): sync Linear follow-ups

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -113,10 +113,13 @@ Sub-issues 4 e 5 de GAR-486 estão em execução agora:
 - **GAR-438 (Lote 2)** ✅ (PR [#64](https://github.com/michelbr84/GarraRUST/pull/64), `1828625`) — fix `e2e` + `playwright` jobs que tentavam executar `./target/release/garraia-gateway` (binário inexistente — `garraia-gateway` é biblioteca). Substituído por `cargo build --bin garraia --release` + `services: postgres:16.8-alpine` + envs de auth via `::add-mask::`. 4 de 7 `continue-on-error: true` removidos.
 - **GAR-443 (Lote 4)** ✅ — Playwright admin specs migrados para `getByTestId(...)` ancorados em `data-testid` estáveis (`admin.html`). Convenção: especificações Playwright do admin DEVEM preferir `data-testid` em vez de `placeholder*=` ou `getByRole(button,{name})`.
 - **GitHub Actions annotations follow-up (2026-05-03)** — CI voltou a ficar verde após PR [#113](https://github.com/michelbr84/GarraRUST/pull/113), mas os jobs `Analyze (javascript-typescript)` e `Analyze (rust)` ainda emitem 2 annotations não-bloqueantes: (a) `github/codeql-action/init@v3` + `analyze@v3` rodam em Node.js 20 (forced switch 2026-06-02, removido em 2026-09-16) — escopo expandido em [GAR-482](https://linear.app/chatgpt25/issue/GAR-482) (Q6.9 third-party Node 24 readiness); (b) CodeQL Action v3 será deprecated em dezembro de 2026 — rastreado em [GAR-502](https://linear.app/chatgpt25/issue/GAR-502) (chore migrate v3 → v4). Manutenção preventiva de CI/runtime, **não** alerta CodeQL real (esses ficam em [GAR-490](https://linear.app/chatgpt25/issue/GAR-490) / [GAR-491](https://linear.app/chatgpt25/issue/GAR-491)) e **não** bloqueia o merge verde atual.
+- **CARGO_BIN_EXE_garraia removal** ([GAR-503](https://linear.app/chatgpt25/issue/GAR-503)) — fallback dead-code em `crates/garraia-cli/tests/migrate_workspace_integration.rs:34-42` para remover.
+- **Benchmark evidence run** ([GAR-504](https://linear.app/chatgpt25/issue/GAR-504)) — primeira execução real de `benches/agent-framework-comparison/run.sh --all` em droplet DigitalOcean 1 vCPU / 1 GB para repor a tabela do `README.md` (PR [#117](https://github.com/michelbr84/GarraRUST/pull/117) §"Open follow-ups").
+- **Mutation Testing 2026-05-04 missed mutants** ([GAR-505](https://linear.app/chatgpt25/issue/GAR-505)) — sub-issue de [GAR-436](https://linear.app/chatgpt25/issue/GAR-436) cobrindo 6 NEW missed mutants em `jwt.rs` / `storage_redacted.rs` / `app_pool.rs` + 3 timeouts (run [25307117776](https://github.com/michelbr84/GarraRUST/actions/runs/25307117776)).
 
-### Status do umbrella GAR-486
+### Status do umbrella [GAR-486](https://linear.app/chatgpt25/issue/GAR-486)
 
-GAR-486 fica em **In Progress** até GAR-491 e GAR-490 mergearem. Não promover para Done sem essas duas sub-issues fecharem.
+✅ **Done** (2026-05-04). Fechado após [GAR-490](https://linear.app/chatgpt25/issue/GAR-490) (PR [#112](https://github.com/michelbr84/GarraRUST/pull/112), 2026-05-04) e [GAR-491](https://linear.app/chatgpt25/issue/GAR-491) (PR [#109](https://github.com/michelbr84/GarraRUST/pull/109), 2026-05-01) mergearem.
 
 ---
 
@@ -223,17 +226,17 @@ Dar ao Garra um modo agente avançado de primeira-classe acionável por `garra m
 - **Memória/Auto Dream PII-leak:** `.garra-estado.md` versionado com prompt do usuário pode vazar dados. Mitigação: schema com allow-list de campos; nada de message bodies por padrão.
 - **CI overhead:** `garra verify` em CI pode ficar lento. Mitigação: passos paralelos + cache; budget documentado por etapa.
 
-**Issues Linear sugeridas (épico abaixo):**
+**Issues Linear filhas do épico [GAR-492](https://linear.app/chatgpt25/issue/GAR-492):**
 
-- `GarraMaxPower roadmap + ADR` — esta seção + ADR 0009 (umbrella já registra; issue filha amarra commits).
-- `/max-power MVP` — subcomando `garra max-power` esqueleto + roteamento + banner.
-- `Capability prompt nativo` — gerador provider-agnóstico em runtime, testado contra ≥ 3 providers.
-- `Repo workflow seguro` — wrappers `gh`/`git` com pré-checagens; cobertura de "main protegida" e "tree limpo".
-- `Safety gates para bash` — `safety_gate(cmd)` + denylist + testes + integração com tools.
-- `Skills MVP` — 3-5 skills nativas via registry `garraia-skills`.
-- `Agent team MVP` — orquestrador + 2 sub-agentes, dogfooded em um bug real.
-- `Auto Dream / handoff` — schema `.garra-estado.md` + reader/writer + redaction.
-- `garra verify` — pipeline local idempotente, exit-codes sysexits, relatório markdown.
+- `GarraMaxPower roadmap + ADR` ([GAR-493](https://linear.app/chatgpt25/issue/GAR-493)) — esta seção + ADR 0009 (umbrella já registra; issue filha amarra commits).
+- `/max-power MVP` ([GAR-494](https://linear.app/chatgpt25/issue/GAR-494)) — subcomando `garra max-power` esqueleto + roteamento + banner.
+- `Capability prompt nativo` ([GAR-495](https://linear.app/chatgpt25/issue/GAR-495)) — gerador provider-agnóstico em runtime, testado contra ≥ 3 providers.
+- `Repo workflow seguro` ([GAR-496](https://linear.app/chatgpt25/issue/GAR-496)) — wrappers `gh`/`git` com pré-checagens; cobertura de "main protegida" e "tree limpo".
+- `Safety gates para bash` ([GAR-497](https://linear.app/chatgpt25/issue/GAR-497)) — `safety_gate(cmd)` + denylist + testes + integração com tools.
+- `Skills MVP` ([GAR-498](https://linear.app/chatgpt25/issue/GAR-498)) — 3-5 skills nativas via registry `garraia-skills`.
+- `Agent team MVP` ([GAR-499](https://linear.app/chatgpt25/issue/GAR-499)) — orquestrador + 2 sub-agentes, dogfooded em um bug real.
+- `Auto Dream / handoff` ([GAR-500](https://linear.app/chatgpt25/issue/GAR-500)) — schema `.garra-estado.md` + reader/writer + redaction.
+- `garra verify` ([GAR-501](https://linear.app/chatgpt25/issue/GAR-501)) — pipeline local idempotente, exit-codes sysexits, relatório markdown.
 
 **Estimativa:** 3 / 5 / 8 semanas, em paralelo a 1.2 e 1.3.
 


### PR DESCRIPTION
## Summary

Syncs `ROADMAP.md` with Linear after the `#115`/`#116`/`#117` cycle. **Docs-only**, single file, no code touched.

- **§1.2.1 GarraMaxPower** — replaces the "sugeridas (épico abaixo)" wording with "filhas do épico [GAR-492](https://linear.app/chatgpt25/issue/GAR-492)" (the 9 children already exist) and adds inline cross-links `(GAR-NNN)` to GAR-493…GAR-501.
- **§1.5 umbrella GAR-486** — promoted to ✅ Done after GAR-490 (PR #112, 2026-05-04) and GAR-491 (PR #109, 2026-05-01) closed. Linear issue [GAR-486](https://linear.app/chatgpt25/issue/GAR-486) was transitioned to Done in the same session.
- **§1.5 CI infrastructure** — adds 3 short pointers to newly filed follow-ups:
  - [GAR-503](https://linear.app/chatgpt25/issue/GAR-503) — Remove `CARGO_BIN_EXE_garraia` fallback (`crates/garraia-cli/tests/migrate_workspace_integration.rs:34-42`).
  - [GAR-504](https://linear.app/chatgpt25/issue/GAR-504) — Benchmark evidence run on DigitalOcean droplet (1 vCPU / 1 GB), umbrella for the bench harness execution + optional `bench.yml` follow-up.
  - [GAR-505](https://linear.app/chatgpt25/issue/GAR-505) — Q6.10 mutation triage of the 2026-05-04 red run (run [25307117776](https://github.com/michelbr84/GarraRUST/actions/runs/25307117776)): 6 NEW missed mutants in `jwt.rs`/`storage_redacted.rs`/`app_pool.rs` + 3 timeouts.

## Why now

PRs #115/#116/#117 closed three structural gaps but left orphan follow-ups in PR bodies, README scaffolding (`benches/agent-framework-comparison/`), and a freshly-failed `mutants.yml` schedule (2026-05-04). Linear was missing the corresponding tickets and the ROADMAP wasn't cross-linking the 9 GarraMaxPower children that already exist. Before resuming code work (next: GAR-503), the backlog and the roadmap had to become trustworthy.

## Scope guards (verified)

- 1 file, `ROADMAP.md`, +16 / -13.
- No code, no workflow, no `docs/security/`, no `benches/` edits.
- No `--admin`, no force-push, no `main` mutation.
- The 3 new Linear issues + the GAR-486 promotion happened **before** this PR and are independently auditable.
- `mutants.yml` is untouched — its `:25-27` ban on `continue-on-error` stays in force.

## Test plan

- [x] `git diff --stat origin/main..HEAD` → 1 file, 16 insertions, 13 deletions.
- [x] `grep -E "GAR-49[3-9]\b|GAR-50[01]\b" ROADMAP.md` returns ≥ 9 hits in §1.2.1 (none before this PR).
- [x] `grep "fica em \*\*In Progress\*\*" ROADMAP.md` returns 0 hits.
- [ ] CI green: `Format Check`, `Clippy Linting`, `Test (ubuntu-latest)`, `Test (windows-latest)` (4 required by ruleset 15901595).
- [ ] After merge: GAR-486 in Linear shows `completed`; new bullets in ROADMAP §1.5 visible on `main`.

## Follow-up

Next session: branch off `main` for [GAR-503](https://linear.app/chatgpt25/issue/GAR-503) (single-file removal of the `CARGO_BIN_EXE_garraia` fallback). Benchmark evidence ([GAR-504](https://linear.app/chatgpt25/issue/GAR-504)) and Q6.10 triage ([GAR-505](https://linear.app/chatgpt25/issue/GAR-505)) execute out-of-band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)