### PR TITLE
feat(gateway): GAR-522 — audit REST API slice 1 (GET /v1/groups/{group_id}/audit)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -424,7 +424,7 @@ Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
 
 **Auditoria**
 
-- [ ] `GET /v1/groups/{group_id}/audit?cursor=...`
+- [x] `GET /v1/groups/{group_id}/audit?cursor=...` — plan 0070 / [GAR-522](https://linear.app/chatgpt25/issue/GAR-522), implementado 2026-05-05 (Florida)
 
 **Erros:** todos os erros seguem **RFC 9457 Problem Details**.
 

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -239,6 +239,14 @@ name = "rest_v1_tasks"
 path = "tests/rest_v1_tasks.rs"
 required-features = ["test-helpers"]
 
+# Plan 0070 (GAR-522) — audit API slice 1: GET /v1/groups/{group_id}/audit.
+# Feature-gated so plain `cargo test -p garraia-gateway` (without
+# --features test-helpers) skips compilation cleanly.
+[[test]]
+name = "rest_v1_audit"
+path = "tests/rest_v1_audit.rs"
+required-features = ["test-helpers"]
+
 [dev-dependencies]
 # Plan 0024 T4 (GAR-412): metrics_exporter tests and the
 # metrics_auth_integration binary build a `PrometheusRecorder` directly

--- a/crates/garraia-gateway/src/rest_v1/audit.rs
+++ b/crates/garraia-gateway/src/rest_v1/audit.rs
@@ -1,0 +1,319 @@
+//! `GET /v1/groups/{group_id}/audit` — cursor-paginated audit trail (plan 0070, GAR-522).
+//!
+//! Authz: `Action::ExportGroup` (owner-only per migration 002 seed).
+//! Cross-group: `path_group_id ≠ principal.group_id` → 404.
+//! No audit event is emitted for reads (avoids circular audit noise).
+//!
+//! ## Tenant-context protocol
+//!
+//! `audit_events` has FORCE RLS. Both `app.current_user_id` and
+//! `app.current_group_id` are SET LOCAL via parameterized `set_config`
+//! before any SELECT (plan 0056 protocol — no `format!()` interpolation).
+
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use chrono::{DateTime, Utc};
+use garraia_auth::{Action, Principal, can};
+use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
+use uuid::Uuid;
+
+use super::RestV1FullState;
+use super::problem::RestError;
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const DEFAULT_LIMIT: u32 = 50;
+const MAX_LIMIT: u32 = 100;
+
+// ─── DTOs ─────────────────────────────────────────────────────────────────────
+
+/// Compact summary of one audit event returned in list responses.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AuditEventSummary {
+    pub id: Uuid,
+    pub action: String,
+    pub resource_type: String,
+    pub resource_id: Option<String>,
+    pub actor_user_id: Option<Uuid>,
+    pub actor_label: Option<String>,
+    /// Textual representation of the client IP (inet → text). `None` if the
+    /// original event had no IP (e.g. background jobs).
+    pub ip: Option<String>,
+    pub metadata: serde_json::Value,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Response body for `GET /v1/groups/{group_id}/audit`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ListAuditResponse {
+    pub items: Vec<AuditEventSummary>,
+    /// Opaque cursor for the next page. `None` when the end of the list is
+    /// reached. Pass as `?cursor=<uuid>` in the next request.
+    pub next_cursor: Option<Uuid>,
+}
+
+/// Query parameters for `GET /v1/groups/{group_id}/audit`.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ListAuditQuery {
+    /// Keyset cursor — UUID of the last audit event received. Omit for the
+    /// first page.
+    pub cursor: Option<Uuid>,
+    /// Page size. Default 50, max 100.
+    pub limit: Option<u32>,
+    /// Filter by action string (e.g. `member.role_changed`). Must be
+    /// non-empty if provided.
+    pub action: Option<String>,
+    /// Filter by resource type (e.g. `group_members`). Must be non-empty if
+    /// provided.
+    pub resource_type: Option<String>,
+}
+
+impl ListAuditQuery {
+    pub fn validate(&self) -> Result<(), &'static str> {
+        if self.action.as_deref().is_some_and(str::is_empty) {
+            return Err("action must not be empty if provided");
+        }
+        if self.resource_type.as_deref().is_some_and(str::is_empty) {
+            return Err("resource_type must not be empty if provided");
+        }
+        Ok(())
+    }
+}
+
+// ─── Private row type ─────────────────────────────────────────────────────────
+
+#[derive(sqlx::FromRow)]
+struct AuditEventRow {
+    id: Uuid,
+    action: String,
+    resource_type: String,
+    resource_id: Option<String>,
+    actor_user_id: Option<Uuid>,
+    actor_label: Option<String>,
+    /// ip::text cast from inet; Postgres names the result column "ip".
+    ip: Option<String>,
+    metadata: serde_json::Value,
+    created_at: DateTime<Utc>,
+}
+
+impl AuditEventRow {
+    fn into_summary(self) -> AuditEventSummary {
+        AuditEventSummary {
+            id: self.id,
+            action: self.action,
+            resource_type: self.resource_type,
+            resource_id: self.resource_id,
+            actor_user_id: self.actor_user_id,
+            actor_label: self.actor_label,
+            ip: self.ip,
+            metadata: self.metadata,
+            created_at: self.created_at,
+        }
+    }
+}
+
+// ─── RLS context helper ───────────────────────────────────────────────────────
+
+async fn set_rls_context(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    user_id: Uuid,
+    group_id: Uuid,
+) -> Result<(), RestError> {
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(user_id.to_string())
+        .execute(&mut **tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_group_id', $1, true)")
+        .bind(group_id.to_string())
+        .execute(&mut **tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(())
+}
+
+// ─── Handler ──────────────────────────────────────────────────────────────────
+
+/// `GET /v1/groups/{group_id}/audit` — cursor-paginated group audit trail.
+///
+/// Authz: `Action::ExportGroup` (owner-only).
+///
+/// Cross-group: path `group_id` ≠ caller's `group_id` → 404 (avoids revealing
+/// foreign group existence).
+///
+/// No audit event is emitted for reads (invariant: no circular noise).
+///
+/// ## Error matrix
+///
+/// | Condition                          | Status |
+/// |------------------------------------|--------|
+/// | Missing/invalid JWT                | 401    |
+/// | No X-Group-Id / no membership      | 404    |
+/// | Cross-group (path ≠ caller group)  | 404    |
+/// | Insufficient permission (member)   | 403    |
+/// | Empty `action` / `resource_type`   | 400    |
+/// | Happy path                         | 200    |
+#[utoipa::path(
+    get,
+    path = "/v1/groups/{group_id}/audit",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ListAuditQuery,
+    ),
+    responses(
+        (status = 200, description = "Audit events.", body = ListAuditResponse),
+        (status = 400, description = "Invalid query parameters.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller lacks ExportGroup permission.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Group not found or cross-group attempt.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn list_audit(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(path_group_id): Path<Uuid>,
+    Query(params): Query<ListAuditQuery>,
+) -> Result<Json<ListAuditResponse>, RestError> {
+    // Caller must belong to a group.
+    let caller_group_id = match principal.group_id {
+        Some(g) => g,
+        None => return Err(RestError::NotFound),
+    };
+
+    // Cross-group isolation: reveal nothing about foreign groups.
+    if path_group_id != caller_group_id {
+        return Err(RestError::NotFound);
+    }
+
+    // Authz gate: owner-only.
+    if !can(&principal, Action::ExportGroup) {
+        return Err(RestError::Forbidden);
+    }
+
+    // Validate optional filter params.
+    params
+        .validate()
+        .map_err(|msg| RestError::BadRequest(msg.into()))?;
+
+    let effective_limit = params.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+    let fetch_limit = (effective_limit + 1) as i64;
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    set_rls_context(&mut tx, principal.user_id, caller_group_id).await?;
+
+    // Build the SELECT dynamically — push_bind produces $N parameters (no
+    // string interpolation). The only static SQL pushed via push() are
+    // clause keywords and operators.
+    let mut qb = sqlx::QueryBuilder::<sqlx::Postgres>::new(
+        "SELECT id, action, resource_type, resource_id, actor_user_id, actor_label, \
+         ip::text AS ip, metadata, created_at \
+         FROM audit_events WHERE group_id = ",
+    );
+    qb.push_bind(caller_group_id);
+
+    if let Some(action_filter) = &params.action {
+        qb.push(" AND action = ");
+        qb.push_bind(action_filter.clone());
+    }
+    if let Some(rt_filter) = &params.resource_type {
+        qb.push(" AND resource_type = ");
+        qb.push_bind(rt_filter.clone());
+    }
+    if let Some(cursor_id) = params.cursor {
+        qb.push(
+            " AND (created_at, id) < \
+             (SELECT created_at, id FROM audit_events WHERE id = ",
+        );
+        qb.push_bind(cursor_id);
+        qb.push(" AND group_id = ");
+        qb.push_bind(caller_group_id);
+        qb.push(")");
+    }
+    qb.push(" ORDER BY created_at DESC, id DESC LIMIT ");
+    qb.push_bind(fetch_limit);
+
+    let rows: Vec<AuditEventRow> = qb
+        .build_query_as()
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    let has_more = rows.len() as u32 > effective_limit;
+    let items: Vec<AuditEventSummary> = rows
+        .into_iter()
+        .take(effective_limit as usize)
+        .map(AuditEventRow::into_summary)
+        .collect();
+
+    let next_cursor = if has_more {
+        items.last().map(|it| it.id)
+    } else {
+        None
+    };
+
+    Ok(Json(ListAuditResponse { items, next_cursor }))
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_empty_action_rejected() {
+        let q = ListAuditQuery {
+            cursor: None,
+            limit: None,
+            action: Some(String::new()),
+            resource_type: None,
+        };
+        assert!(q.validate().is_err());
+    }
+
+    #[test]
+    fn validate_empty_resource_type_rejected() {
+        let q = ListAuditQuery {
+            cursor: None,
+            limit: None,
+            action: None,
+            resource_type: Some(String::new()),
+        };
+        assert!(q.validate().is_err());
+    }
+
+    #[test]
+    fn validate_both_provided_ok() {
+        let q = ListAuditQuery {
+            cursor: None,
+            limit: None,
+            action: Some("member.role_changed".to_string()),
+            resource_type: Some("group_members".to_string()),
+        };
+        assert!(q.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_none_provided_ok() {
+        let q = ListAuditQuery {
+            cursor: None,
+            limit: None,
+            action: None,
+            resource_type: None,
+        };
+        assert!(q.validate().is_ok());
+    }
+}

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -29,6 +29,7 @@
 //! In mode 3 the routes are registered explicitly (no `.fallback()`)
 //! so the merged main router keeps its own 404 behavior.
 
+pub mod audit;
 pub mod chats;
 pub mod groups;
 pub mod invites;
@@ -306,6 +307,8 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                         .patch(tasks::patch_task)
                         .delete(tasks::delete_task),
                 )
+                // Plan 0070 (GAR-522) — audit API slice 1.
+                .route("/v1/groups/{group_id}/audit", get(audit::list_audit))
                 .merge(rate_limited_routes)
                 .merge(tus_routes)
                 .with_state(full)
@@ -374,6 +377,8 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                         .patch(unconfigured_handler)
                         .delete(unconfigured_handler),
                 )
+                // Plan 0070 (GAR-522) — audit API slice 1, fail-soft 503.
+                .route("/v1/groups/{group_id}/audit", get(unconfigured_handler))
                 .route(
                     "/v1/uploads",
                     post(unconfigured_handler).options(uploads::options_uploads),
@@ -448,6 +453,8 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                         .patch(unconfigured_handler)
                         .delete(unconfigured_handler),
                 )
+                // Plan 0070 (GAR-522) — audit API slice 1, no-auth stub.
+                .route("/v1/groups/{group_id}/audit", get(unconfigured_handler))
                 .route(
                     "/v1/uploads",
                     post(unconfigured_handler).options(uploads::options_uploads),

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -12,6 +12,7 @@
 use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
 use utoipa::{Modify, OpenApi};
 
+use super::audit::{AuditEventSummary, ListAuditResponse};
 use super::chats::{ChatListResponse, ChatResponse, ChatSummary, CreateChatRequest};
 use super::groups::{
     CreateGroupRequest, CreateInviteRequest, GroupReadResponse, GroupResponse, InviteResponse,
@@ -104,6 +105,7 @@ impl Modify for SecurityAddon {
         super::tasks::get_task,
         super::tasks::patch_task,
         super::tasks::delete_task,
+        super::audit::list_audit,
     ),
     components(schemas(
         MeResponse,
@@ -143,6 +145,8 @@ impl Modify for SecurityAddon {
         TaskSummary,
         ListTasksResponse,
         PatchTaskRequest,
+        AuditEventSummary,
+        ListAuditResponse,
     )),
     modifiers(&SecurityAddon)
 )]

--- a/crates/garraia-gateway/tests/rest_v1_audit.rs
+++ b/crates/garraia-gateway/tests/rest_v1_audit.rs
@@ -1,0 +1,355 @@
+//! Integration tests for `GET /v1/groups/{group_id}/audit` (plan 0070, GAR-522).
+//!
+//! All scenarios in ONE `#[tokio::test]` — same pattern as `rest_v1_memory.rs`.
+//! Splitting into multiple `#[tokio::test]`s triggers the sqlx runtime-teardown
+//! race documented in plan 0016 M3 commit `4f8be37`.
+//!
+//! Scenarios:
+//!   A1. GET 200 — happy path: owner retrieves audit events.
+//!   A2. GET 200 — cursor pagination: limit=2 on 3 events, second page via cursor.
+//!   A3. GET 200 — action filter: only events matching `?action=` are returned.
+//!   A4. GET 404 — cross-group: owner of group A requests group B's audit.
+//!   A5. GET 403 — member role: member of own group is denied (ExportGroup = owner only).
+//!   A6. GET 401 — no JWT: unauthenticated request rejected.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use common::Harness;
+use common::fixtures::{seed_member_via_admin, seed_user_with_group};
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("failed to collect response body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("response body is not JSON")
+}
+
+fn get_audit(
+    token: Option<&str>,
+    group_id: &str,
+    cursor: Option<&str>,
+    limit: Option<u32>,
+    action: Option<&str>,
+    resource_type: Option<&str>,
+) -> Request<Body> {
+    let mut query = String::new();
+    let mut sep = '?';
+    let mut push_param = |k: &str, v: &str| {
+        query.push(sep);
+        query.push_str(k);
+        query.push('=');
+        query.push_str(v);
+        sep = '&';
+    };
+    if let Some(c) = cursor {
+        push_param("cursor", c);
+    }
+    if let Some(l) = limit {
+        push_param("limit", &l.to_string());
+    }
+    if let Some(a) = action {
+        push_param("action", a);
+    }
+    if let Some(r) = resource_type {
+        push_param("resource_type", r);
+    }
+
+    let mut req = Request::builder()
+        .method("GET")
+        .uri(format!("/v1/groups/{group_id}/audit{query}"))
+        .body(Body::empty())
+        .expect("request builder");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    if let Some(t) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {t}")).unwrap(),
+        );
+    }
+    req.headers_mut().insert(
+        HeaderName::from_static("x-group-id"),
+        HeaderValue::from_str(group_id).unwrap(),
+    );
+    req
+}
+
+/// Seed `n` audit events for `group_id` via the superuser pool (bypasses RLS).
+/// Events are inserted with `created_at = now() - (n - i) * interval '1 second'`
+/// so they arrive oldest-first in time but query newest-first (`ORDER BY created_at
+/// DESC`). Returns the vector of inserted IDs in creation order (oldest first).
+async fn seed_audit_events(
+    h: &Harness,
+    group_id: Uuid,
+    actor_user_id: Uuid,
+    action: &str,
+    resource_type: &str,
+    n: u32,
+) -> Vec<Uuid> {
+    let mut ids = Vec::new();
+    for i in 0..n {
+        let id = Uuid::new_v4();
+        let offset_secs = (n - i) as i64;
+        sqlx::query(
+            "INSERT INTO audit_events \
+             (id, group_id, actor_user_id, actor_label, action, resource_type, \
+              resource_id, metadata, created_at) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now() - ($9 || ' seconds')::interval)",
+        )
+        .bind(id)
+        .bind(group_id)
+        .bind(actor_user_id)
+        .bind("Test Actor")
+        .bind(action)
+        .bind(resource_type)
+        .bind(id.to_string())
+        .bind(json!({"seeded": true}))
+        .bind(offset_secs.to_string())
+        .execute(&h.admin_pool)
+        .await
+        .expect("seed_audit_events insert");
+        ids.push(id);
+    }
+    ids
+}
+
+// ─── Test ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn audit_api_scenarios() {
+    let h = Harness::get().await;
+
+    // ── Seed: owner user + group ──────────────────────────────────────────────
+    let (owner_id, group_id, owner_token) = seed_user_with_group(&h, "audit-owner@test.local")
+        .await
+        .unwrap();
+
+    // ── Seed: member in same group ────────────────────────────────────────────
+    let (_member_id, member_token) =
+        seed_member_via_admin(&h, group_id, "member", "audit-member@test.local")
+            .await
+            .unwrap();
+
+    // ── Seed: a completely separate group (for cross-group test) ──────────────
+    let (_other_id, other_group_id, other_token) =
+        seed_user_with_group(&h, "audit-other@test.local")
+            .await
+            .unwrap();
+
+    // ── Seed audit events for the owner's group ───────────────────────────────
+    // Seed 3 events with action "tasks.created" for pagination/filter tests.
+    let event_ids = seed_audit_events(&h, group_id, owner_id, "tasks.created", "tasks", 3).await;
+
+    // Seed 1 event with a different action for the action-filter test.
+    seed_audit_events(&h, group_id, owner_id, "member.joined", "group_members", 1).await;
+
+    // ─── A1: happy path — owner retrieves audit events ────────────────────────
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_audit(
+                Some(&owner_token),
+                &group_id.to_string(),
+                None,
+                None,
+                None,
+                None,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK, "A1: expected 200");
+        let body = body_json(resp).await;
+        let items = body["items"].as_array().unwrap();
+        // At least the 4 events we seeded.
+        assert!(
+            items.len() >= 4,
+            "A1: expected at least 4 items, got {}",
+            items.len()
+        );
+        // Each item has the expected fields.
+        let first = &items[0];
+        assert!(first["id"].is_string(), "A1: item missing id");
+        assert!(first["action"].is_string(), "A1: item missing action");
+        assert!(
+            first["resource_type"].is_string(),
+            "A1: item missing resource_type"
+        );
+        assert!(
+            first["created_at"].is_string(),
+            "A1: item missing created_at"
+        );
+    }
+
+    // ─── A2: cursor pagination ────────────────────────────────────────────────
+    // Seed 3 "tasks.created" events (already done above). Query with limit=2.
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_audit(
+                Some(&owner_token),
+                &group_id.to_string(),
+                None,
+                Some(2),
+                Some("tasks.created"),
+                Some("tasks"),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK, "A2 page1: expected 200");
+        let body = body_json(resp).await;
+        let items = body["items"].as_array().unwrap();
+        assert_eq!(items.len(), 2, "A2: first page should have 2 items");
+        let next_cursor = body["next_cursor"]
+            .as_str()
+            .expect("A2: next_cursor must be set");
+
+        // Second page via cursor.
+        let resp2 = h
+            .router
+            .clone()
+            .oneshot(get_audit(
+                Some(&owner_token),
+                &group_id.to_string(),
+                Some(next_cursor),
+                Some(2),
+                Some("tasks.created"),
+                Some("tasks"),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp2.status(), StatusCode::OK, "A2 page2: expected 200");
+        let body2 = body_json(resp2).await;
+        let items2 = body2["items"].as_array().unwrap();
+        assert_eq!(
+            items2.len(),
+            1,
+            "A2: second page should have 1 item (the oldest)"
+        );
+        // The oldest event_id (index 0 = oldest) should appear on page 2.
+        let oldest_id = event_ids[0].to_string();
+        assert_eq!(
+            items2[0]["id"].as_str().unwrap(),
+            oldest_id,
+            "A2: second page item should be the oldest seeded event"
+        );
+        // No more pages.
+        assert!(
+            body2["next_cursor"].is_null(),
+            "A2: second page should have no next_cursor"
+        );
+    }
+
+    // ─── A3: action filter ────────────────────────────────────────────────────
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_audit(
+                Some(&owner_token),
+                &group_id.to_string(),
+                None,
+                None,
+                Some("member.joined"),
+                None,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK, "A3: expected 200");
+        let body = body_json(resp).await;
+        let items = body["items"].as_array().unwrap();
+        assert!(
+            !items.is_empty(),
+            "A3: expected at least 1 member.joined event"
+        );
+        for item in items {
+            assert_eq!(
+                item["action"].as_str().unwrap(),
+                "member.joined",
+                "A3: all items must match the action filter"
+            );
+        }
+    }
+
+    // ─── A4: cross-group — owner of groupA requests groupB's audit → 404 ─────
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_audit(
+                Some(&other_token),
+                &group_id.to_string(), // other user requests group_id (not their group)
+                None,
+                None,
+                None,
+                None,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "A4: expected 404 for cross-group"
+        );
+        let _ = other_group_id; // used to ensure seed ran
+    }
+
+    // ─── A5: member role — 403 ───────────────────────────────────────────────
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_audit(
+                Some(&member_token),
+                &group_id.to_string(),
+                None,
+                None,
+                None,
+                None,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "A5: expected 403 for member"
+        );
+    }
+
+    // ─── A6: no JWT — 401 ────────────────────────────────────────────────────
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_audit(
+                None,
+                &group_id.to_string(),
+                None,
+                None,
+                None,
+                None,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "A6: expected 401 for no JWT"
+        );
+    }
+}

--- a/plans/0070-gar-522-audit-api-slice1.md
+++ b/plans/0070-gar-522-audit-api-slice1.md
@@ -1,0 +1,148 @@
+# Plan 0070 — GAR-522: REST /v1 audit slice 1 (`GET /v1/groups/{group_id}/audit`)
+
+**Status:** Em execução
+**Autor:** Claude Sonnet 4.6 (garra-routine 2026-05-05, America/New_York)
+**Data:** 2026-05-05 (America/New_York)
+**Issue:** [GAR-522](https://linear.app/chatgpt25/issue/GAR-522)
+**Branch:** `routine/202605052222-audit-api-slice1`
+**Epic:** `epic:ws-api`
+**Parent:** GAR-396
+
+---
+
+## §1 Goal
+
+Land `GET /v1/groups/{group_id}/audit` — a cursor-paginated endpoint exposing
+`audit_events` for group owners (ROADMAP §3.4 "Auditoria", LGPD art. 8 §5).
+
+Single endpoint this slice:
+
+- `GET /v1/groups/{group_id}/audit?cursor=<uuid>&limit=<n>&action=<str>&resource_type=<str>`
+
+## §2 Architecture
+
+`audit_events` has **FORCE RLS** via two migrations:
+
+- Migration 007: `CREATE POLICY audit_events_group_or_self … USING (group_id = current_setting('app.current_group_id')::uuid OR actor_user_id = current_setting('app.current_user_id')::uuid)`
+- Migration 013: adds `WITH CHECK` to the same policy
+
+The handler must SET LOCAL both `app.current_user_id` **and** `app.current_group_id` using
+the parameterized `set_config` approach (plan 0056 — no `format!()` interpolation).
+
+Cross-group isolation: if the path `group_id` ≠ `principal.group_id`, return 404
+(don't reveal existence of foreign groups).
+
+No audit event is emitted for reads to avoid circular audit noise.
+
+## §3 Tech stack
+
+- Axum 0.8 + `RestV1FullState` (same as memory.rs, tasks.rs)
+- `sqlx::query_as` with `sqlx::types::Json<serde_json::Value>` for the `metadata` jsonb column
+- `garraia_auth::{Action, Principal, can}`
+- `utoipa::path` for OpenAPI registration
+- Integration test in `crates/garraia-gateway/tests/rest_v1_audit.rs`
+
+## §4 Design invariants
+
+1. **Authz gate first**: `can(&principal, Action::ExportGroup)` → 403 if false. Owner-only
+   per migration 002 seed (`admin` has `export.self` only, NOT `export.group`).
+2. **Cross-group → 404**: `path_group_id ≠ principal.group_id` → 404 (not 403).
+3. **SET LOCAL both vars**: `app.current_user_id` + `app.current_group_id` via parameterized
+   `set_config` inside the transaction, before any SELECT.
+4. **No audit on read**: reading audit events does NOT itself emit an audit event.
+5. **Cursor keyset**: `(created_at DESC, id DESC)` — `id` is UUID v4 (random), serves as
+   tiebreaker only; the subquery lookup pattern from memory.rs applies here.
+6. **`ip` exposed as text**: `ip::text` (inet → string). Owner is entitled to forensic data.
+7. **`metadata` as jsonb**: exposed as-is (already PII-safe by audit_workspace_event invariant).
+8. **Optional filters**: `?action=<str>` and `?resource_type=<str>` are validated to be
+   non-empty if provided; no allow-list (action strings are internal enums from `WorkspaceAuditAction`).
+
+## §5 Validações pré-plano
+
+- [x] `audit_events` table exists with FORCE RLS (migration 007 + 013). Index `audit_events_group_created_idx` on `(group_id, created_at DESC) WHERE group_id IS NOT NULL` supports this query efficiently.
+- [x] `Action::ExportGroup` is in the enum (action.rs:41).
+- [x] `can()` central table maps `owner` → `ExportGroup` = true; `admin` → false.
+- [x] `set_config` parameterized protocol shipped in plan 0056 — reuse exact pattern from memory.rs.
+- [x] `RestV1FullState` wired with `app_pool` (mode 1 real, modes 2-3 fail-soft 503).
+- [x] No new migration needed.
+
+## §6 Out of scope
+
+- `?actor_user_id=` filter (slice 2).
+- `GET /v1/audit/me` personal audit log (slice 2, `ExportSelf`).
+- Export download ZIP/CSV — GAR-400 (epic:compliance).
+- Write endpoints (audit events are immutable by design).
+- `user_events` (login/logout, `group_id IS NULL`) — deferred to slice 2.
+
+## §7 Rollback
+
+This PR adds only new files (`audit.rs`, `rest_v1_audit.rs` test) plus route
+wiring in `mod.rs` and `openapi.rs`. Rolling back = revert those additions.
+No schema change. No data migration.
+
+## §8 Open questions
+
+- None blocking.
+
+## §9 File structure
+
+```text
+crates/garraia-gateway/src/rest_v1/
+  audit.rs                    ← NEW (T1-T3)
+  mod.rs                      ← MODIFIED: add `pub mod audit;` + route wiring (T4)
+  openapi.rs                  ← MODIFIED: register AuditEventSummary + list_audit path (T5)
+crates/garraia-gateway/tests/
+  rest_v1_audit.rs            ← NEW integration test (T6)
+plans/
+  0070-gar-522-audit-api-slice1.md   ← this file
+  README.md                   ← MODIFIED: add row 0070
+ROADMAP.md                    ← MODIFIED: check [x] audit endpoint in §3.4
+```
+
+## §10 Tasks (M1)
+
+- [ ] **T1** — `audit.rs`: DTOs (`AuditEventSummary`, `ListAuditResponse`, `ListAuditQuery`) + 4 unit tests (validate query params)
+- [ ] **T2** — `audit.rs`: `list_audit` handler — RLS context, authz gate, cursor query (no filter), map rows, next_cursor
+- [ ] **T3** — `audit.rs`: add optional `action` + `resource_type` filter branches to the query
+- [ ] **T4** — `mod.rs`: `pub mod audit;` + route `GET /v1/groups/:group_id/audit` wired into mode-1 router
+- [ ] **T5** — `openapi.rs`: register `AuditEventSummary`, `ListAuditResponse`, `list_audit` path (200/401/403/404)
+- [ ] **T6** — `rest_v1_audit.rs`: 6 integration scenarios (A1–A6): happy path, cursor pagination, action filter, cross-group 404, member 403, no JWT 401
+- [ ] **T7** — `cargo fmt --all` + `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` green
+- [ ] **T8** — ROADMAP §3.4 audit checkbox + plans/README.md row 0070
+
+## §11 Risk register
+
+| Risk | Mitigation |
+|------|-----------|
+| `ip::text` cast fails on NULL | `ip` column is nullable; `SELECT ip::text` returns NULL if ip IS NULL — handled by `Option<String>` |
+| `metadata` jsonb deserialization | Use `serde_json::Value` via `sqlx::types::Json` — flexible, no schema assumption |
+| Cursor lookup race (row deleted between pages) | Subquery returns no rows → treated as "cursor not found" → 400 Bad Request |
+| Cross-group data leak via RLS bypass | Double-checked: path_group_id == principal.group_id enforced app-layer + RLS enforced db-layer |
+
+## §12 Acceptance criteria
+
+- `GET /v1/groups/{group_id}/audit` returns 200 with a list of `AuditEventSummary` items for an owner after at least one audit event exists (seeded by other endpoints in the integration harness).
+- Cursor pagination: first page returns up to `limit` items with `next_cursor`; second page returns items older than the cursor.
+- `?action=member.role_changed` returns only matching events.
+- Cross-group attempt → 404.
+- Member role → 403.
+- No JWT → 401.
+- `cargo clippy -- -D warnings` and `cargo fmt --check` green.
+- CI 16+ checks green.
+
+## §13 Cross-references
+
+- ROADMAP §3.4 "Auditoria": `GET /v1/groups/{group_id}/audit?cursor=...`
+- migration 002 (`audit_events` table + `export.group` permission seed)
+- migration 007 + 013 (RLS FORCE + WITH CHECK for `audit_events`)
+- plan 0056 (parameterized `set_config` — no `format!()`)
+- plan 0062 (memory GET — cursor pagination pattern reference)
+- GAR-400 (compliance export — downstream consumer of this data)
+
+## §14 Estimativa
+
+| Cenário | LOC | Tempo |
+|---------|-----|-------|
+| Optimista | ~280 | 1.5h |
+| Provável  | ~340 | 2h   |
+| Pessimista| ~420 | 3h   |

--- a/plans/README.md
+++ b/plans/README.md
@@ -92,6 +92,8 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0066 | [GAR-516 — REST /v1 tasks slice 1: task-lists + tasks CRUD](0066-gar-516-tasks-api-slice1.md) | [GAR-516](https://linear.app/chatgpt25/issue/GAR-516) | ✅ Merged 2026-05-05 via PR #145 (`6432998`) |
 | 0067 | [GAR-519 — modeSidebar.js XSS: escapeHtml/escapeAttr on 7 sinks (mode.name/description/id)](0067-gar-519-modesidebar-xss.md) | [GAR-519](https://linear.app/chatgpt25/issue/GAR-519) | ✅ Merged 2026-05-05 (`ca744ce`, PR #149) |
 | 0068 | [GAR-518 — REST /v1 tasks slice 2: GET single task + task-list PATCH/DELETE](0068-gar-518-tasks-api-slice2.md) | [GAR-518](https://linear.app/chatgpt25/issue/GAR-518) | ✅ Merged 2026-05-05 via PR #150 (`58421d6`) |
+| 0069 | [GAR-520 — REST /v1 tasks slice 3: task comments API (POST/GET/DELETE)](0069-gar-520-task-comments-api.md) | [GAR-520](https://linear.app/chatgpt25/issue/GAR-520) | 🟡 Em execução 2026-05-05 (garra-routine) |
+| 0070 | [GAR-522 — REST /v1 audit slice 1: GET /v1/groups/{group_id}/audit](0070-gar-522-audit-api-slice1.md) | [GAR-522](https://linear.app/chatgpt25/issue/GAR-522) | 🟡 Em execução 2026-05-05 (garra-routine) |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

- Adds `GET /v1/groups/{group_id}/audit?cursor=&limit=&action=&resource_type=` — cursor-paginated audit trail for group owners (LGPD art. 8 §5)
- Authz: `Action::ExportGroup` (owner-only per migration 002 RBAC seed); member → 403
- Cross-group isolation: `path_group_id ≠ principal.group_id` → 404 (no foreign group existence leak)
- RLS: `SET LOCAL app.current_user_id` + `app.current_group_id` via parameterized `set_config` (plan 0056 protocol — no `format!()`)
- No audit event emitted for reads (circular noise prevention)
- `ip` column exposed as `ip::text` (forensic data, owner-entitled)
- `metadata` exposed as-is (already PII-safe by `audit_workspace_event` invariant)
- Dynamic query via `sqlx::QueryBuilder` (no string concat — push_bind generates `$N` params)
- Optional `?action=` + `?resource_type=` filters validated non-empty if provided
- OpenAPI paths + schemas registered (`AuditEventSummary`, `ListAuditResponse`)
- Plan doc: `plans/0070-gar-522-audit-api-slice1.md`
- Bookkeeping: ROADMAP §3.4 "Auditoria" `[x]` ticked

## Test plan

- [x] A1: `GET /audit` → 200; items array with `id`, `action`, `resource_type`, `created_at` fields
- [x] A2: cursor pagination — limit=2 on 3 events; second page via `next_cursor` returns oldest event
- [x] A3: `?action=member.joined` filter → only matching events returned
- [x] A4: owner of group A requests group B's audit → 404
- [x] A5: member role (not owner) → 403
- [x] A6: no JWT → 401
- [x] `cargo clippy -- -D warnings` green
- [x] `cargo fmt --check` green

https://claude.ai/code/session_0161WnrwAiYojdKW9fR9WaVu

---
_Generated by [Claude Code](https://claude.ai/code/session_0161WnrwAiYojdKW9fR9WaVu)_