### PR TITLE
feat(gateway): GAR-520 — task comments REST API (plan 0069 slice 3)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -504,17 +504,21 @@ Módulo dentro de `garraia-workspace`. Schema entregue via migration 006 com **R
 
 **API REST `/v1`:**
 
-- [ ] `POST /v1/groups/{group_id}/task-lists`
-- [ ] `GET /v1/groups/{group_id}/task-lists`
-- [ ] `POST /v1/task-lists/{list_id}/tasks`
-- [ ] `GET /v1/task-lists/{list_id}/tasks?status=...&assignee=...&cursor=...`
-- [ ] `GET /v1/tasks/{task_id}`
-- [ ] `PATCH /v1/tasks/{task_id}` (status, priority, assignees, due_at, labels)
-- [ ] `POST /v1/tasks/{task_id}/comments`
-- [ ] `POST /v1/tasks/{task_id}/attachments`
-- [ ] `POST /v1/tasks/{task_id}:move` (reordenar/mudar lista)
-- [ ] `DELETE /v1/tasks/{task_id}` (soft delete)
-- [ ] WebSocket `/v1/task-lists/{list_id}/stream` para updates em tempo real (kanban colaborativo)
+- [x] `POST /v1/groups/{group_id}/task-lists` — plan 0066 / GAR-516 ✅
+- [x] `GET /v1/groups/{group_id}/task-lists` — plan 0066 / GAR-516 ✅
+- [x] `PATCH /v1/groups/{group_id}/task-lists/{list_id}` — plan 0066 / GAR-516 ✅
+- [x] `DELETE /v1/groups/{group_id}/task-lists/{list_id}` (archive, idempotente) — plan 0066 / GAR-516 ✅
+- [x] `POST /v1/groups/{group_id}/task-lists/{list_id}/tasks` — plan 0066 / GAR-516 ✅
+- [x] `GET /v1/groups/{group_id}/task-lists/{list_id}/tasks?status=...&cursor=...` — plan 0066 / GAR-516 ✅
+- [x] `GET /v1/groups/{group_id}/tasks/{task_id}` — plan 0068 / GAR-518 ✅
+- [x] `PATCH /v1/groups/{group_id}/tasks/{task_id}` (status, priority, title, due_at) — plan 0068 / GAR-518 ✅
+- [x] `DELETE /v1/groups/{group_id}/tasks/{task_id}` (soft delete) — plan 0068 / GAR-518 ✅
+- [ ] `POST /v1/groups/{group_id}/tasks/{task_id}/comments` — plan 0069 / GAR-520 (em execução 2026-05-05)
+- [ ] `GET /v1/groups/{group_id}/tasks/{task_id}/comments?cursor=...` — plan 0069 / GAR-520 (em execução 2026-05-05)
+- [ ] `DELETE /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}` — plan 0069 / GAR-520 (em execução 2026-05-05)
+- [ ] `POST /v1/groups/{group_id}/tasks/{task_id}/attachments`
+- [ ] `POST /v1/groups/{group_id}/tasks/{task_id}:move` (reordenar/mudar lista)
+- [ ] WebSocket `/v1/groups/{group_id}/task-lists/{list_id}/stream` para updates em tempo real (kanban colaborativo)
 
 **RBAC:**
 

--- a/crates/garraia-auth/src/audit_workspace.rs
+++ b/crates/garraia-auth/src/audit_workspace.rs
@@ -205,6 +205,23 @@ pub enum WorkspaceAuditAction {
     /// Metadata: `{ type }`. List is not physically removed;
     /// `archived_at` is set to `now()`.
     TaskListArchived,
+
+    /// A comment was created via
+    /// `POST /v1/groups/{group_id}/tasks/{task_id}/comments`
+    /// (plan 0069 / GAR-520, epic GAR-WS-TASKS slice 3).
+    ///
+    /// `resource_type = "task_comments"`, `resource_id = "{comment_id}"`.
+    /// Metadata: `{ body_len }`. Body text is user-controlled PII — only
+    /// length is carried.
+    TaskCommentCreated,
+
+    /// A comment was soft-deleted via
+    /// `DELETE /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}`
+    /// (plan 0069 / GAR-520, epic GAR-WS-TASKS slice 3).
+    ///
+    /// `resource_type = "task_comments"`, `resource_id = "{comment_id}"`.
+    /// Metadata: `{ body_len }`.
+    TaskCommentDeleted,
 }
 
 impl WorkspaceAuditAction {
@@ -227,6 +244,8 @@ impl WorkspaceAuditAction {
             WorkspaceAuditAction::TaskDeleted => "task.deleted",
             WorkspaceAuditAction::TaskListUpdated => "task_list.updated",
             WorkspaceAuditAction::TaskListArchived => "task_list.archived",
+            WorkspaceAuditAction::TaskCommentCreated => "task.comment.created",
+            WorkspaceAuditAction::TaskCommentDeleted => "task.comment.deleted",
         }
     }
 }
@@ -345,6 +364,14 @@ mod tests {
             WorkspaceAuditAction::TaskListArchived.as_str(),
             "task_list.archived"
         );
+        assert_eq!(
+            WorkspaceAuditAction::TaskCommentCreated.as_str(),
+            "task.comment.created"
+        );
+        assert_eq!(
+            WorkspaceAuditAction::TaskCommentDeleted.as_str(),
+            "task.comment.deleted"
+        );
     }
 
     #[test]
@@ -367,6 +394,8 @@ mod tests {
             WorkspaceAuditAction::TaskDeleted.as_str(),
             WorkspaceAuditAction::TaskListUpdated.as_str(),
             WorkspaceAuditAction::TaskListArchived.as_str(),
+            WorkspaceAuditAction::TaskCommentCreated.as_str(),
+            WorkspaceAuditAction::TaskCommentDeleted.as_str(),
         ];
         let unique: std::collections::HashSet<_> = strings.iter().collect();
         assert_eq!(unique.len(), strings.len(), "duplicate action strings");

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -306,6 +306,15 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                         .patch(tasks::patch_task)
                         .delete(tasks::delete_task),
                 )
+                // Plan 0069 (GAR-520) — task comments API slice 3.
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/comments",
+                    post(tasks::create_task_comment).get(tasks::list_task_comments),
+                )
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}",
+                    delete(tasks::delete_task_comment),
+                )
                 .merge(rate_limited_routes)
                 .merge(tus_routes)
                 .with_state(full)
@@ -355,7 +364,7 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     get(unconfigured_handler).post(unconfigured_handler),
                 )
                 .route("/v1/memory/{id}", delete(unconfigured_handler))
-                // Plan 0066/0067 (GAR-516/GAR-518) — tasks API slices 1+2, fail-soft 503.
+                // Plan 0066/0067/0069 (GAR-516/GAR-518/GAR-520) — tasks API slices 1+2+3, fail-soft 503.
                 .route(
                     "/v1/groups/{group_id}/task-lists",
                     post(unconfigured_handler).get(unconfigured_handler),
@@ -373,6 +382,14 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     get(unconfigured_handler)
                         .patch(unconfigured_handler)
                         .delete(unconfigured_handler),
+                )
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/comments",
+                    post(unconfigured_handler).get(unconfigured_handler),
+                )
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}",
+                    delete(unconfigured_handler),
                 )
                 .route(
                     "/v1/uploads",
@@ -429,7 +446,7 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     get(unconfigured_handler).post(unconfigured_handler),
                 )
                 .route("/v1/memory/{id}", delete(unconfigured_handler))
-                // Plan 0066/0067 (GAR-516/GAR-518) — tasks API slices 1+2, no-auth stub.
+                // Plan 0066/0067/0069 (GAR-516/GAR-518/GAR-520) — tasks API slices 1+2+3, no-auth stub.
                 .route(
                     "/v1/groups/{group_id}/task-lists",
                     post(unconfigured_handler).get(unconfigured_handler),
@@ -447,6 +464,14 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     get(unconfigured_handler)
                         .patch(unconfigured_handler)
                         .delete(unconfigured_handler),
+                )
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/comments",
+                    post(unconfigured_handler).get(unconfigured_handler),
+                )
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}",
+                    delete(unconfigured_handler),
                 )
                 .route(
                     "/v1/uploads",

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -28,9 +28,9 @@ use super::messages::{
 };
 use super::problem::ProblemDetails;
 use super::tasks::{
-    CreateTaskListRequest, CreateTaskRequest, ListTaskListsResponse, ListTasksResponse,
-    PatchTaskListRequest, PatchTaskRequest, TaskListResponse, TaskListSummary, TaskResponse,
-    TaskSummary,
+    CommentResponse, CreateCommentRequest, CreateTaskListRequest, CreateTaskRequest,
+    ListCommentsResponse, ListTaskListsResponse, ListTasksResponse, PatchTaskListRequest,
+    PatchTaskRequest, TaskListResponse, TaskListSummary, TaskResponse, TaskSummary,
 };
 use super::uploads::{CreateUploadRequest, CreateUploadResponse};
 
@@ -104,6 +104,9 @@ impl Modify for SecurityAddon {
         super::tasks::get_task,
         super::tasks::patch_task,
         super::tasks::delete_task,
+        super::tasks::create_task_comment,
+        super::tasks::list_task_comments,
+        super::tasks::delete_task_comment,
     ),
     components(schemas(
         MeResponse,
@@ -143,6 +146,9 @@ impl Modify for SecurityAddon {
         TaskSummary,
         ListTasksResponse,
         PatchTaskRequest,
+        CreateCommentRequest,
+        CommentResponse,
+        ListCommentsResponse,
     )),
     modifiers(&SecurityAddon)
 )]

--- a/crates/garraia-gateway/src/rest_v1/tasks.rs
+++ b/crates/garraia-gateway/src/rest_v1/tasks.rs
@@ -1574,12 +1574,11 @@ pub async fn create_task_comment(
         return Err(RestError::NotFound);
     }
 
-    let (author_label,): (String,) =
-        sqlx::query_as("SELECT display_name FROM users WHERE id = $1")
-            .bind(principal.user_id)
-            .fetch_one(&mut *tx)
-            .await
-            .map_err(|e| RestError::Internal(e.into()))?;
+    let (author_label,): (String,) = sqlx::query_as("SELECT display_name FROM users WHERE id = $1")
+        .bind(principal.user_id)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
 
     let row: CommentRow = sqlx::query_as(
         "INSERT INTO task_comments \

--- a/crates/garraia-gateway/src/rest_v1/tasks.rs
+++ b/crates/garraia-gateway/src/rest_v1/tasks.rs
@@ -1,6 +1,6 @@
-//! `/v1/groups/{group_id}/task-lists` and task handlers (plan 0066/0067, GAR-516/GAR-518).
+//! `/v1/groups/{group_id}/task-lists` and task/comment handlers (plan 0066/0067/0069, GAR-516/GAR-518/GAR-520).
 //!
-//! Nine endpoints on the `garraia_app` RLS-enforced pool:
+//! Twelve endpoints on the `garraia_app` RLS-enforced pool:
 //!
 //! **Slice 1 (plan 0066 / GAR-516):**
 //! - `POST /v1/groups/{group_id}/task-lists` — create task list
@@ -14,6 +14,11 @@
 //! - `GET /v1/groups/{group_id}/tasks/{task_id}` — fetch single task
 //! - `PATCH /v1/groups/{group_id}/task-lists/{list_id}` — update task list name/type/description
 //! - `DELETE /v1/groups/{group_id}/task-lists/{list_id}` — archive task list (idempotent)
+//!
+//! **Slice 3 (plan 0069 / GAR-520):**
+//! - `POST /v1/groups/{group_id}/tasks/{task_id}/comments` — create comment
+//! - `GET /v1/groups/{group_id}/tasks/{task_id}/comments` — cursor-paginated comment list
+//! - `DELETE /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}` — soft-delete comment
 //!
 //! ## Tenant-context protocol
 //!
@@ -1415,6 +1420,413 @@ pub async fn delete_task_list(
         .await
         .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
     }
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ─── DTOs — slice 3 (plan 0069 / GAR-520) ────────────────────────────────────
+
+/// DB row struct for `task_comments`.
+#[derive(sqlx::FromRow)]
+struct CommentRow {
+    id: Uuid,
+    task_id: Uuid,
+    author_user_id: Option<Uuid>,
+    author_label: String,
+    body_md: String,
+    created_at: DateTime<Utc>,
+    edited_at: Option<DateTime<Utc>>,
+}
+
+/// Full comment representation returned by `POST` and included in `GET` list.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct CommentResponse {
+    pub id: Uuid,
+    pub task_id: Uuid,
+    pub author_user_id: Option<Uuid>,
+    pub author_label: String,
+    pub body_md: String,
+    pub created_at: DateTime<Utc>,
+    pub edited_at: Option<DateTime<Utc>>,
+}
+
+impl From<CommentRow> for CommentResponse {
+    fn from(r: CommentRow) -> Self {
+        Self {
+            id: r.id,
+            task_id: r.task_id,
+            author_user_id: r.author_user_id,
+            author_label: r.author_label,
+            body_md: r.body_md,
+            created_at: r.created_at,
+            edited_at: r.edited_at,
+        }
+    }
+}
+
+/// Request body for `POST /v1/groups/{group_id}/tasks/{task_id}/comments`.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct CreateCommentRequest {
+    /// Markdown comment body. 1–50,000 characters.
+    pub body_md: String,
+}
+
+impl CreateCommentRequest {
+    fn validate(&self) -> Result<(), &'static str> {
+        let len = self.body_md.chars().count();
+        if len == 0 {
+            return Err("body_md must not be empty");
+        }
+        if len > 50_000 {
+            return Err("body_md exceeds 50,000 character limit");
+        }
+        Ok(())
+    }
+}
+
+/// Query parameters for `GET /v1/groups/{group_id}/tasks/{task_id}/comments`.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ListCommentsQuery {
+    /// Cursor: the `id` of the last comment on the previous page.
+    pub cursor: Option<Uuid>,
+    /// Page size. 1–100. Defaults to 50.
+    pub limit: Option<u32>,
+}
+
+/// Response body for `GET /v1/groups/{group_id}/tasks/{task_id}/comments`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ListCommentsResponse {
+    pub items: Vec<CommentResponse>,
+    pub next_cursor: Option<Uuid>,
+}
+
+// ─── Handlers — slice 3 (plan 0069 / GAR-520) ────────────────────────────────
+
+/// `POST /v1/groups/{group_id}/tasks/{task_id}/comments` — create a comment.
+///
+/// Author label is resolved from the caller's `display_name` in the `users` table.
+/// Returns 404 if the task does not exist or belongs to a different group.
+/// Authz: `Action::TasksWrite`.
+///
+/// ## Error matrix
+///
+/// | Condition                          | Status |
+/// |------------------------------------|--------|
+/// | Missing/invalid JWT                | 401    |
+/// | Non-member of group                | 403    |
+/// | Path group_id ≠ principal group_id | 403    |
+/// | Validation failure                 | 400    |
+/// | Task not found / cross-tenant      | 404    |
+/// | Happy path                         | 201    |
+#[utoipa::path(
+    post,
+    path = "/v1/groups/{group_id}/tasks/{task_id}/comments",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("task_id" = Uuid, Path, description = "Task UUID."),
+    ),
+    request_body = CreateCommentRequest,
+    responses(
+        (status = 201, description = "Comment created.", body = CommentResponse),
+        (status = 400, description = "Validation error.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Task not found or cross-tenant.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn create_task_comment(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, task_id)): Path<(Uuid, Uuid)>,
+    Json(body): Json<CreateCommentRequest>,
+) -> Result<(StatusCode, Json<CommentResponse>), RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksWrite) {
+        return Err(RestError::Forbidden);
+    }
+    body.validate()
+        .map_err(|msg| RestError::BadRequest(msg.into()))?;
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Verify the task exists in this group (and is not soft-deleted).
+    let task_exists: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM tasks WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+    )
+    .bind(task_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if task_exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    let (author_label,): (String,) =
+        sqlx::query_as("SELECT display_name FROM users WHERE id = $1")
+            .bind(principal.user_id)
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(|e| RestError::Internal(e.into()))?;
+
+    let row: CommentRow = sqlx::query_as(
+        "INSERT INTO task_comments \
+             (task_id, author_user_id, author_label, body_md) \
+         VALUES ($1, $2, $3, $4) \
+         RETURNING id, task_id, author_user_id, author_label, body_md, \
+                   created_at, edited_at",
+    )
+    .bind(task_id)
+    .bind(principal.user_id)
+    .bind(&author_label)
+    .bind(&body.body_md)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let comment_id = row.id;
+    let body_len = body.body_md.chars().count();
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::TaskCommentCreated,
+        principal.user_id,
+        group_id,
+        "task_comments",
+        comment_id.to_string(),
+        json!({ "body_len": body_len }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok((StatusCode::CREATED, Json(CommentResponse::from(row))))
+}
+
+/// `GET /v1/groups/{group_id}/tasks/{task_id}/comments` — list comments.
+///
+/// Returns non-deleted comments for the task, newest first, cursor-paginated.
+/// Returns 404 if the task does not exist or belongs to a different group.
+/// Authz: `Action::TasksRead`.
+///
+/// ## Error matrix
+///
+/// | Condition                          | Status |
+/// |------------------------------------|--------|
+/// | Missing/invalid JWT                | 401    |
+/// | Non-member of group                | 403    |
+/// | Path group_id ≠ principal group_id | 403    |
+/// | Task not found / cross-tenant      | 404    |
+/// | Happy path                         | 200    |
+#[utoipa::path(
+    get,
+    path = "/v1/groups/{group_id}/tasks/{task_id}/comments",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("task_id" = Uuid, Path, description = "Task UUID."),
+        ListCommentsQuery,
+    ),
+    responses(
+        (status = 200, description = "Comment list.", body = ListCommentsResponse),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Task not found or cross-tenant.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn list_task_comments(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, task_id)): Path<(Uuid, Uuid)>,
+    Query(params): Query<ListCommentsQuery>,
+) -> Result<Json<ListCommentsResponse>, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksRead) {
+        return Err(RestError::Forbidden);
+    }
+
+    let effective_limit = params.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+    let fetch_limit = i64::from(effective_limit + 1);
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Verify task exists in this group.
+    let task_exists: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM tasks WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+    )
+    .bind(task_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if task_exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    let rows: Vec<CommentRow> = if let Some(cursor_id) = params.cursor {
+        sqlx::query_as(
+            "SELECT id, task_id, author_user_id, author_label, body_md, \
+                    created_at, edited_at \
+             FROM task_comments \
+             WHERE task_id = $1 \
+               AND deleted_at IS NULL \
+               AND (created_at, id) < ( \
+                   SELECT created_at, id FROM task_comments WHERE id = $2 \
+               ) \
+             ORDER BY created_at DESC, id DESC \
+             LIMIT $3",
+        )
+        .bind(task_id)
+        .bind(cursor_id)
+        .bind(fetch_limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?
+    } else {
+        sqlx::query_as(
+            "SELECT id, task_id, author_user_id, author_label, body_md, \
+                    created_at, edited_at \
+             FROM task_comments \
+             WHERE task_id = $1 AND deleted_at IS NULL \
+             ORDER BY created_at DESC, id DESC \
+             LIMIT $2",
+        )
+        .bind(task_id)
+        .bind(fetch_limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?
+    };
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    let has_more = rows.len() as u32 > effective_limit;
+    let items: Vec<CommentResponse> = rows
+        .into_iter()
+        .take(effective_limit as usize)
+        .map(CommentResponse::from)
+        .collect();
+    let next_cursor = if has_more {
+        items.last().map(|it| it.id)
+    } else {
+        None
+    };
+
+    Ok(Json(ListCommentsResponse { items, next_cursor }))
+}
+
+/// `DELETE /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}` — soft-delete a comment.
+///
+/// Sets `deleted_at = now()`. Returns 404 if the comment does not exist,
+/// is already deleted, or belongs to a task in a different group (RLS).
+/// Authz: `Action::TasksWrite`.
+///
+/// ## Error matrix
+///
+/// | Condition                          | Status |
+/// |------------------------------------|--------|
+/// | Missing/invalid JWT                | 401    |
+/// | Non-member of group                | 403    |
+/// | Path group_id ≠ principal group_id | 403    |
+/// | Comment not found / deleted / cross-tenant | 404 |
+/// | Happy path                         | 204    |
+#[utoipa::path(
+    delete,
+    path = "/v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("task_id" = Uuid, Path, description = "Task UUID."),
+        ("comment_id" = Uuid, Path, description = "Comment UUID."),
+    ),
+    responses(
+        (status = 204, description = "Comment deleted."),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Comment not found, already deleted, or cross-tenant.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn delete_task_comment(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, task_id, comment_id)): Path<(Uuid, Uuid, Uuid)>,
+) -> Result<StatusCode, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksWrite) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Fetch comment to get body_len for audit; also verifies it exists and is not deleted.
+    // RLS JOIN policy scopes to current group via tasks.
+    let existing: Option<(String,)> = sqlx::query_as(
+        "SELECT body_md FROM task_comments \
+         WHERE id = $1 AND task_id = $2 AND deleted_at IS NULL",
+    )
+    .bind(comment_id)
+    .bind(task_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let (body_md,) = match existing {
+        Some(r) => r,
+        None => return Err(RestError::NotFound),
+    };
+
+    let body_len = body_md.chars().count();
+
+    sqlx::query(
+        "UPDATE task_comments SET deleted_at = now() \
+         WHERE id = $1 AND deleted_at IS NULL",
+    )
+    .bind(comment_id)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::TaskCommentDeleted,
+        principal.user_id,
+        group_id,
+        "task_comments",
+        comment_id.to_string(),
+        json!({ "body_len": body_len }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
 
     tx.commit()
         .await

--- a/crates/garraia-gateway/tests/rest_v1_tasks.rs
+++ b/crates/garraia-gateway/tests/rest_v1_tasks.rs
@@ -1,10 +1,10 @@
-//! Integration tests for task-lists + tasks REST API (plan 0066/0067, GAR-516/GAR-518).
+//! Integration tests for task-lists + tasks REST API (plan 0066/0067/0069, GAR-516/GAR-518/GAR-520).
 //!
 //! All scenarios bundled into ONE `#[tokio::test]` — same pattern as
 //! `rest_v1_memory.rs` / `rest_v1_chats.rs`. Splitting triggers the
 //! sqlx runtime-teardown race documented in plan 0016 M3.
 //!
-//! Scenarios (21 total):
+//! Scenarios (29 total):
 //!
 //! Task-list scenarios (10):
 //!   TL1.  POST 201 — create task list; assert response shape + audit row.
@@ -30,6 +30,16 @@
 //!   T9.  GET 404 — cross-group task returns 404 (RLS isolation).
 //!   T10. GET 404 — deleted task returns 404.
 //!   T11. PATCH 403 — path group_id ≠ principal group_id returns 403.
+//!
+//! Task comment scenarios (8, plan 0069 / GAR-520):
+//!   C1.  POST 201 — create comment; assert response shape + audit row.
+//!   C2.  POST 400 — empty body_md fails validation.
+//!   C3.  POST 404 — unknown task_id.
+//!   C4.  GET 200 — list comments; returns C1 comment; cursor pagination present.
+//!   C5.  GET 404 — cross-group task_id returns 404 (RLS isolation).
+//!   C6.  DELETE 204 — soft-delete comment; no longer in list.
+//!   C7.  DELETE 404 — already-deleted comment is 404.
+//!   C8.  POST 404 — cross-group task returns 404 (RLS isolation).
 
 mod common;
 
@@ -220,6 +230,53 @@ fn get_task_req(
     auth_req(
         "GET",
         &format!("/v1/groups/{path_group_id}/tasks/{task_id}"),
+        token,
+        x_group_id,
+        None,
+    )
+}
+
+fn post_comment(
+    token: Option<&str>,
+    x_group_id: Option<&str>,
+    path_group_id: &str,
+    task_id: &str,
+    body: serde_json::Value,
+) -> Request<Body> {
+    auth_req(
+        "POST",
+        &format!("/v1/groups/{path_group_id}/tasks/{task_id}/comments"),
+        token,
+        x_group_id,
+        Some(body),
+    )
+}
+
+fn get_comments(
+    token: Option<&str>,
+    x_group_id: Option<&str>,
+    path_group_id: &str,
+    task_id: &str,
+) -> Request<Body> {
+    auth_req(
+        "GET",
+        &format!("/v1/groups/{path_group_id}/tasks/{task_id}/comments"),
+        token,
+        x_group_id,
+        None,
+    )
+}
+
+fn delete_comment_req(
+    token: Option<&str>,
+    x_group_id: Option<&str>,
+    path_group_id: &str,
+    task_id: &str,
+    comment_id: &str,
+) -> Request<Body> {
+    auth_req(
+        "DELETE",
+        &format!("/v1/groups/{path_group_id}/tasks/{task_id}/comments/{comment_id}"),
         token,
         x_group_id,
         None,
@@ -816,5 +873,199 @@ async fn rest_v1_tasks_scenarios() {
         resp.status(),
         StatusCode::FORBIDDEN,
         "T11 path group_id mismatch must return 403"
+    );
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Task comment scenarios (plan 0069 / GAR-520)
+    // t8_task_id is alice's live task used as the comment target.
+    // ═══════════════════════════════════════════════════════════════════════
+
+    // ── C1. POST 201 — create comment; response shape + audit row ─────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(post_comment(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            &t8_task_id,
+            json!({ "body_md": "This is a **test** comment." }),
+        ))
+        .await
+        .expect("C1 oneshot");
+    assert_eq!(resp.status(), StatusCode::CREATED, "C1 status");
+    let c1_body = body_json(resp).await;
+    let comment_id = c1_body["id"].as_str().expect("C1 comment id").to_string();
+    assert_eq!(c1_body["task_id"], t8_task_id, "C1 task_id");
+    assert_eq!(c1_body["body_md"], "This is a **test** comment.", "C1 body_md");
+    assert!(
+        c1_body.get("author_label").is_some(),
+        "C1 author_label present"
+    );
+    assert!(c1_body.get("created_at").is_some(), "C1 created_at present");
+
+    let c1_audit = fetch_audit_events_for_group(&h, group_id)
+        .await
+        .expect("C1 fetch audit");
+    let c1_audit_row = c1_audit
+        .iter()
+        .find(|e| e.0 == "task.comment.created")
+        .expect("C1 audit row task.comment.created");
+    let (_, _, c1_res_type, c1_res_id, c1_meta) = c1_audit_row;
+    assert_eq!(c1_res_type, "task_comments", "C1 audit resource_type");
+    assert_eq!(c1_res_id, &comment_id, "C1 audit resource_id");
+    assert!(
+        c1_meta["body_len"].as_u64().is_some(),
+        "C1 audit metadata has body_len"
+    );
+    assert!(
+        c1_meta.get("body_md").is_none(),
+        "C1 audit must not contain body_md text (PII guard)"
+    );
+
+    // ── C2. POST 400 — empty body_md fails validation ─────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(post_comment(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            &t8_task_id,
+            json!({ "body_md": "" }),
+        ))
+        .await
+        .expect("C2 oneshot");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "C2 empty body_md must be 400");
+
+    // ── C3. POST 404 — unknown task_id ────────────────────────────────────
+    let unknown_task = uuid::Uuid::new_v4().to_string();
+    let resp = h
+        .router
+        .clone()
+        .oneshot(post_comment(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            &unknown_task,
+            json!({ "body_md": "comment on ghost task" }),
+        ))
+        .await
+        .expect("C3 oneshot");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND, "C3 unknown task must be 404");
+
+    // ── C4. GET 200 — list comments; includes C1; cursor pagination ────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(get_comments(Some(&owner_token), Some(&gid), &gid, &t8_task_id))
+        .await
+        .expect("C4 oneshot");
+    assert_eq!(resp.status(), StatusCode::OK, "C4 status");
+    let c4_body = body_json(resp).await;
+    let comments = c4_body["items"].as_array().expect("C4 items array");
+    assert!(
+        comments.iter().any(|it| it["id"] == comment_id),
+        "C4 should contain C1 comment"
+    );
+    assert!(
+        c4_body.get("next_cursor").is_some(),
+        "C4 next_cursor field present (null when no more pages)"
+    );
+
+    // ── C5. GET 404 — cross-group task_id hidden by RLS ───────────────────
+    // Alice uses her own gid but bob's task_id — RLS filters → 404.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(get_comments(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            &bob_task_id,
+        ))
+        .await
+        .expect("C5 cross-group GET comments oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "C5 cross-group task_id must return 404"
+    );
+
+    // ── C6. DELETE 204 — soft-delete comment ──────────────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(delete_comment_req(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            &t8_task_id,
+            &comment_id,
+        ))
+        .await
+        .expect("C6 oneshot");
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT, "C6 status");
+
+    // Deleted comment must not appear in the list.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(get_comments(Some(&owner_token), Some(&gid), &gid, &t8_task_id))
+        .await
+        .expect("C6 list after delete");
+    let c6_list = body_json(resp).await;
+    let after_del = c6_list["items"].as_array().expect("C6 items array");
+    assert!(
+        !after_del.iter().any(|it| it["id"] == comment_id),
+        "C6 deleted comment must not appear in list"
+    );
+
+    let c6_audit = fetch_audit_events_for_group(&h, group_id)
+        .await
+        .expect("C6 fetch audit");
+    assert!(
+        c6_audit
+            .iter()
+            .any(|e| e.0 == "task.comment.deleted" && e.3 == comment_id),
+        "C6 audit row task.comment.deleted must be present"
+    );
+
+    // ── C7. DELETE 404 — already-deleted comment ───────────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(delete_comment_req(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            &t8_task_id,
+            &comment_id,
+        ))
+        .await
+        .expect("C7 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "C7 re-delete must return 404 (not idempotent)"
+    );
+
+    // ── C8. POST 404 — cross-group task returns 404 (RLS isolation) ────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(post_comment(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            &bob_task_id,
+            json!({ "body_md": "Alice trying to comment on Bob's task" }),
+        ))
+        .await
+        .expect("C8 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "C8 cross-group task must return 404 (not 403)"
     );
 }

--- a/crates/garraia-gateway/tests/rest_v1_tasks.rs
+++ b/crates/garraia-gateway/tests/rest_v1_tasks.rs
@@ -897,7 +897,10 @@ async fn rest_v1_tasks_scenarios() {
     let c1_body = body_json(resp).await;
     let comment_id = c1_body["id"].as_str().expect("C1 comment id").to_string();
     assert_eq!(c1_body["task_id"], t8_task_id, "C1 task_id");
-    assert_eq!(c1_body["body_md"], "This is a **test** comment.", "C1 body_md");
+    assert_eq!(
+        c1_body["body_md"], "This is a **test** comment.",
+        "C1 body_md"
+    );
     assert!(
         c1_body.get("author_label").is_some(),
         "C1 author_label present"
@@ -936,7 +939,11 @@ async fn rest_v1_tasks_scenarios() {
         ))
         .await
         .expect("C2 oneshot");
-    assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "C2 empty body_md must be 400");
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "C2 empty body_md must be 400"
+    );
 
     // ── C3. POST 404 — unknown task_id ────────────────────────────────────
     let unknown_task = uuid::Uuid::new_v4().to_string();
@@ -952,13 +959,22 @@ async fn rest_v1_tasks_scenarios() {
         ))
         .await
         .expect("C3 oneshot");
-    assert_eq!(resp.status(), StatusCode::NOT_FOUND, "C3 unknown task must be 404");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "C3 unknown task must be 404"
+    );
 
     // ── C4. GET 200 — list comments; includes C1; cursor pagination ────────
     let resp = h
         .router
         .clone()
-        .oneshot(get_comments(Some(&owner_token), Some(&gid), &gid, &t8_task_id))
+        .oneshot(get_comments(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            &t8_task_id,
+        ))
         .await
         .expect("C4 oneshot");
     assert_eq!(resp.status(), StatusCode::OK, "C4 status");
@@ -1011,7 +1027,12 @@ async fn rest_v1_tasks_scenarios() {
     let resp = h
         .router
         .clone()
-        .oneshot(get_comments(Some(&owner_token), Some(&gid), &gid, &t8_task_id))
+        .oneshot(get_comments(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            &t8_task_id,
+        ))
         .await
         .expect("C6 list after delete");
     let c6_list = body_json(resp).await;

--- a/plans/0068-gar-518-tasks-api-slice2.md
+++ b/plans/0068-gar-518-tasks-api-slice2.md
@@ -1,6 +1,6 @@
 # Plan 0068 — GAR-518: REST /v1 Tasks slice 2 (single task GET + task-list PATCH/DELETE)
 
-**Status:** Em execução
+**Status:** ✅ Merged 2026-05-05 via PR #150 (`58421d6e`)
 **Autor:** Claude Sonnet 4.6 (garra-routine 2026-05-05, America/New_York)
 **Data:** 2026-05-05 (America/New_York)
 **Issue:** [GAR-518](https://linear.app/chatgpt25/issue/GAR-518)
@@ -129,10 +129,10 @@ None — schema and RLS already shipped; all DTOs and DB row structs in tasks.rs
 
 ## M1 Tasks
 
-- [ ] T1: Add `TaskListUpdated` + `TaskListArchived` to `WorkspaceAuditAction` + unit tests
-- [ ] T2: DTO: `PatchTaskListRequest` (name/description Option<Option<String>>/type all optional)
-- [ ] T3: Handler: `get_task` — `GET /v1/groups/{group_id}/tasks/{task_id}`
-- [ ] T4: Handler: `patch_task_list` — `PATCH /v1/groups/{group_id}/task-lists/{list_id}`
-- [ ] T5: Handler: `delete_task_list` — `DELETE /v1/groups/{group_id}/task-lists/{list_id}` (archive, idempotent)
-- [ ] T6: Route wiring in `mod.rs` + OpenAPI paths + schemas in `openapi.rs`
-- [ ] T7: Integration tests (get_task 200/404/cross-group, patch_task_list 200/404/null-clear, delete_task_list 204/idempotent)
+- [x] T1: Add `TaskListUpdated` + `TaskListArchived` to `WorkspaceAuditAction` + unit tests
+- [x] T2: DTO: `PatchTaskListRequest` (name/description Option<Option<String>>/type all optional)
+- [x] T3: Handler: `get_task` — `GET /v1/groups/{group_id}/tasks/{task_id}`
+- [x] T4: Handler: `patch_task_list` — `PATCH /v1/groups/{group_id}/task-lists/{list_id}`
+- [x] T5: Handler: `delete_task_list` — `DELETE /v1/groups/{group_id}/task-lists/{list_id}` (archive, idempotent)
+- [x] T6: Route wiring in `mod.rs` + OpenAPI paths + schemas in `openapi.rs`
+- [x] T7: Integration tests (get_task 200/404/cross-group, patch_task_list 200/404/null-clear, delete_task_list 204/idempotent)

--- a/plans/0069-gar-520-task-comments-api.md
+++ b/plans/0069-gar-520-task-comments-api.md
@@ -1,0 +1,144 @@
+# Plan 0069 — GAR-520: REST /v1 tasks slice 3 (task comments API)
+
+**Status:** Em execução
+**Autor:** Claude Sonnet 4.6 (garra-routine 2026-05-05, America/New_York)
+**Data:** 2026-05-05 (America/New_York)
+**Issue:** [GAR-520](https://linear.app/chatgpt25/issue/GAR-520)
+**Branch:** `routine/202605051835-task-comments-api`
+**Epic:** `epic:ws-api`
+**Parent:** GAR-396
+
+---
+
+## §1 Goal
+
+Land task comments REST API (ROADMAP §3.8), delivering three endpoints:
+
+- `POST /v1/groups/{group_id}/tasks/{task_id}/comments` — create comment
+- `GET /v1/groups/{group_id}/tasks/{task_id}/comments` — cursor-paginated list
+- `DELETE /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}` — soft-delete
+
+## §2 Architecture
+
+`task_comments` uses FORCE RLS via the `task_comments_through_tasks` JOIN policy:
+`USING (task_id IN (SELECT id FROM tasks))`. Since `tasks` itself is filtered by
+`app.current_group_id`, this transitively scopes comments to the current group.
+
+The SET LOCAL protocol (both `app.current_user_id` AND `app.current_group_id`)
+is required for every transaction even though the comments policy is JOIN-based,
+because the underlying `tasks` query uses those settings.
+
+`author_label` is populated at POST time by querying `SELECT display_name FROM
+users WHERE id = $1` inside the same transaction (same pattern as
+`created_by_label` in task-list and task handlers).
+
+## §3 Tech stack
+
+- Axum 0.8 + `RestV1FullState` (same as tasks.rs)
+- `sqlx::query_as` (no SQL string concat)
+- `garraia_auth::{Action, Principal, WorkspaceAuditAction, audit_workspace_event}`
+- New `WorkspaceAuditAction` variants: `TaskCommentCreated`, `TaskCommentDeleted`
+- `utoipa` OpenAPI annotations
+
+## §4 Design invariants
+
+1. SET LOCAL both `app.current_user_id` AND `app.current_group_id` in every tx.
+2. Audit metadata is STRUCTURAL only: `body_len` not `body_md`.
+3. Cross-group attempts return 404 (RLS JOIN filters; task not visible → comment
+   INSERT fails or DELETE/SELECT returns 0 rows).
+4. Soft-delete only — `deleted_at = now()`. No hard delete.
+5. Already-deleted comment → 404 (not idempotent like task-list archive).
+6. GET list returns only `deleted_at IS NULL` comments.
+7. No `unwrap()` in production code.
+
+## §5 Validações pré-plano
+
+- [x] `task_comments` FORCE RLS migration 006 ✅
+- [x] `task_comments_through_tasks` JOIN policy ✅
+- [x] `Action::TasksWrite`, `Action::TasksRead`, `Action::TasksDelete` in action.rs ✅
+- [x] `set_config` parameterized SQL pattern (plan 0056) ✅
+- [x] `display_name` lookup pattern in tasks.rs line ~551 ✅
+- [x] `audit_workspace_event` function signature confirmed ✅
+
+## §6 Scope
+
+**In scope:**
+- `POST /v1/groups/{group_id}/tasks/{task_id}/comments`
+- `GET /v1/groups/{group_id}/tasks/{task_id}/comments`
+- `DELETE /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}`
+
+**Out of scope:**
+- Comment editing (`PATCH comment`) — no `edited_at` update
+- `task_subscriptions` / `task_activity` fan-out
+- `@garra` mention dispatch
+- RBAC per-comment authz (any group member may delete any comment for now)
+- Pagination beyond cursor (no total count)
+
+## §7 Affected files
+
+```
+crates/garraia-auth/src/audit_workspace.rs         (+2 variants + tests)
+crates/garraia-gateway/src/rest_v1/tasks.rs        (+3 handlers, +5 DTOs, ~200 LOC)
+crates/garraia-gateway/src/rest_v1/mod.rs          (+2 route entries)
+crates/garraia-gateway/src/rest_v1/openapi.rs      (+3 paths + schemas)
+crates/garraia-gateway/tests/rest_v1_tasks.rs      (+8 scenarios)
+plans/README.md                                    (+row 0069)
+plans/0068-gar-518-tasks-api-slice2.md             (status → ✅ Merged)
+ROADMAP.md                                         (§3.8 task API checkboxes)
+```
+
+## §8 Rollback plan
+
+No schema migration. Revert branch on main. Fully reversible.
+
+## §9 Risk register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| RLS JOIN not triggered (missing set_config) | Low | High | Both vars set at tx start; tests verify cross-group isolation |
+| `author_label` empty string | Very Low | Low | display_name NOT NULL in users table; SELECT verified before INSERT |
+| Comment body DoS (50k chars) | Very Low | None | CHECK in schema; body_md size validate at API layer |
+
+## §10 Acceptance criteria
+
+- `POST` returns 201 with `CommentResponse`; audit row `task.comment.created`
+- `GET` returns 200 with list; excludes soft-deleted comments
+- `DELETE` returns 204; comment no longer in GET; audit row `task.comment.deleted`
+- Cross-group task returns 404 (RLS join blocks insert/select)
+- Unknown task returns 404
+- Already-deleted comment returns 404
+- `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` passes
+
+## §11 Cross-references
+
+- Plan 0066 (GAR-516) — slice 1: task-list + task handlers
+- Plan 0068 (GAR-518) — slice 2: single task GET + task-list PATCH/DELETE
+- Plan 0056 — set_config parameterized SQL pattern
+- Migration 006 (`task_comments` table + RLS)
+- ROADMAP §3.8
+
+## §12 Open questions
+
+None.
+
+## §13 Estimativa
+
+- T1: Audit variants TaskCommentCreated + TaskCommentDeleted: 10 min
+- T2: DTOs CommentRow, CommentResponse, CreateCommentRequest, ListCommentsQuery, ListCommentsResponse: 20 min
+- T3: Handler create_task_comment: 25 min
+- T4: Handler list_task_comments: 20 min
+- T5: Handler delete_task_comment: 15 min
+- T6: Route wiring + OpenAPI: 15 min
+- T7: Tests (+8 scenarios): 35 min
+- CI + follow-ups: 20 min
+- **Total: ~2.5 hours**
+
+## M1 Tasks
+
+- [ ] T1: Add `TaskCommentCreated` + `TaskCommentDeleted` to `WorkspaceAuditAction`
+- [ ] T2: DTOs in tasks.rs
+- [ ] T3: Handler `create_task_comment`
+- [ ] T4: Handler `list_task_comments`
+- [ ] T5: Handler `delete_task_comment`
+- [ ] T6: Route wiring + OpenAPI
+- [ ] T7: Integration tests


### PR DESCRIPTION
## Summary

- Adds `POST /v1/groups/{group_id}/tasks/{task_id}/comments` — create a comment with body_md validation (1–50 000 chars); `author_label` populated at INSERT time via `SELECT display_name FROM users WHERE id = $1` inside the RLS-aware transaction
- Adds `GET /v1/groups/{group_id}/tasks/{task_id}/comments` — cursor-paginated list (`ORDER BY created_at DESC, id DESC`), excludes soft-deleted comments
- Adds `DELETE /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}` — soft-delete (`deleted_at = now()`); second call returns 404 (not idempotent)
- Two new `WorkspaceAuditAction` variants: `TaskCommentCreated` / `TaskCommentDeleted` → strings `"task.comment.created"` / `"task.comment.deleted"`; audit metadata carries `body_len` only (PII guard — no body text)
- Cross-group isolation via `task_comments_through_tasks` JOIN-RLS policy: any request with a task_id from another group returns 404 (not 403)
- OpenAPI paths + schemas registered in `openapi.rs`
- Plan doc: `plans/0069-gar-520-task-comments-api.md`
- Bookkeeping: plan 0068 marked merged, ROADMAP.md §3.8 task API checklist updated

## Test plan

- [ ] C1: `POST /comments` → 201; response has `id`, `task_id`, `body_md`, `author_label`; audit row `task.comment.created` with `body_len` (no `body_md` text)
- [ ] C2: `POST /comments` with `body_md: ""` → 400
- [ ] C3: `POST /comments` on unknown task_id → 404
- [ ] C4: `GET /comments` → 200; contains C1 comment; `next_cursor` field present
- [ ] C5: `GET /comments` with cross-group task_id (RLS) → 404
- [ ] C6: `DELETE /comments/{id}` → 204; comment absent from subsequent GET; audit row `task.comment.deleted`
- [ ] C7: `DELETE /comments/{id}` again → 404
- [ ] C8: `POST /comments` on cross-group task_id → 404

https://claude.ai/code/session_0136R1F6qLK7ZmMdRykCN8qP

---
_Generated by [Claude Code](https://claude.ai/code/session_0136R1F6qLK7ZmMdRykCN8qP)_