### PR TITLE
feat(gateway): GAR-518 — tasks REST API slice 2 (GET task + PATCH/DELETE task-list)

### DIFF
--- a/crates/garraia-auth/src/audit_workspace.rs
+++ b/crates/garraia-auth/src/audit_workspace.rs
@@ -155,6 +155,23 @@ pub enum WorkspaceAuditAction {
     /// removed — `deleted_at` is set to `now()`. Hard deletion is a
     /// future compliance/retention worker task (Fase 5.3).
     MemoryDeleted,
+
+    /// A task list's metadata was updated via
+    /// `PATCH /v1/groups/{group_id}/task-lists/{list_id}`
+    /// (plan 0067 / GAR-518, epic GAR-WS-TASKS slice 2).
+    ///
+    /// `resource_type = "task_lists"`, `resource_id = "{list_id}"`.
+    /// Metadata: `{ name_len, type }`. `name` text is PII-excluded.
+    TaskListUpdated,
+
+    /// A task list was archived (soft-deleted) via
+    /// `DELETE /v1/groups/{group_id}/task-lists/{list_id}`
+    /// (plan 0067 / GAR-518, epic GAR-WS-TASKS slice 2).
+    ///
+    /// `resource_type = "task_lists"`, `resource_id = "{list_id}"`.
+    /// Metadata: `{ type }`. List is not physically removed;
+    /// `archived_at` is set to `now()`.
+    TaskListArchived,
 }
 
 impl WorkspaceAuditAction {
@@ -172,6 +189,8 @@ impl WorkspaceAuditAction {
             WorkspaceAuditAction::ThreadCreated => "thread.created",
             WorkspaceAuditAction::MemoryCreated => "memory.created",
             WorkspaceAuditAction::MemoryDeleted => "memory.deleted",
+            WorkspaceAuditAction::TaskListUpdated => "task_list.updated",
+            WorkspaceAuditAction::TaskListArchived => "task_list.archived",
         }
     }
 }
@@ -276,6 +295,14 @@ mod tests {
             WorkspaceAuditAction::MemoryDeleted.as_str(),
             "memory.deleted"
         );
+        assert_eq!(
+            WorkspaceAuditAction::TaskListUpdated.as_str(),
+            "task_list.updated"
+        );
+        assert_eq!(
+            WorkspaceAuditAction::TaskListArchived.as_str(),
+            "task_list.archived"
+        );
     }
 
     #[test]
@@ -293,6 +320,8 @@ mod tests {
             WorkspaceAuditAction::ThreadCreated.as_str(),
             WorkspaceAuditAction::MemoryCreated.as_str(),
             WorkspaceAuditAction::MemoryDeleted.as_str(),
+            WorkspaceAuditAction::TaskListUpdated.as_str(),
+            WorkspaceAuditAction::TaskListArchived.as_str(),
         ];
         let unique: std::collections::HashSet<_> = strings.iter().collect();
         assert_eq!(unique.len(), strings.len(), "duplicate action strings");

--- a/crates/garraia-auth/src/audit_workspace.rs
+++ b/crates/garraia-auth/src/audit_workspace.rs
@@ -156,6 +156,30 @@ pub enum WorkspaceAuditAction {
     /// future compliance/retention worker task (Fase 5.3).
     MemoryDeleted,
 
+    /// A task list was created via
+    /// `POST /v1/groups/{group_id}/task-lists`
+    /// (plan 0066 / GAR-516, epic GAR-WS-TASKS slice 1).
+    ///
+    /// `resource_type = "task_lists"`, `resource_id = "{task_list_id}"`.
+    /// Metadata: `{ name_len, type }`. `name` text is PII-excluded.
+    TaskListCreated,
+
+    /// A task was created via
+    /// `POST /v1/groups/{group_id}/task-lists/{list_id}/tasks`
+    /// (plan 0066 / GAR-516, epic GAR-WS-TASKS slice 1).
+    ///
+    /// `resource_type = "tasks"`, `resource_id = "{task_id}"`.
+    /// Metadata: `{ title_len, status, priority }`. `title` text is PII-excluded.
+    TaskCreated,
+
+    /// A task was soft-deleted via
+    /// `DELETE /v1/groups/{group_id}/tasks/{task_id}`
+    /// (plan 0066 / GAR-516, epic GAR-WS-TASKS slice 1).
+    ///
+    /// `resource_type = "tasks"`, `resource_id = "{task_id}"`.
+    /// Metadata: `{ title_len, status }`. `title` text is PII-excluded.
+    TaskDeleted,
+
     /// A task list's metadata was updated via
     /// `PATCH /v1/groups/{group_id}/task-lists/{list_id}`
     /// (plan 0067 / GAR-518, epic GAR-WS-TASKS slice 2).
@@ -189,6 +213,9 @@ impl WorkspaceAuditAction {
             WorkspaceAuditAction::ThreadCreated => "thread.created",
             WorkspaceAuditAction::MemoryCreated => "memory.created",
             WorkspaceAuditAction::MemoryDeleted => "memory.deleted",
+            WorkspaceAuditAction::TaskListCreated => "task_list.created",
+            WorkspaceAuditAction::TaskCreated => "task.created",
+            WorkspaceAuditAction::TaskDeleted => "task.deleted",
             WorkspaceAuditAction::TaskListUpdated => "task_list.updated",
             WorkspaceAuditAction::TaskListArchived => "task_list.archived",
         }
@@ -296,6 +323,12 @@ mod tests {
             "memory.deleted"
         );
         assert_eq!(
+            WorkspaceAuditAction::TaskListCreated.as_str(),
+            "task_list.created"
+        );
+        assert_eq!(WorkspaceAuditAction::TaskCreated.as_str(), "task.created");
+        assert_eq!(WorkspaceAuditAction::TaskDeleted.as_str(), "task.deleted");
+        assert_eq!(
             WorkspaceAuditAction::TaskListUpdated.as_str(),
             "task_list.updated"
         );
@@ -320,6 +353,9 @@ mod tests {
             WorkspaceAuditAction::ThreadCreated.as_str(),
             WorkspaceAuditAction::MemoryCreated.as_str(),
             WorkspaceAuditAction::MemoryDeleted.as_str(),
+            WorkspaceAuditAction::TaskListCreated.as_str(),
+            WorkspaceAuditAction::TaskCreated.as_str(),
+            WorkspaceAuditAction::TaskDeleted.as_str(),
             WorkspaceAuditAction::TaskListUpdated.as_str(),
             WorkspaceAuditAction::TaskListArchived.as_str(),
         ];

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -65,7 +65,7 @@ thiserror = { workspace = true }
 # The handlers need sqlx types (`query_as`, transactions) directly.
 # Feature set mirrors dev-dependencies so prod + test link the
 # same version.
-sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "postgres", "uuid", "chrono"] }
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "postgres", "uuid", "chrono", "macros"] }
 dirs = "6"
 governor = "0.8"
 tower_governor = "0.8"

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -37,13 +37,14 @@ pub mod memory;
 pub mod messages;
 pub mod openapi;
 pub mod problem;
+pub mod tasks;
 pub mod uploads;
 
 use std::sync::Arc;
 
 use axum::Router;
 use axum::extract::FromRef;
-use axum::routing::{delete, get, head, post};
+use axum::routing::{delete, get, head, patch, post};
 use garraia_auth::{AppPool, JwtIssuer, LoginPool};
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
@@ -286,6 +287,25 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     get(memory::list_memory).post(memory::create_memory),
                 )
                 .route("/v1/memory/{id}", delete(memory::delete_memory))
+                // Plan 0066/0067 (GAR-516/GAR-518) — tasks API slices 1+2.
+                .route(
+                    "/v1/groups/{group_id}/task-lists",
+                    post(tasks::create_task_list).get(tasks::list_task_lists),
+                )
+                .route(
+                    "/v1/groups/{group_id}/task-lists/{list_id}",
+                    patch(tasks::patch_task_list).delete(tasks::delete_task_list),
+                )
+                .route(
+                    "/v1/groups/{group_id}/task-lists/{list_id}/tasks",
+                    post(tasks::create_task).get(tasks::list_tasks),
+                )
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}",
+                    get(tasks::get_task)
+                        .patch(tasks::patch_task)
+                        .delete(tasks::delete_task),
+                )
                 .merge(rate_limited_routes)
                 .merge(tus_routes)
                 .with_state(full)
@@ -335,6 +355,25 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     get(unconfigured_handler).post(unconfigured_handler),
                 )
                 .route("/v1/memory/{id}", delete(unconfigured_handler))
+                // Plan 0066/0067 (GAR-516/GAR-518) — tasks API slices 1+2, fail-soft 503.
+                .route(
+                    "/v1/groups/{group_id}/task-lists",
+                    post(unconfigured_handler).get(unconfigured_handler),
+                )
+                .route(
+                    "/v1/groups/{group_id}/task-lists/{list_id}",
+                    patch(unconfigured_handler).delete(unconfigured_handler),
+                )
+                .route(
+                    "/v1/groups/{group_id}/task-lists/{list_id}/tasks",
+                    post(unconfigured_handler).get(unconfigured_handler),
+                )
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}",
+                    get(unconfigured_handler)
+                        .patch(unconfigured_handler)
+                        .delete(unconfigured_handler),
+                )
                 .route(
                     "/v1/uploads",
                     post(unconfigured_handler).options(uploads::options_uploads),
@@ -390,6 +429,25 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     get(unconfigured_handler).post(unconfigured_handler),
                 )
                 .route("/v1/memory/{id}", delete(unconfigured_handler))
+                // Plan 0066/0067 (GAR-516/GAR-518) — tasks API slices 1+2, no-auth stub.
+                .route(
+                    "/v1/groups/{group_id}/task-lists",
+                    post(unconfigured_handler).get(unconfigured_handler),
+                )
+                .route(
+                    "/v1/groups/{group_id}/task-lists/{list_id}",
+                    patch(unconfigured_handler).delete(unconfigured_handler),
+                )
+                .route(
+                    "/v1/groups/{group_id}/task-lists/{list_id}/tasks",
+                    post(unconfigured_handler).get(unconfigured_handler),
+                )
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}",
+                    get(unconfigured_handler)
+                        .patch(unconfigured_handler)
+                        .delete(unconfigured_handler),
+                )
                 .route(
                     "/v1/uploads",
                     post(unconfigured_handler).options(uploads::options_uploads),

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -27,6 +27,11 @@ use super::messages::{
     ThreadResponse,
 };
 use super::problem::ProblemDetails;
+use super::tasks::{
+    CreateTaskListRequest, CreateTaskRequest, ListTaskListsResponse, ListTasksResponse,
+    PatchTaskListRequest, PatchTaskRequest, TaskListResponse, TaskListSummary, TaskResponse,
+    TaskSummary,
+};
 use super::uploads::{CreateUploadRequest, CreateUploadResponse};
 
 /// Plan 0016 M3-T1 — registers a bearer JWT `SecurityScheme` in the
@@ -90,6 +95,15 @@ impl Modify for SecurityAddon {
         super::memory::list_memory,
         super::memory::create_memory,
         super::memory::delete_memory,
+        super::tasks::create_task_list,
+        super::tasks::list_task_lists,
+        super::tasks::patch_task_list,
+        super::tasks::delete_task_list,
+        super::tasks::create_task,
+        super::tasks::list_tasks,
+        super::tasks::get_task,
+        super::tasks::patch_task,
+        super::tasks::delete_task,
     ),
     components(schemas(
         MeResponse,
@@ -119,6 +133,16 @@ impl Modify for SecurityAddon {
         MemoryItemResponse,
         MemoryItemSummary,
         ListMemoryResponse,
+        CreateTaskListRequest,
+        TaskListResponse,
+        TaskListSummary,
+        ListTaskListsResponse,
+        PatchTaskListRequest,
+        CreateTaskRequest,
+        TaskResponse,
+        TaskSummary,
+        ListTasksResponse,
+        PatchTaskRequest,
     )),
     modifiers(&SecurityAddon)
 )]

--- a/crates/garraia-gateway/src/rest_v1/tasks.rs
+++ b/crates/garraia-gateway/src/rest_v1/tasks.rs
@@ -1,0 +1,1424 @@
+//! `/v1/groups/{group_id}/task-lists` and task handlers (plan 0066/0067, GAR-516/GAR-518).
+//!
+//! Nine endpoints on the `garraia_app` RLS-enforced pool:
+//!
+//! **Slice 1 (plan 0066 / GAR-516):**
+//! - `POST /v1/groups/{group_id}/task-lists` — create task list
+//! - `GET /v1/groups/{group_id}/task-lists` — cursor-paginated list
+//! - `POST /v1/groups/{group_id}/task-lists/{list_id}/tasks` — create task
+//! - `GET /v1/groups/{group_id}/task-lists/{list_id}/tasks` — cursor-paginated task list
+//! - `PATCH /v1/groups/{group_id}/tasks/{task_id}` — update task fields
+//! - `DELETE /v1/groups/{group_id}/tasks/{task_id}` — soft-delete
+//!
+//! **Slice 2 (plan 0067 / GAR-518):**
+//! - `GET /v1/groups/{group_id}/tasks/{task_id}` — fetch single task
+//! - `PATCH /v1/groups/{group_id}/task-lists/{list_id}` — update task list name/type/description
+//! - `DELETE /v1/groups/{group_id}/task-lists/{list_id}` — archive task list (idempotent)
+//!
+//! ## Tenant-context protocol
+//!
+//! `task_lists` and `tasks` use FORCE RLS with direct `group_id` isolation
+//! (migration 006). Both RLS vars set via parameterized `set_config` (plan 0056).
+//!
+//! ## App-layer group validation
+//!
+//! Path `{group_id}` must equal `principal.group_id` — mismatch returns 403.
+//! The compound FK `(list_id, group_id) → task_lists(id, group_id)` also
+//! prevents cross-group task creation at the DB level.
+
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use chrono::{DateTime, Utc};
+use garraia_auth::{Action, Principal, WorkspaceAuditAction, audit_workspace_event, can};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use utoipa::{IntoParams, ToSchema};
+use uuid::Uuid;
+
+use super::RestV1FullState;
+use super::problem::RestError;
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const DEFAULT_LIMIT: u32 = 50;
+const MAX_LIMIT: u32 = 100;
+
+const ALLOWED_LIST_TYPES: &[&str] = &["list", "board", "calendar"];
+const ALLOWED_STATUSES: &[&str] = &[
+    "backlog",
+    "todo",
+    "in_progress",
+    "review",
+    "done",
+    "canceled",
+];
+const ALLOWED_PRIORITIES: &[&str] = &["none", "low", "medium", "high", "urgent"];
+
+// ─── Serde helper: Option<Option<T>> three-way deserializer ──────────────────
+//
+// Allows PATCH fields to distinguish:
+//   key absent  → None            (leave unchanged)
+//   key: null   → Some(None)      (clear to null)
+//   key: "val"  → Some(Some(val)) (update to value)
+//
+// Usage: #[serde(default, deserialize_with = "option_nullable::deserialize")]
+mod option_nullable {
+    use serde::{Deserialize, Deserializer};
+
+    pub fn deserialize<'de, T, D>(d: D) -> Result<Option<Option<T>>, D::Error>
+    where
+        T: Deserialize<'de>,
+        D: Deserializer<'de>,
+    {
+        Ok(Some(Option::<T>::deserialize(d)?))
+    }
+}
+
+// ─── Private DB row structs ───────────────────────────────────────────────────
+
+#[derive(sqlx::FromRow)]
+struct TaskListRow {
+    id: Uuid,
+    group_id: Uuid,
+    name: String,
+    list_type: String,
+    description: Option<String>,
+    created_by: Option<Uuid>,
+    created_by_label: String,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+    archived_at: Option<DateTime<Utc>>,
+}
+
+#[derive(sqlx::FromRow)]
+struct TaskRow {
+    id: Uuid,
+    list_id: Uuid,
+    group_id: Uuid,
+    parent_task_id: Option<Uuid>,
+    title: String,
+    description_md: Option<String>,
+    status: String,
+    priority: String,
+    due_at: Option<DateTime<Utc>>,
+    started_at: Option<DateTime<Utc>>,
+    completed_at: Option<DateTime<Utc>>,
+    estimated_minutes: Option<i32>,
+    created_by: Option<Uuid>,
+    created_by_label: String,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+    deleted_at: Option<DateTime<Utc>>,
+}
+
+// ─── DTOs ─────────────────────────────────────────────────────────────────────
+
+/// Request body for `POST /v1/groups/{group_id}/task-lists`.
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CreateTaskListRequest {
+    /// Display name. 1–200 characters.
+    pub name: String,
+    /// View type. One of `"list"`, `"board"`, `"calendar"`.
+    #[serde(rename = "type")]
+    pub list_type: String,
+    /// Optional description.
+    pub description: Option<String>,
+}
+
+impl CreateTaskListRequest {
+    fn validate(&self) -> Result<(), &'static str> {
+        let name_chars = self.name.chars().count();
+        if name_chars == 0 {
+            return Err("name must not be empty");
+        }
+        if name_chars > 200 {
+            return Err("name exceeds 200 character limit");
+        }
+        if !ALLOWED_LIST_TYPES.contains(&self.list_type.as_str()) {
+            return Err("type must be one of: list, board, calendar");
+        }
+        Ok(())
+    }
+}
+
+/// Request body for `PATCH /v1/groups/{group_id}/task-lists/{list_id}`.
+///
+/// All fields are optional. `description` supports three-way semantics:
+/// omit key to leave unchanged, `null` to clear, string to update.
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct PatchTaskListRequest {
+    /// Updated name. 1–200 characters when provided.
+    pub name: Option<String>,
+    /// Updated description. Pass `null` explicitly to clear. Omit to leave unchanged.
+    #[serde(default, deserialize_with = "option_nullable::deserialize")]
+    #[schema(value_type = Option<String>, nullable = true)]
+    pub description: Option<Option<String>>,
+    /// Updated type. One of `"list"`, `"board"`, `"calendar"`.
+    #[serde(rename = "type")]
+    pub list_type: Option<String>,
+}
+
+impl PatchTaskListRequest {
+    fn validate(&self) -> Result<(), &'static str> {
+        if let Some(name) = &self.name {
+            let len = name.chars().count();
+            if len == 0 {
+                return Err("name must not be empty");
+            }
+            if len > 200 {
+                return Err("name exceeds 200 character limit");
+            }
+        }
+        if let Some(lt) = &self.list_type
+            && !ALLOWED_LIST_TYPES.contains(&lt.as_str())
+        {
+            return Err("type must be one of: list, board, calendar");
+        }
+        Ok(())
+    }
+}
+
+/// Full task list representation returned by `POST` and single-item `GET`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct TaskListResponse {
+    pub id: Uuid,
+    pub group_id: Uuid,
+    pub name: String,
+    #[serde(rename = "type")]
+    pub list_type: String,
+    pub description: Option<String>,
+    pub created_by: Option<Uuid>,
+    pub created_by_label: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub archived_at: Option<DateTime<Utc>>,
+}
+
+impl From<TaskListRow> for TaskListResponse {
+    fn from(r: TaskListRow) -> Self {
+        Self {
+            id: r.id,
+            group_id: r.group_id,
+            name: r.name,
+            list_type: r.list_type,
+            description: r.description,
+            created_by: r.created_by,
+            created_by_label: r.created_by_label,
+            created_at: r.created_at,
+            updated_at: r.updated_at,
+            archived_at: r.archived_at,
+        }
+    }
+}
+
+/// Compact task list item used in `GET /v1/groups/{group_id}/task-lists`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct TaskListSummary {
+    pub id: Uuid,
+    pub group_id: Uuid,
+    pub name: String,
+    #[serde(rename = "type")]
+    pub list_type: String,
+    pub description: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl From<TaskListRow> for TaskListSummary {
+    fn from(r: TaskListRow) -> Self {
+        Self {
+            id: r.id,
+            group_id: r.group_id,
+            name: r.name,
+            list_type: r.list_type,
+            description: r.description,
+            created_at: r.created_at,
+            updated_at: r.updated_at,
+        }
+    }
+}
+
+/// Response body for `GET /v1/groups/{group_id}/task-lists`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ListTaskListsResponse {
+    pub items: Vec<TaskListSummary>,
+    /// Cursor for the next page. `None` when end of list is reached.
+    pub next_cursor: Option<Uuid>,
+}
+
+/// Query parameters for `GET /v1/groups/{group_id}/task-lists`.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ListTaskListsQuery {
+    /// Keyset cursor — UUID of the last item received. Omit for the first page.
+    pub cursor: Option<Uuid>,
+    /// Page size. Default 50, max 100.
+    pub limit: Option<u32>,
+}
+
+/// Request body for `POST /v1/groups/{group_id}/task-lists/{list_id}/tasks`.
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CreateTaskRequest {
+    /// Task title. 1–500 characters.
+    pub title: String,
+    /// Optional markdown description. 1–50,000 characters when provided.
+    pub description_md: Option<String>,
+    /// Initial status. One of `"backlog"`, `"todo"`, `"in_progress"`, `"review"`, `"done"`, `"canceled"`. Defaults to `"todo"`.
+    #[serde(default = "default_status")]
+    pub status: String,
+    /// Priority tier. One of `"none"`, `"low"`, `"medium"`, `"high"`, `"urgent"`. Defaults to `"none"`.
+    #[serde(default = "default_priority")]
+    pub priority: String,
+    /// Optional due date (UTC).
+    pub due_at: Option<DateTime<Utc>>,
+    /// Optional time estimate in minutes. 0–100,000.
+    pub estimated_minutes: Option<i32>,
+}
+
+fn default_status() -> String {
+    "todo".to_string()
+}
+fn default_priority() -> String {
+    "none".to_string()
+}
+
+impl CreateTaskRequest {
+    fn validate(&self) -> Result<(), &'static str> {
+        let title_chars = self.title.chars().count();
+        if title_chars == 0 {
+            return Err("title must not be empty");
+        }
+        if title_chars > 500 {
+            return Err("title exceeds 500 character limit");
+        }
+        if !ALLOWED_STATUSES.contains(&self.status.as_str()) {
+            return Err(
+                "status must be one of: backlog, todo, in_progress, review, done, canceled",
+            );
+        }
+        if !ALLOWED_PRIORITIES.contains(&self.priority.as_str()) {
+            return Err("priority must be one of: none, low, medium, high, urgent");
+        }
+        if let Some(desc) = &self.description_md {
+            let len = desc.chars().count();
+            if len == 0 {
+                return Err("description_md must not be empty when provided");
+            }
+            if len > 50_000 {
+                return Err("description_md exceeds 50,000 character limit");
+            }
+        }
+        if let Some(mins) = self.estimated_minutes
+            && !(0..=100_000).contains(&mins)
+        {
+            return Err("estimated_minutes must be between 0 and 100000");
+        }
+        Ok(())
+    }
+}
+
+/// Full task representation returned by `POST`, `GET`, and `PATCH`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct TaskResponse {
+    pub id: Uuid,
+    pub list_id: Uuid,
+    pub group_id: Uuid,
+    pub parent_task_id: Option<Uuid>,
+    pub title: String,
+    pub description_md: Option<String>,
+    pub status: String,
+    pub priority: String,
+    pub due_at: Option<DateTime<Utc>>,
+    pub started_at: Option<DateTime<Utc>>,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub estimated_minutes: Option<i32>,
+    pub created_by: Option<Uuid>,
+    pub created_by_label: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+
+impl From<TaskRow> for TaskResponse {
+    fn from(r: TaskRow) -> Self {
+        Self {
+            id: r.id,
+            list_id: r.list_id,
+            group_id: r.group_id,
+            parent_task_id: r.parent_task_id,
+            title: r.title,
+            description_md: r.description_md,
+            status: r.status,
+            priority: r.priority,
+            due_at: r.due_at,
+            started_at: r.started_at,
+            completed_at: r.completed_at,
+            estimated_minutes: r.estimated_minutes,
+            created_by: r.created_by,
+            created_by_label: r.created_by_label,
+            created_at: r.created_at,
+            updated_at: r.updated_at,
+            deleted_at: r.deleted_at,
+        }
+    }
+}
+
+/// Compact task item used in `GET /v1/groups/{group_id}/task-lists/{list_id}/tasks`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct TaskSummary {
+    pub id: Uuid,
+    pub list_id: Uuid,
+    pub group_id: Uuid,
+    pub title: String,
+    pub status: String,
+    pub priority: String,
+    pub due_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Response body for `GET /v1/groups/{group_id}/task-lists/{list_id}/tasks`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ListTasksResponse {
+    pub items: Vec<TaskSummary>,
+    /// Cursor for the next page. `None` when end of list is reached.
+    pub next_cursor: Option<Uuid>,
+}
+
+/// Query parameters for `GET /v1/groups/{group_id}/task-lists/{list_id}/tasks`.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ListTasksQuery {
+    /// Optional status filter. One of `backlog`, `todo`, `in_progress`, `review`, `done`, `canceled`.
+    pub status: Option<String>,
+    /// Keyset cursor — UUID of the last item received. Omit for the first page.
+    pub cursor: Option<Uuid>,
+    /// Page size. Default 50, max 100.
+    pub limit: Option<u32>,
+}
+
+/// Request body for `PATCH /v1/groups/{group_id}/tasks/{task_id}`.
+///
+/// All fields are optional. Only provided (non-null) fields are updated.
+/// Note: nullable fields (`due_at`, `description_md`) cannot be cleared to
+/// `null` via PATCH in slice 1 — omit the field to leave it unchanged.
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct PatchTaskRequest {
+    /// Updated title. 1–500 characters when provided.
+    pub title: Option<String>,
+    /// Updated description. 1–50,000 characters when provided.
+    pub description_md: Option<String>,
+    /// Updated status.
+    pub status: Option<String>,
+    /// Updated priority.
+    pub priority: Option<String>,
+    /// Updated due date. Cannot be set to null via PATCH (omit to leave unchanged).
+    pub due_at: Option<DateTime<Utc>>,
+    /// Updated time estimate. Cannot be set to null via PATCH.
+    pub estimated_minutes: Option<i32>,
+}
+
+impl PatchTaskRequest {
+    fn validate(&self) -> Result<(), &'static str> {
+        if let Some(t) = &self.title {
+            let len = t.chars().count();
+            if len == 0 {
+                return Err("title must not be empty");
+            }
+            if len > 500 {
+                return Err("title exceeds 500 character limit");
+            }
+        }
+        if let Some(d) = &self.description_md {
+            let len = d.chars().count();
+            if len == 0 {
+                return Err("description_md must not be empty when provided");
+            }
+            if len > 50_000 {
+                return Err("description_md exceeds 50,000 character limit");
+            }
+        }
+        if let Some(s) = &self.status
+            && !ALLOWED_STATUSES.contains(&s.as_str())
+        {
+            return Err(
+                "status must be one of: backlog, todo, in_progress, review, done, canceled",
+            );
+        }
+        if let Some(p) = &self.priority
+            && !ALLOWED_PRIORITIES.contains(&p.as_str())
+        {
+            return Err("priority must be one of: none, low, medium, high, urgent");
+        }
+        if let Some(mins) = self.estimated_minutes
+            && !(0..=100_000).contains(&mins)
+        {
+            return Err("estimated_minutes must be between 0 and 100000");
+        }
+        Ok(())
+    }
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async fn set_rls_context(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    user_id: Uuid,
+    group_id: Uuid,
+) -> Result<(), RestError> {
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(user_id.to_string())
+        .execute(&mut **tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    sqlx::query("SELECT set_config('app.current_group_id', $1, true)")
+        .bind(group_id.to_string())
+        .execute(&mut **tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    Ok(())
+}
+
+fn require_group_id(principal: &Principal) -> Result<Uuid, RestError> {
+    principal
+        .group_id
+        .ok_or_else(|| RestError::BadRequest("X-Group-Id header is required".into()))
+}
+
+fn check_group_match(path_group_id: Uuid, principal_group_id: Uuid) -> Result<(), RestError> {
+    if path_group_id != principal_group_id {
+        Err(RestError::Forbidden)
+    } else {
+        Ok(())
+    }
+}
+
+// ─── Handlers — slice 1 (plan 0066 / GAR-516) ────────────────────────────────
+
+/// `POST /v1/groups/{group_id}/task-lists` — create a task list.
+///
+/// Authz: `Action::TasksWrite`. Path `group_id` must equal `principal.group_id`.
+///
+/// ## Error matrix
+///
+/// | Condition                          | Status |
+/// |------------------------------------|--------|
+/// | Missing/invalid JWT                | 401    |
+/// | Non-member of group                | 403    |
+/// | Path group_id ≠ principal group_id | 403    |
+/// | Validation failure                 | 400    |
+/// | Happy path                         | 201    |
+#[utoipa::path(
+    post,
+    path = "/v1/groups/{group_id}/task-lists",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+    ),
+    request_body = CreateTaskListRequest,
+    responses(
+        (status = 201, description = "Task list created.", body = TaskListResponse),
+        (status = 400, description = "Validation error.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn create_task_list(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(path_group_id): Path<Uuid>,
+    Json(body): Json<CreateTaskListRequest>,
+) -> Result<(StatusCode, Json<TaskListResponse>), RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksWrite) {
+        return Err(RestError::Forbidden);
+    }
+    body.validate()
+        .map_err(|msg| RestError::BadRequest(msg.into()))?;
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    let (created_by_label,): (String,) =
+        sqlx::query_as("SELECT display_name FROM users WHERE id = $1")
+            .bind(principal.user_id)
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(|e| RestError::Internal(e.into()))?;
+
+    let row: TaskListRow = sqlx::query_as(
+        "INSERT INTO task_lists \
+             (group_id, name, type, description, created_by, created_by_label) \
+         VALUES ($1, $2, $3, $4, $5, $6) \
+         RETURNING id, group_id, name, type AS list_type, description, \
+                   created_by, created_by_label, created_at, updated_at, archived_at",
+    )
+    .bind(group_id)
+    .bind(&body.name)
+    .bind(&body.list_type)
+    .bind(&body.description)
+    .bind(principal.user_id)
+    .bind(&created_by_label)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let list_id = row.id;
+    let name_len = body.name.chars().count();
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::TaskListCreated,
+        principal.user_id,
+        group_id,
+        "task_lists",
+        list_id.to_string(),
+        json!({ "name_len": name_len, "type": body.list_type }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok((StatusCode::CREATED, Json(TaskListResponse::from(row))))
+}
+
+/// `GET /v1/groups/{group_id}/task-lists` — list task lists (cursor-paginated).
+///
+/// Returns non-archived task lists for the caller's group, newest first.
+/// Authz: `Action::TasksRead`. Path `group_id` must equal `principal.group_id`.
+///
+/// ## Error matrix
+///
+/// | Condition                          | Status |
+/// |------------------------------------|--------|
+/// | Missing/invalid JWT                | 401    |
+/// | Non-member of group                | 403    |
+/// | Path group_id ≠ principal group_id | 403    |
+/// | Happy path                         | 200    |
+#[utoipa::path(
+    get,
+    path = "/v1/groups/{group_id}/task-lists",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ListTaskListsQuery,
+    ),
+    responses(
+        (status = 200, description = "Task lists.", body = ListTaskListsResponse),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn list_task_lists(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(path_group_id): Path<Uuid>,
+    Query(params): Query<ListTaskListsQuery>,
+) -> Result<Json<ListTaskListsResponse>, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksRead) {
+        return Err(RestError::Forbidden);
+    }
+
+    let effective_limit = params.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+    let fetch_limit = (effective_limit + 1) as i64;
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    let rows: Vec<TaskListRow> = if let Some(cursor_id) = params.cursor {
+        sqlx::query_as(
+            "SELECT id, group_id, name, type AS list_type, description, \
+                    created_by, created_by_label, created_at, updated_at, archived_at \
+             FROM task_lists \
+             WHERE group_id = $1 \
+               AND archived_at IS NULL \
+               AND (created_at, id) < ( \
+                   SELECT created_at, id FROM task_lists WHERE id = $2 \
+               ) \
+             ORDER BY created_at DESC, id DESC \
+             LIMIT $3",
+        )
+        .bind(group_id)
+        .bind(cursor_id)
+        .bind(fetch_limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?
+    } else {
+        sqlx::query_as(
+            "SELECT id, group_id, name, type AS list_type, description, \
+                    created_by, created_by_label, created_at, updated_at, archived_at \
+             FROM task_lists \
+             WHERE group_id = $1 \
+               AND archived_at IS NULL \
+             ORDER BY created_at DESC, id DESC \
+             LIMIT $2",
+        )
+        .bind(group_id)
+        .bind(fetch_limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?
+    };
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    let has_more = rows.len() as u32 > effective_limit;
+    let items: Vec<TaskListSummary> = rows
+        .into_iter()
+        .take(effective_limit as usize)
+        .map(TaskListSummary::from)
+        .collect();
+    let next_cursor = if has_more {
+        items.last().map(|it| it.id)
+    } else {
+        None
+    };
+
+    Ok(Json(ListTaskListsResponse { items, next_cursor }))
+}
+
+/// `POST /v1/groups/{group_id}/task-lists/{list_id}/tasks` — create a task.
+///
+/// The task list must exist and belong to `group_id`. Cross-list creation
+/// is prevented at the DB level by the compound FK `(list_id, group_id)`.
+/// Authz: `Action::TasksWrite`.
+///
+/// ## Error matrix
+///
+/// | Condition                          | Status |
+/// |------------------------------------|--------|
+/// | Missing/invalid JWT                | 401    |
+/// | Non-member of group                | 403    |
+/// | Path group_id ≠ principal group_id | 403    |
+/// | Validation failure                 | 400    |
+/// | Task list not found / archived     | 404    |
+/// | Happy path                         | 201    |
+#[utoipa::path(
+    post,
+    path = "/v1/groups/{group_id}/task-lists/{list_id}/tasks",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("list_id" = Uuid, Path, description = "Task list UUID."),
+    ),
+    request_body = CreateTaskRequest,
+    responses(
+        (status = 201, description = "Task created.", body = TaskResponse),
+        (status = 400, description = "Validation error.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Task list not found or archived.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn create_task(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, list_id)): Path<(Uuid, Uuid)>,
+    Json(body): Json<CreateTaskRequest>,
+) -> Result<(StatusCode, Json<TaskResponse>), RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksWrite) {
+        return Err(RestError::Forbidden);
+    }
+    body.validate()
+        .map_err(|msg| RestError::BadRequest(msg.into()))?;
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    let list_exists: Option<(Uuid,)> =
+        sqlx::query_as("SELECT id FROM task_lists WHERE id = $1 AND archived_at IS NULL")
+            .bind(list_id)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(|e| RestError::Internal(e.into()))?;
+
+    if list_exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    let (created_by_label,): (String,) =
+        sqlx::query_as("SELECT display_name FROM users WHERE id = $1")
+            .bind(principal.user_id)
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(|e| RestError::Internal(e.into()))?;
+
+    let title_trimmed = body.title.trim().to_string();
+
+    let row: TaskRow = sqlx::query_as(
+        "INSERT INTO tasks \
+             (list_id, group_id, title, description_md, status, priority, \
+              due_at, estimated_minutes, created_by, created_by_label) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) \
+         RETURNING id, list_id, group_id, parent_task_id, title, description_md, \
+                   status, priority, due_at, started_at, completed_at, \
+                   estimated_minutes, created_by, created_by_label, \
+                   created_at, updated_at, deleted_at",
+    )
+    .bind(list_id)
+    .bind(group_id)
+    .bind(&title_trimmed)
+    .bind(&body.description_md)
+    .bind(&body.status)
+    .bind(&body.priority)
+    .bind(body.due_at)
+    .bind(body.estimated_minutes)
+    .bind(principal.user_id)
+    .bind(&created_by_label)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let task_id = row.id;
+    let title_len = title_trimmed.chars().count();
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::TaskCreated,
+        principal.user_id,
+        group_id,
+        "tasks",
+        task_id.to_string(),
+        json!({ "title_len": title_len, "status": body.status, "priority": body.priority }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok((StatusCode::CREATED, Json(TaskResponse::from(row))))
+}
+
+/// `GET /v1/groups/{group_id}/task-lists/{list_id}/tasks` — list tasks (cursor-paginated).
+///
+/// Returns non-deleted tasks for the specified list, newest first.
+/// Optional `?status=` filter. Authz: `Action::TasksRead`.
+///
+/// ## Error matrix
+///
+/// | Condition                          | Status |
+/// |------------------------------------|--------|
+/// | Missing/invalid JWT                | 401    |
+/// | Non-member of group                | 403    |
+/// | Path group_id ≠ principal group_id | 403    |
+/// | Invalid status filter              | 400    |
+/// | Happy path                         | 200    |
+#[utoipa::path(
+    get,
+    path = "/v1/groups/{group_id}/task-lists/{list_id}/tasks",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("list_id" = Uuid, Path, description = "Task list UUID."),
+        ListTasksQuery,
+    ),
+    responses(
+        (status = 200, description = "Tasks.", body = ListTasksResponse),
+        (status = 400, description = "Invalid status filter.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn list_tasks(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, list_id)): Path<(Uuid, Uuid)>,
+    Query(params): Query<ListTasksQuery>,
+) -> Result<Json<ListTasksResponse>, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksRead) {
+        return Err(RestError::Forbidden);
+    }
+
+    if let Some(s) = &params.status
+        && !ALLOWED_STATUSES.contains(&s.as_str())
+    {
+        return Err(RestError::BadRequest(
+            "status must be one of: backlog, todo, in_progress, review, done, canceled".into(),
+        ));
+    }
+
+    let effective_limit = params.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+    let fetch_limit = (effective_limit + 1) as i64;
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    let rows: Vec<TaskRow> = if let Some(cursor_id) = params.cursor {
+        sqlx::query_as(
+            "SELECT id, list_id, group_id, parent_task_id, title, description_md, \
+                    status, priority, due_at, started_at, completed_at, \
+                    estimated_minutes, created_by, created_by_label, \
+                    created_at, updated_at, deleted_at \
+             FROM tasks \
+             WHERE list_id = $1 \
+               AND group_id = $2 \
+               AND deleted_at IS NULL \
+               AND ($3::text IS NULL OR status = $3) \
+               AND (created_at, id) < ( \
+                   SELECT created_at, id FROM tasks WHERE id = $4 \
+               ) \
+             ORDER BY created_at DESC, id DESC \
+             LIMIT $5",
+        )
+        .bind(list_id)
+        .bind(group_id)
+        .bind(&params.status)
+        .bind(cursor_id)
+        .bind(fetch_limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?
+    } else {
+        sqlx::query_as(
+            "SELECT id, list_id, group_id, parent_task_id, title, description_md, \
+                    status, priority, due_at, started_at, completed_at, \
+                    estimated_minutes, created_by, created_by_label, \
+                    created_at, updated_at, deleted_at \
+             FROM tasks \
+             WHERE list_id = $1 \
+               AND group_id = $2 \
+               AND deleted_at IS NULL \
+               AND ($3::text IS NULL OR status = $3) \
+             ORDER BY created_at DESC, id DESC \
+             LIMIT $4",
+        )
+        .bind(list_id)
+        .bind(group_id)
+        .bind(&params.status)
+        .bind(fetch_limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?
+    };
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    let has_more = rows.len() as u32 > effective_limit;
+    let items: Vec<TaskSummary> = rows
+        .into_iter()
+        .take(effective_limit as usize)
+        .map(|r| TaskSummary {
+            id: r.id,
+            list_id: r.list_id,
+            group_id: r.group_id,
+            title: r.title,
+            status: r.status,
+            priority: r.priority,
+            due_at: r.due_at,
+            created_at: r.created_at,
+            updated_at: r.updated_at,
+        })
+        .collect();
+    let next_cursor = if has_more {
+        items.last().map(|it| it.id)
+    } else {
+        None
+    };
+
+    Ok(Json(ListTasksResponse { items, next_cursor }))
+}
+
+/// `PATCH /v1/groups/{group_id}/tasks/{task_id}` — update task fields.
+///
+/// All body fields are optional. Only provided (non-null) fields are updated.
+/// `updated_at` is always refreshed. Returns 404 for cross-tenant tasks (RLS).
+/// Authz: `Action::TasksWrite`.
+///
+/// ## Error matrix
+///
+/// | Condition                          | Status |
+/// |------------------------------------|--------|
+/// | Missing/invalid JWT                | 401    |
+/// | Non-member of group                | 403    |
+/// | Path group_id ≠ principal group_id | 403    |
+/// | Validation failure                 | 400    |
+/// | Task not found / cross-tenant      | 404    |
+/// | Happy path                         | 200    |
+#[utoipa::path(
+    patch,
+    path = "/v1/groups/{group_id}/tasks/{task_id}",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("task_id" = Uuid, Path, description = "Task UUID."),
+    ),
+    request_body = PatchTaskRequest,
+    responses(
+        (status = 200, description = "Task updated.", body = TaskResponse),
+        (status = 400, description = "Validation error.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Task not found or cross-tenant.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn patch_task(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, task_id)): Path<(Uuid, Uuid)>,
+    Json(body): Json<PatchTaskRequest>,
+) -> Result<Json<TaskResponse>, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksWrite) {
+        return Err(RestError::Forbidden);
+    }
+    body.validate()
+        .map_err(|msg| RestError::BadRequest(msg.into()))?;
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    let row: Option<TaskRow> = sqlx::query_as(
+        "UPDATE tasks \
+         SET title              = COALESCE($2, title), \
+             description_md     = COALESCE($3, description_md), \
+             status             = COALESCE($4, status), \
+             priority           = COALESCE($5, priority), \
+             due_at             = COALESCE($6, due_at), \
+             estimated_minutes  = COALESCE($7, estimated_minutes), \
+             updated_at         = now() \
+         WHERE id = $1 \
+           AND group_id = $8 \
+           AND deleted_at IS NULL \
+         RETURNING id, list_id, group_id, parent_task_id, title, description_md, \
+                   status, priority, due_at, started_at, completed_at, \
+                   estimated_minutes, created_by, created_by_label, \
+                   created_at, updated_at, deleted_at",
+    )
+    .bind(task_id)
+    .bind(&body.title)
+    .bind(&body.description_md)
+    .bind(&body.status)
+    .bind(&body.priority)
+    .bind(body.due_at)
+    .bind(body.estimated_minutes)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let row = match row {
+        Some(r) => r,
+        None => return Err(RestError::NotFound),
+    };
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(Json(TaskResponse::from(row)))
+}
+
+/// `DELETE /v1/groups/{group_id}/tasks/{task_id}` — soft-delete a task.
+///
+/// Sets `deleted_at = now()`. The task is not physically removed. Returns
+/// 404 for cross-tenant tasks (RLS filters them). Authz: `Action::TasksDelete`.
+///
+/// ## Error matrix
+///
+/// | Condition                          | Status |
+/// |------------------------------------|--------|
+/// | Missing/invalid JWT                | 401    |
+/// | Non-member of group                | 403    |
+/// | Path group_id ≠ principal group_id | 403    |
+/// | Task not found / cross-tenant      | 404    |
+/// | Task already deleted               | 404    |
+/// | Happy path                         | 204    |
+#[utoipa::path(
+    delete,
+    path = "/v1/groups/{group_id}/tasks/{task_id}",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("task_id" = Uuid, Path, description = "Task UUID."),
+    ),
+    responses(
+        (status = 204, description = "Task deleted."),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Task not found or cross-tenant.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn delete_task(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, task_id)): Path<(Uuid, Uuid)>,
+) -> Result<StatusCode, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksDelete) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    let existing: Option<(String, String)> = sqlx::query_as(
+        "SELECT title, status FROM tasks \
+         WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+    )
+    .bind(task_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let (title, status) = match existing {
+        Some(row) => row,
+        None => return Err(RestError::NotFound),
+    };
+
+    let title_len = title.chars().count();
+
+    sqlx::query("UPDATE tasks SET deleted_at = now() WHERE id = $1 AND deleted_at IS NULL")
+        .bind(task_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::TaskDeleted,
+        principal.user_id,
+        group_id,
+        "tasks",
+        task_id.to_string(),
+        json!({ "title_len": title_len, "status": status }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ─── Handlers — slice 2 (plan 0067 / GAR-518) ────────────────────────────────
+
+/// `GET /v1/groups/{group_id}/tasks/{task_id}` — fetch a single task.
+///
+/// Returns 404 for missing, cross-tenant, or soft-deleted tasks (no 403 leak).
+/// Authz: `Action::TasksRead`. Path `group_id` must equal `principal.group_id`.
+///
+/// ## Error matrix
+///
+/// | Condition                          | Status |
+/// |------------------------------------|--------|
+/// | Missing/invalid JWT                | 401    |
+/// | Non-member of group                | 403    |
+/// | Path group_id ≠ principal group_id | 403    |
+/// | Task not found / deleted / cross-tenant | 404 |
+/// | Happy path                         | 200    |
+#[utoipa::path(
+    get,
+    path = "/v1/groups/{group_id}/tasks/{task_id}",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("task_id" = Uuid, Path, description = "Task UUID."),
+    ),
+    responses(
+        (status = 200, description = "Task.", body = TaskResponse),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Task not found, deleted, or cross-tenant.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn get_task(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, task_id)): Path<(Uuid, Uuid)>,
+) -> Result<Json<TaskResponse>, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksRead) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    let row: Option<TaskRow> = sqlx::query_as(
+        "SELECT id, list_id, group_id, parent_task_id, title, description_md, \
+                status, priority, due_at, started_at, completed_at, \
+                estimated_minutes, created_by, created_by_label, \
+                created_at, updated_at, deleted_at \
+         FROM tasks \
+         WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+    )
+    .bind(task_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    match row {
+        Some(r) => Ok(Json(TaskResponse::from(r))),
+        None => Err(RestError::NotFound),
+    }
+}
+
+/// `PATCH /v1/groups/{group_id}/task-lists/{list_id}` — update a task list.
+///
+/// All fields are optional. `description` supports three-way semantics: omit
+/// the key to leave unchanged, send `null` to clear, send a string to update.
+/// Returns 404 for archived, cross-tenant, or non-existent lists (RLS).
+/// Authz: `Action::TasksWrite`.
+///
+/// ## Error matrix
+///
+/// | Condition                          | Status |
+/// |------------------------------------|--------|
+/// | Missing/invalid JWT                | 401    |
+/// | Non-member of group                | 403    |
+/// | Path group_id ≠ principal group_id | 403    |
+/// | Validation failure                 | 400    |
+/// | List not found / archived / cross-tenant | 404 |
+/// | Happy path                         | 200    |
+#[utoipa::path(
+    patch,
+    path = "/v1/groups/{group_id}/task-lists/{list_id}",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("list_id" = Uuid, Path, description = "Task list UUID."),
+    ),
+    request_body = PatchTaskListRequest,
+    responses(
+        (status = 200, description = "Task list updated.", body = TaskListResponse),
+        (status = 400, description = "Validation error.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Task list not found, archived, or cross-tenant.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn patch_task_list(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, list_id)): Path<(Uuid, Uuid)>,
+    Json(body): Json<PatchTaskListRequest>,
+) -> Result<Json<TaskListResponse>, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksWrite) {
+        return Err(RestError::Forbidden);
+    }
+    body.validate()
+        .map_err(|msg| RestError::BadRequest(msg.into()))?;
+
+    // Three-way description semantics:
+    //   body.description = None         → key absent, CASE guard = false → keep existing
+    //   body.description = Some(None)   → explicit null → clear to NULL
+    //   body.description = Some(Some(s)) → update to s
+    let description_changed = body.description.is_some();
+    let new_description: Option<String> = body.description.flatten();
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    let row: Option<TaskListRow> = sqlx::query_as(
+        "UPDATE task_lists \
+         SET name        = COALESCE($2, name), \
+             type        = COALESCE($3, type), \
+             description = CASE WHEN $4 THEN $5 ELSE description END, \
+             updated_at  = now() \
+         WHERE id = $1 \
+           AND group_id = $6 \
+           AND archived_at IS NULL \
+         RETURNING id, group_id, name, type AS list_type, description, \
+                   created_by, created_by_label, created_at, updated_at, archived_at",
+    )
+    .bind(list_id)
+    .bind(&body.name)
+    .bind(&body.list_type)
+    .bind(description_changed)
+    .bind(&new_description)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let row = match row {
+        Some(r) => r,
+        None => return Err(RestError::NotFound),
+    };
+
+    let name_len = row.name.chars().count();
+    let list_type = row.list_type.clone();
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::TaskListUpdated,
+        principal.user_id,
+        group_id,
+        "task_lists",
+        list_id.to_string(),
+        json!({ "name_len": name_len, "type": list_type }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(Json(TaskListResponse::from(row)))
+}
+
+/// `DELETE /v1/groups/{group_id}/task-lists/{list_id}` — archive a task list.
+///
+/// Sets `archived_at = now()`. Tasks inside are NOT deleted; they become
+/// de-listed from the default UI view. **Idempotent**: a second call on an
+/// already-archived list returns 204 without error. Returns 404 only when the
+/// list does not exist or belongs to another group (RLS). Authz: `Action::TasksDelete`.
+///
+/// ## Error matrix
+///
+/// | Condition                          | Status |
+/// |------------------------------------|--------|
+/// | Missing/invalid JWT                | 401    |
+/// | Non-member of group                | 403    |
+/// | Path group_id ≠ principal group_id | 403    |
+/// | List not found / cross-tenant      | 404    |
+/// | Happy path (including re-archive)  | 204    |
+#[utoipa::path(
+    delete,
+    path = "/v1/groups/{group_id}/task-lists/{list_id}",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("list_id" = Uuid, Path, description = "Task list UUID."),
+    ),
+    responses(
+        (status = 204, description = "Task list archived (or already archived)."),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Task list not found or cross-tenant.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn delete_task_list(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, list_id)): Path<(Uuid, Uuid)>,
+) -> Result<StatusCode, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksDelete) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Fetch including already-archived rows so we can distinguish
+    // "list doesn't exist / cross-tenant" (→ 404) from "already archived" (→ idempotent 204).
+    let existing: Option<(bool, String, String)> = sqlx::query_as(
+        "SELECT archived_at IS NOT NULL, name, type \
+         FROM task_lists \
+         WHERE id = $1 AND group_id = $2",
+    )
+    .bind(list_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let (already_archived, name, list_type) = match existing {
+        None => return Err(RestError::NotFound),
+        Some(r) => r,
+    };
+
+    if !already_archived {
+        let name_len = name.chars().count();
+
+        sqlx::query(
+            "UPDATE task_lists \
+             SET archived_at = now(), updated_at = now() \
+             WHERE id = $1 AND archived_at IS NULL",
+        )
+        .bind(list_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+        audit_workspace_event(
+            &mut tx,
+            WorkspaceAuditAction::TaskListArchived,
+            principal.user_id,
+            group_id,
+            "task_lists",
+            list_id.to_string(),
+            json!({ "name_len": name_len, "type": list_type }),
+        )
+        .await
+        .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+    }
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/crates/garraia-gateway/tests/rest_v1_tasks.rs
+++ b/crates/garraia-gateway/tests/rest_v1_tasks.rs
@@ -1,0 +1,822 @@
+//! Integration tests for task-lists + tasks REST API (plan 0066/0067, GAR-516/GAR-518).
+//!
+//! All scenarios bundled into ONE `#[tokio::test]` — same pattern as
+//! `rest_v1_memory.rs` / `rest_v1_chats.rs`. Splitting triggers the
+//! sqlx runtime-teardown race documented in plan 0016 M3.
+//!
+//! Scenarios (21 total):
+//!
+//! Task-list scenarios (10):
+//!   TL1.  POST 201 — create task list; assert response shape + audit row.
+//!   TL2.  POST 400 — invalid list type.
+//!   TL3.  POST 401 — missing bearer.
+//!   TL4.  POST 403 — path group_id ≠ principal group_id.
+//!   TL5.  GET 200 — list task lists; returns created list; excludes other groups.
+//!   TL6.  PATCH 200 — update name + type; audit row present.
+//!   TL7.  PATCH 404 — unknown list_id.
+//!   TL8.  PATCH 200 — description null-clear (`{"description": null}`).
+//!   TL9.  DELETE 204 — archive task list; no longer in GET /task-lists.
+//!   TL10. DELETE 204 — already-archived list (idempotent).
+//!
+//! Task scenarios (11):
+//!   T1.  POST 201 — create task; assert response shape + audit row.
+//!   T2.  POST 400 — title too long (>500 chars).
+//!   T3.  POST 404 — unknown list_id.
+//!   T4.  GET 200 — list tasks; includes created task; excludes deleted.
+//!   T5.  PATCH 200 — update status; verify status changed in response.
+//!   T6.  DELETE 204 — soft-delete; task no longer returned in list.
+//!   T7.  DELETE 404 — cross-tenant task returns 404 (RLS isolation).
+//!   T8.  GET 200 — get single task by ID.
+//!   T9.  GET 404 — cross-group task returns 404 (RLS isolation).
+//!   T10. GET 404 — deleted task returns 404.
+//!   T11. PATCH 403 — path group_id ≠ principal group_id returns 403.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+
+use common::Harness;
+use common::fixtures::{fetch_audit_events_for_group, seed_user_with_group};
+
+// ─── Request builders ────────────────────────────────────────────────────────
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect response body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("response body is not JSON")
+}
+
+fn auth_req(
+    method: &str,
+    uri: &str,
+    token: Option<&str>,
+    x_group_id: Option<&str>,
+    body: Option<serde_json::Value>,
+) -> Request<Body> {
+    let body_bytes = match body {
+        Some(v) => Body::from(v.to_string()),
+        None => Body::empty(),
+    };
+    let mut req = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(body_bytes)
+        .expect("request builder");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    if let Some(t) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {t}")).unwrap(),
+        );
+    }
+    if let Some(g) = x_group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    req
+}
+
+fn post_task_list(
+    token: Option<&str>,
+    x_group_id: Option<&str>,
+    path_group_id: &str,
+    body: serde_json::Value,
+) -> Request<Body> {
+    auth_req(
+        "POST",
+        &format!("/v1/groups/{path_group_id}/task-lists"),
+        token,
+        x_group_id,
+        Some(body),
+    )
+}
+
+fn get_task_lists(
+    token: Option<&str>,
+    x_group_id: Option<&str>,
+    path_group_id: &str,
+) -> Request<Body> {
+    auth_req(
+        "GET",
+        &format!("/v1/groups/{path_group_id}/task-lists"),
+        token,
+        x_group_id,
+        None,
+    )
+}
+
+fn patch_task_list_req(
+    token: Option<&str>,
+    x_group_id: Option<&str>,
+    path_group_id: &str,
+    list_id: &str,
+    body: serde_json::Value,
+) -> Request<Body> {
+    auth_req(
+        "PATCH",
+        &format!("/v1/groups/{path_group_id}/task-lists/{list_id}"),
+        token,
+        x_group_id,
+        Some(body),
+    )
+}
+
+fn delete_task_list_req(
+    token: Option<&str>,
+    x_group_id: Option<&str>,
+    path_group_id: &str,
+    list_id: &str,
+) -> Request<Body> {
+    auth_req(
+        "DELETE",
+        &format!("/v1/groups/{path_group_id}/task-lists/{list_id}"),
+        token,
+        x_group_id,
+        None,
+    )
+}
+
+fn post_task(
+    token: Option<&str>,
+    x_group_id: Option<&str>,
+    path_group_id: &str,
+    list_id: &str,
+    body: serde_json::Value,
+) -> Request<Body> {
+    auth_req(
+        "POST",
+        &format!("/v1/groups/{path_group_id}/task-lists/{list_id}/tasks"),
+        token,
+        x_group_id,
+        Some(body),
+    )
+}
+
+fn get_tasks(
+    token: Option<&str>,
+    x_group_id: Option<&str>,
+    path_group_id: &str,
+    list_id: &str,
+    status_filter: Option<&str>,
+) -> Request<Body> {
+    let mut uri = format!("/v1/groups/{path_group_id}/task-lists/{list_id}/tasks");
+    if let Some(s) = status_filter {
+        uri.push_str(&format!("?status={s}"));
+    }
+    auth_req("GET", &uri, token, x_group_id, None)
+}
+
+fn patch_task_req(
+    token: Option<&str>,
+    x_group_id: Option<&str>,
+    path_group_id: &str,
+    task_id: &str,
+    body: serde_json::Value,
+) -> Request<Body> {
+    auth_req(
+        "PATCH",
+        &format!("/v1/groups/{path_group_id}/tasks/{task_id}"),
+        token,
+        x_group_id,
+        Some(body),
+    )
+}
+
+fn delete_task_req(
+    token: Option<&str>,
+    x_group_id: Option<&str>,
+    path_group_id: &str,
+    task_id: &str,
+) -> Request<Body> {
+    auth_req(
+        "DELETE",
+        &format!("/v1/groups/{path_group_id}/tasks/{task_id}"),
+        token,
+        x_group_id,
+        None,
+    )
+}
+
+fn get_task_req(
+    token: Option<&str>,
+    x_group_id: Option<&str>,
+    path_group_id: &str,
+    task_id: &str,
+) -> Request<Body> {
+    auth_req(
+        "GET",
+        &format!("/v1/groups/{path_group_id}/tasks/{task_id}"),
+        token,
+        x_group_id,
+        None,
+    )
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(feature = "test-helpers")]
+#[tokio::test]
+async fn rest_v1_tasks_scenarios() {
+    let h = Harness::get().await;
+
+    // Seed two independent groups for cross-tenant isolation tests.
+    let (_owner_id, group_id, owner_token) = seed_user_with_group(&h, "alice@tasks-slice12.test")
+        .await
+        .expect("seed alice+group1");
+    let (_, group2_id, owner2_token) = seed_user_with_group(&h, "bob@tasks-slice12.test")
+        .await
+        .expect("seed bob+group2");
+
+    let gid = group_id.to_string();
+    let g2id = group2_id.to_string();
+
+    // ── TL1. POST 201 — create task list happy path ──────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(post_task_list(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            json!({ "name": "Sprint Backlog", "type": "list", "description": "Initial backlog" }),
+        ))
+        .await
+        .expect("TL1 oneshot");
+    assert_eq!(resp.status(), StatusCode::CREATED, "TL1 status");
+    let tl1_body = body_json(resp).await;
+    let list_id = tl1_body["id"].as_str().expect("TL1 id").to_string();
+    assert_eq!(tl1_body["name"], "Sprint Backlog", "TL1 name");
+    assert_eq!(tl1_body["type"], "list", "TL1 type");
+    assert_eq!(tl1_body["group_id"], gid, "TL1 group_id");
+    assert_eq!(
+        tl1_body["description"], "Initial backlog",
+        "TL1 description"
+    );
+    assert!(
+        tl1_body.get("created_by_label").is_some(),
+        "TL1 created_by_label present"
+    );
+
+    // Verify audit row: action = "task_list.created", no name in metadata.
+    let audit = fetch_audit_events_for_group(&h, group_id)
+        .await
+        .expect("TL1 fetch audit");
+    let tl_audit = audit
+        .iter()
+        .find(|e| e.0 == "task_list.created")
+        .expect("TL1 audit row");
+    let (_, _, resource_type, resource_id, metadata) = tl_audit;
+    assert_eq!(resource_type, "task_lists", "TL1 audit resource_type");
+    assert_eq!(resource_id, &list_id, "TL1 audit resource_id");
+    assert!(
+        metadata["name_len"].as_u64().is_some(),
+        "TL1 audit metadata has name_len"
+    );
+    assert!(
+        metadata.get("name").is_none(),
+        "TL1 audit metadata must not contain name text (PII guard)"
+    );
+
+    // ── TL2. POST 400 — invalid list type ────────────────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(post_task_list(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            json!({ "name": "Bad", "type": "spreadsheet" }),
+        ))
+        .await
+        .expect("TL2 oneshot");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "TL2 status");
+
+    // ── TL3. POST 401 — missing bearer ───────────────────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(post_task_list(
+            None,
+            Some(&gid),
+            &gid,
+            json!({ "name": "No auth", "type": "board" }),
+        ))
+        .await
+        .expect("TL3 oneshot");
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED, "TL3 status");
+
+    // ── TL4. POST 403 — path group_id ≠ principal group_id ───────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(post_task_list(
+            Some(&owner_token),
+            Some(&gid),
+            &g2id,
+            json!({ "name": "Cross group", "type": "list" }),
+        ))
+        .await
+        .expect("TL4 oneshot");
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN, "TL4 status");
+
+    // ── TL5. GET 200 — list task lists; returns TL1, excludes other groups
+    let resp = h
+        .router
+        .clone()
+        .oneshot(get_task_lists(Some(&owner_token), Some(&gid), &gid))
+        .await
+        .expect("TL5 oneshot");
+    assert_eq!(resp.status(), StatusCode::OK, "TL5 status");
+    let tl5_body = body_json(resp).await;
+    let items = tl5_body["items"].as_array().expect("TL5 items array");
+    assert!(
+        items.iter().any(|it| it["id"] == list_id),
+        "TL5 should contain the created list"
+    );
+    assert!(
+        items.iter().all(|it| it["group_id"] == gid),
+        "TL5 must not leak other groups' task lists"
+    );
+
+    // ── TL6. PATCH 200 — update name + type ──────────────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(patch_task_list_req(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            &list_id,
+            json!({ "name": "Kanban Board", "type": "board" }),
+        ))
+        .await
+        .expect("TL6 oneshot");
+    assert_eq!(resp.status(), StatusCode::OK, "TL6 status");
+    let tl6_body = body_json(resp).await;
+    assert_eq!(tl6_body["name"], "Kanban Board", "TL6 name updated");
+    assert_eq!(tl6_body["type"], "board", "TL6 type updated");
+    assert_eq!(tl6_body["id"], list_id, "TL6 id unchanged");
+    // Description was not sent → should remain unchanged.
+    assert_eq!(
+        tl6_body["description"], "Initial backlog",
+        "TL6 description unchanged when key omitted"
+    );
+
+    // Verify audit: "task_list.updated", name_len present, no name text.
+    let audit2 = fetch_audit_events_for_group(&h, group_id)
+        .await
+        .expect("TL6 fetch audit");
+    let tl6_audit = audit2
+        .iter()
+        .find(|e| e.0 == "task_list.updated")
+        .expect("TL6 audit row");
+    let (_, _, _, _, tl6_meta) = tl6_audit;
+    assert!(
+        tl6_meta["name_len"].as_u64().is_some(),
+        "TL6 audit has name_len"
+    );
+    assert!(
+        tl6_meta.get("name").is_none(),
+        "TL6 audit must not contain name text (PII guard)"
+    );
+    assert_eq!(tl6_meta["type"], "board", "TL6 audit type reflects new value");
+
+    // ── TL7. PATCH 404 — unknown list_id ─────────────────────────────────
+    let unknown_list = uuid::Uuid::new_v4().to_string();
+    let resp = h
+        .router
+        .clone()
+        .oneshot(patch_task_list_req(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            &unknown_list,
+            json!({ "name": "Ghost" }),
+        ))
+        .await
+        .expect("TL7 oneshot");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND, "TL7 status");
+
+    // ── TL8. PATCH 200 — description null-clear ───────────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(patch_task_list_req(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            &list_id,
+            json!({ "description": null }),
+        ))
+        .await
+        .expect("TL8 oneshot");
+    assert_eq!(resp.status(), StatusCode::OK, "TL8 status");
+    let tl8_body = body_json(resp).await;
+    assert!(
+        tl8_body["description"].is_null(),
+        "TL8 description cleared to null"
+    );
+    // Name must still be the value from TL6.
+    assert_eq!(tl8_body["name"], "Kanban Board", "TL8 name unchanged");
+
+    // ── TL9. DELETE 204 — archive task list ───────────────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(delete_task_list_req(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            &list_id,
+        ))
+        .await
+        .expect("TL9 oneshot");
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT, "TL9 status");
+
+    // Archived list should NOT appear in GET /task-lists.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(get_task_lists(Some(&owner_token), Some(&gid), &gid))
+        .await
+        .expect("TL9 list after archive");
+    let tl9_list = body_json(resp).await;
+    let after_archive = tl9_list["items"].as_array().expect("TL9 items");
+    assert!(
+        !after_archive.iter().any(|it| it["id"] == list_id),
+        "TL9 archived list must not appear in GET /task-lists"
+    );
+
+    // Verify audit: "task_list.archived" present.
+    let audit3 = fetch_audit_events_for_group(&h, group_id)
+        .await
+        .expect("TL9 fetch audit");
+    assert!(
+        audit3
+            .iter()
+            .any(|e| e.0 == "task_list.archived" && e.3 == list_id),
+        "TL9 audit row task_list.archived must be present"
+    );
+
+    // ── TL10. DELETE 204 — idempotent: already-archived list ─────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(delete_task_list_req(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            &list_id,
+        ))
+        .await
+        .expect("TL10 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NO_CONTENT,
+        "TL10 re-archive must return 204 (idempotent)"
+    );
+
+    // ── T1. POST 201 — create task in list ───────────────────────────────
+    // Create a fresh list for task scenarios (the original is archived).
+    let resp = h
+        .router
+        .clone()
+        .oneshot(post_task_list(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            json!({ "name": "Task List 2", "type": "list" }),
+        ))
+        .await
+        .expect("T1 create list");
+    let tl2_body = body_json(resp).await;
+    let list2_id = tl2_body["id"].as_str().expect("T1 list2 id").to_string();
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(post_task(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            &list2_id,
+            json!({
+                "title": "Implement login",
+                "status": "in_progress",
+                "priority": "high",
+            }),
+        ))
+        .await
+        .expect("T1 oneshot");
+    assert_eq!(resp.status(), StatusCode::CREATED, "T1 status");
+    let t1_body = body_json(resp).await;
+    let task_id = t1_body["id"].as_str().expect("T1 id").to_string();
+    assert_eq!(t1_body["title"], "Implement login", "T1 title");
+    assert_eq!(t1_body["status"], "in_progress", "T1 status field");
+    assert_eq!(t1_body["priority"], "high", "T1 priority");
+    assert_eq!(t1_body["list_id"], list2_id, "T1 list_id");
+    assert_eq!(t1_body["group_id"], gid, "T1 group_id");
+
+    // Verify audit: action = "task.created", no title text in metadata.
+    let audit4 = fetch_audit_events_for_group(&h, group_id)
+        .await
+        .expect("T1 fetch audit");
+    let t_audit = audit4
+        .iter()
+        .find(|e| e.0 == "task.created")
+        .expect("T1 audit row");
+    let (_, _, t_res_type, t_res_id, t_meta) = t_audit;
+    assert_eq!(t_res_type, "tasks", "T1 audit resource_type");
+    assert_eq!(t_res_id, &task_id, "T1 audit resource_id");
+    assert!(
+        t_meta["title_len"].as_u64().is_some(),
+        "T1 audit metadata has title_len"
+    );
+    assert!(
+        t_meta.get("title").is_none(),
+        "T1 audit metadata must not contain title text (PII guard)"
+    );
+
+    // ── T2. POST 400 — title too long ────────────────────────────────────
+    let long_title = "x".repeat(501);
+    let resp = h
+        .router
+        .clone()
+        .oneshot(post_task(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            &list2_id,
+            json!({ "title": long_title }),
+        ))
+        .await
+        .expect("T2 oneshot");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "T2 status");
+
+    // ── T3. POST 404 — unknown list_id ───────────────────────────────────
+    let unknown_list2 = uuid::Uuid::new_v4().to_string();
+    let resp = h
+        .router
+        .clone()
+        .oneshot(post_task(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            &unknown_list2,
+            json!({ "title": "Orphan task" }),
+        ))
+        .await
+        .expect("T3 oneshot");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND, "T3 status");
+
+    // ── T4. GET 200 — list tasks; includes T1; excludes deleted ──────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(get_tasks(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            &list2_id,
+            None,
+        ))
+        .await
+        .expect("T4 oneshot");
+    assert_eq!(resp.status(), StatusCode::OK, "T4 status");
+    let t4_body = body_json(resp).await;
+    let tasks = t4_body["items"].as_array().expect("T4 items array");
+    assert!(
+        tasks.iter().any(|it| it["id"] == task_id),
+        "T4 should contain the created task"
+    );
+
+    // ── T5. PATCH 200 — update task status ───────────────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(patch_task_req(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            &task_id,
+            json!({ "status": "done", "priority": "low" }),
+        ))
+        .await
+        .expect("T5 oneshot");
+    assert_eq!(resp.status(), StatusCode::OK, "T5 status");
+    let t5_body = body_json(resp).await;
+    assert_eq!(t5_body["status"], "done", "T5 status updated");
+    assert_eq!(t5_body["priority"], "low", "T5 priority updated");
+    assert_eq!(t5_body["title"], "Implement login", "T5 title unchanged");
+
+    // ── T6. DELETE 204 — soft-delete; task no longer in list ─────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(delete_task_req(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            &task_id,
+        ))
+        .await
+        .expect("T6 oneshot");
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT, "T6 status");
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(get_tasks(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            &list2_id,
+            None,
+        ))
+        .await
+        .expect("T6 list after delete");
+    let t6_list_body = body_json(resp).await;
+    let remaining = t6_list_body["items"].as_array().expect("T6 items array");
+    assert!(
+        !remaining.iter().any(|it| it["id"] == task_id),
+        "T6 deleted task must not appear in list"
+    );
+
+    let audit5 = fetch_audit_events_for_group(&h, group_id)
+        .await
+        .expect("T6 fetch audit");
+    let del_audit = audit5
+        .iter()
+        .find(|e| e.0 == "task.deleted" && e.3 == task_id)
+        .expect("T6 audit row");
+    let (_, _, _, _, del_meta) = del_audit;
+    assert!(
+        del_meta["title_len"].as_u64().is_some(),
+        "T6 audit has title_len"
+    );
+    assert!(
+        del_meta.get("title").is_none(),
+        "T6 audit must not contain title text (PII guard)"
+    );
+
+    // ── T7. DELETE 404 — cross-tenant task ───────────────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(post_task_list(
+            Some(&owner2_token),
+            Some(&g2id),
+            &g2id,
+            json!({ "name": "Bob list", "type": "board" }),
+        ))
+        .await
+        .expect("T7 create bob list");
+    assert_eq!(resp.status(), StatusCode::CREATED, "T7 bob list created");
+    let bob_list_body = body_json(resp).await;
+    let bob_list_id = bob_list_body["id"]
+        .as_str()
+        .expect("T7 bob list id")
+        .to_string();
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(post_task(
+            Some(&owner2_token),
+            Some(&g2id),
+            &g2id,
+            &bob_list_id,
+            json!({ "title": "Bob's secret task" }),
+        ))
+        .await
+        .expect("T7 create bob task");
+    assert_eq!(resp.status(), StatusCode::CREATED, "T7 bob task created");
+    let bob_task_body = body_json(resp).await;
+    let bob_task_id = bob_task_body["id"]
+        .as_str()
+        .expect("T7 bob task id")
+        .to_string();
+
+    // Alice tries to delete Bob's task — RLS filters it → 404.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(delete_task_req(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            &bob_task_id,
+        ))
+        .await
+        .expect("T7 cross-tenant delete");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "T7 cross-tenant delete must return 404 (not 403)"
+    );
+
+    // ── T8. GET 200 — get single task by ID ──────────────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(post_task(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            &list2_id,
+            json!({ "title": "GET me", "priority": "medium" }),
+        ))
+        .await
+        .expect("T8 create task");
+    assert_eq!(resp.status(), StatusCode::CREATED, "T8 task created");
+    let t8_created = body_json(resp).await;
+    let t8_task_id = t8_created["id"].as_str().expect("T8 task id").to_string();
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(get_task_req(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            &t8_task_id,
+        ))
+        .await
+        .expect("T8 get task oneshot");
+    assert_eq!(resp.status(), StatusCode::OK, "T8 status");
+    let t8_body = body_json(resp).await;
+    assert_eq!(t8_body["id"], t8_task_id, "T8 id matches");
+    assert_eq!(t8_body["title"], "GET me", "T8 title matches");
+    assert_eq!(t8_body["priority"], "medium", "T8 priority matches");
+    assert_eq!(t8_body["group_id"], gid, "T8 group_id matches");
+
+    // ── T9. GET 404 — cross-group task returns 404 (RLS isolation) ───────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(get_task_req(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            &bob_task_id,
+        ))
+        .await
+        .expect("T9 cross-group GET oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "T9 cross-group task GET must return 404"
+    );
+
+    // ── T10. GET 404 — deleted task returns 404 ───────────────────────────
+    // task_id was soft-deleted in T6.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(get_task_req(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            &task_id,
+        ))
+        .await
+        .expect("T10 deleted task GET oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "T10 deleted task GET must return 404"
+    );
+
+    // ── T11. PATCH 403 — path group_id ≠ principal group_id ─────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(patch_task_req(
+            Some(&owner_token),
+            Some(&gid),  // X-Group-Id = alice's group
+            &g2id,       // path = bob's group → 403 mismatch
+            &t8_task_id,
+            json!({ "status": "done" }),
+        ))
+        .await
+        .expect("T11 cross-group PATCH oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "T11 path group_id mismatch must return 403"
+    );
+}

--- a/plans/0067-gar-518-tasks-api-slice2.md
+++ b/plans/0067-gar-518-tasks-api-slice2.md
@@ -1,0 +1,138 @@
+# Plan 0067 — GAR-518: REST /v1 Tasks slice 2 (single task GET + task-list PATCH/DELETE)
+
+**Status:** Em execução
+**Autor:** Claude Sonnet 4.6 (garra-routine 2026-05-05, America/New_York)
+**Data:** 2026-05-05 (America/New_York)
+**Issue:** [GAR-518](https://linear.app/chatgpt25/issue/GAR-518)
+**Branch:** `routine/<UTC-yyyymmddhhmm>-tasks-api-slice2`
+**Epic:** `epic:ws-api`
+
+---
+
+## §1 Goal
+
+Land tasks REST slice 2, delivering three endpoints deferred from plan 0066:
+
+- `GET /v1/groups/{group_id}/tasks/{task_id}` — fetch a single task by ID
+- `PATCH /v1/groups/{group_id}/task-lists/{list_id}` — update task list name/description/type
+- `DELETE /v1/groups/{group_id}/task-lists/{list_id}` — archive task list (soft-delete via `archived_at`)
+
+## §2 Architecture
+
+Same RLS pattern as plan 0066 (task_lists + tasks FORCE RLS, migration 006). All handlers
+follow the `set_config` parameterized SQL protocol (plan 0056): both `app.current_user_id`
+AND `app.current_group_id` SET LOCAL in every transaction.
+
+- `GET /{task_id}`: single row fetch with `SELECT … WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL` — cross-group → 404 (not 403), same as PATCH/DELETE in slice 1.
+- `PATCH task-lists/{list_id}`: COALESCE semantics for name/type; nullable description can be **explicitly cleared** in this slice via `Option<Option<String>>` with `#[serde(default)]`.
+- `DELETE task-lists/{list_id}`: `UPDATE task_lists SET archived_at = now(), updated_at = now() WHERE id = $1 AND group_id = $2 AND archived_at IS NULL` — idempotent 204 if already archived.
+
+## §3 Tech stack
+
+- Axum 0.8 + `RestV1FullState` (same as tasks.rs slice 1)
+- `sqlx::query_as` + existing `TaskRow` / `TaskListRow` db-row structs (no new DB structs needed)
+- `garraia_auth::{Action, Principal, WorkspaceAuditAction, audit_workspace_event}`
+- `utoipa` OpenAPI annotations
+
+## §4 Design invariants
+
+1. Path `group_id` must equal `principal.group_id` → 403 on mismatch.
+2. SET LOCAL both `app.current_user_id` AND `app.current_group_id` in every tx.
+3. `GET /{task_id}` → 404 for missing/cross-tenant/deleted tasks (no 403 leak).
+4. `PATCH task-lists/{list_id}` allows clearing `description` via `{"description": null}` using `Option<Option<String>>` serde pattern.
+5. `DELETE task-lists/{list_id}` archives the list; tasks inside are NOT deleted (they become orphaned from the default UI view). Idempotent: already-archived list → 204.
+6. Audit metadata is STRUCTURAL only: `name_len` not `name`, `type`, `status`. No PII.
+7. `PATCH task-lists` does NOT expose or mutate `settings` jsonb (plan 0067+).
+8. Cross-tenant PATCH/DELETE task-lists → 404 (RLS filters to 0 rows; UPDATE affects 0 rows → 404).
+
+## §5 Validações pré-plano
+
+- [x] `task_lists` + `tasks` FORCE RLS migration 006 in main ✅
+- [x] `Action::TasksRead`, `Action::TasksWrite`, `Action::TasksDelete` in `action.rs` ✅
+- [x] `set_config` parameterized SQL pattern established by plan 0056 ✅
+- [x] `TaskRow` + `TaskListRow` + `TaskResponse` + `TaskListResponse` structs in tasks.rs (plan 0066) ✅
+- [x] `RestV1FullState` + route wiring pattern confirmed in tasks.rs ✅
+- [x] Existing `ALLOWED_LIST_TYPES` constant usable for PATCH type validation ✅
+
+## §6 Scope
+
+**In scope:**
+- `GET /v1/groups/{group_id}/tasks/{task_id}` — fetch single task
+- `PATCH /v1/groups/{group_id}/task-lists/{list_id}` — update name/description/type (with description null-clear support)
+- `DELETE /v1/groups/{group_id}/task-lists/{list_id}` — archive task list
+
+**Out of scope:**
+- `task_assignees` / `task_labels` / `task_comments` / `task_activity` (plan 0068+)
+- Subtask management (plan 0068+)
+- `settings` jsonb exposure via API (plan 0068+)
+- Task hard-delete or task list hard-delete (not in schema)
+- `PATCH /v1/groups/{group_id}/tasks/{task_id}` nullable-clear fix (already works via COALESCE; full null-clear deferred to plan 0068+)
+
+## §7 Affected files
+
+```
+crates/garraia-auth/src/audit_workspace.rs         (+ 2 variants: TaskListUpdated, TaskListArchived + unit tests)
+crates/garraia-gateway/src/rest_v1/tasks.rs        (+ 3 handlers + 2 new DTOs, ~180 LOC)
+crates/garraia-gateway/src/rest_v1/mod.rs          (3 route entries: GET + PATCH + DELETE task-lists)
+crates/garraia-gateway/src/rest_v1/openapi.rs      (+ 3 paths + 3 schemas)
+crates/garraia-gateway/tests/rest_v1_tasks.rs      (extend: +6 scenarios, ~120 LOC)
+plans/README.md                                    (+ row 0067)
+```
+
+## §8 Rollback plan
+
+Revert the branch. No schema migration, no data mutation. Fully reversible.
+
+## §9 Risk register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| RLS SET LOCAL omitted | Low | High | Parameterized set_config pattern; tests verify cross-group isolation |
+| `description: null` PATCH clears unintentionally | Low | Low | Only triggered by explicit `{"description": null}`; omitting key = COALESCE keep |
+| Archive races (two workers archive same list) | Very Low | None | UPDATE WHERE archived_at IS NULL is a no-op on already-archived; both get 204 |
+| `title` text leaks in audit metadata | Low | Medium | Audit carries `name_len` only; snapshot test validates no content |
+
+## §10 Acceptance criteria
+
+- `GET /v1/groups/{group_id}/tasks/{task_id}` returns 200 with full task body
+- `GET /{task_id}` returns 404 for deleted/missing/cross-group tasks
+- `PATCH /v1/groups/{group_id}/task-lists/{list_id}` returns 200 with updated list; `{"description": null}` clears the field
+- `PATCH` returns 404 for missing/cross-group/archived lists
+- `DELETE /v1/groups/{group_id}/task-lists/{list_id}` returns 204; list no longer appears in `GET /task-lists`
+- `DELETE` is idempotent: second call on already-archived list returns 204
+- Wrong `group_id` in path returns 403 (not 404)
+- `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` passes
+- All CI checks pass
+
+## §11 Cross-references
+
+- ROADMAP §3.8 — Tasks Tier 1 Notion-like
+- Plan 0066 (GAR-516) — tasks slice 1; this plan extends its handlers and tests
+- Plan 0056 — `set_config` parameterized SQL pattern
+- Migration 006 (`task_lists` + `tasks` + FORCE RLS)
+
+## §12 Open questions
+
+None — schema and RLS already shipped; all DTOs and DB row structs in tasks.rs from plan 0066.
+
+## §13 Estimativa
+
+- T1: Audit variants TaskListUpdated + TaskListArchived: 10 min
+- T2: DTOs PatchTaskListRequest: 10 min
+- T3: Handler `get_task`: 20 min
+- T4: Handler `patch_task_list`: 25 min
+- T5: Handler `delete_task_list` (archive): 15 min
+- T6: Route wiring + OpenAPI: 20 min
+- T7: Integration tests (+6 scenarios): 30 min
+- CI + review follow-ups: 20 min
+- **Total: ~2 hours**
+
+## M1 Tasks
+
+- [ ] T1: Add `TaskListUpdated` + `TaskListArchived` to `WorkspaceAuditAction` + unit tests
+- [ ] T2: DTO: `PatchTaskListRequest` (name/description Option<Option<String>>/type all optional)
+- [ ] T3: Handler: `get_task` — `GET /v1/groups/{group_id}/tasks/{task_id}`
+- [ ] T4: Handler: `patch_task_list` — `PATCH /v1/groups/{group_id}/task-lists/{list_id}`
+- [ ] T5: Handler: `delete_task_list` — `DELETE /v1/groups/{group_id}/task-lists/{list_id}` (archive, idempotent)
+- [ ] T6: Route wiring in `mod.rs` + OpenAPI paths + schemas in `openapi.rs`
+- [ ] T7: Integration tests (get_task 200/404/cross-group, patch_task_list 200/404/null-clear, delete_task_list 204/idempotent)

--- a/plans/README.md
+++ b/plans/README.md
@@ -89,6 +89,8 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0063 | [GAR-515 — webchat.html XSS: DOMPurify for marked.parse() + langLabel + event delegation](0063-gar-515-webchat-dompurify.md) | [GAR-515](https://linear.app/chatgpt25/issue/GAR-515) | ✅ Merged 2026-05-05 via PR #136 (`8115d7a`) |
 | 0064 | [AI Quality Ratchet PR-1 — scaffold report-only](0064-quality-ratchet-pr1.md) | (epic Quality Ratchet — Linear issue TBD) | 🟡 Em execução 2026-05-05 |
 | 0065 | [GAR-517 — api.js + mcpView.js XSS: add escapeHtml utils module, wrap 7 innerHTML sinks](0065-gar-517-api-js-xss-utils.md) | [GAR-517](https://linear.app/chatgpt25/issue/GAR-517) | ✅ Merged PR #144 `15ec51e3` 2026-05-05 |
+| 0066 | [GAR-516 — REST /v1 tasks slice 1: task-lists + tasks CRUD](0066-gar-516-tasks-api-slice1.md) | [GAR-516](https://linear.app/chatgpt25/issue/GAR-516) | 🟡 Em execução 2026-05-05 (PR #145) |
+| 0067 | [GAR-518 — REST /v1 tasks slice 2: GET single task + task-list PATCH/DELETE](0067-gar-518-tasks-api-slice2.md) | [GAR-518](https://linear.app/chatgpt25/issue/GAR-518) | 🟡 Em execução 2026-05-05 (garra-routine) |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

- Adds three endpoints extending the tasks REST API (plan 0067 / GAR-518):
  - `GET /v1/groups/{group_id}/tasks/{task_id}` — fetch single task by ID; 404 for missing/deleted/cross-tenant (no 403 leak)
  - `PATCH /v1/groups/{group_id}/task-lists/{list_id}` — update name/type/description with three-way description semantics (`null` = clear, absent = keep, string = update)
  - `DELETE /v1/groups/{group_id}/task-lists/{list_id}` — archive task list (idempotent: already-archived → 204, missing/cross-tenant → 404)
- Adds `WorkspaceAuditAction::TaskListUpdated` + `TaskListArchived` (plan 0067) and pre-lands `TaskListCreated`/`TaskCreated`/`TaskDeleted` (plan 0066) so the branch compiles before PR #145 merges
- Adds `sqlx/macros` feature to garraia-gateway (needed for `#[derive(sqlx::FromRow)]` on `TaskListRow`/`TaskRow`)
- Adds `PatchTaskListRequest` DTO with `option_nullable` serde module for `Option<Option<String>>` three-way field semantics
- All handlers follow `set_config` parameterized SQL protocol (plan 0056): both `SET LOCAL` calls in every tx
- Audit metadata is STRUCTURAL only: `name_len`, `type` — no PII text

## Test plan

- [ ] TL1–TL5: task-list slice 1 scenarios (POST 201/400/401/403, GET 200)
- [ ] TL6: PATCH 200 — name/type update; audit row with name_len (no name text)
- [ ] TL7: PATCH 404 — unknown list_id
- [ ] TL8: PATCH 200 — `{"description": null}` clears description field
- [ ] TL9: DELETE 204 — archive; list no longer in GET /task-lists; audit row present
- [ ] TL10: DELETE 204 — already-archived list is idempotent
- [ ] T1–T7: task slice 1 scenarios (POST/GET/PATCH/DELETE + cross-tenant RLS)
- [ ] T8: GET 200 — fetch single task by ID; all fields match
- [ ] T9: GET 404 — cross-group task returns 404 (not 403)
- [ ] T10: GET 404 — soft-deleted task returns 404
- [ ] T11: PATCH 403 — path group_id ≠ principal group_id
- [ ] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` passes
- [ ] All 18 CI checks green

**Note:** This PR has a planned merge conflict with PR #145 on `audit_workspace.rs` and `tasks.rs` (PR #145 adds the slice 1 handlers; this PR adds the slice 2 handlers + pre-lands the same audit variants). Resolution: keep both sets of changes (all 5 task audit variants + all 9 task handlers). The merge is straightforward after PR #145 lands on main.

Closes GAR-518.

https://claude.ai/code/session_01Umbtop3uxddoeACjjeCVsS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Umbtop3uxddoeACjjeCVsS)_