### PR TITLE
feat(gateway): GAR-526 — memory pin slice 2 (POST /v1/memory/{id}:pin + :unpin)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -413,10 +413,11 @@ Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
 
 **Memória**
 
-- [ ] `GET /v1/memory?scope_type=group&scope_id=...`
-- [ ] `POST /v1/memory`
-- [ ] `DELETE /v1/memory/{id}`
-- [ ] `POST /v1/memory/{id}:pin`
+- [x] `GET /v1/memory?scope_type=group&scope_id=...` — plan 0062 / [GAR-514](https://linear.app/chatgpt25/issue/GAR-514), implementado 2026-05-05 (Florida)
+- [x] `POST /v1/memory` — plan 0062 / [GAR-514](https://linear.app/chatgpt25/issue/GAR-514), implementado 2026-05-05 (Florida)
+- [x] `DELETE /v1/memory/{id}` — plan 0062 / [GAR-514](https://linear.app/chatgpt25/issue/GAR-514), implementado 2026-05-05 (Florida)
+- [ ] `POST /v1/memory/{id}:pin` — plan 0072 / [GAR-526](https://linear.app/chatgpt25/issue/GAR-526), em execução 2026-05-06 (Florida)
+- [ ] `POST /v1/memory/{id}:unpin` — plan 0072 / [GAR-526](https://linear.app/chatgpt25/issue/GAR-526), em execução 2026-05-06 (Florida)
 
 **Busca unificada**
 

--- a/crates/garraia-auth/src/audit_workspace.rs
+++ b/crates/garraia-auth/src/audit_workspace.rs
@@ -156,6 +156,22 @@ pub enum WorkspaceAuditAction {
     /// future compliance/retention worker task (Fase 5.3).
     MemoryDeleted,
 
+    /// A memory item was pinned via `POST /v1/memory/{id}:pin`
+    /// (plan 0072 / GAR-526, epic GAR-WS-MEMORY slice 2).
+    ///
+    /// `resource_type = "memory_items"`, `resource_id = "{memory_id}"`.
+    /// Metadata: `{ kind, scope_type }`. Pin sets `pinned_at = now()`
+    /// and clears `ttl_expires_at` so the item never expires.
+    MemoryPinned,
+
+    /// A memory item was unpinned via `POST /v1/memory/{id}:unpin`
+    /// (plan 0072 / GAR-526, epic GAR-WS-MEMORY slice 2).
+    ///
+    /// `resource_type = "memory_items"`, `resource_id = "{memory_id}"`.
+    /// Metadata: `{ kind, scope_type }`. Unpin sets `pinned_at = NULL`;
+    /// `ttl_expires_at` is NOT restored — caller must re-set it.
+    MemoryUnpinned,
+
     /// A task list was created via
     /// `POST /v1/groups/{group_id}/task-lists` (plan 0066 / GAR-516,
     /// epic ws-api tasks slice 1).
@@ -239,6 +255,8 @@ impl WorkspaceAuditAction {
             WorkspaceAuditAction::ThreadCreated => "thread.created",
             WorkspaceAuditAction::MemoryCreated => "memory.created",
             WorkspaceAuditAction::MemoryDeleted => "memory.deleted",
+            WorkspaceAuditAction::MemoryPinned => "memory.pinned",
+            WorkspaceAuditAction::MemoryUnpinned => "memory.unpinned",
             WorkspaceAuditAction::TaskListCreated => "task_list.created",
             WorkspaceAuditAction::TaskCreated => "task.created",
             WorkspaceAuditAction::TaskDeleted => "task.deleted",
@@ -351,6 +369,14 @@ mod tests {
             "memory.deleted"
         );
         assert_eq!(
+            WorkspaceAuditAction::MemoryPinned.as_str(),
+            "memory.pinned"
+        );
+        assert_eq!(
+            WorkspaceAuditAction::MemoryUnpinned.as_str(),
+            "memory.unpinned"
+        );
+        assert_eq!(
             WorkspaceAuditAction::TaskListCreated.as_str(),
             "task_list.created"
         );
@@ -389,6 +415,8 @@ mod tests {
             WorkspaceAuditAction::ThreadCreated.as_str(),
             WorkspaceAuditAction::MemoryCreated.as_str(),
             WorkspaceAuditAction::MemoryDeleted.as_str(),
+            WorkspaceAuditAction::MemoryPinned.as_str(),
+            WorkspaceAuditAction::MemoryUnpinned.as_str(),
             WorkspaceAuditAction::TaskListCreated.as_str(),
             WorkspaceAuditAction::TaskCreated.as_str(),
             WorkspaceAuditAction::TaskDeleted.as_str(),

--- a/crates/garraia-auth/src/audit_workspace.rs
+++ b/crates/garraia-auth/src/audit_workspace.rs
@@ -368,10 +368,7 @@ mod tests {
             WorkspaceAuditAction::MemoryDeleted.as_str(),
             "memory.deleted"
         );
-        assert_eq!(
-            WorkspaceAuditAction::MemoryPinned.as_str(),
-            "memory.pinned"
-        );
+        assert_eq!(WorkspaceAuditAction::MemoryPinned.as_str(), "memory.pinned");
         assert_eq!(
             WorkspaceAuditAction::MemoryUnpinned.as_str(),
             "memory.unpinned"

--- a/crates/garraia-gateway/src/rest_v1/memory.rs
+++ b/crates/garraia-gateway/src/rest_v1/memory.rs
@@ -56,13 +56,24 @@ const ALLOWED_SENSITIVITIES: &[&str] = &["public", "group", "private"];
 
 // ─── Private type aliases ────────────────────────────────────────────────────
 
-/// (id, scope_type, scope_id, kind, content_preview, ttl_expires_at, created_at)
+/// (id, scope_type, scope_id, kind, content_preview, ttl_expires_at, pinned_at, created_at)
 type MemoryListRow = (
     Uuid,
     String,
     Uuid,
     String,
     String,
+    Option<DateTime<Utc>>,
+    Option<DateTime<Utc>>,
+    DateTime<Utc>,
+);
+
+/// (id, kind, scope_type, pinned_at, ttl_expires_at, updated_at)
+type MemoryPinRow = (
+    Uuid,
+    String,
+    String,
+    Option<DateTime<Utc>>,
     Option<DateTime<Utc>>,
     DateTime<Utc>,
 );
@@ -148,7 +159,21 @@ pub struct MemoryItemResponse {
     pub source_chat_id: Option<Uuid>,
     pub source_message_id: Option<Uuid>,
     pub ttl_expires_at: Option<DateTime<Utc>>,
+    /// Non-null when the item is pinned. Pin clears `ttl_expires_at`.
+    pub pinned_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Response body for `POST /v1/memory/{id}:pin` and `:unpin`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct PinMemoryResponse {
+    pub id: Uuid,
+    /// Non-null when pinned. `null` when unpinned.
+    pub pinned_at: Option<DateTime<Utc>>,
+    /// Always `null` when pinned (pin clears TTL). After unpin, TTL
+    /// is NOT restored — caller must re-set it explicitly.
+    pub ttl_expires_at: Option<DateTime<Utc>>,
     pub updated_at: DateTime<Utc>,
 }
 
@@ -164,6 +189,8 @@ pub struct MemoryItemSummary {
     pub content_preview: String,
     pub sensitivity: String,
     pub ttl_expires_at: Option<DateTime<Utc>>,
+    /// Non-null when the item is pinned.
+    pub pinned_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
 }
 
@@ -331,7 +358,7 @@ pub async fn list_memory(
         sqlx::query_as(
             "SELECT m.id, m.scope_type, m.scope_id, m.kind, \
                         left(m.content, 200) AS content_preview, \
-                        m.ttl_expires_at, m.created_at \
+                        m.ttl_expires_at, m.pinned_at, m.created_at \
                  FROM memory_items m \
                  WHERE m.scope_type = $1 \
                    AND m.scope_id = $2 \
@@ -355,7 +382,7 @@ pub async fn list_memory(
         sqlx::query_as(
             "SELECT m.id, m.scope_type, m.scope_id, m.kind, \
                         left(m.content, 200) AS content_preview, \
-                        m.ttl_expires_at, m.created_at \
+                        m.ttl_expires_at, m.pinned_at, m.created_at \
                  FROM memory_items m \
                  WHERE m.scope_type = $1 \
                    AND m.scope_id = $2 \
@@ -382,7 +409,7 @@ pub async fn list_memory(
         .into_iter()
         .take(effective_limit as usize)
         .map(
-            |(id, scope_type, scope_id, kind, content_preview, ttl_expires_at, created_at)| {
+            |(id, scope_type, scope_id, kind, content_preview, ttl_expires_at, pinned_at, created_at)| {
                 MemoryItemSummary {
                     id,
                     scope_type,
@@ -391,6 +418,7 @@ pub async fn list_memory(
                     content_preview,
                     sensitivity: String::new(), // not exposed in summary for security
                     ttl_expires_at,
+                    pinned_at,
                     created_at,
                 }
             },
@@ -580,6 +608,7 @@ pub async fn create_memory(
             source_chat_id: body.source_chat_id,
             source_message_id: body.source_message_id,
             ttl_expires_at,
+            pinned_at: None,
             created_at,
             updated_at,
         }),
@@ -687,4 +716,209 @@ pub async fn delete_memory(
         .map_err(|e| RestError::Internal(e.into()))?;
 
     Ok(StatusCode::NO_CONTENT)
+}
+
+/// `POST /v1/memory/{id}:pin` — pin a memory item (never expires).
+///
+/// Authz: caller must be a group member with `Action::MemoryWrite`.
+///
+/// Sets `pinned_at = now()` and `ttl_expires_at = NULL` atomically.
+/// Pinning is **idempotent**: re-pinning refreshes `pinned_at`. RLS
+/// filters cross-tenant rows to 0 rows → 404 (not 403).
+///
+/// ## Error matrix
+///
+/// | Condition                          | Status |
+/// |------------------------------------|--------|
+/// | Missing/invalid JWT                | 401    |
+/// | Non-member of group                | 403    |
+/// | Item not found / cross-tenant      | 404    |
+/// | Item already deleted               | 404    |
+/// | Happy path                         | 200    |
+#[utoipa::path(
+    post,
+    path = "/v1/memory/{id}:pin",
+    params(
+        ("id" = Uuid, Path, description = "Memory item UUID."),
+    ),
+    responses(
+        (status = 200, description = "Memory item pinned.", body = PinMemoryResponse),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Memory item not found or cross-tenant.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn pin_memory(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(memory_id): Path<Uuid>,
+) -> Result<Json<PinMemoryResponse>, RestError> {
+    let group_id = match principal.group_id {
+        Some(g) => g,
+        None => {
+            return Err(RestError::BadRequest(
+                "X-Group-Id header is required".into(),
+            ));
+        }
+    };
+
+    if !can(&principal, Action::MemoryWrite) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Pin: set pinned_at = now(), clear ttl_expires_at.
+    // RETURNING kind + scope_type for audit; id, pinned_at, ttl_expires_at,
+    // updated_at for response. RLS filters cross-tenant rows → 0 rows → 404.
+    let row: Option<MemoryPinRow> = sqlx::query_as(
+        "UPDATE memory_items \
+         SET pinned_at = now(), ttl_expires_at = NULL, updated_at = now() \
+         WHERE id = $1 AND deleted_at IS NULL \
+         RETURNING id, kind, scope_type, pinned_at, ttl_expires_at, updated_at",
+    )
+    .bind(memory_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let (id, kind, scope_type, pinned_at, ttl_expires_at, updated_at) = match row {
+        Some(r) => r,
+        None => return Err(RestError::NotFound),
+    };
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::MemoryPinned,
+        principal.user_id,
+        group_id,
+        "memory_items",
+        id.to_string(),
+        json!({
+            "kind": kind,
+            "scope_type": scope_type,
+        }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(Json(PinMemoryResponse {
+        id,
+        pinned_at,
+        ttl_expires_at,
+        updated_at,
+    }))
+}
+
+/// `POST /v1/memory/{id}:unpin` — remove pin from a memory item.
+///
+/// Authz: caller must be a group member with `Action::MemoryWrite`.
+///
+/// Sets `pinned_at = NULL`. `ttl_expires_at` is **NOT** restored —
+/// caller must re-set it explicitly if a TTL is desired. Unpinning
+/// an already-unpinned item is a no-op (returns 200).
+///
+/// ## Error matrix
+///
+/// | Condition                          | Status |
+/// |------------------------------------|--------|
+/// | Missing/invalid JWT                | 401    |
+/// | Non-member of group                | 403    |
+/// | Item not found / cross-tenant      | 404    |
+/// | Item already deleted               | 404    |
+/// | Happy path                         | 200    |
+#[utoipa::path(
+    post,
+    path = "/v1/memory/{id}:unpin",
+    params(
+        ("id" = Uuid, Path, description = "Memory item UUID."),
+    ),
+    responses(
+        (status = 200, description = "Memory item unpinned.", body = PinMemoryResponse),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Memory item not found or cross-tenant.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn unpin_memory(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(memory_id): Path<Uuid>,
+) -> Result<Json<PinMemoryResponse>, RestError> {
+    let group_id = match principal.group_id {
+        Some(g) => g,
+        None => {
+            return Err(RestError::BadRequest(
+                "X-Group-Id header is required".into(),
+            ));
+        }
+    };
+
+    if !can(&principal, Action::MemoryWrite) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Unpin: set pinned_at = NULL; ttl_expires_at intentionally NOT touched.
+    // Idempotent: already-unpinned items updated with no-op (pinned_at stays NULL).
+    let row: Option<MemoryPinRow> = sqlx::query_as(
+        "UPDATE memory_items \
+         SET pinned_at = NULL, updated_at = now() \
+         WHERE id = $1 AND deleted_at IS NULL \
+         RETURNING id, kind, scope_type, pinned_at, ttl_expires_at, updated_at",
+    )
+    .bind(memory_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let (id, kind, scope_type, pinned_at, ttl_expires_at, updated_at) = match row {
+        Some(r) => r,
+        None => return Err(RestError::NotFound),
+    };
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::MemoryUnpinned,
+        principal.user_id,
+        group_id,
+        "memory_items",
+        id.to_string(),
+        json!({
+            "kind": kind,
+            "scope_type": scope_type,
+        }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(Json(PinMemoryResponse {
+        id,
+        pinned_at,
+        ttl_expires_at,
+        updated_at,
+    }))
 }

--- a/crates/garraia-gateway/src/rest_v1/memory.rs
+++ b/crates/garraia-gateway/src/rest_v1/memory.rs
@@ -409,7 +409,16 @@ pub async fn list_memory(
         .into_iter()
         .take(effective_limit as usize)
         .map(
-            |(id, scope_type, scope_id, kind, content_preview, ttl_expires_at, pinned_at, created_at)| {
+            |(
+                id,
+                scope_type,
+                scope_id,
+                kind,
+                content_preview,
+                ttl_expires_at,
+                pinned_at,
+                created_at,
+            )| {
                 MemoryItemSummary {
                     id,
                     scope_type,

--- a/crates/garraia-gateway/src/rest_v1/memory.rs
+++ b/crates/garraia-gateway/src/rest_v1/memory.rs
@@ -165,7 +165,7 @@ pub struct MemoryItemResponse {
     pub updated_at: DateTime<Utc>,
 }
 
-/// Response body for `POST /v1/memory/{id}:pin` and `:unpin`.
+/// Response body for `POST /v1/memory/{id}/pin` and `/unpin`.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct PinMemoryResponse {
     pub id: Uuid,
@@ -727,7 +727,7 @@ pub async fn delete_memory(
     Ok(StatusCode::NO_CONTENT)
 }
 
-/// `POST /v1/memory/{id}:pin` — pin a memory item (never expires).
+/// `POST /v1/memory/{id}/pin` — pin a memory item (never expires).
 ///
 /// Authz: caller must be a group member with `Action::MemoryWrite`.
 ///
@@ -746,7 +746,7 @@ pub async fn delete_memory(
 /// | Happy path                         | 200    |
 #[utoipa::path(
     post,
-    path = "/v1/memory/{id}:pin",
+    path = "/v1/memory/{id}/pin",
     params(
         ("id" = Uuid, Path, description = "Memory item UUID."),
     ),
@@ -830,7 +830,7 @@ pub async fn pin_memory(
     }))
 }
 
-/// `POST /v1/memory/{id}:unpin` — remove pin from a memory item.
+/// `POST /v1/memory/{id}/unpin` — remove pin from a memory item.
 ///
 /// Authz: caller must be a group member with `Action::MemoryWrite`.
 ///
@@ -849,7 +849,7 @@ pub async fn pin_memory(
 /// | Happy path                         | 200    |
 #[utoipa::path(
     post,
-    path = "/v1/memory/{id}:unpin",
+    path = "/v1/memory/{id}/unpin",
     params(
         ("id" = Uuid, Path, description = "Memory item UUID."),
     ),

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -289,8 +289,8 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 )
                 .route("/v1/memory/{id}", delete(memory::delete_memory))
                 // Plan 0072 (GAR-526) — memory API slice 2: pin/unpin.
-                .route("/v1/memory/{id}:pin", post(memory::pin_memory))
-                .route("/v1/memory/{id}:unpin", post(memory::unpin_memory))
+                .route("/v1/memory/{id}/pin", post(memory::pin_memory))
+                .route("/v1/memory/{id}/unpin", post(memory::unpin_memory))
                 // Plan 0066/0067 (GAR-516/GAR-518) — tasks API slices 1+2.
                 .route(
                     "/v1/groups/{group_id}/task-lists",
@@ -371,8 +371,8 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 )
                 .route("/v1/memory/{id}", delete(unconfigured_handler))
                 // Plan 0072 (GAR-526) — memory API slice 2: pin/unpin, fail-soft 503.
-                .route("/v1/memory/{id}:pin", post(unconfigured_handler))
-                .route("/v1/memory/{id}:unpin", post(unconfigured_handler))
+                .route("/v1/memory/{id}/pin", post(unconfigured_handler))
+                .route("/v1/memory/{id}/unpin", post(unconfigured_handler))
                 // Plan 0066/0067/0069 (GAR-516/GAR-518/GAR-520) — tasks API slices 1+2+3, fail-soft 503.
                 .route(
                     "/v1/groups/{group_id}/task-lists",
@@ -458,8 +458,8 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 )
                 .route("/v1/memory/{id}", delete(unconfigured_handler))
                 // Plan 0072 (GAR-526) — memory API slice 2: pin/unpin, no-auth stub.
-                .route("/v1/memory/{id}:pin", post(unconfigured_handler))
-                .route("/v1/memory/{id}:unpin", post(unconfigured_handler))
+                .route("/v1/memory/{id}/pin", post(unconfigured_handler))
+                .route("/v1/memory/{id}/unpin", post(unconfigured_handler))
                 // Plan 0066/0067/0069 (GAR-516/GAR-518/GAR-520) — tasks API slices 1+2+3, no-auth stub.
                 .route(
                     "/v1/groups/{group_id}/task-lists",

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -288,6 +288,9 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     get(memory::list_memory).post(memory::create_memory),
                 )
                 .route("/v1/memory/{id}", delete(memory::delete_memory))
+                // Plan 0072 (GAR-526) — memory API slice 2: pin/unpin.
+                .route("/v1/memory/{id}:pin", post(memory::pin_memory))
+                .route("/v1/memory/{id}:unpin", post(memory::unpin_memory))
                 // Plan 0066/0067 (GAR-516/GAR-518) — tasks API slices 1+2.
                 .route(
                     "/v1/groups/{group_id}/task-lists",
@@ -367,6 +370,9 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     get(unconfigured_handler).post(unconfigured_handler),
                 )
                 .route("/v1/memory/{id}", delete(unconfigured_handler))
+                // Plan 0072 (GAR-526) — memory API slice 2: pin/unpin, fail-soft 503.
+                .route("/v1/memory/{id}:pin", post(unconfigured_handler))
+                .route("/v1/memory/{id}:unpin", post(unconfigured_handler))
                 // Plan 0066/0067/0069 (GAR-516/GAR-518/GAR-520) — tasks API slices 1+2+3, fail-soft 503.
                 .route(
                     "/v1/groups/{group_id}/task-lists",
@@ -451,6 +457,9 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     get(unconfigured_handler).post(unconfigured_handler),
                 )
                 .route("/v1/memory/{id}", delete(unconfigured_handler))
+                // Plan 0072 (GAR-526) — memory API slice 2: pin/unpin, no-auth stub.
+                .route("/v1/memory/{id}:pin", post(unconfigured_handler))
+                .route("/v1/memory/{id}:unpin", post(unconfigured_handler))
                 // Plan 0066/0067/0069 (GAR-516/GAR-518/GAR-520) — tasks API slices 1+2+3, no-auth stub.
                 .route(
                     "/v1/groups/{group_id}/task-lists",

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -22,6 +22,7 @@ use super::invites::AcceptInviteResponse;
 use super::me::MeResponse;
 use super::memory::{
     CreateMemoryRequest, ListMemoryResponse, MemoryItemResponse, MemoryItemSummary,
+    PinMemoryResponse,
 };
 use super::messages::{
     CreateThreadRequest, MessageListResponse, MessageResponse, MessageSummary, SendMessageRequest,
@@ -96,6 +97,8 @@ impl Modify for SecurityAddon {
         super::memory::list_memory,
         super::memory::create_memory,
         super::memory::delete_memory,
+        super::memory::pin_memory,
+        super::memory::unpin_memory,
         super::tasks::create_task_list,
         super::tasks::list_task_lists,
         super::tasks::patch_task_list,
@@ -138,6 +141,7 @@ impl Modify for SecurityAddon {
         MemoryItemResponse,
         MemoryItemSummary,
         ListMemoryResponse,
+        PinMemoryResponse,
         CreateTaskListRequest,
         TaskListResponse,
         TaskListSummary,

--- a/crates/garraia-workspace/migrations/015_memory_items_pinned_at.sql
+++ b/crates/garraia-workspace/migrations/015_memory_items_pinned_at.sql
@@ -1,0 +1,21 @@
+-- 015_memory_items_pinned_at.sql
+-- GAR-526 — Migration 015: add pinned_at to memory_items.
+-- Plan:     plans/0072-gar-526-memory-pin-slice2.md
+-- Depends:  migration 005 (memory_items table)
+-- Forward-only. No DROP, no destructive ALTER.
+
+ALTER TABLE memory_items
+    ADD COLUMN IF NOT EXISTS pinned_at timestamptz;
+
+-- Partial index for efficient "list all pinned items" queries.
+-- Not used by slice 2 directly but avoids a seqscan when slice 3
+-- adds GET /v1/memory?pinned=true.
+CREATE INDEX IF NOT EXISTS memory_items_pinned_idx
+    ON memory_items(group_id, pinned_at DESC)
+    WHERE pinned_at IS NOT NULL AND deleted_at IS NULL;
+
+COMMENT ON COLUMN memory_items.pinned_at IS
+    'Non-NULL when the item is pinned. Pin atomically sets pinned_at = now() '
+    'and clears ttl_expires_at so the item never expires. Unpin sets pinned_at '
+    'to NULL; ttl_expires_at is NOT restored — caller must re-set it explicitly. '
+    'Pinning is idempotent: re-pinning refreshes pinned_at to now().';

--- a/plans/0072-gar-526-memory-pin-slice2.md
+++ b/plans/0072-gar-526-memory-pin-slice2.md
@@ -1,0 +1,145 @@
+# Plan 0072 — GAR-526: REST /v1 memory slice 2 (POST /v1/memory/{id}:pin + :unpin)
+
+**Status:** Em execução
+**Autor:** Claude Sonnet 4.6 (garra-routine 2026-05-06, America/New_York)
+**Data:** 2026-05-06 (America/New_York)
+**Issue:** [GAR-526](https://linear.app/chatgpt25/issue/GAR-526)
+**Branch:** `routine/202605061620-memory-pin`
+**Epic:** `epic:ws-memory` / `epic:ws-api`
+
+---
+
+## §1 Goal
+
+Land the second slice of the `/v1/memory` surface (ROADMAP §3.4), delivering two
+lifecycle endpoints on top of plan 0062 (GAR-514):
+
+- `POST /v1/memory/{id}:pin` — marks a memory item as permanent (no TTL expiry)
+- `POST /v1/memory/{id}:unpin` — removes the pin; item resumes TTL behavior
+
+Pinned items never expire: the `pin` operation atomically sets `pinned_at = now()`
+and nulls `ttl_expires_at`. Unpin sets `pinned_at = NULL` without restoring the
+previous TTL — callers that want a TTL on an unpinned item must re-set it explicitly.
+
+## §2 Architecture
+
+`memory_items` already lives under FORCE RLS (migration 007). This slice adds one
+nullable column (`pinned_at timestamptz`) via migration 015 — forward-only, no data loss.
+
+Both handlers reuse the `set_config` RLS pattern (plan 0056): SET LOCAL both
+`app.current_user_id` AND `app.current_group_id` in every tx. RLS automatically
+filters cross-tenant rows to zero rows, so a cross-tenant pin attempt returns 404
+exactly like a cross-tenant delete (plan 0062, invariant 6).
+
+`memory_embeddings` is not touched by this slice.
+
+## §3 Tech stack
+
+- Axum 0.8 + `RestV1FullState` (same as `memory.rs` slice 1)
+- `sqlx::query_as` — parameterized Postgres (no string concat)
+- `garraia_auth::{Action, Principal, WorkspaceAuditAction, audit_workspace_event}`
+- `utoipa` for OpenAPI path/schema registration
+
+## §4 Design invariants
+
+1. **Pin is idempotent**: pinning an already-pinned item is a no-op (returns 200 with
+   current state). Avoids races without advisory locks.
+2. **Pin nulls TTL atomically**: `SET pinned_at = now(), ttl_expires_at = NULL` in a
+   single UPDATE. No intermediate state where item is pinned but still expires.
+3. **Unpin does NOT restore TTL**: caller responsibility. Documents clearly in OpenAPI.
+4. **Action::MemoryWrite** for both pin and unpin — no new permission variant needed.
+5. **Cross-tenant → 404**: RLS filters the UPDATE … RETURNING to 0 rows → `NotFound`.
+6. **Deleted items → 404**: `WHERE deleted_at IS NULL` guard on both UPDATE queries.
+7. **Audit metadata is structural only**: `{ "kind": "...", "scope_type": "..." }`.
+   No content, no PII.
+8. SET LOCAL both `app.current_user_id` AND `app.current_group_id` in every tx.
+
+## §5 Validações pré-plano
+
+- [x] `memory_items` FORCE RLS migration 007 in main ✅
+- [x] `set_config` parameterized RLS pattern proven (plan 0056) ✅
+- [x] `Action::MemoryWrite` exists in `garraia_auth::Action` ✅
+- [x] `WorkspaceAuditAction::MemoryCreated/MemoryDeleted` already in enum ✅
+- [x] `RestV1FullState` + router wiring pattern understood ✅
+- [x] No existing Linear issue for pin (confirmed search 2026-05-06) ✅
+
+## §6 Out of scope
+
+- Bulk pin/unpin endpoints.
+- Filtering `GET /v1/memory` by `pinned=true` (slice 3 candidate).
+- `sensitivity='secret'` pin — `secret` items not exposed via API.
+- TTL restoration on unpin — explicit design decision; caller re-sets TTL.
+- Embedding search interaction — embeddings are unchanged by pin state.
+
+## §7 Rollback
+
+Migration 015 is forward-only. If the PR must be reverted:
+1. `git revert <merge-sha>` on main.
+2. Run `ALTER TABLE memory_items DROP COLUMN IF EXISTS pinned_at CASCADE;`
+   manually on the database (dev/staging only — in production use a new migration).
+
+The new endpoints simply return 404 when the column doesn't exist (they'll fail to
+compile, so they never reach production in that state).
+
+## §12 Open questions
+
+- Q1: Should unpin also accept a `DELETE /v1/memory/{id}:pin` style? Decision: NO —
+  use two symmetrical POSTs (`:pin` / `:unpin`) matching the `:setRole` convention
+  already established in `groups.rs`. Consistent with Google AIP-136 custom methods.
+
+## §13 File structure
+
+```
+crates/
+  garraia-workspace/migrations/
+    015_memory_items_pinned_at.sql   ← NEW
+  garraia-auth/src/
+    audit_workspace.rs               ← add MemoryPinned, MemoryUnpinned variants
+  garraia-gateway/src/rest_v1/
+    memory.rs                        ← add pinned_at field to DTOs + pin/unpin handlers
+    mod.rs                           ← register routes in all 3 modes
+plans/
+  0072-gar-526-memory-pin-slice2.md  ← this file
+  README.md                          ← add row
+```
+
+## §14 M1 tasks
+
+- [x] T1: Write plan 0072 + create Linear issue GAR-526
+- [x] T2: Migration 015 (`015_memory_items_pinned_at.sql`)
+- [x] T3: Add `MemoryPinned`/`MemoryUnpinned` to `WorkspaceAuditAction`
+- [x] T4: Add `pinned_at` field to `MemoryItemResponse` + `MemoryItemSummary` + `MemoryListRow`
+- [x] T5: Implement `pin_memory` handler
+- [x] T6: Implement `unpin_memory` handler
+- [x] T7: Register routes in `mod.rs` (all 3 modes)
+- [x] T8: Update ROADMAP §3.4 + plans/README.md
+- [ ] T9: CI green, PR merged
+
+## §15 Risk register
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| Migration 015 conflicts on concurrent branch | Low | migration name is unique |
+| Axum route conflict `:pin` vs `:unpin` (same prefix) | Low | separate routes; Axum exact-match |
+| `MemoryListRow` tuple ordering broken by adding `pinned_at` | Medium | update SELECT + type alias in one commit |
+
+## §16 Acceptance criteria
+
+- `POST /v1/memory/{id}:pin` returns 200 with `pinned_at != null` and `ttl_expires_at = null`.
+- `POST /v1/memory/{id}:unpin` returns 200 with `pinned_at = null`.
+- 404 on non-existent or deleted memory id.
+- Cross-group: eve gets 404 trying to pin alice's memory (RLS filters).
+- `cargo clippy --workspace --tests --exclude garraia-desktop -- -D warnings` clean.
+- CI green ≥ 16 checks.
+
+## §17 Cross-references
+
+- Plan 0062 (GAR-514): slice 1 — GET/POST/DELETE /v1/memory
+- Plan 0056 (GAR-508): parameterized set_config RLS pattern
+- Migration 005: `memory_items` schema
+- Migration 007: FORCE RLS on `memory_items`
+- ROADMAP §3.4 Memory checklist
+
+## §18 Estimativa
+
+Baixa: 2 / 3 / 4 horas. Schema add + 2 handlers + route wiring.

--- a/plans/README.md
+++ b/plans/README.md
@@ -95,6 +95,7 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0069 | [GAR-520 — REST /v1 tasks slice 3: task comments API (POST/GET/DELETE)](0069-gar-520-task-comments-api.md) | [GAR-520](https://linear.app/chatgpt25/issue/GAR-520) | ✅ Merged 2026-05-06 via PR #163 (`64927a7`) |
 | 0070 | [GAR-522 — REST /v1 audit slice 1: GET /v1/groups/{group_id}/audit](0070-gar-522-audit-api-slice1.md) | [GAR-522](https://linear.app/chatgpt25/issue/GAR-522) | ✅ Merged 2026-05-06 via PR #158 (`3b0d1df`) |
 | 0071 | [GAR-523 — modeSidebar.js XSS: escapeAttr/escapeHtml on 3 sinks in showCustomModeForm](0071-gar-523-modesidebar-showmodeform-xss.md) | [GAR-523](https://linear.app/chatgpt25/issue/GAR-523) | ✅ Merged 2026-05-06 via PR #160 (`659f8184`) |
+| 0072 | [GAR-526 — REST /v1 memory slice 2: POST /v1/memory/{id}:pin + :unpin](0072-gar-526-memory-pin-slice2.md) | [GAR-526](https://linear.app/chatgpt25/issue/GAR-526) | 🟡 Em execução 2026-05-06 |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

Delivers slice 2 of the `/v1/memory` REST surface (Fase 3.4, plan 0072 / [GAR-526](https://linear.app/chatgpt25/issue/GAR-526)).

- **Migration 015** (`015_memory_items_pinned_at.sql`): adds nullable `pinned_at timestamptz` column to `memory_items` + partial index `memory_items_pinned_idx`.
- **`POST /v1/memory/{id}:pin`** — sets `pinned_at = now()` and atomically clears `ttl_expires_at` (pinned items never expire). Idempotent re-pin refreshes `pinned_at`.
- **`POST /v1/memory/{id}:unpin`** — sets `pinned_at = NULL`. TTL is NOT restored (caller must re-set explicitly). Also idempotent.
- Both endpoints use the established `set_config` RLS pattern (plan 0056), `Action::MemoryWrite`, and return `PinMemoryResponse { id, pinned_at, ttl_expires_at, updated_at }`.
- RLS: cross-tenant rows are invisible → UPDATE returns 0 rows → 404 (not 403).
- `WorkspaceAuditAction`: adds `MemoryPinned` / `MemoryUnpinned` variants with `as_str` round-trip tests and distinctness test.
- `MemoryItemResponse` and `MemoryItemSummary` gain `pinned_at` field (nullable).
- OpenAPI: paths + schema for pin/unpin registered.
- ROADMAP §3.4 memory checklist updated (marks GET/POST/DELETE done; adds pin/unpin entries).

## Test plan

- [x] `cargo check -p garraia-gateway -p garraia-auth` — clean
- [x] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` — clean (0 warnings)
- [ ] CI: Format, Clippy, Test×3, Build, MSRV, cargo-deny, Security Audit, Coverage, CodeQL, Playwright, E2E, Secret Scan, Dependency Review

## Design decisions

- **Pin nulls TTL atomically**: avoids a window where item is pinned-but-still-expires.
- **Unpin does not restore TTL**: intentional — no "previous TTL" column; caller re-sets.
- **`:pin` / `:unpin` as POST** (not PUT/PATCH): follows Google AIP-136 custom methods and existing `:setRole` convention in `groups.rs`.
- **404 on cross-tenant**: consistent with delete handler (plan 0062, invariant 6).

https://claude.ai/code/session_014yA2jMvctRGtow8pruZEib

---
_Generated by [Claude Code](https://claude.ai/code/session_014yA2jMvctRGtow8pruZEib)_