### PR TITLE
docs(plans): mark plan 0072 merged — GAR-526 (PR #167, 0558abb)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -416,8 +416,8 @@ Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
 - [x] `GET /v1/memory?scope_type=group&scope_id=...` — plan 0062 / [GAR-514](https://linear.app/chatgpt25/issue/GAR-514), implementado 2026-05-05 (Florida)
 - [x] `POST /v1/memory` — plan 0062 / [GAR-514](https://linear.app/chatgpt25/issue/GAR-514), implementado 2026-05-05 (Florida)
 - [x] `DELETE /v1/memory/{id}` — plan 0062 / [GAR-514](https://linear.app/chatgpt25/issue/GAR-514), implementado 2026-05-05 (Florida)
-- [ ] `POST /v1/memory/{id}:pin` — plan 0072 / [GAR-526](https://linear.app/chatgpt25/issue/GAR-526), em execução 2026-05-06 (Florida)
-- [ ] `POST /v1/memory/{id}:unpin` — plan 0072 / [GAR-526](https://linear.app/chatgpt25/issue/GAR-526), em execução 2026-05-06 (Florida)
+- [x] `POST /v1/memory/{id}/pin` — plan 0072 / [GAR-526](https://linear.app/chatgpt25/issue/GAR-526), implementado 2026-05-06 (Florida)
+- [x] `POST /v1/memory/{id}/unpin` — plan 0072 / [GAR-526](https://linear.app/chatgpt25/issue/GAR-526), implementado 2026-05-06 (Florida)
 
 **Busca unificada**
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -95,7 +95,7 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0069 | [GAR-520 — REST /v1 tasks slice 3: task comments API (POST/GET/DELETE)](0069-gar-520-task-comments-api.md) | [GAR-520](https://linear.app/chatgpt25/issue/GAR-520) | ✅ Merged 2026-05-06 via PR #163 (`64927a7`) |
 | 0070 | [GAR-522 — REST /v1 audit slice 1: GET /v1/groups/{group_id}/audit](0070-gar-522-audit-api-slice1.md) | [GAR-522](https://linear.app/chatgpt25/issue/GAR-522) | ✅ Merged 2026-05-06 via PR #158 (`3b0d1df`) |
 | 0071 | [GAR-523 — modeSidebar.js XSS: escapeAttr/escapeHtml on 3 sinks in showCustomModeForm](0071-gar-523-modesidebar-showmodeform-xss.md) | [GAR-523](https://linear.app/chatgpt25/issue/GAR-523) | ✅ Merged 2026-05-06 via PR #160 (`659f8184`) |
-| 0072 | [GAR-526 — REST /v1 memory slice 2: POST /v1/memory/{id}:pin + :unpin](0072-gar-526-memory-pin-slice2.md) | [GAR-526](https://linear.app/chatgpt25/issue/GAR-526) | 🟡 Em execução 2026-05-06 |
+| 0072 | [GAR-526 — REST /v1 memory slice 2: POST /v1/memory/{id}:pin + :unpin](0072-gar-526-memory-pin-slice2.md) | [GAR-526](https://linear.app/chatgpt25/issue/GAR-526) | ✅ Merged 2026-05-06 via PR #167 (`0558abb`) |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

- Flips `plans/README.md` row 0072 from 🟡 Em execução → ✅ Merged 2026-05-06 via PR #167 (`0558abb`)
- Flips `ROADMAP.md` §3.4 memory pin/unpin entries `[ ]` → `[x]` and corrects path notation `:pin`/`:unpin` → `/pin`/`/unpin` (aligning with the actual route convention used in the implementation)

Bookkeeping-only — no code changes.

## Test plan

- [x] Docs-only change, CI Format + Secret Scan sufficient

https://claude.ai/code/session_014yA2jMvctRGtow8pruZEib

---
_Generated by [Claude Code](https://claude.ai/code/session_014yA2jMvctRGtow8pruZEib)_