### PR TITLE
fix(gateway): GAR-512 — webchat.html XSS: fix 5 unescaped innerHTML sinks

### DIFF
--- a/crates/garraia-gateway/src/webchat.html
+++ b/crates/garraia-gateway/src/webchat.html
@@ -1885,11 +1885,11 @@ async function refreshStatus() {
   try {
     const r = await fetch('/api/status');
     const j = await r.json();
-    apiStatusEl.innerHTML = '<span class="dot dot-online" style="display:inline-block;width:6px;height:6px;border-radius:50%;background:var(--success);margin-right:4px;"></span>' + j.status;
+    apiStatusEl.innerHTML = '<span class="dot dot-online" style="display:inline-block;width:6px;height:6px;border-radius:50%;background:var(--success);margin-right:4px;"></span>' + escapeHtml(j.status);
     sessionCountEl.textContent = j.sessions;
     if (channelListEl) {
       if (j.channels && j.channels.length > 0) {
-        channelListEl.innerHTML = j.channels.map(ch => '<span class="channel-tag"><span class="dot dot-online" style="display:inline-block;width:5px;height:5px;border-radius:50%;background:var(--success);"></span> ' + ch + '</span>').join('');
+        channelListEl.innerHTML = j.channels.map(ch => '<span class="channel-tag"><span class="dot dot-online" style="display:inline-block;width:5px;height:5px;border-radius:50%;background:var(--success);"></span> ' + escapeHtml(ch) + '</span>').join('');
       } else {
         channelListEl.innerHTML = '<span style="color:var(--text-muted);font-size:12px;">No channels</span>';
       }
@@ -1964,7 +1964,7 @@ async function loadExtensions() {
         item.className = 'dropdown-item';
         item.style.fontSize = '12px';
         const statusColor = (s.status && s.status.state === 'running') ? 'var(--success)' : 'var(--text-muted)';
-        item.innerHTML = `<span style="color:${statusColor};font-size:8px;">&#9679;</span> <span>${s.name}</span> <span style="color:var(--text-muted);font-size:10px;">${s.transport || ''}</span>`;
+        item.innerHTML = `<span style="color:${statusColor};font-size:8px;">&#9679;</span> <span>${escapeHtml(s.name)}</span> <span style="color:var(--text-muted);font-size:10px;">${escapeHtml(s.transport || '')}</span>`;
         mcpList.appendChild(item);
       });
       const badge = $('ext-badge-count');
@@ -2120,7 +2120,7 @@ function addSessionToList(sessionId) {
   item.dataset.session = sessionId;
   item.innerHTML = `
     <span class="session-item-icon">&#128172;</span>
-    <span class="session-item-text">${sessionId.slice(0, 16)}...</span>
+    <span class="session-item-text">${escapeHtml(sessionId.slice(0, 16))}...</span>
     <span class="session-item-time">${formatTime(new Date())}</span>
   `;
   item.addEventListener('click', () => {
@@ -2650,7 +2650,7 @@ function renderSessionList(sessions) {
     item.className = 'session-item' + (id === State.session ? ' active' : '');
     item.dataset.session = id;
     item.dataset.channel = channel;
-    const channelBadge = channel !== 'web' ? `<span style="font-size:9px;padding:1px 5px;border-radius:8px;background:var(--accent-light);color:var(--accent);margin-left:auto;">${channel}</span>` : '';
+    const channelBadge = channel !== 'web' ? `<span style="font-size:9px;padding:1px 5px;border-radius:8px;background:var(--accent-light);color:var(--accent);margin-left:auto;">${escapeHtml(channel)}</span>` : '';
     item.innerHTML = `
       <span class="session-item-icon">&#128172;</span>
       <span class="session-item-text">${escapeHtml(id.slice(0, 16))}...</span>

--- a/plans/0061-gar-512-webchat-xss-escapehtml.md
+++ b/plans/0061-gar-512-webchat-xss-escapehtml.md
@@ -1,0 +1,109 @@
+# Plan 0061 — GAR-512: webchat.html XSS — fix 4 unescaped innerHTML sinks
+
+**Status:** Em execução
+**Autor:** Claude Sonnet 4.6 (health routine 2026-05-05, America/New_York)
+**Data:** 2026-05-05 (America/New_York)
+**Issue:** [GAR-512](https://linear.app/chatgpt25/issue/GAR-512)
+**Branch:** `health/202605050652-gar-512-webchat-xss`
+**CodeQL rule:** `js/xss` (high severity)
+
+## §1 Goal
+
+Close `js/xss` CodeQL alerts in `crates/garraia-gateway/src/webchat.html` by wrapping
+all server-API-returned strings injected via `innerHTML` with the existing `escapeHtml()`
+helper. Companion fix to GAR-510 (admin.html, PR #128, 2026-05-05).
+
+## §2 Architecture
+
+`webchat.html` is a single-file chat SPA served by `garraia-gateway`. It fetches data from
+`/api/status`, `/api/mcp`, `/api/sessions`, and the WebSocket stream, then renders responses
+via JavaScript DOM manipulation. The `escapeHtml()` and `escapeAttr()` helpers are already
+defined (lines 1841–1849) and correctly applied to user-message bodies, system messages,
+error messages, project names, file names, and skill names. However, four blocks that
+render server-API metadata (API status string, channel names, MCP server names/transports,
+and session channel badges) are missing the wrapper.
+
+## §3 Tech stack
+
+Pure client-side JavaScript in a single HTML file. No build step, no npm. The fix uses
+only the `escapeHtml()` DOM-trick already present in the same file.
+
+## §4 Design invariants
+
+- `escapeHtml()` only wraps string values going into `innerHTML`. Template literals that
+  contain only hardcoded markup (no user/API data) are left as-is.
+- `marked.parse()` calls (AI response markdown rendering, lines 1707 and 1803) are
+  intentional by-design and are NOT changed in this plan — they require a DOMPurify
+  integration decision (tracked separately).
+- Zero logic changes; zero Rust changes; zero schema changes.
+
+## §5 Scope
+
+**In scope:**
+- 5 specific innerHTML injection sites listed in §7.
+
+**Out of scope:**
+- `marked.parse()` XSS (DOMPurify integration — separate plan needed).
+- Refactoring other HTML files or template rendering.
+- Any Rust / database changes.
+
+## §6 Affected files
+
+```
+crates/garraia-gateway/src/webchat.html   (5 targeted line changes)
+plans/README.md                            (add row 0061)
+```
+
+## §7 Vulnerable sinks → fix
+
+| Line (pre-fix) | Sink | Source | Fix |
+|---|---|---|---|
+| 1888 | `'...' + j.status` | `/api/status` → `j.status` | `escapeHtml(j.status)` |
+| 1892 | `'...' + ch + '...'` | `/api/status` → `j.channels[i]` | `escapeHtml(ch)` |
+| 1967 | `${s.name}`, `${s.transport \|\| ''}` | `/api/mcp` → `s.name`, `s.transport` | `${escapeHtml(s.name)}`, `${escapeHtml(s.transport \|\| '')}` |
+| 2123 | `${sessionId.slice(0, 16)}` | WebSocket / server-assigned ID | `${escapeHtml(sessionId.slice(0, 16))}` |
+| 2653 | `channel` in `channelBadge` template | `/api/sessions` → `s.channel_id` | `escapeHtml(channel)` |
+
+## §8 Rollback plan
+
+Revert the single commit on `webchat.html`. No data migration required.
+The change is purely additive (wrapping calls); reverting is a one-line
+git revert. No service restart needed (static file hot-reload).
+
+## §9 Risk register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Visual regression if a valid channel name contains `&` or `<` | Low | Low | `escapeHtml` uses DOM `textContent` trick — correct HTML entity encoding |
+| CodeQL re-scan delay (alerts stay open 15-30 min after merge) | Certain | Cosmetic | Not actionable; alerts auto-close on next CodeQL run |
+
+## §10 Acceptance criteria
+
+- `grep -n "innerHTML\s*=" crates/garraia-gateway/src/webchat.html` shows no
+  API-data concatenation without `escapeHtml()`
+- `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` passes
+- All CI checks pass (Format, Clippy, Tests, Build, MSRV, cargo-deny, Security Audit,
+  Coverage, Analyze rust, Analyze js-ts, Playwright, E2E, Secret Scan, Dependency Review)
+
+## §11 Cross-references
+
+- GAR-510 — companion fix for `admin.html` (merged PR #128)
+- GAR-511 — companion fix for `uploads_worker.rs` SQL injection (merged PR #130)
+- GAR-486 — CodeQL umbrella
+- CodeQL rule: `js/xss`
+
+## §12 Open questions
+
+None — fix is structurally identical to GAR-510.
+
+## §13 Estimativa
+
+T1: Implement 5 escapeHtml wraps in webchat.html — 15 min
+T2: Update plans/README.md — 5 min
+Total: ~20 min
+
+## M1 Tasks
+
+- [x] T1: Fix 5 innerHTML sinks in `webchat.html`
+- [x] T2: Update `plans/README.md` with row 0061
+- [ ] T3: CI green + merge

--- a/plans/README.md
+++ b/plans/README.md
@@ -83,6 +83,7 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0057 | [GAR-510 — admin.html XSS: add escapeHtml + fix 3 unescaped innerHTML sinks](0057-gar-510-admin-xss-escapehtml.md) | [GAR-510](https://linear.app/chatgpt25/issue/GAR-510) | ✅ Merged 2026-05-05 via PR #128 (`5e5302d`) |
 | 0058 | [GAR-WS-CHAT slice 3 — `POST /v1/messages/{message_id}/threads`](0058-gar-ws-chat-slice3-threads.md) | [GAR-509](https://linear.app/chatgpt25/issue/GAR-509) | 🟡 Em execução 2026-05-05 |
 | 0059 | [GAR-511 — uploads_worker.rs SET LOCAL format! → set_config() + admin.html XSS cleanup](0059-gar-511-uploads-worker-set-config.md) | [GAR-511](https://linear.app/chatgpt25/issue/GAR-511) | 🟡 Em execução 2026-05-05 (health routine) |
+| 0061 | [GAR-512 — webchat.html XSS: fix 5 unescaped innerHTML sinks](0061-gar-512-webchat-xss-escapehtml.md) | [GAR-512](https://linear.app/chatgpt25/issue/GAR-512) | 🟡 Em execução 2026-05-05 (health routine) |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

Companion fix to GAR-510 (admin.html XSS, merged PR #128, 2026-05-05). `webchat.html` already has `escapeHtml()` and `escapeAttr()` helpers correctly applied to user messages, system messages, and error messages — but **5 innerHTML sinks that inject server-API-returned data were missing the wrapper**.

**CodeQL rule:** `js/xss` (High severity) — same rule closed by GAR-510/PR #128.

### Sinks fixed

| Line | Sink | Source API | Fix |
|------|------|-----------|-----|
| 1888 | `'...' + j.status` | `/api/status` | `escapeHtml(j.status)` |
| 1892 | `'...' + ch + '...'` | `/api/status` → channel names | `escapeHtml(ch)` |
| 1967 | `${s.name}`, `${s.transport\|\|''}` | `/api/mcp` → MCP server name + transport | `${escapeHtml(s.name)}`, `${escapeHtml(s.transport\|\|'')}` |
| 2123 | `${sessionId.slice(0,16)}` | WebSocket / server-assigned session ID | `${escapeHtml(sessionId.slice(0,16))}` |
| 2653 | `${channel}` in channelBadge | `/api/sessions` → `s.channel_id` | `${escapeHtml(channel)}` |

**Out of scope:** `marked.parse()` calls (lines 1707, 1803) — intentional Markdown rendering of LLM responses; requires DOMPurify integration decision, tracked separately.

## Files changed

- `crates/garraia-gateway/src/webchat.html` — 5 `escapeHtml()` wraps added
- `plans/0061-gar-512-webchat-xss-escapehtml.md` — new plan file
- `plans/README.md` — row 0061 added

## Test plan

- [x] `grep -n "innerHTML" crates/garraia-gateway/src/webchat.html | grep -v escapeHtml` shows no API-data concatenation without wrapping
- [x] `cargo check -p garraia-gateway` passes (verified with SWAGGER_UI_DOWNLOAD_URL workaround)
- [ ] CI green on all 17 checks (Format, Clippy, Test×3, Build, MSRV, cargo-deny, Security Audit, Coverage, Analyze rust, Analyze js-ts, Playwright, E2E, Secret Scan, Dependency Review)
- [ ] CodeQL `js/xss` alerts for `webchat.html` auto-close on next scan

**Closes GAR-512.** Refs GAR-510, GAR-486.

https://claude.ai/code/session_01Px5Qm28CHy1LYfKarUatyX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Px5Qm28CHy1LYfKarUatyX)_