### PR TITLE
chore(repo): ignore local AI Quality Gates research folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,6 @@ crates/garraia-desktop/ui/assets/parrot-sprite.png
 current-metrics.json
 quality-report.md
 .quality/baseline.proposed.json
+
+# Local research / reference material (not committed)
+AI Quality Gates/


### PR DESCRIPTION
## Summary
- Adds `AI Quality Gates/` to `.gitignore` so the local research folder (alternative JS implementations of the ratchet, `files.zip`, a `baseline.json` that conflicts with `.quality/baseline.json`, plus PNG/MD references) stops surfacing in `git status` and can't be accidentally swept in by a `git add -A`.

## Why a separate PR?
- Keeps PR #141 atomic (1 unused-import removal in a Flutter test).
- This change is unrelated to the test cleanup and to the Quality Ratchet PR-1 (#139).

## Test plan
- [x] `git status --ignored --short` shows `!! "AI Quality Gates/"` after the edit (confirmed locally).
- [ ] CI green (no functional code touched; only a `.gitignore` line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)