### PR TITLE
test(auth): triage mutation testing missed mutants

### DIFF
--- a/crates/garraia-auth/src/jwt.rs
+++ b/crates/garraia-auth/src/jwt.rs
@@ -479,4 +479,66 @@ mod tests {
         assert_eq!(claims.sub, uid);
         assert_eq!(claims.iss, ISSUER);
     }
+
+    /// GAR-505 #1+#2 — kills `jwt.rs:31` `*` → `+` (yields TTL = 75) and
+    /// `*` → `/` (yields TTL = 0). Asserts the access-token expiry window
+    /// is exactly 900 seconds, the contract of `15 * 60`.
+    #[test]
+    fn access_token_ttl_window_is_900_seconds() {
+        let issuer = JwtIssuer::new(cfg()).expect("ctor");
+        let (token, _) = issuer.issue_access(Uuid::now_v7()).expect("issue");
+        let claims = issuer.verify_access(&token).expect("verify");
+        assert_eq!(
+            claims.exp - claims.iat,
+            900,
+            "ACCESS_TTL_SECS must be 15 * 60 = 900 seconds"
+        );
+    }
+
+    /// GAR-505 #3 — kills `jwt.rs:177` `<` → `<=` in `JwtIssuer::new_for_test`.
+    /// The padding loop must stop at `padded.len() == 32` (original `<`),
+    /// not at `padded.len() == 33` (mutant `<=`). With a 32-byte input the
+    /// mutant pushes one extra `=` to 33 bytes; the resulting HMAC differs
+    /// from the oracle computed against the literal 32-byte secret.
+    #[test]
+    fn new_for_test_does_not_pad_already_32_byte_secret() {
+        // `Mac` trait brings `new_from_slice`, `update`, `finalize` into scope
+        // for the local oracle. Keep the import local so the rest of the test
+        // module is unaffected.
+        use hmac::Mac;
+
+        let secret = "x".repeat(32);
+        let issuer = JwtIssuer::new_for_test(&secret);
+        let plaintext = "GAR-505-oracle";
+        let actual = issuer
+            .hmac_refresh(plaintext)
+            .expect("hmac_refresh on 32-byte secret");
+
+        let mut mac =
+            HmacSha256::new_from_slice(secret.as_bytes()).expect("32 bytes is a valid HMAC key");
+        mac.update(plaintext.as_bytes());
+        let expected = hex_encode(&mac.finalize().into_bytes());
+
+        assert_eq!(
+            actual, expected,
+            "secret must NOT be padded when input length is already 32"
+        );
+    }
+
+    /// GAR-505 #4 — kills `jwt.rs:250` `<` → `<=` in `extract_bearer_token`.
+    /// Header `"Bearer "` (exactly 7 bytes) must pass the length guard
+    /// under the original `<`, returning `Some("")`. The mutant `<=` would
+    /// reject and return `None`.
+    #[test]
+    fn extract_bearer_token_accepts_seven_char_boundary() {
+        use axum::http::{HeaderMap, HeaderValue, header::AUTHORIZATION};
+
+        let mut h = HeaderMap::new();
+        h.insert(AUTHORIZATION, HeaderValue::from_static("Bearer "));
+        assert_eq!(
+            extract_bearer_token(&h),
+            Some(""),
+            "header `Bearer ` (7 bytes) must satisfy `len < 7` rejection guard"
+        );
+    }
 }

--- a/crates/garraia-auth/src/storage_redacted.rs
+++ b/crates/garraia-auth/src/storage_redacted.rs
@@ -64,6 +64,47 @@ pub(crate) fn redact(raw: &str) -> String {
 /// a fixed `postgres://[REDACTED]@[REDACTED]` placeholder. The redaction
 /// consumes characters up to the next whitespace, quote, or delimiter so
 /// that the surrounding message remains readable.
+///
+/// # Mutation testing — `mutants::skip` justification (GAR-505, 2026-05-04)
+///
+/// `cargo-mutants` 25.x supports skipping at file-glob (`exclude_globs`)
+/// or function-attribute granularity only — there is no per-line/per-column
+/// skip via `cargo-mutants.toml` regex, and no `// mutants: skip` line
+/// comment exists. This function hosts four mutants that are either
+/// equivalent or produce loops; skipping the function is the precise tool
+/// the linter offers, and is preferred over excluding the whole file
+/// (which would also drop signal for `redact()` and `redact_key_value()`).
+/// Coverage is preserved by the seven `#[test]` cases in `mod tests`
+/// below, which exercise `redact()` end-to-end.
+///
+/// The `cfg_attr(any(), …)` shape means rustc never expands the inner
+/// `mutants::skip` attribute (`any()` is empty ⇒ false ⇒ the attribute is
+/// stripped), so no `mutants` crate dependency is required. cargo-mutants
+/// recognises the skip because it greps the source for the literal string
+/// `mutants::skip` before invoking rustc (see `https://mutants.rs/attrs.html`:
+/// "it only looks for the sequence `mutants::skip` in the attribute").
+///
+/// Mutants covered:
+/// - line 71 `<` → `<=` (loop guard): **equivalent**. With `<=`, the
+///   iteration at `i == bytes.len()` produces `rest = ""`, falls into the
+///   else branch, `chars().next()` returns `None`, `unwrap_or('\0')` yields
+///   `'\0'`, and `if ch == '\0' { break; }` exits without modifying output.
+/// - line 91 `+=` → `-=` (cursor advance): underflows `usize` (debug panic)
+///   or repeats the same URL match indefinitely → reported as `timeout`.
+/// - line 91 `+=` → `*=` (cursor advance): on the first match `i = 0`,
+///   `i *= (prefix_len + end) = 0`, the loop re-enters at `i = 0` →
+///   infinite loop on any input whose URL begins at offset 0 → `timeout`.
+/// - line 104 `+=` → `*=` (ASCII advance): for `ch.len_utf8() == 1`,
+///   `i *= 1` leaves `i` unchanged → infinite loop on any non-empty input
+///   without a URL → `timeout`.
+///
+/// This is **not** silencing the workflow — `.github/workflows/mutants.yml`
+/// is unchanged and there is no `continue-on-error: true`. It is classifying
+/// these four mutants as known-equivalent / known-loop, which is exactly
+/// what the cargo-mutants attribute is intended for. The trade-off — losing
+/// mutation signal inside this single function — is accepted because the
+/// `mod tests` suite already covers the redaction contract end-to-end.
+#[cfg_attr(any(), mutants::skip)]
 fn redact_urls(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
     let bytes = input.as_bytes();

--- a/crates/garraia-auth/tests/app_pool_role_guard.rs
+++ b/crates/garraia-auth/tests/app_pool_role_guard.rs
@@ -1,0 +1,78 @@
+//! GAR-505 #6 — kills `app_pool.rs:203` `!=` → `==` mutant in
+//! `AppPool::from_dedicated_config`.
+//!
+//! The role guard rejects any role that is not `garraia_app`. We exercise
+//! the rejection path by promoting `garraia_login` to LOGIN and pointing
+//! the AppPool constructor at it. The constructor must return
+//! `AuthError::WrongRole("garraia_login")`. Mutating `!=` → `==` would
+//! flip the guard (accept `garraia_login`, reject `garraia_app`) and this
+//! test would fail.
+//!
+//! Pattern follows `verify_internal.rs` — self-contained container boot,
+//! no `mod common` dependency (the shared harness is gated behind the
+//! `test-support` feature and would over-couple this single test).
+
+use garraia_auth::{AppPool, AppPoolConfig, AuthError};
+use garraia_workspace::{Workspace, WorkspaceConfig};
+use testcontainers::ImageExt;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres as PgImage;
+
+#[tokio::test]
+async fn from_dedicated_config_rejects_non_app_role() -> anyhow::Result<()> {
+    // 1. Boot pgvector/pg16. The container handle is kept alive in scope
+    //    for the duration of the test; dropping it stops the container.
+    let container = PgImage::default()
+        .with_name("pgvector/pgvector")
+        .with_tag("pg16")
+        .start()
+        .await?;
+    let host = container.get_host().await?;
+    let port = container.get_host_port_ipv4(5432).await?;
+    let admin_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+    // 2. Apply migrations 001..010 — defines `garraia_app`, `garraia_login`,
+    //    and `garraia_signup` as NOLOGIN roles.
+    Workspace::connect(WorkspaceConfig {
+        database_url: admin_url.clone(),
+        max_connections: 5,
+        migrate_on_start: true,
+    })
+    .await?;
+
+    // 3. Promote `garraia_login` to LOGIN with a deterministic test password
+    //    so we can build a connect URL for it. We do NOT promote
+    //    `garraia_app` — the AppPool guard would accept that, defeating the
+    //    test.
+    let admin_pool = sqlx::PgPool::connect(&admin_url).await?;
+    sqlx::query("ALTER ROLE garraia_login WITH LOGIN PASSWORD 'login-pw'")
+        .execute(&admin_pool)
+        .await?;
+    admin_pool.close().await;
+
+    // 4. Point AppPool::from_dedicated_config at garraia_login. The guard
+    //    at app_pool.rs:203 must fire and return WrongRole("garraia_login").
+    let wrong_role_url = admin_url.replace("postgres:postgres@", "garraia_login:login-pw@");
+    let cfg = AppPoolConfig {
+        database_url: wrong_role_url,
+        max_connections: 4,
+    };
+
+    let result = AppPool::from_dedicated_config(&cfg).await;
+    match result {
+        Err(AuthError::WrongRole(role)) => {
+            assert_eq!(
+                role, "garraia_login",
+                "WrongRole error must carry the actual observed role"
+            );
+        }
+        Err(other) => {
+            panic!("expected Err(AuthError::WrongRole(\"garraia_login\")), got Err({other:?})")
+        }
+        Ok(_) => panic!(
+            "expected Err(AuthError::WrongRole(\"garraia_login\")), got Ok(_) — \
+             the role guard at app_pool.rs:203 did not fire"
+        ),
+    }
+    Ok(())
+}

--- a/docs/mutation-baseline-2026-04.md
+++ b/docs/mutation-baseline-2026-04.md
@@ -274,3 +274,132 @@ Recomenda-se atacar GAR-481 primeiro (deadline) e GAR-468 logo em seguida.
 - Run anterior (cancelled): https://github.com/michelbr84/GarraRUST/actions/runs/25109221846
 - Run atual (completo): https://github.com/michelbr84/GarraRUST/actions/runs/25116031135
 - Linear Q6.1..Q6.8: GAR-463, GAR-464, GAR-465, GAR-466, GAR-467, GAR-468, GAR-469, GAR-481
+
+---
+
+## Atualização — Run 25307117776 (GAR-505, 2026-05-04)
+
+Triage dos 6 missed novos + 3 timeouts em `garraia-auth`. Esta seção precede o
+merge do PR de GAR-505 e documenta o estado pré-PR (run scheduled de segunda
+05:00 UTC, ficou vermelho) e o estado esperado pós-PR.
+
+### Metadata
+
+| Campo | Valor |
+|---|---|
+| Run ID | `25307117776` |
+| Workflow | `Mutation Testing — garraia-auth (pilot)` (`mutants.yml`) |
+| Trigger | `schedule` (cron Monday 05:00 UTC) |
+| Commit base | `5c63a162` (`main`, após PR #118) |
+| Duração | 2h05m29s (dentro do limite de 150 min) |
+| Conclusão | `failure` (esperado — havia missed/timeouts) |
+
+### Score (pré-PR)
+
+```
+total_mutants:    179
+caught:           128  (vs 125 em 25116031135 — +3 por crescimento de testes existente)
+missed:            10  (-3 vs 13)
+timeout:            3  (=)
+unviable:          38  (=)
+```
+
+- Mutantes viáveis: `179 - 38 = 141`
+- Killed (caught + timeout): `128 + 3 = 131`
+- **Score: `131 / 141 = 92.91%`** (vs `90.78%` → **+2.13 p.p.**)
+
+### Triage GAR-505 (5 caught + 4 skip via `mutants::skip`)
+
+| # | File:line | Mutação | Resolução |
+|---|---|---|---|
+| 1 | `jwt.rs:31` | `*` → `+` em `ACCESS_TTL_SECS` | killed por `access_token_ttl_window_is_900_seconds` |
+| 2 | `jwt.rs:31` | `*` → `/` em `ACCESS_TTL_SECS` | killed pelo mesmo teste |
+| 3 | `jwt.rs:177` | `<` → `<=` em `JwtIssuer::new_for_test` | killed por `new_for_test_does_not_pad_already_32_byte_secret` (HMAC oracle) |
+| 4 | `jwt.rs:250` | `<` → `<=` em `extract_bearer_token` | killed por `extract_bearer_token_accepts_seven_char_boundary` |
+| 5 | `storage_redacted.rs:71` | `<` → `<=` em `redact_urls` | **equivalente** — `#[cfg_attr(any(), mutants::skip)]` em `redact_urls` |
+| 6 | `app_pool.rs:203` | `!=` → `==` em `AppPool::from_dedicated_config` | killed por integration test `app_pool_role_guard.rs::from_dedicated_config_rejects_non_app_role` |
+| T1 | `storage_redacted.rs:91` | `+=` → `-=` em `redact_urls` | **timeout** (underflow `usize` ou loop) — coberto pelo mesmo skip da função |
+| T2 | `storage_redacted.rs:91` | `+=` → `*=` em `redact_urls` | **timeout** (`i = 0` estagnado em URL no offset 0) — coberto pelo mesmo skip |
+| T3 | `storage_redacted.rs:104` | `+=` → `*=` em `redact_urls` | **timeout** (`i *= 1` estagnado em ASCII) — coberto pelo mesmo skip |
+
+### Score esperado pós-PR
+
+| Métrica | Pré-PR (`25307117776`) | Pós-PR (estimado) | Δ |
+|---|---|---|---|
+| `total_mutants` | 179 | ~179 (idem; novos tests não geram mutants extras significativos) | ~0 |
+| `caught` | 128 | **133** (+5 dos novos tests) | +5 |
+| `missed` | 10 | **4** (sites #1..#4 + #6 mortos; site #5 sai como skipped) | −6 |
+| `timeout` | 3 | **0** (T1..T3 saem como skipped) | −3 |
+| `unviable` | 38 | 38 | 0 |
+| `skipped` | 0 | **4** (mutants em `redact_urls` cobertos pelo `cfg_attr(any(), mutants::skip)`) | +4 |
+| **Mutantes viáveis** | 141 | **137** (`179 - 38 - 4`) | −4 |
+| **Killed (caught+timeout)** | 131 | **133** | +2 |
+| **Score** | **92.91%** | **97.08%** (`133 / 137`) | **+4.17 p.p.** |
+| Workflow | `failure` | `failure` ainda esperado se ≥1 dos 4 missed remanescentes não estiver resolvido em outras issues | — |
+
+> Os 4 missed remanescentes pertencem a GAR-464/467/483/468 e estão fora do escopo de GAR-505:
+> `audit_workspace.rs:156` (GAR-467), `internal.rs:430` (GAR-466 ou GAR-464), `signup_pool.rs:153`
+> (GAR-483, Debug), `app_pool.rs:218` (GAR-483, Debug). O workflow só ficará completamente
+> verde quando essas issues fecharem ou quando os mutantes correspondentes forem reclassificados
+> em PRs subsequentes.
+
+### Decisão técnica — `redact_urls` skip
+
+`cargo-mutants` 25.x não suporta skip por linha/coluna nem inline:
+
+- `cargo-mutants.toml`: aceita só `exclude_globs` / `examine_globs` (file-path) — confirmado em
+  https://mutants.rs/skip_files.html.
+- Atributos: sempre function-level (`#[mutants::skip]` ou qualquer attr contendo essa
+  string) — confirmado em https://mutants.rs/attrs.html ("it only looks for the
+  sequence `mutants::skip` in the attribute").
+- Não existe `// mutants: skip` line comment.
+
+As três alternativas avaliadas:
+
+- **A — function-level skip em `redact_urls`** (escolhida): perde mutation signal dentro de
+  uma função. Compensação: 7 unit tests no `mod tests` (linhas 156-242) cobrem `redact()`
+  end-to-end com inputs realistas (URL com porta/path, `postgresql://`, multi-key, passthrough,
+  source chain).
+- **B — só documentar, sem skip**: deixa workflow vermelho perpetuamente por causa do site #5
+  (mutante equivalente — não há teste possível que o distingua). **Recusada.**
+- **C — `exclude_globs` no arquivo**: perderia signal de `redact()` e `redact_key_value()`
+  que estão saudáveis. **Recusada.**
+
+### Padrão `cfg_attr(any(), mutants::skip)` — justificativa
+
+`#[cfg_attr(any(), mutants::skip)]` evita adicionar a crate `mutants` (`0.0.3`) como
+dependência. cargo-mutants greps o source pela string literal `mutants::skip` antes da
+compilação; `cfg_attr(any(), …)` nunca é expandido pelo rustc porque `any()` é vazio
+(= false), então o atributo `mutants::skip` interno nunca chega ao type-checker. Resultado:
+cargo-mutants reconhece o skip; rustc compila sem dep adicional.
+
+### Não-silenciamento — invariantes preservadas
+
+- `.github/workflows/mutants.yml` permanece **inalterado** em GAR-505 (zero diff).
+- `continue-on-error: true` continua **ausente** em todo o workflow.
+- O skip é classificação explícita, não supressão de erro.
+- Cada um dos 4 mutantes cobertos pelo skip tem prova técnica linha-a-linha no comentário
+  acima de `redact_urls` (storage_redacted.rs).
+
+### Status atualizado das sub-issues Q6.x
+
+| Sub-issue | State (pós-GAR-505) | Mutantes restantes |
+|---|---|---|
+| GAR-463 (Q6.1 security bypass) | Done | 0 |
+| GAR-464 (Q6.2 boundary) | Backlog | 0 ou 1 (depende do mapeamento de `internal.rs:430`) |
+| GAR-465 (Q6.3 TTL arithmetic) | Done (incorporado em GAR-505 #1+#2) | 0 |
+| GAR-466 (Q6.4 unique-violation) | Backlog | 1 (`internal.rs:430`) |
+| GAR-467 (Q6.5 audit observability) | Backlog | 1 (`audit_workspace.rs:156`) |
+| GAR-468 (Q6.6 Debug skip) | Done para `JwtConfig`/`RefreshTokenPair`/`Credential` | 2 (alocados a GAR-483) |
+| GAR-469 (Q6.7 timeout 90→150) | Done | 0 |
+| GAR-481 (Q6.8 Node 24) | Backlog | — (não relacionado a mutants) |
+| GAR-483 (Debug skip pendentes) | Backlog | 2 (`signup_pool.rs:153`, `app_pool.rs:218`) |
+| **GAR-505** (este triage) | **em PR** | 0 dentro do escopo |
+
+### Referências adicionais (GAR-505)
+
+- Run vermelho: https://github.com/michelbr84/GarraRUST/actions/runs/25307117776
+- PR (a preencher após `gh pr create`): https://github.com/michelbr84/GarraRUST/pull/XX
+- Linear: https://linear.app/chatgpt25/issue/GAR-505
+- cargo-mutants attrs spec: https://mutants.rs/attrs.html
+- cargo-mutants config spec: https://mutants.rs/skip_files.html


### PR DESCRIPTION
## Summary

GAR-505 triage of run [25307117776](https://github.com/michelbr84/GarraRUST/actions/runs/25307117776) (10 missed + 3 timeouts in `garraia-auth`):

- **5 mutants killed by new tests** (3 unit + 1 integration)
- **4 mutants in `redact_urls` classified** as known-equivalent / known-loop via function-level `#[cfg_attr(any(), mutants::skip)]` with line-by-line technical proof in the function doc-comment
- **`.github/workflows/mutants.yml` is unchanged**; no `continue-on-error` added — this is classification, not silencing

The 4 missed remaining after this PR (`audit_workspace.rs:156`, `internal.rs:430`, `signup_pool.rs:153` Debug, `app_pool.rs:218` Debug) are tracked in GAR-464/467/483/468 and out of scope here. The workflow will only go fully green when those issues close.

## Mutantes mortos por testes (5)

| File:line | Mutação | Test (file → fn) |
|---|---|---|
| `jwt.rs:31` | `*` → `+` (`ACCESS_TTL_SECS = 15 * 60`) | `jwt.rs::tests::access_token_ttl_window_is_900_seconds` |
| `jwt.rs:31` | `*` → `/` | mesmo teste |
| `jwt.rs:177` | `<` → `<=` em `JwtIssuer::new_for_test` | `jwt.rs::tests::new_for_test_does_not_pad_already_32_byte_secret` (HMAC oracle com chave 32-byte literal) |
| `jwt.rs:250` | `<` → `<=` em `extract_bearer_token` | `jwt.rs::tests::extract_bearer_token_accepts_seven_char_boundary` |
| `app_pool.rs:203` | `!=` → `==` em `AppPool::from_dedicated_config` | `tests/app_pool_role_guard.rs::from_dedicated_config_rejects_non_app_role` (testcontainers + pgvector/pg16, padrão de `verify_internal.rs`) |

## Mutantes classificados como equivalente / timeout (4)

Aplicado `#[cfg_attr(any(), mutants::skip)]` em `fn redact_urls` (storage_redacted.rs:67) com prova técnica linha-a-linha no doc-comment da função:

| File:line | Mutação | Classe |
|---|---|---|
| `storage_redacted.rs:71` | `<` → `<=` | **Equivalente** — iteração extra cai em `rest = \"\"`, `chars().next() = None`, `unwrap_or('\0')`, break. Output idêntico. |
| `storage_redacted.rs:91` | `+=` → `-=` | **Timeout** — underflow `usize` em debug ou re-match infinito |
| `storage_redacted.rs:91` | `+=` → `*=` | **Timeout** — `i = 0` estagnado em qualquer input com URL no offset 0 |
| `storage_redacted.rs:104` | `+=` → `*=` | **Timeout** — ASCII width 1 ⇒ `i *= 1` ⇒ estagnado |

### Por que opção A (function-level skip)?

Validação da sintaxe real do `cargo-mutants` 25.x revelou que **não existe skip por linha/coluna**:

- `cargo-mutants.toml` aceita só `exclude_globs` / `examine_globs` (file-path) — confirmado em https://mutants.rs/skip_files.html.
- Atributos são function-level (`#[mutants::skip]` ou qualquer attr contendo a string) — https://mutants.rs/attrs.html: \"it only looks for the sequence `mutants::skip` in the attribute\".
- Não existe `// mutants: skip` line comment.

Alternativas avaliadas:
- **A** (escolhida): function-level skip em `redact_urls`. Perde mutation signal apenas dentro de uma função; coverage compensada pelos 7 unit tests do `mod tests` (linhas 156-242 da unidade) que cobrem `redact()` end-to-end.
- **B**: só documentar. Workflow ficaria vermelho perpetuamente por causa do site #5 (mutante equivalente — sem teste possível). **Recusada**.
- **C**: `exclude_globs` no arquivo. Perderia signal de `redact()` e `redact_key_value()` saudáveis. **Recusada**.

### Por que `cfg_attr(any(), …)`?

`#[cfg_attr(any(), mutants::skip)]` evita adicionar a crate `mutants = \"0.0.3\"` como dependência. cargo-mutants greps a string literal `mutants::skip` antes da compilação; `cfg_attr(any(), …)` nunca é expandido pelo rustc porque `any()` é vazio (= false). cargo-mutants reconhece o skip; rustc compila sem dep extra.

## Score esperado

| Métrica | Pré-PR (run 25307117776) | Pós-PR (estimado) |
|---|---|---|
| `caught` | 128 | **133** |
| `missed` | 10 | **4** (residual de outras issues) |
| `timeout` | 3 | **0** |
| `unviable` | 38 | 38 |
| `skipped` | 0 | **4** (todos em `redact_urls`) |
| Mutantes viáveis | 141 | 137 |
| Killed | 131 | 133 |
| **Score** | **92.91%** | **97.08%** (+4.17 p.p.) |

## Comandos executados

\`\`\`text
$ cargo check -p garraia-auth --all-targets
Finished `dev` profile [unoptimized + debuginfo] target(s) in 24.58s

$ cargo clippy -p garraia-auth --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.47s

$ cargo fmt -p garraia-auth --check
(clean)

$ cargo test -p garraia-auth --lib
test result: ok. 54 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.75s
  ✓ jwt::tests::access_token_ttl_window_is_900_seconds
  ✓ jwt::tests::extract_bearer_token_accepts_seven_char_boundary
  ✓ jwt::tests::new_for_test_does_not_pad_already_32_byte_secret

$ cargo test -p garraia-auth --test app_pool_role_guard --no-run
Finished `test` profile [unoptimized + debuginfo] target(s) in 8.08s
Executable tests/app_pool_role_guard.rs (target/debug/deps/app_pool_role_guard-*.exe)
\`\`\`

**Local mutation spot-check não executado** — `cargo-mutants` não está instalado nesta workstation Windows. Validação via CI no próximo `workflow_dispatch` ou cron de segunda. **Integration test runtime não exercitado localmente** — Docker Desktop não estava em execução; CI tem Docker preinstalado e o teste foi exercitado em padrão idêntico (`verify_internal.rs`).

## Confirmação de invariantes

- [x] `.github/workflows/mutants.yml` **não foi modificado** (`git diff origin/main -- .github/workflows/mutants.yml` retorna vazio).
- [x] Nenhum `continue-on-error: true` adicionado.
- [x] `crates/garraia-auth/src/storage_redacted.rs` sem refactor de produção (apenas comment block + `cfg_attr` attribute).
- [x] `crates/garraia-auth/src/app_pool.rs` sem mudanças (teste vive em `tests/`).
- [x] Sem mudanças em `ROADMAP.md`, `docs/adr/**`, `.github/workflows/*` exceto este PR.
- [x] `git add` por nome (4 paths explícitos), nunca `git add -A`.

## Test plan

- [ ] CI verde — Rust check / clippy / fmt / tests / e2e / playwright.
- [ ] CI Mutation Testing — verificar manualmente via `gh workflow run mutants.yml` após merge ou aguardar a próxima cron de segunda. Esperado: cair de 10 missed + 3 timeouts para 4 missed + 0 timeouts.
- [ ] Linear GAR-505 → Done apenas após PR mergeado e workflow validado.
- [ ] **Não mergear com `--admin`** — se a ruleset bloquear, atualizar `docs/security/protect-main-ruleset.json` na próxima sessão (padrão `feedback_ruleset_drift_no_admin_bypass.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)