### PR TITLE
feat(gateway): GAR-530 — chat management slice 4 (individual chat ops + member CRUD)

### DIFF
--- a/crates/garraia-auth/src/audit_workspace.rs
+++ b/crates/garraia-auth/src/audit_workspace.rs
@@ -248,6 +248,40 @@ pub enum WorkspaceAuditAction {
     /// `resource_type = "task_comments"`, `resource_id = "{comment_id}"`.
     /// Metadata: `{ body_len }`.
     TaskCommentDeleted,
+
+    /// A chat was updated (name/topic changed) via
+    /// `PATCH /v1/chats/{chat_id}` (plan 0076 / GAR-530,
+    /// epic GAR-WS-CHAT slice 4).
+    ///
+    /// `resource_type = "chats"`, `resource_id = "{chat_id}"`.
+    /// Metadata: `{ changed_name, changed_topic }`. Boolean flags only —
+    /// new values are PII-adjacent (chat names may be project codenames).
+    ChatUpdated,
+
+    /// A chat was soft-archived via
+    /// `DELETE /v1/chats/{chat_id}` (plan 0076 / GAR-530,
+    /// epic GAR-WS-CHAT slice 4).
+    ///
+    /// `resource_type = "chats"`, `resource_id = "{chat_id}"`.
+    /// Metadata: `{ type }`. The chat row is not removed — `archived_at`
+    /// is set to `now()`.
+    ChatArchived,
+
+    /// A user was added to a chat via
+    /// `POST /v1/chats/{chat_id}/members` (plan 0076 / GAR-530,
+    /// epic GAR-WS-CHAT slice 4).
+    ///
+    /// `resource_type = "chat_members"`, `resource_id = "{user_id}"`.
+    /// Metadata: `{ role }`.
+    ChatMemberAdded,
+
+    /// A user was removed from a chat via
+    /// `DELETE /v1/chats/{chat_id}/members/{user_id}` (plan 0076 / GAR-530,
+    /// epic GAR-WS-CHAT slice 4).
+    ///
+    /// `resource_type = "chat_members"`, `resource_id = "{user_id}"`.
+    /// Metadata: `{ role }`.
+    ChatMemberRemoved,
 }
 
 impl WorkspaceAuditAction {
@@ -275,6 +309,10 @@ impl WorkspaceAuditAction {
             WorkspaceAuditAction::TaskListArchived => "task_list.archived",
             WorkspaceAuditAction::TaskCommentCreated => "task.comment.created",
             WorkspaceAuditAction::TaskCommentDeleted => "task.comment.deleted",
+            WorkspaceAuditAction::ChatUpdated => "chat.updated",
+            WorkspaceAuditAction::ChatArchived => "chat.archived",
+            WorkspaceAuditAction::ChatMemberAdded => "chat.member.added",
+            WorkspaceAuditAction::ChatMemberRemoved => "chat.member.removed",
         }
     }
 }
@@ -406,6 +444,16 @@ mod tests {
             WorkspaceAuditAction::TaskCommentDeleted.as_str(),
             "task.comment.deleted"
         );
+        assert_eq!(WorkspaceAuditAction::ChatUpdated.as_str(), "chat.updated");
+        assert_eq!(WorkspaceAuditAction::ChatArchived.as_str(), "chat.archived");
+        assert_eq!(
+            WorkspaceAuditAction::ChatMemberAdded.as_str(),
+            "chat.member.added"
+        );
+        assert_eq!(
+            WorkspaceAuditAction::ChatMemberRemoved.as_str(),
+            "chat.member.removed"
+        );
     }
 
     #[test]
@@ -432,6 +480,10 @@ mod tests {
             WorkspaceAuditAction::TaskListArchived.as_str(),
             WorkspaceAuditAction::TaskCommentCreated.as_str(),
             WorkspaceAuditAction::TaskCommentDeleted.as_str(),
+            WorkspaceAuditAction::ChatUpdated.as_str(),
+            WorkspaceAuditAction::ChatArchived.as_str(),
+            WorkspaceAuditAction::ChatMemberAdded.as_str(),
+            WorkspaceAuditAction::ChatMemberRemoved.as_str(),
         ];
         let unique: std::collections::HashSet<_> = strings.iter().collect();
         assert_eq!(unique.len(), strings.len(), "duplicate action strings");

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -257,6 +257,13 @@ name = "rest_v1_audit"
 path = "tests/rest_v1_audit.rs"
 required-features = ["test-helpers"]
 
+# Plan 0076 (GAR-530) — individual chat ops + member CRUD integration tests.
+# Feature-gated like all other harness tests.
+[[test]]
+name = "rest_v1_chat_mgmt"
+path = "tests/rest_v1_chat_mgmt.rs"
+required-features = ["test-helpers"]
+
 [dev-dependencies]
 # Plan 0024 T4 (GAR-412): metrics_exporter tests and the
 # metrics_auth_integration binary build a `PrometheusRecorder` directly

--- a/crates/garraia-gateway/src/rest_v1/chats.rs
+++ b/crates/garraia-gateway/src/rest_v1/chats.rs
@@ -416,6 +416,721 @@ pub async fn list_chats(
     Ok(Json(ChatListResponse { items }))
 }
 
+// ── Slice 4 (plan 0076 / GAR-530) — individual chat management + member CRUD ──
+
+/// Full detail returned by `GET /v1/chats/{chat_id}`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ChatDetailResponse {
+    pub id: Uuid,
+    pub group_id: Uuid,
+    #[serde(rename = "type")]
+    pub chat_type: String,
+    pub name: String,
+    pub topic: Option<String>,
+    pub created_by: Uuid,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Request body for `PATCH /v1/chats/{chat_id}`.
+///
+/// At least one field must be provided. `topic: ""` clears the topic
+/// (empty string is normalised to `NULL` after trim).
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct PatchChatRequest {
+    pub name: Option<String>,
+    pub topic: Option<String>,
+}
+
+impl PatchChatRequest {
+    pub fn validate(&self) -> Result<(), &'static str> {
+        if self.name.is_none() && self.topic.is_none() {
+            return Err("at least one of name or topic must be provided");
+        }
+        if let Some(n) = &self.name
+            && n.trim().is_empty()
+        {
+            return Err("name must not be empty");
+        }
+        if let Some(t) = &self.topic
+            && t.chars().count() > MAX_TOPIC_CHARS
+        {
+            return Err("topic must be 4000 characters or fewer");
+        }
+        Ok(())
+    }
+}
+
+/// One entry in the members list.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ChatMemberResponse {
+    pub user_id: Uuid,
+    pub role: String,
+    pub joined_at: DateTime<Utc>,
+}
+
+/// Response body for `GET /v1/chats/{chat_id}/members`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ChatMemberListResponse {
+    pub items: Vec<ChatMemberResponse>,
+}
+
+/// Request body for `POST /v1/chats/{chat_id}/members`.
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AddChatMemberRequest {
+    pub user_id: Uuid,
+    #[serde(default = "default_member_role")]
+    pub role: String,
+}
+
+fn default_member_role() -> String {
+    "member".into()
+}
+
+impl AddChatMemberRequest {
+    pub fn validate(&self) -> Result<(), &'static str> {
+        match self.role.as_str() {
+            "owner" | "moderator" | "member" | "viewer" => Ok(()),
+            _ => Err("role must be one of: owner, moderator, member, viewer"),
+        }
+    }
+}
+
+/// `GET /v1/chats/{chat_id}` — fetch a single chat.
+///
+/// Returns 404 for archived chats or chats in other groups (no 403 leakage).
+#[utoipa::path(
+    get,
+    path = "/v1/chats/{chat_id}",
+    params(("chat_id" = Uuid, Path, description = "Chat UUID.")),
+    responses(
+        (status = 200, description = "Chat detail.", body = ChatDetailResponse),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a group member.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Chat not found, archived, or in another group.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn get_chat(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(chat_id): Path<Uuid>,
+) -> Result<Json<ChatDetailResponse>, RestError> {
+    let group_id = principal
+        .group_id
+        .ok_or_else(|| RestError::BadRequest("X-Group-Id header is required".into()))?;
+
+    if !can(&principal, Action::ChatsRead) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(principal.user_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_group_id', $1, true)")
+        .bind(group_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    type Row = (Uuid, Uuid, String, String, Option<String>, Uuid, DateTime<Utc>, DateTime<Utc>);
+    let row: Option<Row> = sqlx::query_as(
+        "SELECT id, group_id, type, name, topic, created_by, created_at, updated_at \
+         FROM chats \
+         WHERE id = $1 AND group_id = $2 AND archived_at IS NULL",
+    )
+    .bind(chat_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    let (id, gid, ct, name, topic, created_by, created_at, updated_at) =
+        row.ok_or(RestError::NotFound)?;
+
+    Ok(Json(ChatDetailResponse {
+        id,
+        group_id: gid,
+        chat_type: ct,
+        name,
+        topic,
+        created_by,
+        created_at,
+        updated_at,
+    }))
+}
+
+/// `PATCH /v1/chats/{chat_id}` — update name and/or topic.
+///
+/// Uses `COALESCE($new, column)` so only supplied fields are overwritten.
+/// An empty `topic` string after trim clears the topic field (`NULL`).
+/// Returns the updated chat detail on success.
+#[utoipa::path(
+    patch,
+    path = "/v1/chats/{chat_id}",
+    params(("chat_id" = Uuid, Path, description = "Chat UUID.")),
+    request_body = PatchChatRequest,
+    responses(
+        (status = 200, description = "Updated chat detail.", body = ChatDetailResponse),
+        (status = 400, description = "Validation failure.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller lacks ChatsWrite.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Chat not found, archived, or in another group.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn patch_chat(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(chat_id): Path<Uuid>,
+    Json(body): Json<PatchChatRequest>,
+) -> Result<Json<ChatDetailResponse>, RestError> {
+    let group_id = principal
+        .group_id
+        .ok_or_else(|| RestError::BadRequest("X-Group-Id header is required".into()))?;
+
+    if !can(&principal, Action::ChatsWrite) {
+        return Err(RestError::Forbidden);
+    }
+
+    body.validate()
+        .map_err(|msg| RestError::BadRequest(msg.into()))?;
+
+    let trimmed_name: Option<String> = body.name.as_deref().map(str::trim).map(str::to_string);
+    // Empty topic after trim → NULL (clears the field).
+    let new_topic: Option<Option<String>> = body.topic.as_deref().map(|t| {
+        let s = t.trim().to_string();
+        if s.is_empty() { None } else { Some(s) }
+    });
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(principal.user_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_group_id', $1, true)")
+        .bind(group_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    // COALESCE keeps existing value when the caller did not provide the field.
+    // For topic: if caller provided `topic` (even empty → None), we replace;
+    // otherwise keep the DB value.
+    type Row = (Uuid, Uuid, String, String, Option<String>, Uuid, DateTime<Utc>, DateTime<Utc>);
+    let row: Option<Row> = if body.topic.is_some() {
+        // Caller supplied topic — may be clearing it (new_topic inner = None).
+        sqlx::query_as(
+            "UPDATE chats \
+             SET name = COALESCE($1, name), topic = $2, updated_at = now() \
+             WHERE id = $3 AND group_id = $4 AND archived_at IS NULL \
+             RETURNING id, group_id, type, name, topic, created_by, created_at, updated_at",
+        )
+        .bind(trimmed_name.as_deref())
+        .bind(new_topic.flatten().as_deref())
+        .bind(chat_id)
+        .bind(group_id)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?
+    } else {
+        // Only name supplied — topic untouched.
+        sqlx::query_as(
+            "UPDATE chats \
+             SET name = COALESCE($1, name), updated_at = now() \
+             WHERE id = $2 AND group_id = $3 AND archived_at IS NULL \
+             RETURNING id, group_id, type, name, topic, created_by, created_at, updated_at",
+        )
+        .bind(trimmed_name.as_deref())
+        .bind(chat_id)
+        .bind(group_id)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?
+    };
+
+    let (id, gid, ct, name, topic, created_by, created_at, updated_at) =
+        row.ok_or(RestError::NotFound)?;
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::ChatUpdated,
+        principal.user_id,
+        group_id,
+        "chats",
+        chat_id.to_string(),
+        json!({
+            "changed_name": body.name.is_some(),
+            "changed_topic": body.topic.is_some(),
+        }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(Json(ChatDetailResponse {
+        id,
+        group_id: gid,
+        chat_type: ct,
+        name,
+        topic,
+        created_by,
+        created_at,
+        updated_at,
+    }))
+}
+
+/// `DELETE /v1/chats/{chat_id}` — soft-archive a chat.
+///
+/// Sets `archived_at = now()`. Messages are preserved. Returns 204 on
+/// success; subsequent GET/PATCH on the same chat returns 404.
+#[utoipa::path(
+    delete,
+    path = "/v1/chats/{chat_id}",
+    params(("chat_id" = Uuid, Path, description = "Chat UUID.")),
+    responses(
+        (status = 204, description = "Chat archived."),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller lacks ChatsWrite.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Chat not found, already archived, or in another group.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn delete_chat(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(chat_id): Path<Uuid>,
+) -> Result<StatusCode, RestError> {
+    let group_id = principal
+        .group_id
+        .ok_or_else(|| RestError::BadRequest("X-Group-Id header is required".into()))?;
+
+    if !can(&principal, Action::ChatsWrite) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(principal.user_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_group_id', $1, true)")
+        .bind(group_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    let (chat_type,): (String,) = sqlx::query_as(
+        "UPDATE chats SET archived_at = now() \
+         WHERE id = $1 AND group_id = $2 AND archived_at IS NULL \
+         RETURNING type",
+    )
+    .bind(chat_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?
+    .ok_or(RestError::NotFound)?;
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::ChatArchived,
+        principal.user_id,
+        group_id,
+        "chats",
+        chat_id.to_string(),
+        json!({ "type": chat_type }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `GET /v1/chats/{chat_id}/members` — list all members of a chat.
+///
+/// Returns members ordered by `joined_at ASC`. No pagination (bounded by
+/// group size; real groups rarely exceed hundreds of members per chat).
+#[utoipa::path(
+    get,
+    path = "/v1/chats/{chat_id}/members",
+    params(("chat_id" = Uuid, Path, description = "Chat UUID.")),
+    responses(
+        (status = 200, description = "Member list.", body = ChatMemberListResponse),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a group member.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Chat not found, archived, or in another group.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn list_chat_members(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(chat_id): Path<Uuid>,
+) -> Result<Json<ChatMemberListResponse>, RestError> {
+    let group_id = principal
+        .group_id
+        .ok_or_else(|| RestError::BadRequest("X-Group-Id header is required".into()))?;
+
+    if !can(&principal, Action::ChatsRead) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(principal.user_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_group_id', $1, true)")
+        .bind(group_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    // Verify chat exists in group (404 not 403 — no cross-tenant leak).
+    let exists: Option<(bool,)> = sqlx::query_as(
+        "SELECT true FROM chats WHERE id = $1 AND group_id = $2 AND archived_at IS NULL",
+    )
+    .bind(chat_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    type MemberRow = (Uuid, String, DateTime<Utc>);
+    let rows: Vec<MemberRow> = sqlx::query_as(
+        "SELECT user_id, role, joined_at \
+         FROM chat_members \
+         WHERE chat_id = $1 \
+         ORDER BY joined_at ASC",
+    )
+    .bind(chat_id)
+    .fetch_all(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    let items = rows
+        .into_iter()
+        .map(|(user_id, role, joined_at)| ChatMemberResponse {
+            user_id,
+            role,
+            joined_at,
+        })
+        .collect();
+
+    Ok(Json(ChatMemberListResponse { items }))
+}
+
+/// `POST /v1/chats/{chat_id}/members` — add a group member to a chat.
+///
+/// The target `user_id` must be a member of the same group; otherwise the
+/// insert would silently succeed in RLS terms (chat_members JOIN-RLS only
+/// checks group isolation via the chats table) but would violate the
+/// group-membership invariant. An explicit guard prevents this.
+///
+/// Returns 409 if the user is already a member.
+#[utoipa::path(
+    post,
+    path = "/v1/chats/{chat_id}/members",
+    params(("chat_id" = Uuid, Path, description = "Chat UUID.")),
+    request_body = AddChatMemberRequest,
+    responses(
+        (status = 201, description = "Member added.", body = ChatMemberResponse),
+        (status = 400, description = "Validation failure.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller lacks MembersManage.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Chat not found, archived, target user not in group.", body = super::problem::ProblemDetails),
+        (status = 409, description = "User is already a member of this chat.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn add_chat_member(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(chat_id): Path<Uuid>,
+    Json(body): Json<AddChatMemberRequest>,
+) -> Result<(StatusCode, Json<ChatMemberResponse>), RestError> {
+    let group_id = principal
+        .group_id
+        .ok_or_else(|| RestError::BadRequest("X-Group-Id header is required".into()))?;
+
+    if !can(&principal, Action::MembersManage) {
+        return Err(RestError::Forbidden);
+    }
+
+    body.validate()
+        .map_err(|msg| RestError::BadRequest(msg.into()))?;
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(principal.user_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_group_id', $1, true)")
+        .bind(group_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    // Verify chat exists and is not archived.
+    let exists: Option<(bool,)> = sqlx::query_as(
+        "SELECT true FROM chats WHERE id = $1 AND group_id = $2 AND archived_at IS NULL",
+    )
+    .bind(chat_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    // Verify target user is a member of this group (group_members is not
+    // FORCE RLS — it is app-layer enforced).
+    let in_group: Option<(bool,)> = sqlx::query_as(
+        "SELECT true FROM group_members WHERE group_id = $1 AND user_id = $2",
+    )
+    .bind(group_id)
+    .bind(body.user_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if in_group.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    // Check for existing membership.
+    let already: Option<(bool,)> = sqlx::query_as(
+        "SELECT true FROM chat_members WHERE chat_id = $1 AND user_id = $2",
+    )
+    .bind(chat_id)
+    .bind(body.user_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if already.is_some() {
+        return Err(RestError::Conflict("user is already a member of this chat".into()));
+    }
+
+    let (joined_at,): (DateTime<Utc>,) = sqlx::query_as(
+        "INSERT INTO chat_members (chat_id, user_id, role) VALUES ($1, $2, $3) \
+         RETURNING joined_at",
+    )
+    .bind(chat_id)
+    .bind(body.user_id)
+    .bind(&body.role)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::ChatMemberAdded,
+        principal.user_id,
+        group_id,
+        "chat_members",
+        body.user_id.to_string(),
+        json!({ "role": body.role }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(ChatMemberResponse {
+            user_id: body.user_id,
+            role: body.role,
+            joined_at,
+        }),
+    ))
+}
+
+/// `DELETE /v1/chats/{chat_id}/members/{user_id}` — remove a member.
+///
+/// Guards:
+/// - Cannot remove the last owner (409).
+/// - Caller must have `MembersManage`.
+/// - Chat must exist and not be archived (404).
+#[utoipa::path(
+    delete,
+    path = "/v1/chats/{chat_id}/members/{user_id}",
+    params(
+        ("chat_id" = Uuid, Path, description = "Chat UUID."),
+        ("user_id" = Uuid, Path, description = "User UUID to remove."),
+    ),
+    responses(
+        (status = 204, description = "Member removed."),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller lacks MembersManage.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Chat not found, archived, or user not a member.", body = super::problem::ProblemDetails),
+        (status = 409, description = "Cannot remove the last owner of a chat.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn remove_chat_member(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((chat_id, target_user_id)): Path<(Uuid, Uuid)>,
+) -> Result<StatusCode, RestError> {
+    let group_id = principal
+        .group_id
+        .ok_or_else(|| RestError::BadRequest("X-Group-Id header is required".into()))?;
+
+    if !can(&principal, Action::MembersManage) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(principal.user_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_group_id', $1, true)")
+        .bind(group_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    // Verify chat in group and not archived.
+    let exists: Option<(bool,)> = sqlx::query_as(
+        "SELECT true FROM chats WHERE id = $1 AND group_id = $2 AND archived_at IS NULL",
+    )
+    .bind(chat_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    // Fetch target member's role before deletion.
+    let target_role: Option<(String,)> =
+        sqlx::query_as("SELECT role FROM chat_members WHERE chat_id = $1 AND user_id = $2")
+            .bind(chat_id)
+            .bind(target_user_id)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(|e| RestError::Internal(e.into()))?;
+
+    let role = target_role.map(|(r,)| r).ok_or(RestError::NotFound)?;
+
+    // Guard: cannot remove last owner.
+    if role == "owner" {
+        let (owner_count,): (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM chat_members WHERE chat_id = $1 AND role = 'owner'",
+        )
+        .bind(chat_id)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+        if owner_count <= 1 {
+            return Err(RestError::Conflict(
+                "cannot remove the last owner of a chat".into(),
+            ));
+        }
+    }
+
+    sqlx::query("DELETE FROM chat_members WHERE chat_id = $1 AND user_id = $2")
+        .bind(chat_id)
+        .bind(target_user_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::ChatMemberRemoved,
+        principal.user_id,
+        group_id,
+        "chat_members",
+        target_user_id.to_string(),
+        json!({ "role": role }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/garraia-gateway/src/rest_v1/chats.rs
+++ b/crates/garraia-gateway/src/rest_v1/chats.rs
@@ -544,7 +544,16 @@ pub async fn get_chat(
         .await
         .map_err(|e| RestError::Internal(e.into()))?;
 
-    type Row = (Uuid, Uuid, String, String, Option<String>, Uuid, DateTime<Utc>, DateTime<Utc>);
+    type Row = (
+        Uuid,
+        Uuid,
+        String,
+        String,
+        Option<String>,
+        Uuid,
+        DateTime<Utc>,
+        DateTime<Utc>,
+    );
     let row: Option<Row> = sqlx::query_as(
         "SELECT id, group_id, type, name, topic, created_by, created_at, updated_at \
          FROM chats \
@@ -639,7 +648,16 @@ pub async fn patch_chat(
     // COALESCE keeps existing value when the caller did not provide the field.
     // For topic: if caller provided `topic` (even empty → None), we replace;
     // otherwise keep the DB value.
-    type Row = (Uuid, Uuid, String, String, Option<String>, Uuid, DateTime<Utc>, DateTime<Utc>);
+    type Row = (
+        Uuid,
+        Uuid,
+        String,
+        String,
+        Option<String>,
+        Uuid,
+        DateTime<Utc>,
+        DateTime<Utc>,
+    );
     let row: Option<Row> = if body.topic.is_some() {
         // Caller supplied topic — may be clearing it (new_topic inner = None).
         sqlx::query_as(
@@ -946,31 +964,31 @@ pub async fn add_chat_member(
 
     // Verify target user is a member of this group (group_members is not
     // FORCE RLS — it is app-layer enforced).
-    let in_group: Option<(bool,)> = sqlx::query_as(
-        "SELECT true FROM group_members WHERE group_id = $1 AND user_id = $2",
-    )
-    .bind(group_id)
-    .bind(body.user_id)
-    .fetch_optional(&mut *tx)
-    .await
-    .map_err(|e| RestError::Internal(e.into()))?;
+    let in_group: Option<(bool,)> =
+        sqlx::query_as("SELECT true FROM group_members WHERE group_id = $1 AND user_id = $2")
+            .bind(group_id)
+            .bind(body.user_id)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(|e| RestError::Internal(e.into()))?;
 
     if in_group.is_none() {
         return Err(RestError::NotFound);
     }
 
     // Check for existing membership.
-    let already: Option<(bool,)> = sqlx::query_as(
-        "SELECT true FROM chat_members WHERE chat_id = $1 AND user_id = $2",
-    )
-    .bind(chat_id)
-    .bind(body.user_id)
-    .fetch_optional(&mut *tx)
-    .await
-    .map_err(|e| RestError::Internal(e.into()))?;
+    let already: Option<(bool,)> =
+        sqlx::query_as("SELECT true FROM chat_members WHERE chat_id = $1 AND user_id = $2")
+            .bind(chat_id)
+            .bind(body.user_id)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(|e| RestError::Internal(e.into()))?;
 
     if already.is_some() {
-        return Err(RestError::Conflict("user is already a member of this chat".into()));
+        return Err(RestError::Conflict(
+            "user is already a member of this chat".into(),
+        ));
     }
 
     let (joined_at,): (DateTime<Utc>,) = sqlx::query_as(

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -272,6 +272,21 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     "/v1/groups/{group_id}/chats",
                     post(chats::create_chat).get(chats::list_chats),
                 )
+                // Plan 0076 (GAR-530) — chats slice 4: individual chat ops + member CRUD.
+                .route(
+                    "/v1/chats/{chat_id}",
+                    get(chats::get_chat)
+                        .patch(chats::patch_chat)
+                        .delete(chats::delete_chat),
+                )
+                .route(
+                    "/v1/chats/{chat_id}/members",
+                    get(chats::list_chat_members).post(chats::add_chat_member),
+                )
+                .route(
+                    "/v1/chats/{chat_id}/members/{user_id}",
+                    delete(chats::remove_chat_member),
+                )
                 // Plan 0055 (GAR-507) — messages slice 2.
                 .route(
                     "/v1/chats/{chat_id}/messages",
@@ -358,6 +373,21 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 .route(
                     "/v1/groups/{group_id}/chats",
                     post(unconfigured_handler).get(unconfigured_handler),
+                )
+                // Plan 0076 (GAR-530) — chats slice 4, fail-soft 503.
+                .route(
+                    "/v1/chats/{chat_id}",
+                    get(unconfigured_handler)
+                        .patch(unconfigured_handler)
+                        .delete(unconfigured_handler),
+                )
+                .route(
+                    "/v1/chats/{chat_id}/members",
+                    get(unconfigured_handler).post(unconfigured_handler),
+                )
+                .route(
+                    "/v1/chats/{chat_id}/members/{user_id}",
+                    delete(unconfigured_handler),
                 )
                 // Plan 0055 (GAR-507) — messages slice 2, fail-soft 503.
                 .route(
@@ -446,17 +476,32 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     delete(unconfigured_handler),
                 )
                 .route("/v1/invites/{token}/accept", post(unconfigured_handler))
-                // Plan 0054 (GAR-506) — chats slice 1, fail-soft 503.
+                // Plan 0054 (GAR-506) — chats slice 1, no-auth stub.
                 .route(
                     "/v1/groups/{group_id}/chats",
                     post(unconfigured_handler).get(unconfigured_handler),
                 )
-                // Plan 0055 (GAR-507) — messages slice 2, fail-soft 503.
+                // Plan 0076 (GAR-530) — chats slice 4, no-auth stub.
+                .route(
+                    "/v1/chats/{chat_id}",
+                    get(unconfigured_handler)
+                        .patch(unconfigured_handler)
+                        .delete(unconfigured_handler),
+                )
+                .route(
+                    "/v1/chats/{chat_id}/members",
+                    get(unconfigured_handler).post(unconfigured_handler),
+                )
+                .route(
+                    "/v1/chats/{chat_id}/members/{user_id}",
+                    delete(unconfigured_handler),
+                )
+                // Plan 0055 (GAR-507) — messages slice 2, no-auth stub.
                 .route(
                     "/v1/chats/{chat_id}/messages",
                     post(unconfigured_handler).get(unconfigured_handler),
                 )
-                // Plan 0057 (GAR-509) — threads slice 3, fail-soft 503.
+                // Plan 0057 (GAR-509) — threads slice 3, no-auth stub.
                 .route(
                     "/v1/messages/{message_id}/threads",
                     post(unconfigured_handler),

--- a/crates/garraia-gateway/tests/rest_v1_chat_mgmt.rs
+++ b/crates/garraia-gateway/tests/rest_v1_chat_mgmt.rs
@@ -1,0 +1,405 @@
+//! Integration tests for individual chat ops + member CRUD (plan 0076, GAR-530).
+//!
+//! All scenarios bundled into ONE `#[tokio::test]` function to avoid the
+//! sqlx runtime-teardown race documented in plan 0016 M3 commit `4f8be37`.
+//!
+//! Scenarios (M1–M12):
+//!   GET /v1/chats/{chat_id}:
+//!     M1. 200 — owner fetches a chat they created.
+//!     M2. 404 — archived chat returns 404.
+//!     M3. 404 — chat from a different group returns 404 (not 403).
+//!     M4. 401 — missing bearer.
+//!
+//!   PATCH /v1/chats/{chat_id}:
+//!     M5. 200 — owner renames a chat; `updated_at` advances.
+//!     M6. 400 — empty body (no name or topic).
+//!
+//!   DELETE /v1/chats/{chat_id}:
+//!     M7. 204 — owner archives a chat; subsequent GET returns 404.
+//!
+//!   GET /v1/chats/{chat_id}/members:
+//!     M8. 200 — list includes creator as owner.
+//!
+//!   POST /v1/chats/{chat_id}/members:
+//!     M9.  201 — add a second group member to chat.
+//!     M10. 409 — adding same user twice returns 409.
+//!
+//!   DELETE /v1/chats/{chat_id}/members/{user_id}:
+//!     M11. 204 — remove the added member.
+//!     M12. 409 — cannot remove last owner.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use common::Harness;
+use common::fixtures::{fetch_audit_events_for_group, seed_member_via_admin, seed_user_with_group};
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("failed to collect response body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("response body is not JSON")
+}
+
+fn connect_info() -> axum::extract::ConnectInfo<std::net::SocketAddr> {
+    axum::extract::ConnectInfo("127.0.0.1:1".parse().unwrap())
+}
+
+fn authed_request(method: &str, uri: &str, token: Option<&str>, body: Body) -> Request<Body> {
+    let mut req = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(body)
+        .expect("request builder");
+    req.extensions_mut().insert(connect_info());
+    if let Some(t) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {t}")).unwrap(),
+        );
+    }
+    req
+}
+
+/// Seed a chat via admin pool (bypasses RLS for fixture setup).
+/// Inserts into `chats` + one `chat_members` owner row.
+/// Returns the `chat_id`.
+async fn seed_chat(h: &Harness, group_id: Uuid, creator_id: Uuid, name: &str) -> Uuid {
+    let chat_id = Uuid::new_v4();
+    let mut tx = h.admin_pool.begin().await.expect("seed_chat tx begin");
+
+    sqlx::query(
+        "INSERT INTO chats (id, group_id, type, name, created_by) \
+         VALUES ($1, $2, 'channel', $3, $4)",
+    )
+    .bind(chat_id)
+    .bind(group_id)
+    .bind(name)
+    .bind(creator_id)
+    .execute(&mut *tx)
+    .await
+    .expect("seed_chat: insert chats");
+
+    sqlx::query(
+        "INSERT INTO chat_members (chat_id, user_id, role) \
+         VALUES ($1, $2, 'owner')",
+    )
+    .bind(chat_id)
+    .bind(creator_id)
+    .execute(&mut *tx)
+    .await
+    .expect("seed_chat: insert chat_members");
+
+    tx.commit().await.expect("seed_chat tx commit");
+    chat_id
+}
+
+#[tokio::test]
+async fn v1_chat_mgmt_scenarios() {
+    let h = Harness::get().await;
+
+    // Group A — main actor (owner_a).
+    let (owner_a_id, group_a_id, owner_a_token) =
+        seed_user_with_group(&h, "owner@chat-mgmt-m1.test")
+            .await
+            .expect("seed group A owner");
+
+    // Group B — used for cross-group 404 (M3).
+    let (_owner_b_id, group_b_id, _owner_b_token) =
+        seed_user_with_group(&h, "owner@chat-mgmt-m3.test")
+            .await
+            .expect("seed group B owner");
+
+    // Seed a chat in group A for M1/M2/M5/M7/M8.
+    let chat_a_id = seed_chat(&h, group_a_id, owner_a_id, "main-channel").await;
+
+    // Seed a chat in group B for M3 cross-group probe.
+    let chat_b_id = seed_chat(&h, group_b_id, _owner_b_id, "other-group-chat").await;
+
+    // ── M1. GET 200 — owner can fetch a chat they created ───────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(authed_request(
+            "GET",
+            &format!("/v1/chats/{chat_a_id}"),
+            Some(&owner_a_token),
+            Body::empty(),
+        ))
+        .await
+        .expect("M1 oneshot");
+    assert_eq!(resp.status(), StatusCode::OK, "M1 status");
+    let v = body_json(resp).await;
+    assert_eq!(v["id"], chat_a_id.to_string(), "M1 id");
+    assert_eq!(v["name"], "main-channel", "M1 name");
+    assert_eq!(v["group_id"], group_a_id.to_string(), "M1 group_id");
+    assert_eq!(v["created_by"], owner_a_id.to_string(), "M1 created_by");
+    assert!(v.get("updated_at").is_some(), "M1 updated_at present");
+
+    // ── M2. GET 404 — archived chat returns 404 ─────────────────────
+    let archived_chat_id = seed_chat(&h, group_a_id, owner_a_id, "to-archive-m2").await;
+    sqlx::query("UPDATE chats SET archived_at = now() WHERE id = $1")
+        .bind(archived_chat_id)
+        .execute(&h.admin_pool)
+        .await
+        .expect("M2 archive chat");
+    let resp = h
+        .router
+        .clone()
+        .oneshot(authed_request(
+            "GET",
+            &format!("/v1/chats/{archived_chat_id}"),
+            Some(&owner_a_token),
+            Body::empty(),
+        ))
+        .await
+        .expect("M2 oneshot");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND, "M2 status");
+
+    // ── M3. GET 404 — chat from different group returns 404, not 403 ─
+    // owner_a tries to access a chat in group_b.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(authed_request(
+            "GET",
+            &format!("/v1/chats/{chat_b_id}"),
+            Some(&owner_a_token),
+            Body::empty(),
+        ))
+        .await
+        .expect("M3 oneshot");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND, "M3 status (not 403)");
+
+    // ── M4. GET 401 — missing bearer ────────────────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(authed_request(
+            "GET",
+            &format!("/v1/chats/{chat_a_id}"),
+            None,
+            Body::empty(),
+        ))
+        .await
+        .expect("M4 oneshot");
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED, "M4 status");
+
+    // ── M5. PATCH 200 — owner renames a chat; updated_at advances ───
+    // Capture current updated_at before patch.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(authed_request(
+            "GET",
+            &format!("/v1/chats/{chat_a_id}"),
+            Some(&owner_a_token),
+            Body::empty(),
+        ))
+        .await
+        .expect("M5 pre-patch GET");
+    let before = body_json(resp).await;
+    let before_updated_at = before["updated_at"].as_str().unwrap_or("").to_string();
+
+    // Small delay so updated_at actually changes.
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(authed_request(
+            "PATCH",
+            &format!("/v1/chats/{chat_a_id}"),
+            Some(&owner_a_token),
+            Body::from(json!({"name": "renamed-channel"}).to_string()),
+        ))
+        .await
+        .expect("M5 oneshot");
+    assert_eq!(resp.status(), StatusCode::OK, "M5 status");
+    let v = body_json(resp).await;
+    assert_eq!(v["name"], "renamed-channel", "M5 new name");
+    assert_eq!(v["id"], chat_a_id.to_string(), "M5 id unchanged");
+    let after_updated_at = v["updated_at"].as_str().unwrap_or("").to_string();
+    assert!(
+        after_updated_at >= before_updated_at,
+        "M5 updated_at advanced or same: before={before_updated_at} after={after_updated_at}"
+    );
+
+    // Verify ChatUpdated audit event emitted.
+    let events = fetch_audit_events_for_group(&h, group_a_id)
+        .await
+        .expect("M5 fetch audit");
+    let upd_event = events
+        .iter()
+        .find(|(action, _, _, rid, _)| action == "chat.updated" && rid == &chat_a_id.to_string());
+    assert!(upd_event.is_some(), "M5 chat.updated audit event present");
+
+    // ── M6. PATCH 400 — empty body (no name or topic) ───────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(authed_request(
+            "PATCH",
+            &format!("/v1/chats/{chat_a_id}"),
+            Some(&owner_a_token),
+            Body::from(json!({}).to_string()),
+        ))
+        .await
+        .expect("M6 oneshot");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "M6 status");
+
+    // ── M7. DELETE 204 — owner archives a chat; GET → 404 ───────────
+    let delete_chat_id = seed_chat(&h, group_a_id, owner_a_id, "to-delete-m7").await;
+    let resp = h
+        .router
+        .clone()
+        .oneshot(authed_request(
+            "DELETE",
+            &format!("/v1/chats/{delete_chat_id}"),
+            Some(&owner_a_token),
+            Body::empty(),
+        ))
+        .await
+        .expect("M7 DELETE oneshot");
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT, "M7 DELETE status");
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(authed_request(
+            "GET",
+            &format!("/v1/chats/{delete_chat_id}"),
+            Some(&owner_a_token),
+            Body::empty(),
+        ))
+        .await
+        .expect("M7 GET after archive oneshot");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND, "M7 GET after archive");
+
+    // Verify ChatArchived audit event.
+    let events = fetch_audit_events_for_group(&h, group_a_id)
+        .await
+        .expect("M7 fetch audit");
+    let arch_event = events.iter().find(|(action, _, _, rid, _)| {
+        action == "chat.archived" && rid == &delete_chat_id.to_string()
+    });
+    assert!(arch_event.is_some(), "M7 chat.archived audit event present");
+
+    // ── M8. GET /members 200 — list includes creator as owner ────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(authed_request(
+            "GET",
+            &format!("/v1/chats/{chat_a_id}/members"),
+            Some(&owner_a_token),
+            Body::empty(),
+        ))
+        .await
+        .expect("M8 oneshot");
+    assert_eq!(resp.status(), StatusCode::OK, "M8 status");
+    let v = body_json(resp).await;
+    let items = v["items"].as_array().expect("M8 items array");
+    assert!(!items.is_empty(), "M8 members not empty");
+    let owner_member = items
+        .iter()
+        .find(|m| m["user_id"] == owner_a_id.to_string());
+    assert!(owner_member.is_some(), "M8 owner present in members");
+    assert_eq!(
+        owner_member.unwrap()["role"],
+        "owner",
+        "M8 creator role = owner"
+    );
+
+    // ── M9. POST /members 201 — add a second group member ────────────
+    let (second_user_id, _second_token) =
+        seed_member_via_admin(&h, group_a_id, "member", "second@chat-mgmt-m9.test")
+            .await
+            .expect("M9 seed second member");
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(authed_request(
+            "POST",
+            &format!("/v1/chats/{chat_a_id}/members"),
+            Some(&owner_a_token),
+            Body::from(json!({"user_id": second_user_id, "role": "member"}).to_string()),
+        ))
+        .await
+        .expect("M9 oneshot");
+    assert_eq!(resp.status(), StatusCode::CREATED, "M9 status");
+    let v = body_json(resp).await;
+    assert_eq!(v["user_id"], second_user_id.to_string(), "M9 user_id");
+    assert_eq!(v["role"], "member", "M9 role");
+
+    // Verify ChatMemberAdded audit.
+    let events = fetch_audit_events_for_group(&h, group_a_id)
+        .await
+        .expect("M9 fetch audit");
+    let add_event = events.iter().find(|(action, _, _, rid, _)| {
+        action == "chat.member.added" && rid == &chat_a_id.to_string()
+    });
+    assert!(add_event.is_some(), "M9 chat.member.added audit present");
+
+    // ── M10. POST /members 409 — adding same user twice ──────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(authed_request(
+            "POST",
+            &format!("/v1/chats/{chat_a_id}/members"),
+            Some(&owner_a_token),
+            Body::from(json!({"user_id": second_user_id, "role": "member"}).to_string()),
+        ))
+        .await
+        .expect("M10 oneshot");
+    assert_eq!(resp.status(), StatusCode::CONFLICT, "M10 status");
+
+    // ── M11. DELETE /members/{user_id} 204 — remove the added member ─
+    let resp = h
+        .router
+        .clone()
+        .oneshot(authed_request(
+            "DELETE",
+            &format!("/v1/chats/{chat_a_id}/members/{second_user_id}"),
+            Some(&owner_a_token),
+            Body::empty(),
+        ))
+        .await
+        .expect("M11 oneshot");
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT, "M11 status");
+
+    // Verify ChatMemberRemoved audit.
+    let events = fetch_audit_events_for_group(&h, group_a_id)
+        .await
+        .expect("M11 fetch audit");
+    let rem_event = events.iter().find(|(action, _, _, rid, _)| {
+        action == "chat.member.removed" && rid == &chat_a_id.to_string()
+    });
+    assert!(rem_event.is_some(), "M11 chat.member.removed audit present");
+
+    // ── M12. DELETE /members/{owner_id} 409 — cannot remove last owner
+    let resp = h
+        .router
+        .clone()
+        .oneshot(authed_request(
+            "DELETE",
+            &format!("/v1/chats/{chat_a_id}/members/{owner_a_id}"),
+            Some(&owner_a_token),
+            Body::empty(),
+        ))
+        .await
+        .expect("M12 oneshot");
+    assert_eq!(resp.status(), StatusCode::CONFLICT, "M12 status");
+}

--- a/plans/0076-gar-530-chat-mgmt-slice4.md
+++ b/plans/0076-gar-530-chat-mgmt-slice4.md
@@ -1,0 +1,196 @@
+# Plan 0076 — GAR-530: Chat Management Slice 4
+
+> **Status:** ⏳ In Progress
+> **Linear:** [GAR-530](https://linear.app/chatgpt25/issue/GAR-530)
+> **Branch:** `routine/202505070024-chat-mgmt-slice4`
+> **Epic:** GAR-WS-CHAT / Fase 3.4
+
+---
+
+## 1. Goal
+
+Complete individual chat management and chat member CRUD on the
+`garraia_app` RLS-enforced pool. Slice 1 (plan 0054) landed
+`POST/GET /v1/groups/{group_id}/chats`. This slice adds the
+single-resource operations and member management needed for real clients.
+
+---
+
+## 2. Architecture
+
+Extends `crates/garraia-gateway/src/rest_v1/chats.rs` with six handlers
+following the established plan 0054/0056 pattern:
+- Tenant context via `set_config()` (parameterized, tx-scoped)
+- Cross-group 404 guard (not 403) on individual ops
+- Audit metadata STRUCTURAL only (no name/topic/content PII)
+- `garraia_auth::WorkspaceAuditAction` extended with 4 new variants
+
+---
+
+## 3. Tech Stack
+
+- Rust + Axum 0.8 + sqlx + garraia_auth + utoipa
+- Postgres 16 + pgvector, migrations 004 + 007
+- Integration tests: tokio-test + testcontainers
+
+---
+
+## 4. Design Invariants
+
+1. Both `app.current_user_id` AND `app.current_group_id` set before any
+   RLS table access.
+2. Individual chat ops: look up `group_id` from `chats` and verify it
+   matches `principal.group_id` — 404 on mismatch (never 403).
+3. Archived (`archived_at IS NOT NULL`) chats return 404 to all ops.
+4. Cannot remove last owner from a chat — 409 guard.
+5. `add_chat_member` verifies the target user is a group member before
+   adding to chat (prevents silent cross-group member addition).
+6. Audit metadata carries only structural data (counts, role, boolean
+   flags) — never name/body/topic content.
+
+---
+
+## 5. Validações pré-plano
+
+- [x] Schema `chats` + `chat_members` confirmed in migration 004
+- [x] RLS policy `chats_group_isolation` confirmed in migration 007:89-94
+- [x] RLS policy `chat_members_through_chats` (JOIN) confirmed in 007:99-112
+- [x] `Action::ChatsRead`, `Action::ChatsWrite`, `Action::MembersManage`
+      all exist in `garraia-auth`
+- [x] Plan 0054 handlers established set_config pattern
+
+---
+
+## 6. Out of Scope
+
+- DM chat creation (requires two-member UNIQUE constraint logic)
+- WebSocket real-time member events
+- `last_read_at` update (read receipts)
+- Cursor pagination on members list (bounded by group size)
+
+---
+
+## 7. Rollback
+
+Routes are additive; removing them from `mod.rs` is the rollback.
+Audit action variants are append-only in a non-exhaustive-match enum
+— adding them does not break existing match arms.
+
+---
+
+## 8. Open Questions
+
+None blocking implementation.
+
+---
+
+## 9. File Structure
+
+```
+crates/garraia-auth/src/audit_workspace.rs   — +4 variants + as_str + tests
+crates/garraia-gateway/src/rest_v1/chats.rs  — +6 handlers, +5 types
+crates/garraia-gateway/src/rest_v1/mod.rs    — +6 routes (all 3 branches)
+crates/garraia-gateway/tests/rest_v1_chat_mgmt.rs  — new, ≥12 scenarios
+plans/0076-gar-530-chat-mgmt-slice4.md       — this file
+plans/README.md                              — row added
+```
+
+---
+
+## 10. Tasks
+
+### T1 — Plan file
+- [x] Write `plans/0076-gar-530-chat-mgmt-slice4.md`
+- [x] Create Linear issue GAR-530
+
+### T2 — Audit action variants
+- [ ] Add `ChatUpdated`, `ChatArchived`, `ChatMemberAdded`, `ChatMemberRemoved`
+      to `WorkspaceAuditAction` enum
+- [ ] Add 4 `as_str` entries
+- [ ] Add 4 assertions in the existing audit_workspace tests
+
+### T3 — Types
+- [ ] `ChatDetailResponse` (with `updated_at`)
+- [ ] `PatchChatRequest` (name?, topic?)
+- [ ] `ChatMemberResponse` (user_id, role, joined_at)
+- [ ] `ChatMemberListResponse` ({ items })
+- [ ] `AddChatMemberRequest` (user_id, role default='member')
+
+### T4 — Handlers
+- [ ] `get_chat` — GET /v1/chats/{chat_id}
+- [ ] `patch_chat` — PATCH /v1/chats/{chat_id}
+- [ ] `delete_chat` — DELETE /v1/chats/{chat_id} (archive, 204)
+- [ ] `list_chat_members` — GET /v1/chats/{chat_id}/members
+- [ ] `add_chat_member` — POST /v1/chats/{chat_id}/members
+- [ ] `remove_chat_member` — DELETE /v1/chats/{chat_id}/members/{user_id}
+
+### T5 — Route registration
+- [ ] 6 routes in `RestV1FullState` branch
+- [ ] 6 `unconfigured_handler` routes in auth-only branch
+- [ ] 6 `unconfigured_handler` routes in no-auth branch
+
+### T6 — Tests
+- [ ] `tests/rest_v1_chat_mgmt.rs` with ≥12 scenarios (see §11)
+
+### T7 — Lint + cargo check
+- [ ] `cargo check -p garraia-auth -p garraia-gateway` green
+- [ ] `cargo clippy --workspace --tests --exclude garraia-desktop \
+      --features garraia-gateway/test-helpers --no-deps -- -D warnings` green
+
+### T8 — Bookkeeping
+- [ ] PR merged, commit sha captured in this file
+- [ ] `plans/README.md` row updated
+
+---
+
+## 11. Acceptance Criteria / Test Scenarios
+
+**GET /v1/chats/{chat_id}:**
+- M1: 200 — owner can fetch a chat they created
+- M2: 404 — archived chat returns 404
+- M3: 404 — chat from a different group returns 404 (not 403)
+- M4: 401 — missing bearer
+
+**PATCH /v1/chats/{chat_id}:**
+- M5: 200 — owner renames a chat; `updated_at` advances
+- M6: 400 — empty body (no name or topic)
+
+**DELETE /v1/chats/{chat_id}:**
+- M7: 204 — owner archives a chat; subsequent GET returns 404
+
+**GET /v1/chats/{chat_id}/members:**
+- M8: 200 — list includes creator as owner
+
+**POST /v1/chats/{chat_id}/members:**
+- M9: 201 — add a second group member to chat
+- M10: 409 — adding same user twice returns 409
+
+**DELETE /v1/chats/{chat_id}/members/{user_id}:**
+- M11: 204 — remove the added member
+- M12: 409 — cannot remove last owner
+
+---
+
+## 12. Risk Register
+
+| Risk | Mitigation |
+|------|------------|
+| RLS blocks INSERT into `chat_members` | JOIN policy via `chats` resolves correctly |
+| Last-owner guard missed | Explicit COUNT check before DELETE |
+| Cross-group member add | Verify target user is in `group_members` |
+
+---
+
+## 13. Cross-references
+
+- Plan 0054 (GAR-506) — chats slice 1 (create + list)
+- Plan 0055 (GAR-507) — messages slice 2 (send + list)
+- Plan 0056 (GAR-508) — SET LOCAL SQL injection posture (set_config pattern)
+- Migration 004 — `chats`, `chat_members` schema
+- Migration 007 — RLS policies
+
+---
+
+## 14. Estimativa
+
+≤ 400 LOC net (handlers + tests). 1 / 2 / 3 hours.

--- a/plans/README.md
+++ b/plans/README.md
@@ -98,7 +98,8 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0072 | [GAR-526 — REST /v1 memory slice 2: POST /v1/memory/{id}:pin + :unpin](0072-gar-526-memory-pin-slice2.md) | [GAR-526](https://linear.app/chatgpt25/issue/GAR-526) | ✅ Merged 2026-05-06 via PR #167 (`0558abb`) |
 | 0073 | [GAR-527 — openssl 0.10.78→0.10.79 + openssl-sys 0.9.114→0.9.115 security patch](0073-gar-527-openssl-0.10.79.md) | [GAR-527](https://linear.app/chatgpt25/issue/GAR-527) | ✅ Merged 2026-05-06 via PR #168 (`8e41201`) |
 | 0074 | [GAR-528 — REST /v1 memory slice 3: GET + PATCH /v1/memory/{id}](0074-gar-528-memory-slice3-get-patch.md) | [GAR-528](https://linear.app/chatgpt25/issue/GAR-528) | ✅ Merged 2026-05-06 via PR #171 (`63cec45`) |
-| 0075 | [GAR-529 — tauri 2.10.3→2.11.1 security upgrade (ACL enforcement for remote origins)](0075-gar-529-tauri-2.11.1-acl-enforcement.md) | [GAR-529](https://linear.app/chatgpt25/issue/GAR-529) | 🟡 Em execução 2026-05-06 (health routine) |
+| 0075 | [GAR-529 — tauri 2.10.3→2.11.1 security upgrade (ACL enforcement for remote origins)](0075-gar-529-tauri-2.11.1-acl-enforcement.md) | [GAR-529](https://linear.app/chatgpt25/issue/GAR-529) | ✅ Merged 2026-05-07 via PR #177 (`ba76287`) |
+| 0076 | [GAR-530 — Chat management slice 4: individual chat ops + member CRUD](0076-gar-530-chat-mgmt-slice4.md) | [GAR-530](https://linear.app/chatgpt25/issue/GAR-530) | ⏳ In Progress |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

- **GET/PATCH/DELETE `/v1/chats/{chat_id}`** — fetch, rename/retopic, and archive individual chats with RLS tenant context and cross-group 404 guard (never 403).
- **GET/POST/DELETE `/v1/chats/{chat_id}/members`** — list, add, and remove chat members with last-owner 409 guard and cross-group member injection prevention.
- **`garraia-auth`** — +4 `WorkspaceAuditAction` variants (`ChatUpdated`, `ChatArchived`, `ChatMemberAdded`, `ChatMemberRemoved`) with `as_str()` entries and test assertions.
- **Integration tests** — 12 scenarios (M1–M12) in `tests/rest_v1_chat_mgmt.rs` covering all acceptance criteria from plan 0076 §11.

## Design invariants enforced

- Both `app.current_user_id` and `app.current_group_id` set before any RLS table access (plan 0056 `set_config` pattern).
- Individual chat ops: looks up `group_id` from `chats` and verifies it matches `principal.group_id` — 404 on mismatch.
- Archived (`archived_at IS NOT NULL`) chats return 404 to all ops.
- Cannot remove last owner from a chat — 409 guard.
- `add_chat_member` verifies the target user is a group member before adding to chat.
- Audit metadata carries only structural data (counts, role, boolean flags) — never name/body/topic content.

## Test plan

- [x] `cargo check -p garraia-auth -p garraia-gateway` green
- [x] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` green
- [x] 12 integration scenarios in `tests/rest_v1_chat_mgmt.rs` (M1–M12)
- [ ] CI green (all 18 checks)

## References

- Plan 0076 (`plans/0076-gar-530-chat-mgmt-slice4.md`)
- Linear: GAR-530
- Builds on plan 0054 (GAR-506, chats slice 1) and plan 0056 (GAR-508, set_config posture)

https://claude.ai/code/session_01VZesND9jq1ibr6T573Hy7J

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZesND9jq1ibr6T573Hy7J)_