### PR TITLE
chore(mobile): remove unused auth_provider import in settings_screen_test

### DIFF
--- a/apps/garraia-mobile/test/settings_screen_test.dart
+++ b/apps/garraia-mobile/test/settings_screen_test.dart
@@ -12,7 +12,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:garraia_mobile/providers/auth_provider.dart';
 import 'package:garraia_mobile/screens/settings_screen.dart';
 import 'package:garraia_mobile/services/api_service.dart';
 


### PR DESCRIPTION
## Summary
- Removes the unused `package:garraia_mobile/providers/auth_provider.dart` import from `apps/garraia-mobile/test/settings_screen_test.dart` (Flutter analyzer was flagging it as `unused_import`).

## Test plan
- [x] `cargo check --workspace` (no Rust changes)
- [ ] CI green on this branch (Quality Ratchet PR-1 still in report-only mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)