### PR TITLE
fix(gateway): GAR-511 — uploads_worker.rs SET LOCAL format! → set_config() + admin.html XSS

### DIFF
--- a/crates/garraia-gateway/src/admin.html
+++ b/crates/garraia-gateway/src/admin.html
@@ -757,7 +757,7 @@ async function pageDashboard() {
     ];
     metricCards.forEach(c => {
       var card = el('div', { className: 'metric-card ' + c.cls });
-      card.innerHTML = '<div class="metric-label">' + c.icon + ' ' + c.label + '</div><div class="metric-value">' + c.value + '</div>';
+      card.innerHTML = '<div class="metric-label">' + c.icon + ' ' + escapeHtml(c.label) + '</div><div class="metric-value">' + escapeHtml(c.value) + '</div>';
       grid.appendChild(card);
     });
     frag.appendChild(grid);
@@ -1218,7 +1218,7 @@ async function pageSessions() {
     var frag = document.createDocumentFragment();
     var grid = el('div', { className: 'card-grid', style: 'margin-bottom:16px' });
     var sc = el('div', { className: 'metric-card metric-blue' });
-    sc.innerHTML = '<div class="metric-label">Active Sessions</div><div class="metric-value">' + (data.count || sessions.length) + '</div>';
+    sc.innerHTML = '<div class="metric-label">Active Sessions</div><div class="metric-value">' + escapeHtml(String(data.count || sessions.length)) + '</div>';
     grid.appendChild(sc);
     frag.appendChild(grid);
     var card = el('div', { className: 'card' });
@@ -1335,7 +1335,7 @@ async function pageMetrics() {
       { label: 'Active Sessions', value: String(data.active_sessions || 0), cls: 'metric-blue' },
     ].forEach(item => {
       var sc = el('div', { className: 'metric-card ' + item.cls });
-      sc.innerHTML = '<div class="metric-label">' + item.label + '</div><div class="metric-value">' + item.value + '</div>';
+      sc.innerHTML = '<div class="metric-label">' + escapeHtml(item.label) + '</div><div class="metric-value">' + escapeHtml(item.value) + '</div>';
       grid.appendChild(sc);
     });
     frag.appendChild(grid);

--- a/crates/garraia-gateway/src/uploads_worker.rs
+++ b/crates/garraia-gateway/src/uploads_worker.rs
@@ -205,12 +205,12 @@ async fn emit_expiration_audit(
     age_secs: i64,
 ) -> Result<(), sqlx::Error> {
     let mut tx = pool.pool_for_handlers().begin().await?;
-    sqlx::query(&format!(
-        "SET LOCAL app.current_user_id = '{actor_user_id}'"
-    ))
-    .execute(&mut *tx)
-    .await?;
-    sqlx::query(&format!("SET LOCAL app.current_group_id = '{group_id}'"))
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(actor_user_id.to_string())
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query("SELECT set_config('app.current_group_id', $1, true)")
+        .bind(group_id.to_string())
         .execute(&mut *tx)
         .await?;
 

--- a/plans/0059-gar-511-uploads-worker-set-config.md
+++ b/plans/0059-gar-511-uploads-worker-set-config.md
@@ -1,0 +1,87 @@
+# Plan 0059 — GAR-511: uploads_worker.rs SET LOCAL format! → set_config() + admin.html XSS cleanup
+
+**Status:** 🟡 In Progress (health routine 2026-05-05)
+**Linear:** [GAR-511](https://linear.app/chatgpt25/issue/GAR-511)
+**Branch:** `health/202605050446-uploads-worker-set-config`
+**Parent:** GAR-508 (closed, missed `uploads_worker.rs`)
+
+---
+
+## 1. Goal
+
+Close the CodeQL `rust/sql-injection` taint path in `emit_expiration_audit`
+(`crates/garraia-gateway/src/uploads_worker.rs:208-215`) that GAR-508's scope
+missed, and apply defense-in-depth `escapeHtml()` to 3 remaining metric-card
+`innerHTML` sinks in `admin.html` that GAR-510 did not reach (lines 760, 1221,
+1338).
+
+## 2. Architecture
+
+No schema, no migration, no API change.
+
+- `uploads_worker.rs::emit_expiration_audit` — replace 2 `sqlx::query(&format!("SET LOCAL ..."))` calls with `sqlx::query("SELECT set_config(..., $1, true)").bind(...)`.
+- `admin.html` — add `escapeHtml()` wrapper around dynamic values injected via `innerHTML` in `pageDashboard` (line 760), `pageSessions` (line 1221), and `pageMetrics` (line 1338).
+
+## 3. Tech stack
+
+Rust / sqlx 0.8 / Axum 0.8, vanilla JS (admin.html).
+
+## 4. Design invariants
+
+- `set_config('app.current_X_id', $1, true)` is transaction-scoped — identical RLS semantics to `SET LOCAL` (same as GAR-508 §5.1).
+- `escapeHtml()` helper is already defined in `admin.html:639` (GAR-510). No new dependency.
+- No behavior change for metric card rendering — all current values are numeric strings; escapeHtml is a no-op over them. Defense-in-depth only.
+
+## 5. Out of scope
+
+- Introducing a `BYPASSRLS` worker role (future improvement noted in `uploads_worker.rs:21-24`).
+- Other CodeQL rules.
+- `deny.toml` / `audit.toml` changes.
+
+## 6. Rollback
+
+`git revert <merge-sha>` — zero schema / migration risk.
+
+## 7. File structure
+
+```
+crates/garraia-gateway/src/uploads_worker.rs   ← T1: 2-line SQL fix
+crates/garraia-gateway/src/admin.html          ← T2: 3-sink escapeHtml
+plans/0059-gar-511-uploads-worker-set-config.md ← this file
+plans/README.md                                ← update row
+```
+
+## 8. Tasks (M1)
+
+- [x] T1 — `uploads_worker.rs:208-215`: replace both `format!("SET LOCAL …")` with `set_config()` bind-parameter queries
+- [x] T2 — `admin.html` lines 760, 1221, 1338: wrap `innerHTML` dynamic values with `escapeHtml()`
+- [ ] T3 — `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` → 0 warnings
+- [ ] T4 — commit + push + open PR
+- [ ] T5 — CI green; merge; mark GAR-511 Done; update plans/README.md
+
+## 9. Risk register
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| `set_config` changes session config scope | Negligible | `is_local=true` means tx-scoped — same as `SET LOCAL` |
+| escapeHtml breaks metric display | None | All current values are numeric; escapeHtml is identity on them |
+| CI flaky (E2E/Playwright) | Low | No gateway logic changed |
+
+## 10. Acceptance criteria
+
+- `grep -n "SET LOCAL\|format!(.*current" crates/garraia-gateway/src/uploads_worker.rs` → 0 hits outside comments
+- `grep -n "innerHTML.*item\.value\|innerHTML.*c\.value" crates/garraia-gateway/src/admin.html | grep -v escapeHtml` → 0 hits
+- Clippy strict → 0 warnings
+- CI ≥16 checks pass; PR squash-merged to main
+- GAR-511 moved to Done in Linear
+
+## 11. Estimativa
+
+< 1h end-to-end (pure mechanical substitution, no test authoring needed — existing tests in `rest_v1_uploads_delete_worker.rs` cover the audit path).
+
+## 12. Cross-references
+
+- GAR-508 / plan 0056 — original `set_config()` wave (scope: `rest_v1/*.rs`)
+- GAR-510 / plan 0057 — `escapeHtml` introduction + first 3 XSS sinks
+- GAR-395 / plan 0047 — `uploads_worker.rs` original implementation (slice 3)
+- CodeQL rule `rust/sql-injection`; rule `js/xss`

--- a/plans/README.md
+++ b/plans/README.md
@@ -82,6 +82,7 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0056 | [GAR-508 — replace SET LOCAL format! with set_config() parameterized SQL (sql-injection CodeQL real-fix)](0056-gar-508-set-config-sql-injection.md) | [GAR-508](https://linear.app/chatgpt25/issue/GAR-508) | ✅ Merged 2026-05-05 via PR #126 (`115104b`) |
 | 0057 | [GAR-510 — admin.html XSS: add escapeHtml + fix 3 unescaped innerHTML sinks](0057-gar-510-admin-xss-escapehtml.md) | [GAR-510](https://linear.app/chatgpt25/issue/GAR-510) | ✅ Merged 2026-05-05 via PR #128 (`5e5302d`) |
 | 0058 | [GAR-WS-CHAT slice 3 — `POST /v1/messages/{message_id}/threads`](0058-gar-ws-chat-slice3-threads.md) | [GAR-509](https://linear.app/chatgpt25/issue/GAR-509) | 🟡 Em execução 2026-05-05 |
+| 0059 | [GAR-511 — uploads_worker.rs SET LOCAL format! → set_config() + admin.html XSS cleanup](0059-gar-511-uploads-worker-set-config.md) | [GAR-511](https://linear.app/chatgpt25/issue/GAR-511) | 🟡 Em execução 2026-05-05 (health routine) |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

Missed-file follow-up to GAR-508 (plan 0056, PR #126, merged 2026-05-05).

- **`uploads_worker.rs` SQL injection (CodeQL `rust/sql-injection`):** `emit_expiration_audit` still used `sqlx::query(&format!("SET LOCAL app.current_X_id = '{val}'"` — the same pattern fixed across 19 occurrences in `rest_v1/*.rs` by GAR-508. Replaces both occurrences with `SELECT set_config('app.current_X_id', $1, true)` + `.bind(uuid.to_string())`. `is_local=true` preserves transaction-scoped RLS semantics — zero behavior change.

- **`admin.html` XSS defense-in-depth (CodeQL `js/xss`):** 3 remaining metric-card `innerHTML` sinks (lines 760, 1221, 1338) now wrap dynamic values with the existing `escapeHtml()` helper (introduced in GAR-510). All current values are numeric; this is identity over them — zero behavior change.

## Alert origin

- CodeQL rule: `rust/sql-injection` — `crates/garraia-gateway/src/uploads_worker.rs:208-215`
- CodeQL rule: `js/xss` — `crates/garraia-gateway/src/admin.html:760,1221,1338`
- GAR-508 was scoped to `rest_v1/*.rs` only; `uploads_worker.rs` was not in scope.

## Grep invariant verified

```
$ grep -n "SET LOCAL\|format!(.*current" crates/garraia-gateway/src/uploads_worker.rs
# → 0 hits outside comments
```

## Test plan

- [x] `cargo check -p garraia-gateway --features test-helpers` → Finished (0 errors)
- [x] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` → 0 warnings
- [ ] CI ≥16 checks green
- [ ] CodeQL `rust/sql-injection` alert for `uploads_worker.rs` auto-closes on next scheduled scan

## Linear

[GAR-511](https://linear.app/chatgpt25/issue/GAR-511) | Plan: `plans/0059-gar-511-uploads-worker-set-config.md`

https://claude.ai/code/session_018dmddjRwkVD8ce2yR8tNrh

---
_Generated by [Claude Code](https://claude.ai/code/session_018dmddjRwkVD8ce2yR8tNrh)_