### PR TITLE
fix(gateway): GAR-515 — webchat.html XSS: DOMPurify for marked.parse() + langLabel injection + event delegation

### DIFF
--- a/crates/garraia-gateway/src/webchat.html
+++ b/crates/garraia-gateway/src/webchat.html
@@ -6,6 +6,7 @@
 <title>GarraIA Chat</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" id="hljs-theme" />
 <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/12.0.0/marked.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.1.7/purify.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
 <style>
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap");
@@ -1466,7 +1467,7 @@ renderer.code = function(codeObj) {
     highlighted = hljs.highlightAuto(text).value;
   }
   const langLabel = lang || 'code';
-  return `<div class="code-block-wrapper"><div class="code-block-header"><span>${langLabel}</span><button class="copy-code-btn" onclick="copyCodeBlock(this)">Copy</button></div><pre><code class="hljs">${highlighted}</code></pre></div>`;
+  return `<div class="code-block-wrapper"><div class="code-block-header"><span>${escapeHtml(langLabel)}</span><button class="copy-code-btn">Copy</button></div><pre><code class="hljs">${highlighted}</code></pre></div>`;
 };
 
 marked.setOptions({
@@ -1482,6 +1483,12 @@ window.copyCodeBlock = function(btn) {
     setTimeout(() => { btn.textContent = 'Copy'; }, 2000);
   });
 };
+
+// DOMPurify strips onclick attributes — use event delegation for copy buttons
+chatMessages.addEventListener('click', function(e) {
+  const btn = e.target.closest('.copy-code-btn');
+  if (btn) copyCodeBlock(btn);
+});
 
 // ─── Theme System ─────────────────────────────────────────────────────
 function applyTheme(theme) {
@@ -1704,7 +1711,7 @@ function handleAssistantMessage(content) {
     const currentText = bodyEl.getAttribute('data-raw') || '';
     const newText = currentText + parsedContent;
     bodyEl.setAttribute('data-raw', newText);
-    bodyEl.innerHTML = marked.parse(newText);
+    bodyEl.innerHTML = DOMPurify.sanitize(marked.parse(newText));
     chatMessages.scrollTop = chatMessages.scrollHeight;
   } else {
     appendAIMsg(parsedContent, true);
@@ -1800,7 +1807,7 @@ function appendAIMsg(text, isStreaming) {
   const group = document.createElement('div');
   group.className = 'message-group ai-group';
 
-  const rendered = marked.parse(text);
+  const rendered = DOMPurify.sanitize(marked.parse(text));
   const bodyClass = isStreaming ? 'msg-body streaming-cursor' : 'msg-body';
   group.innerHTML = `
     <div class="msg-avatar ai-avatar">&#x1f99c;</div>

--- a/crates/garraia-gateway/src/webchat.html
+++ b/crates/garraia-gateway/src/webchat.html
@@ -6,7 +6,7 @@
 <title>GarraIA Chat</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" id="hljs-theme" />
 <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/12.0.0/marked.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.1.7/purify.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.1.7/purify.min.js" integrity="sha384-XQqX/4yiUGu+oyr87jvWzRuqBUK/adrY0DunhL+tID9m/9dwSpV8h9Fk/Sg6ifVQ" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
 <style>
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap");

--- a/plans/0063-gar-515-webchat-dompurify.md
+++ b/plans/0063-gar-515-webchat-dompurify.md
@@ -1,0 +1,120 @@
+# Plan 0063 — GAR-515: webchat.html XSS — DOMPurify for marked.parse() + langLabel + event delegation
+
+**Status:** ⏳ Draft  
+**Linear:** [GAR-515](https://linear.app/chatgpt25/issue/GAR-515)  
+**Branch:** `health/202605051248-webchat-dompurify`  
+**Created:** 2026-05-05 (Florida)  
+**Author:** health-routine
+
+---
+
+## §1 Goal
+
+Close two HIGH-severity CodeQL `js/xss` alerts in `webchat.html`:
+
+1. **Sink L1707** (streaming path): `bodyEl.innerHTML = marked.parse(newText)` — server WebSocket frames taint `newText`; marked 12.x allows raw HTML passthrough; no sanitizer.
+2. **Sink L1803** (non-streaming path): `const rendered = marked.parse(text)` used verbatim inside a template literal → `group.innerHTML`.
+
+Additionally close a secondary injection path:
+- **Code-block renderer L1469**: `${langLabel}` (from code-fence language identifier in markdown) injected unescaped into `<span>` inside the renderer string.
+
+---
+
+## §2 Architecture / Context
+
+`webchat.html` is a single-file SPA served by `garraia-gateway`. It receives AI responses via WebSocket (`/ws`). Streamed chunks are accumulated in `data-raw` and re-rendered with `marked.parse()` on each chunk. All prior XSS fixes (GAR-510, GAR-511, GAR-512) handled *data-field* escaping (`escapeHtml()`), but the AI message rendering pipeline was left without a sanitizer — intentionally deferred to this plan.
+
+The fix follows the industry-standard pattern for markdown-to-HTML pipelines: **marked → DOMPurify → innerHTML**.
+
+---
+
+## §3 Tech stack
+
+- DOMPurify 3.1.7 (cdnjs, same CDN as marked.min.js and highlight.js already in-use)
+- JavaScript (no build step; single-file HTML)
+- No Rust changes
+
+---
+
+## §4 Design invariants
+
+1. **No regression on code-block copy button**: DOMPurify strips `onclick`; fix uses event delegation on `chatMessages` instead. `window.copyCodeBlock(btn)` function is unchanged.
+2. **Markdown rendering preserved**: DOMPurify default config allows `<b>`, `<i>`, `<a>`, `<code>`, `<pre>`, `<table>`, `<img src>`, etc. Only `<script>` and event-handler attributes are stripped.
+3. **No CSP change required**: DOMPurify runs client-side without additional network requests.
+4. **`escapeHtml` hoisted**: the code renderer uses `escapeHtml(langLabel)` — safe because `escapeHtml` is a `function` declaration (hoisted to file scope).
+
+---
+
+## §5 Out of scope
+
+- DOMPurify configuration tightening (e.g., blocking `<img>`) — tracked separately under GAR-486 follow-up.
+- admin.html markdown rendering (admin.html uses `textContent` for log lines, no markdown renderer).
+- Playwright test for actual XSS injection (tracked under GAR-430 quality-gates wave).
+
+---
+
+## §6 Rollback
+
+Pure HTML/JS change. Rollback = revert the commit on `webchat.html`. No schema, no migration, no binary dependency.
+
+---
+
+## §7 File structure (changes)
+
+```
+crates/garraia-gateway/src/webchat.html   ← 5 targeted edits (see M1 tasks)
+plans/0063-gar-515-webchat-dompurify.md   ← this file
+plans/README.md                           ← add row 0063
+```
+
+---
+
+## §8 Tasks (M1)
+
+- [x] T1 — Add DOMPurify 3.1.7 CDN `<script>` tag to `<head>` (after marked.min.js)
+- [x] T2 — Escape `langLabel` in code-block renderer: `${escapeHtml(langLabel)}`
+- [x] T3 — Remove `onclick="copyCodeBlock(this)"` from code-block button; keep class `copy-code-btn`
+- [x] T4 — Add event delegation on `chatMessages` for `.copy-code-btn` click
+- [x] T5 — Wrap streaming sink: `DOMPurify.sanitize(marked.parse(newText))`
+- [x] T6 — Wrap non-streaming sink: `DOMPurify.sanitize(marked.parse(text))`
+- [ ] T7 — Verify: `grep "marked\.parse" webchat.html` shows 0 unwrapped calls
+- [ ] T8 — PR + CI green (17/17) + squash-merge
+- [ ] T9 — Update plans/README.md row status to ✅ Merged
+- [ ] T10 — Mark GAR-515 Done in Linear; note GAR-510 bookkeeping (still open in Linear, actually merged via PR #128 — close that too)
+
+---
+
+## §9 Risk register
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| DOMPurify strips `onclick` on copy button | Certain (by design) | T3+T4: event delegation replaces inline handler |
+| DOMPurify strips legitimate HTML in AI response | Low (default config is permissive) | Markdown headings, links, bold, italic, tables all survive |
+| CDN availability | Low | Same CDN (cdnjs) used for marked.min.js and highlight.js |
+
+---
+
+## §10 Acceptance criteria
+
+1. No `marked.parse()` call in `webchat.html` without `DOMPurify.sanitize()` wrapper.
+2. `escapeHtml(langLabel)` used in code-block renderer `<span>`.
+3. No `onclick` attribute on code-block copy buttons.
+4. Event delegation on `chatMessages` handles `.copy-code-btn` clicks.
+5. CI 17/17 green.
+6. CodeQL `Analyze (javascript-typescript)` re-run closes the L1707 and L1803 `js/xss` alerts.
+
+---
+
+## §11 Cross-references
+
+- GAR-510 (admin.html XSS, PR #128) — companion fix
+- GAR-511 (uploads_worker.rs + admin.html, PR #130) — companion fix
+- GAR-512 (webchat.html data-field escaping, PR #133) — companion fix
+- GAR-486 (Green Security Baseline umbrella) — parent issue
+- docs/security/codeql-suppressions.md — suppression ledger (this fix does NOT need a suppression entry; it's a real fix)
+
+---
+
+## §12 Estimativa
+
+~30 min (5 surgical edits to a single file + plan + PR bookkeeping).

--- a/plans/README.md
+++ b/plans/README.md
@@ -84,7 +84,8 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0058 | [GAR-WS-CHAT slice 3 — `POST /v1/messages/{message_id}/threads`](0058-gar-ws-chat-slice3-threads.md) | [GAR-509](https://linear.app/chatgpt25/issue/GAR-509) | ✅ Merged 2026-05-05 (`679cd9a`, PR #127) |
 | 0059 | [GAR-511 — uploads_worker.rs SET LOCAL format! → set_config() + admin.html XSS cleanup](0059-gar-511-uploads-worker-set-config.md) | [GAR-511](https://linear.app/chatgpt25/issue/GAR-511) | ✅ Merged 2026-05-05 (`f9091f0`, PR #130) |
 | 0060 | [GAR-503 — remove `CARGO_BIN_EXE_garraia` dead-code fallback + doc bookkeeping](0060-gar-503-cargo-bin-exe-cleanup.md) | [GAR-503](https://linear.app/chatgpt25/issue/GAR-503) | ✅ Merged 2026-05-05 (`750fb50`, PR #132) |
-| 0061 | [GAR-512 — webchat.html XSS: fix 5 unescaped innerHTML sinks](0061-gar-512-webchat-xss-escapehtml.md) | [GAR-512](https://linear.app/chatgpt25/issue/GAR-512) | 🟡 Em execução 2026-05-05 (health routine) |
+| 0061 | [GAR-512 — webchat.html XSS: fix 5 unescaped innerHTML sinks](0061-gar-512-webchat-xss-escapehtml.md) | [GAR-512](https://linear.app/chatgpt25/issue/GAR-512) | ✅ Merged 2026-05-05 via PR #133 (`5944ad1`) |
+| 0063 | [GAR-515 — webchat.html XSS: DOMPurify for marked.parse() + langLabel + event delegation](0063-gar-515-webchat-dompurify.md) | [GAR-515](https://linear.app/chatgpt25/issue/GAR-515) | ⏳ Draft 2026-05-05 (health routine) |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

Closes **2 HIGH-severity CodeQL `js/xss` sinks** in `webchat.html` that were left open after GAR-512 (PR #133), plus a secondary injection in the code-block renderer.

**Originating alerts:** CodeQL rule `js/xss` — same rule that drove GAR-510 (PR #128), GAR-511 (PR #130), GAR-512 (PR #133). The `marked.parse()` paths were intentionally deferred from those PRs because the fix required adding a sanitizer library, not just `escapeHtml()`.

**Attack scenario:** prompt injection → AI response contains `<script>` or `<img onerror=…>` → `marked.parse()` passes it through verbatim (marked 12.x has no built-in sanitizer) → browser executes it in the webchat context.

### Changes (`crates/garraia-gateway/src/webchat.html`)

| # | Location | Change |
|---|----------|--------|
| T1 | `<head>` line 9 | Add DOMPurify 3.1.7 CDN script (same cdnjs CDN as marked + highlight.js) |
| T2 | Code-block renderer L1470 | `${escapeHtml(langLabel)}` — prevents injection via code-fence language identifier |
| T3 | Code-block renderer L1470 | Remove `onclick="copyCodeBlock(this)"` (DOMPurify strips `onclick`; replaced by T4) |
| T4 | After `copyCodeBlock` def | Event delegation on `chatMessages` for `.copy-code-btn` clicks |
| T5 | Streaming sink L1714 | `bodyEl.innerHTML = DOMPurify.sanitize(marked.parse(newText))` |
| T6 | Non-streaming sink L1810 | `const rendered = DOMPurify.sanitize(marked.parse(text))` |

No Rust/schema/migration changes. No new dependencies in `Cargo.toml`/`Cargo.lock`.

## Test plan

- [ ] `grep "marked\.parse" crates/garraia-gateway/src/webchat.html` → all calls wrapped with `DOMPurify.sanitize()`
- [ ] `grep "onclick.*copyCodeBlock" crates/garraia-gateway/src/webchat.html` → 0 matches
- [ ] Playwright: copy-button still works (event delegation path)
- [ ] CI 17/17 green
- [ ] CodeQL `Analyze (javascript-typescript)` re-run auto-closes the two `js/xss` alerts on L1707 and L1803

**Linear:** [GAR-515](https://linear.app/chatgpt25/issue/GAR-515) | **Plan:** `plans/0063-gar-515-webchat-dompurify.md` | **Parent:** GAR-486

https://claude.ai/code/session_01Pu3Td7hYEUnPbj1meMUGJm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pu3Td7hYEUnPbj1meMUGJm)_