### PR TITLE
docs(plans): mark plan 0073 merged — GAR-527 (PR #168, 8e41201)

### DIFF
--- a/plans/0073-gar-527-openssl-0.10.79.md
+++ b/plans/0073-gar-527-openssl-0.10.79.md
@@ -2,7 +2,7 @@
 
 **Linear issue:** [GAR-527](https://linear.app/chatgpt25/issue/GAR-527) — "openssl 0.10.78 → 0.10.79 security patch (Dependabot PR #166 follow-up)"
 
-**Status:** ⏳ In Progress — health routine, 2026-05-06 (Florida).
+**Status:** ✅ Merged — PR #168 (`8e41201`), 2026-05-06 (Florida).
 
 **Goal:** Apply the openssl 0.10.78 → 0.10.79 + openssl-sys 0.9.114 → 0.9.115 lockfile-only bump that was identified as a Dependabot security update (GH Dependabot PR #166). The grouped PR was intentionally closed by the repo owner because it included a breaking rand 0.8/0.9 → 0.10 major-version upgrade; the owner explicitly requested a narrower follow-up PR with just the openssl patch.
 
@@ -46,14 +46,14 @@
 
 - [x] T1: Create health/ branch `health/202505061650-openssl-0.10.79` from main
 - [x] T2: Create this plan file + README row + commit `docs(plans): add plan 0073 for GAR-527 openssl 0.10.79 security patch`
-- [ ] T3: Run `cargo update -p openssl --precise 0.10.79`; verify only openssl+openssl-sys change via `git diff Cargo.lock`
-- [ ] T4: Run `cargo build --workspace --exclude garraia-desktop` to confirm no compilation errors
-- [ ] T5: Run `cargo test --workspace --exclude garraia-desktop --no-run` to confirm test artifacts compile
-- [ ] T6: Run `cargo audit --no-fetch` to confirm openssl advisory no longer fires (or remains in allowlist if advisory not yet in local DB)
-- [ ] T7: Commit `fix(deps): GAR-527 — bump openssl 0.10.78→0.10.79 + openssl-sys 0.9.114→0.9.115 (security patch)`
-- [ ] T8: Update `docs/security/dependabot-status.md` snapshot row; commit
-- [ ] T9: Push + open PR via GitHub MCP; poll CI until green; squash-merge
-- [ ] T10: Mark GAR-527 Done in Linear; update plans/README.md row
+- [x] T3: Run `cargo update -p openssl --precise 0.10.79`; verify only openssl+openssl-sys change via `git diff Cargo.lock`
+- [x] T4: Run `cargo build --workspace --exclude garraia-desktop` to confirm no compilation errors
+- [x] T5: Run `cargo test --workspace --exclude garraia-desktop --no-run` to confirm test artifacts compile
+- [x] T6: Run `cargo audit --no-fetch` to confirm openssl advisory no longer fires (or remains in allowlist if advisory not yet in local DB)
+- [x] T7: Commit `fix(deps): GAR-527 — bump openssl 0.10.78→0.10.79 + openssl-sys 0.9.114→0.9.115 (security patch)`
+- [x] T8: Update `docs/security/dependabot-status.md` snapshot row; commit
+- [x] T9: Push + open PR via GitHub MCP; poll CI until green; squash-merge
+- [x] T10: Mark GAR-527 Done in Linear; update plans/README.md row
 
 ---
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -96,7 +96,7 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0070 | [GAR-522 — REST /v1 audit slice 1: GET /v1/groups/{group_id}/audit](0070-gar-522-audit-api-slice1.md) | [GAR-522](https://linear.app/chatgpt25/issue/GAR-522) | ✅ Merged 2026-05-06 via PR #158 (`3b0d1df`) |
 | 0071 | [GAR-523 — modeSidebar.js XSS: escapeAttr/escapeHtml on 3 sinks in showCustomModeForm](0071-gar-523-modesidebar-showmodeform-xss.md) | [GAR-523](https://linear.app/chatgpt25/issue/GAR-523) | ✅ Merged 2026-05-06 via PR #160 (`659f8184`) |
 | 0072 | [GAR-526 — REST /v1 memory slice 2: POST /v1/memory/{id}:pin + :unpin](0072-gar-526-memory-pin-slice2.md) | [GAR-526](https://linear.app/chatgpt25/issue/GAR-526) | ✅ Merged 2026-05-06 via PR #167 (`0558abb`) |
-| 0073 | [GAR-527 — openssl 0.10.78→0.10.79 + openssl-sys 0.9.114→0.9.115 security patch](0073-gar-527-openssl-0.10.79.md) | [GAR-527](https://linear.app/chatgpt25/issue/GAR-527) | 🟡 Em execução 2026-05-06 (health routine) |
+| 0073 | [GAR-527 — openssl 0.10.78→0.10.79 + openssl-sys 0.9.114→0.9.115 security patch](0073-gar-527-openssl-0.10.79.md) | [GAR-527](https://linear.app/chatgpt25/issue/GAR-527) | ✅ Merged 2026-05-06 via PR #168 (`8e41201`) |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
Flips `plans/README.md` row 0073 to ✅ and marks all T3–T10 tasks done in the plan file.

`openssl` 0.10.78→0.10.79 + `openssl-sys` 0.9.114→0.9.115 security patch squash-merged 2026-05-06 via PR #168 (`8e41201`). GAR-527 marked Done in Linear.

https://claude.ai/code/session_01JPdGbBpfxW3LvjrTp2k4Ag

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPdGbBpfxW3LvjrTp2k4Ag)_