### PR TITLE
feat(tasks): GAR-533 — task assignees API (plan 0077, slice 4)

### DIFF
--- a/crates/garraia-auth/src/audit_workspace.rs
+++ b/crates/garraia-auth/src/audit_workspace.rs
@@ -282,6 +282,23 @@ pub enum WorkspaceAuditAction {
     /// `resource_type = "chat_members"`, `resource_id = "{user_id}"`.
     /// Metadata: `{ role }`.
     ChatMemberRemoved,
+
+    /// A user was assigned to a task via
+    /// `POST /v1/groups/{group_id}/tasks/{task_id}/assignees`
+    /// (plan 0077 / GAR-533, epic GAR-WS-TASKS slice 4).
+    ///
+    /// `resource_type = "task_assignees"`, `resource_id = "{task_id}"`.
+    /// Metadata: `{ assignee_user_id_len: 36 }`. User IDs are UUIDs — length
+    /// is structural, not PII.
+    TaskAssigneeAdded,
+
+    /// A user was removed from task assignees via
+    /// `DELETE /v1/groups/{group_id}/tasks/{task_id}/assignees/{user_id}`
+    /// (plan 0077 / GAR-533, epic GAR-WS-TASKS slice 4).
+    ///
+    /// `resource_type = "task_assignees"`, `resource_id = "{task_id}"`.
+    /// Metadata: `{ assignee_user_id_len: 36 }`.
+    TaskAssigneeRemoved,
 }
 
 impl WorkspaceAuditAction {
@@ -313,6 +330,8 @@ impl WorkspaceAuditAction {
             WorkspaceAuditAction::ChatArchived => "chat.archived",
             WorkspaceAuditAction::ChatMemberAdded => "chat.member.added",
             WorkspaceAuditAction::ChatMemberRemoved => "chat.member.removed",
+            WorkspaceAuditAction::TaskAssigneeAdded => "task.assignee.added",
+            WorkspaceAuditAction::TaskAssigneeRemoved => "task.assignee.removed",
         }
     }
 }
@@ -454,6 +473,14 @@ mod tests {
             WorkspaceAuditAction::ChatMemberRemoved.as_str(),
             "chat.member.removed"
         );
+        assert_eq!(
+            WorkspaceAuditAction::TaskAssigneeAdded.as_str(),
+            "task.assignee.added"
+        );
+        assert_eq!(
+            WorkspaceAuditAction::TaskAssigneeRemoved.as_str(),
+            "task.assignee.removed"
+        );
     }
 
     #[test]
@@ -484,6 +511,8 @@ mod tests {
             WorkspaceAuditAction::ChatArchived.as_str(),
             WorkspaceAuditAction::ChatMemberAdded.as_str(),
             WorkspaceAuditAction::ChatMemberRemoved.as_str(),
+            WorkspaceAuditAction::TaskAssigneeAdded.as_str(),
+            WorkspaceAuditAction::TaskAssigneeRemoved.as_str(),
         ];
         let unique: std::collections::HashSet<_> = strings.iter().collect();
         assert_eq!(unique.len(), strings.len(), "duplicate action strings");

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -264,6 +264,17 @@ name = "rest_v1_chat_mgmt"
 path = "tests/rest_v1_chat_mgmt.rs"
 required-features = ["test-helpers"]
 
+# Plan 0077 (GAR-533) — tasks slice 4: task assignees API
+# (POST/GET /v1/groups/{gid}/tasks/{tid}/assignees, DELETE .../assignees/{uid}).
+# 9 bundled scenarios covering happy paths, 409 duplicate, 404 cross-group
+# injection guard, and idempotent DELETE. Feature-gated so plain
+# `cargo test -p garraia-gateway` (without --features test-helpers) skips
+# compilation cleanly.
+[[test]]
+name = "rest_v1_task_assignees"
+path = "tests/rest_v1_task_assignees.rs"
+required-features = ["test-helpers"]
+
 [dev-dependencies]
 # Plan 0024 T4 (GAR-412): metrics_exporter tests and the
 # metrics_auth_integration binary build a `PrometheusRecorder` directly

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -339,6 +339,15 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     "/v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}",
                     delete(tasks::delete_task_comment),
                 )
+                // Plan 0077 (GAR-533) — task assignees API slice 4.
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/assignees",
+                    post(tasks::add_task_assignee).get(tasks::list_task_assignees),
+                )
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/assignees/{user_id}",
+                    delete(tasks::remove_task_assignee),
+                )
                 // Plan 0070 (GAR-522) — audit API slice 1.
                 .route("/v1/groups/{group_id}/audit", get(audit::list_audit))
                 .merge(rate_limited_routes)
@@ -413,7 +422,7 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 // Plan 0072 (GAR-526) — memory API slice 2: pin/unpin, fail-soft 503.
                 .route("/v1/memory/{id}/pin", post(unconfigured_handler))
                 .route("/v1/memory/{id}/unpin", post(unconfigured_handler))
-                // Plan 0066/0067/0069 (GAR-516/GAR-518/GAR-520) — tasks API slices 1+2+3, fail-soft 503.
+                // Plan 0066/0067/0069/0077 (GAR-516/GAR-518/GAR-520/GAR-533) — tasks API slices 1+2+3+4, fail-soft 503.
                 .route(
                     "/v1/groups/{group_id}/task-lists",
                     post(unconfigured_handler).get(unconfigured_handler),
@@ -440,6 +449,14 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 )
                 .route(
                     "/v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}",
+                    delete(unconfigured_handler),
+                )
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/assignees",
+                    post(unconfigured_handler).get(unconfigured_handler),
+                )
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/assignees/{user_id}",
                     delete(unconfigured_handler),
                 )
                 .route(
@@ -520,7 +537,7 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 // Plan 0072 (GAR-526) — memory API slice 2: pin/unpin, no-auth stub.
                 .route("/v1/memory/{id}/pin", post(unconfigured_handler))
                 .route("/v1/memory/{id}/unpin", post(unconfigured_handler))
-                // Plan 0066/0067/0069 (GAR-516/GAR-518/GAR-520) — tasks API slices 1+2+3, no-auth stub.
+                // Plan 0066/0067/0069/0077 (GAR-516/GAR-518/GAR-520/GAR-533) — tasks API slices 1+2+3+4, no-auth stub.
                 .route(
                     "/v1/groups/{group_id}/task-lists",
                     post(unconfigured_handler).get(unconfigured_handler),
@@ -547,6 +564,14 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 )
                 .route(
                     "/v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}",
+                    delete(unconfigured_handler),
+                )
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/assignees",
+                    post(unconfigured_handler).get(unconfigured_handler),
+                )
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/assignees/{user_id}",
                     delete(unconfigured_handler),
                 )
                 .route(

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -30,9 +30,10 @@ use super::messages::{
 };
 use super::problem::ProblemDetails;
 use super::tasks::{
-    CommentResponse, CreateCommentRequest, CreateTaskListRequest, CreateTaskRequest,
-    ListCommentsResponse, ListTaskListsResponse, ListTasksResponse, PatchTaskListRequest,
-    PatchTaskRequest, TaskListResponse, TaskListSummary, TaskResponse, TaskSummary,
+    AddAssigneeRequest, AssigneeResponse, CommentResponse, CreateCommentRequest,
+    CreateTaskListRequest, CreateTaskRequest, ListCommentsResponse, ListTaskListsResponse,
+    ListTasksResponse, PatchTaskListRequest, PatchTaskRequest, TaskListResponse, TaskListSummary,
+    TaskResponse, TaskSummary,
 };
 use super::uploads::{CreateUploadRequest, CreateUploadResponse};
 
@@ -113,6 +114,9 @@ impl Modify for SecurityAddon {
         super::tasks::create_task_comment,
         super::tasks::list_task_comments,
         super::tasks::delete_task_comment,
+        super::tasks::add_task_assignee,
+        super::tasks::list_task_assignees,
+        super::tasks::remove_task_assignee,
         super::audit::list_audit,
     ),
     components(schemas(
@@ -158,6 +162,8 @@ impl Modify for SecurityAddon {
         CreateCommentRequest,
         CommentResponse,
         ListCommentsResponse,
+        AddAssigneeRequest,
+        AssigneeResponse,
         AuditEventSummary,
         ListAuditResponse,
     )),

--- a/crates/garraia-gateway/src/rest_v1/tasks.rs
+++ b/crates/garraia-gateway/src/rest_v1/tasks.rs
@@ -1,6 +1,7 @@
-//! `/v1/groups/{group_id}/task-lists` and task/comment handlers (plan 0066/0067/0069, GAR-516/GAR-518/GAR-520).
+//! `/v1/groups/{group_id}/task-lists` and task/comment/assignee handlers
+//! (plan 0066/0067/0069/0077, GAR-516/GAR-518/GAR-520/GAR-533).
 //!
-//! Twelve endpoints on the `garraia_app` RLS-enforced pool:
+//! Fifteen endpoints on the `garraia_app` RLS-enforced pool:
 //!
 //! **Slice 1 (plan 0066 / GAR-516):**
 //! - `POST /v1/groups/{group_id}/task-lists` — create task list
@@ -19,6 +20,11 @@
 //! - `POST /v1/groups/{group_id}/tasks/{task_id}/comments` — create comment
 //! - `GET /v1/groups/{group_id}/tasks/{task_id}/comments` — cursor-paginated comment list
 //! - `DELETE /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}` — soft-delete comment
+//!
+//! **Slice 4 (plan 0077 / GAR-533):**
+//! - `POST /v1/groups/{group_id}/tasks/{task_id}/assignees` — assign group member
+//! - `GET /v1/groups/{group_id}/tasks/{task_id}/assignees` — list assignees
+//! - `DELETE /v1/groups/{group_id}/tasks/{task_id}/assignees/{user_id}` — remove assignee (idempotent)
 //!
 //! ## Tenant-context protocol
 //!
@@ -1823,6 +1829,306 @@ pub async fn delete_task_comment(
         "task_comments",
         comment_id.to_string(),
         json!({ "body_len": body_len }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ─── Slice 4 (plan 0077 / GAR-533): Task Assignees ───────────────────────────
+
+/// DB row returned from `task_assignees`.
+#[derive(sqlx::FromRow)]
+struct AssigneeRow {
+    user_id: Uuid,
+    assigned_at: DateTime<Utc>,
+    assigned_by: Option<Uuid>,
+}
+
+/// Public response shape for a single assignee record.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct AssigneeResponse {
+    pub task_id: Uuid,
+    pub user_id: Uuid,
+    pub assigned_at: DateTime<Utc>,
+    pub assigned_by: Option<Uuid>,
+}
+
+/// Request body for `POST /v1/groups/{group_id}/tasks/{task_id}/assignees`.
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct AddAssigneeRequest {
+    pub user_id: Uuid,
+}
+
+/// `POST /v1/groups/{group_id}/tasks/{task_id}/assignees` — assign a group member to a task.
+///
+/// Returns 201 on success, 409 if already assigned, 404 if task or target user
+/// not found in the group. Both `app.current_user_id` and `app.current_group_id`
+/// are set before accessing any FORCE-RLS table. Authz: `Action::TasksWrite`.
+#[utoipa::path(
+    post,
+    path = "/v1/groups/{group_id}/tasks/{task_id}/assignees",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("task_id" = Uuid, Path, description = "Task UUID."),
+    ),
+    request_body = AddAssigneeRequest,
+    responses(
+        (status = 201, description = "Assignee added.", body = AssigneeResponse),
+        (status = 400, description = "Validation error.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Task or target user not found in this group.", body = super::problem::ProblemDetails),
+        (status = 409, description = "User already assigned to this task.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn add_task_assignee(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, task_id)): Path<(Uuid, Uuid)>,
+    Json(body): Json<AddAssigneeRequest>,
+) -> Result<(StatusCode, Json<AssigneeResponse>), RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksWrite) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Verify task exists in this group and is not soft-deleted.
+    let task_exists: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM tasks WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+    )
+    .bind(task_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if task_exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    // Verify target user is an active member of this group.
+    // Cross-group injection: a user_id from another group returns 404 (never 403).
+    let member_exists: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT user_id FROM group_members \
+         WHERE group_id = $1 AND user_id = $2 AND status = 'active'",
+    )
+    .bind(group_id)
+    .bind(body.user_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if member_exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    let row: AssigneeRow = sqlx::query_as(
+        "INSERT INTO task_assignees (task_id, user_id, assigned_by) \
+         VALUES ($1, $2, $3) \
+         RETURNING user_id, assigned_at, assigned_by",
+    )
+    .bind(task_id)
+    .bind(body.user_id)
+    .bind(principal.user_id)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| {
+        if let sqlx::Error::Database(ref db_err) = e
+            && db_err.code().as_deref() == Some("23505")
+        {
+            return RestError::Conflict("user already assigned to this task".into());
+        }
+        RestError::Internal(e.into())
+    })?;
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::TaskAssigneeAdded,
+        principal.user_id,
+        group_id,
+        "task_assignees",
+        task_id.to_string(),
+        json!({ "assignee_user_id_len": 36 }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(AssigneeResponse {
+            task_id,
+            user_id: row.user_id,
+            assigned_at: row.assigned_at,
+            assigned_by: row.assigned_by,
+        }),
+    ))
+}
+
+/// `GET /v1/groups/{group_id}/tasks/{task_id}/assignees` — list assignees for a task.
+///
+/// Returns all current assignees ordered by `assigned_at ASC`.
+/// Authz: `Action::TasksRead`.
+#[utoipa::path(
+    get,
+    path = "/v1/groups/{group_id}/tasks/{task_id}/assignees",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("task_id" = Uuid, Path, description = "Task UUID."),
+    ),
+    responses(
+        (status = 200, description = "List of assignees.", body = Vec<AssigneeResponse>),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Task not found in this group.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn list_task_assignees(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, task_id)): Path<(Uuid, Uuid)>,
+) -> Result<Json<Vec<AssigneeResponse>>, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksRead) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Explicit 404 if task not found (RLS also filters, but clearer UX).
+    let task_exists: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM tasks WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+    )
+    .bind(task_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if task_exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    let rows: Vec<AssigneeRow> = sqlx::query_as(
+        "SELECT user_id, assigned_at, assigned_by \
+         FROM task_assignees \
+         WHERE task_id = $1 \
+         ORDER BY assigned_at ASC",
+    )
+    .bind(task_id)
+    .fetch_all(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    let items = rows
+        .into_iter()
+        .map(|r| AssigneeResponse {
+            task_id,
+            user_id: r.user_id,
+            assigned_at: r.assigned_at,
+            assigned_by: r.assigned_by,
+        })
+        .collect();
+
+    Ok(Json(items))
+}
+
+/// `DELETE /v1/groups/{group_id}/tasks/{task_id}/assignees/{user_id}` — remove an assignee.
+///
+/// Idempotent: returns 204 whether or not the row existed.
+/// Authz: `Action::TasksWrite`.
+#[utoipa::path(
+    delete,
+    path = "/v1/groups/{group_id}/tasks/{task_id}/assignees/{user_id}",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("task_id" = Uuid, Path, description = "Task UUID."),
+        ("user_id" = Uuid, Path, description = "User to unassign."),
+    ),
+    responses(
+        (status = 204, description = "Assignee removed (or was never assigned)."),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Task not found in this group.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn remove_task_assignee(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, task_id, assignee_user_id)): Path<(Uuid, Uuid, Uuid)>,
+) -> Result<StatusCode, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksWrite) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Verify task exists before emitting audit.
+    let task_exists: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM tasks WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+    )
+    .bind(task_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if task_exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    sqlx::query("DELETE FROM task_assignees WHERE task_id = $1 AND user_id = $2")
+        .bind(task_id)
+        .bind(assignee_user_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::TaskAssigneeRemoved,
+        principal.user_id,
+        group_id,
+        "task_assignees",
+        task_id.to_string(),
+        json!({ "assignee_user_id_len": 36 }),
     )
     .await
     .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;

--- a/crates/garraia-gateway/tests/rest_v1_task_assignees.rs
+++ b/crates/garraia-gateway/tests/rest_v1_task_assignees.rs
@@ -1,0 +1,401 @@
+//! Integration tests for task assignees REST API (plan 0077, GAR-533).
+//!
+//! All scenarios bundled into ONE `#[tokio::test]` — same pattern as
+//! `rest_v1_tasks.rs` / `rest_v1_memory.rs`. Splitting triggers the
+//! sqlx runtime-teardown race documented in plan 0016 M3.
+//!
+//! Scenarios (9 total):
+//!
+//!   A1.  POST 201 — assign group member; assert response shape + audit row.
+//!   A2.  POST 409 — duplicate assignee returns 409 Conflict.
+//!   A3.  POST 404 — target user not an active member of the group (cross-group injection guard).
+//!   A4.  POST 404 — task not in group (cross-group task isolation).
+//!   A5.  GET 200 — list assignees; returns A1 entry.
+//!   A6.  DELETE 204 — remove assignee; verify audit row emitted.
+//!   A7.  DELETE 204 — idempotent: user was just removed; returns 204 again.
+//!   A8.  GET 404 + DELETE 404 — unknown task_id returns 404 on both endpoints.
+//!   A9.  POST 403 — path group_id ≠ principal group_id returns 403.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+
+use common::Harness;
+use common::fixtures::{fetch_audit_events_for_group, seed_member_via_admin, seed_user_with_group};
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect response body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("response body is not JSON")
+}
+
+fn auth_req(
+    method: &str,
+    uri: &str,
+    token: Option<&str>,
+    x_group_id: Option<&str>,
+    body: Option<serde_json::Value>,
+) -> Request<Body> {
+    let body_bytes = match body {
+        Some(v) => Body::from(v.to_string()),
+        None => Body::empty(),
+    };
+    let mut req = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(body_bytes)
+        .expect("request builder");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    if let Some(t) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {t}")).unwrap(),
+        );
+    }
+    if let Some(g) = x_group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    req
+}
+
+// Create a task list, returns (task_list_id, task_id) for the created entries.
+async fn create_task_list_and_task(h: &Harness, token: &str, group_id: &str) -> (String, String) {
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{group_id}/task-lists"),
+            Some(token),
+            Some(group_id),
+            Some(json!({ "name": "Assignee Test List", "type": "list" })),
+        ))
+        .await
+        .expect("create task-list");
+    assert_eq!(resp.status(), StatusCode::CREATED, "setup: task-list 201");
+    let tl_body = body_json(resp).await;
+    let list_id = tl_body["id"].as_str().expect("list id").to_string();
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{group_id}/task-lists/{list_id}/tasks"),
+            Some(token),
+            Some(group_id),
+            Some(json!({ "title": "Task with assignees" })),
+        ))
+        .await
+        .expect("create task");
+    assert_eq!(resp.status(), StatusCode::CREATED, "setup: task 201");
+    let task_body = body_json(resp).await;
+    let task_id = task_body["id"].as_str().expect("task id").to_string();
+
+    (list_id, task_id)
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(feature = "test-helpers")]
+#[tokio::test]
+async fn rest_v1_task_assignees_scenarios() {
+    let h = Harness::get().await;
+
+    // Seed Alice as group owner, Charlie as a member of Alice's group.
+    // Bob owns a separate group for isolation tests.
+    let (_alice_id, group_id, alice_token) = seed_user_with_group(&h, "alice@assignees.test")
+        .await
+        .expect("seed alice+group");
+    let (charlie_id, _charlie_token) =
+        seed_member_via_admin(&h, group_id, "member", "charlie@assignees.test")
+            .await
+            .expect("seed charlie as member");
+    let (_, bob_group_id, bob_token) = seed_user_with_group(&h, "bob@assignees.test")
+        .await
+        .expect("seed bob+group2");
+
+    let gid = group_id.to_string();
+    let g2id = bob_group_id.to_string();
+    let charlie_str = charlie_id.to_string();
+
+    // Set up a task list + task under Alice's group.
+    let (_list_id, task_id) = create_task_list_and_task(&h, &alice_token, &gid).await;
+
+    // Set up a task under Bob's group (for cross-group isolation).
+    let (_bob_list_id, bob_task_id) = create_task_list_and_task(&h, &bob_token, &g2id).await;
+
+    // ── A1. POST 201 — assign group member; response shape + audit row ─────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/assignees"),
+            Some(&alice_token),
+            Some(&gid),
+            Some(json!({ "user_id": charlie_str })),
+        ))
+        .await
+        .expect("A1 oneshot");
+    assert_eq!(resp.status(), StatusCode::CREATED, "A1 status");
+    let a1_body = body_json(resp).await;
+    assert_eq!(a1_body["task_id"], task_id, "A1 task_id matches");
+    assert_eq!(a1_body["user_id"], charlie_str, "A1 user_id matches");
+    assert!(
+        a1_body.get("assigned_at").is_some(),
+        "A1 assigned_at present"
+    );
+    // assigned_by should be Alice's user_id (non-null since caller assigned).
+    assert!(
+        !a1_body["assigned_by"].is_null(),
+        "A1 assigned_by is non-null"
+    );
+
+    // Verify audit row: action = "task.assignee.added", resource = task_id.
+    let audit = fetch_audit_events_for_group(&h, group_id)
+        .await
+        .expect("A1 fetch audit");
+    let a1_audit = audit
+        .iter()
+        .find(|e| e.0 == "task.assignee.added")
+        .expect("A1 audit row task.assignee.added");
+    let (_, _, a1_res_type, a1_res_id, a1_meta) = a1_audit;
+    assert_eq!(a1_res_type, "task_assignees", "A1 audit resource_type");
+    assert_eq!(a1_res_id, &task_id, "A1 audit resource_id is task_id");
+    assert!(
+        a1_meta["assignee_user_id_len"].as_u64().is_some(),
+        "A1 audit metadata has assignee_user_id_len"
+    );
+    assert!(
+        a1_meta.get("user_id").is_none(),
+        "A1 audit must not contain user_id value (PII guard)"
+    );
+
+    // ── A2. POST 409 — duplicate assignee ─────────────────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/assignees"),
+            Some(&alice_token),
+            Some(&gid),
+            Some(json!({ "user_id": charlie_str })),
+        ))
+        .await
+        .expect("A2 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::CONFLICT,
+        "A2 duplicate assignee must be 409"
+    );
+
+    // ── A3. POST 404 — target user not a member of this group ─────────────
+    // Use a freshly generated UUID that is not in Alice's group_members.
+    let outsider_id = uuid::Uuid::new_v4().to_string();
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/assignees"),
+            Some(&alice_token),
+            Some(&gid),
+            Some(json!({ "user_id": outsider_id })),
+        ))
+        .await
+        .expect("A3 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "A3 non-member user must be 404 (never 403)"
+    );
+
+    // ── A4. POST 404 — task not in caller's group (cross-group task) ───────
+    // Alice uses her own group context but references Bob's task_id.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{gid}/tasks/{bob_task_id}/assignees"),
+            Some(&alice_token),
+            Some(&gid),
+            Some(json!({ "user_id": charlie_str })),
+        ))
+        .await
+        .expect("A4 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "A4 cross-group task must be 404"
+    );
+
+    // ── A5. GET 200 — list assignees; includes A1 entry ──────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "GET",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/assignees"),
+            Some(&alice_token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("A5 oneshot");
+    assert_eq!(resp.status(), StatusCode::OK, "A5 status");
+    let a5_body = body_json(resp).await;
+    let items = a5_body.as_array().expect("A5 response is array");
+    assert!(
+        items.iter().any(|it| it["user_id"] == charlie_str),
+        "A5 should contain charlie's assignee entry"
+    );
+    for item in items {
+        assert_eq!(
+            item["task_id"], task_id,
+            "A5 all items reference correct task_id"
+        );
+    }
+
+    // ── A6. DELETE 204 — remove assignee; verify audit row ────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "DELETE",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/assignees/{charlie_str}"),
+            Some(&alice_token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("A6 oneshot");
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT, "A6 status");
+
+    // Assignee must no longer appear in the list.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "GET",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/assignees"),
+            Some(&alice_token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("A6 list after remove");
+    let a6_list = body_json(resp).await;
+    let after_del = a6_list.as_array().expect("A6 items array");
+    assert!(
+        !after_del.iter().any(|it| it["user_id"] == charlie_str),
+        "A6 removed assignee must not appear in GET list"
+    );
+
+    // Verify audit row: action = "task.assignee.removed".
+    let audit2 = fetch_audit_events_for_group(&h, group_id)
+        .await
+        .expect("A6 fetch audit");
+    assert!(
+        audit2
+            .iter()
+            .any(|e| e.0 == "task.assignee.removed" && e.3 == task_id),
+        "A6 audit row task.assignee.removed must be present"
+    );
+
+    // ── A7. DELETE 204 — idempotent: charlie already removed → 204 again ──
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "DELETE",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/assignees/{charlie_str}"),
+            Some(&alice_token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("A7 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NO_CONTENT,
+        "A7 idempotent DELETE must return 204"
+    );
+
+    // ── A8. GET 404 + DELETE 404 — unknown task_id ────────────────────────
+    let unknown_task = uuid::Uuid::new_v4().to_string();
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "GET",
+            &format!("/v1/groups/{gid}/tasks/{unknown_task}/assignees"),
+            Some(&alice_token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("A8 GET oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "A8 GET unknown task must be 404"
+    );
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "DELETE",
+            &format!("/v1/groups/{gid}/tasks/{unknown_task}/assignees/{charlie_str}"),
+            Some(&alice_token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("A8 DELETE oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "A8 DELETE unknown task must be 404"
+    );
+
+    // ── A9. POST 403 — path group_id ≠ principal group_id ─────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{g2id}/tasks/{task_id}/assignees"),
+            Some(&alice_token),
+            Some(&gid), // X-Group-Id = alice's group
+            Some(json!({ "user_id": charlie_str })),
+        ))
+        .await
+        .expect("A9 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "A9 path group_id mismatch must return 403"
+    );
+}

--- a/plans/0077-gar-533-task-assignees-api.md
+++ b/plans/0077-gar-533-task-assignees-api.md
@@ -1,0 +1,162 @@
+# Plan 0077 — GAR-533: REST /v1 tasks slice 4 (task assignees API)
+
+**Status:** Em execução
+**Autor:** Claude Sonnet 4.6 (garra-routine 2026-05-07, America/New_York)
+**Data:** 2026-05-07 (America/New_York)
+**Issue:** [GAR-533](https://linear.app/chatgpt25/issue/GAR-533)
+**Branch:** `routine/202505070621-task-assignees-api`
+**Epic:** `epic:ws-api`, `epic:ws-tasks`
+**Parent:** GAR-396
+
+---
+
+## §1 Goal
+
+Land the task assignees REST API (ROADMAP §3.8 Tier 1), delivering three endpoints
+on the `garraia_app` RLS-enforced pool:
+
+- `POST /v1/groups/{group_id}/tasks/{task_id}/assignees` — assign group member (201)
+- `GET /v1/groups/{group_id}/tasks/{task_id}/assignees` — list assignees (200)
+- `DELETE /v1/groups/{group_id}/tasks/{task_id}/assignees/{user_id}` — remove assignee (204, idempotent)
+
+## §2 Architecture
+
+`task_assignees` uses FORCE RLS via the `task_assignees_through_tasks` JOIN policy:
+
+```sql
+CREATE POLICY task_assignees_through_tasks ON task_assignees
+    USING (task_id IN (SELECT id FROM tasks));
+```
+
+Since `tasks` itself is filtered by `app.current_group_id`, this transitively
+scopes assignees to the current group. The pattern is identical to
+`task_comments_through_tasks` (plan 0069).
+
+**Cross-group injection guard:** Before inserting, we verify the target `user_id`
+is an active member of the current group via a SELECT on `group_members`. If the
+user is not found in the group, we return 404 (same as "not found") — never 403,
+to avoid confirming user existence.
+
+**Idempotent DELETE:** `DELETE FROM task_assignees WHERE task_id=$1 AND user_id=$2`
+always returns 204 regardless of whether the row existed.
+
+**409 Conflict:** INSERT fails on the composite PK (`task_id, user_id`). We catch
+the Postgres unique violation SQLSTATE `23505` and return 409.
+
+## §3 Tech stack
+
+- Axum 0.8 + `RestV1FullState` (same as tasks.rs)
+- `sqlx::query` / `sqlx::query_as` (no SQL string concat)
+- `garraia_auth::{Action, Principal, WorkspaceAuditAction, audit_workspace_event}`
+- New `WorkspaceAuditAction` variants: `TaskAssigneeAdded`, `TaskAssigneeRemoved`
+- `utoipa` OpenAPI annotations
+
+## §4 Design invariants
+
+1. SET LOCAL both `app.current_user_id` AND `app.current_group_id` in every tx.
+2. Audit metadata is STRUCTURAL only: `{ task_id, assignee_user_id_len: 36 }` — never user display names.
+3. Cross-group injection returns 404 (group_members check + RLS filter).
+4. DELETE is always 204 (idempotent — no 404 for already-removed).
+5. POST 409 on duplicate (PK violation SQLSTATE 23505).
+6. No `unwrap()` in production code.
+7. `assignee_label` NOT stored — this is not needed for audit; task detail can JOIN if needed.
+
+## §5 Validações pré-plano
+
+- [x] `task_assignees` table in migration 006 ✅
+- [x] `task_assignees_through_tasks` FORCE RLS JOIN policy ✅
+- [x] `Action::TasksWrite` / `Action::TasksRead` in action.rs ✅
+- [x] `set_config` parameterized SQL pattern (plan 0056) ✅
+- [x] `group_members` membership lookup pattern in groups.rs ✅
+- [x] `audit_workspace_event` function signature confirmed ✅
+- [x] 23505 unique violation catch pattern in signup_pool.rs ✅
+
+## §6 Scope
+
+**In scope:**
+- `POST /v1/groups/{group_id}/tasks/{task_id}/assignees`
+- `GET /v1/groups/{group_id}/tasks/{task_id}/assignees`
+- `DELETE /v1/groups/{group_id}/tasks/{task_id}/assignees/{user_id}`
+- `WorkspaceAuditAction::TaskAssigneeAdded` + `TaskAssigneeRemoved`
+- 8+ integration tests in `tests/rest_v1_task_assignees.rs`
+
+**Out of scope:**
+- `assigned_by_label` caching (overkill for this surface)
+- `task_subscriptions` fan-out on assignment
+- PATCH to re-assign (use DELETE + POST)
+- Pagination (assignees per task are a small set; full list is fine)
+
+## §7 Affected files
+
+```
+crates/garraia-auth/src/audit_workspace.rs         (+2 variants + as_str() + tests)
+crates/garraia-gateway/src/rest_v1/tasks.rs        (+3 handlers, +3 DTOs, ~220 LOC)
+crates/garraia-gateway/src/rest_v1/mod.rs          (+3 route entries)
+crates/garraia-gateway/src/rest_v1/openapi.rs      (+3 paths + schemas)
+crates/garraia-gateway/Cargo.toml                  (+[[test]] required-features entry)
+crates/garraia-gateway/tests/rest_v1_task_assignees.rs  (new file, 8+ scenarios)
+plans/README.md                                    (+row 0077)
+plans/0076-gar-530-chat-mgmt-slice4.md             (status → ✅ Merged, after PR #181)
+ROADMAP.md                                         (§3.8 task API checkboxes)
+```
+
+## §8 Rollback plan
+
+No schema migration. Revert branch on main. Fully reversible.
+
+## §9 Risk register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| RLS JOIN not triggered (missing set_config) | Low | High | Both vars set at tx start; tests verify cross-group isolation |
+| group_members check race (user removed between check and insert) | Very Low | Low | INSERT succeeds (FK on users); RLS blocks future reads; acceptable |
+| task not found / deleted — 404 passthrough | Low | Low | tasks SELECT inside RLS sees nothing; foreign key fails gracefully |
+| 23505 catch missing — duplicate returns 500 | Low | High | Explicit SQLSTATE match in error handler |
+
+## §10 Acceptance criteria
+
+- `POST` returns 201 with `AssigneeResponse`; audit row `task.assignee.added`
+- `POST` returns 409 if user already assigned
+- `POST` returns 404 if target user is not a group member
+- `GET` returns 200 with list of assignees for the task
+- `DELETE` returns 204 (idempotent — succeeds even if not assigned)
+- Cross-group task returns 404 (RLS + group_id check)
+- Unknown task returns 404
+- `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` passes
+- All 18 CI checks green
+
+## §11 Cross-references
+
+- Plan 0066 (GAR-516) — slice 1: task-list + task handlers
+- Plan 0068 (GAR-518) — slice 2: single task GET + task-list PATCH/DELETE
+- Plan 0069 (GAR-520) — slice 3: task comments (same RLS JOIN pattern)
+- Plan 0076 (GAR-530) — chat management slice 4 (same `set_config` pattern)
+- Plan 0056 — set_config parameterized SQL pattern
+- Migration 006 (`task_assignees` table + RLS)
+- ROADMAP §3.8
+
+## §12 Open questions
+
+None.
+
+## §13 Estimativa
+
+- T1: Audit variants `TaskAssigneeAdded` + `TaskAssigneeRemoved`: 15 min
+- T2: DTOs (`AssigneeRow`, `AssigneeResponse`, `AddAssigneeRequest`): 15 min
+- T3: Handler `add_task_assignee` (POST): 25 min
+- T4: Handler `list_task_assignees` (GET): 20 min
+- T5: Handler `remove_task_assignee` (DELETE, idempotent): 15 min
+- T6: Route wiring + OpenAPI: 15 min
+- T7: Integration tests (8+ scenarios): 35 min
+- CI + follow-ups: 20 min
+- **Total: ~2.5 hours**
+
+## M1 Tasks
+
+- [ ] T1: Add `TaskAssigneeAdded` + `TaskAssigneeRemoved` to `WorkspaceAuditAction`
+- [ ] T2: DTOs in tasks.rs (`AssigneeRow`, `AssigneeResponse`, `AddAssigneeRequest`)
+- [ ] T3: Handler `add_task_assignee`
+- [ ] T4: Handler `list_task_assignees`
+- [ ] T5: Handler `remove_task_assignee`
+- [ ] T6: Route wiring + OpenAPI
+- [ ] T7: Integration tests `tests/rest_v1_task_assignees.rs`

--- a/plans/README.md
+++ b/plans/README.md
@@ -99,7 +99,8 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0073 | [GAR-527 — openssl 0.10.78→0.10.79 + openssl-sys 0.9.114→0.9.115 security patch](0073-gar-527-openssl-0.10.79.md) | [GAR-527](https://linear.app/chatgpt25/issue/GAR-527) | ✅ Merged 2026-05-06 via PR #168 (`8e41201`) |
 | 0074 | [GAR-528 — REST /v1 memory slice 3: GET + PATCH /v1/memory/{id}](0074-gar-528-memory-slice3-get-patch.md) | [GAR-528](https://linear.app/chatgpt25/issue/GAR-528) | ✅ Merged 2026-05-06 via PR #171 (`63cec45`) |
 | 0075 | [GAR-529 — tauri 2.10.3→2.11.1 security upgrade (ACL enforcement for remote origins)](0075-gar-529-tauri-2.11.1-acl-enforcement.md) | [GAR-529](https://linear.app/chatgpt25/issue/GAR-529) | ✅ Merged 2026-05-07 via PR #177 (`ba76287`) |
-| 0076 | [GAR-530 — Chat management slice 4: individual chat ops + member CRUD](0076-gar-530-chat-mgmt-slice4.md) | [GAR-530](https://linear.app/chatgpt25/issue/GAR-530) | ⏳ In Progress |
+| 0076 | [GAR-530 — Chat management slice 4: individual chat ops + member CRUD](0076-gar-530-chat-mgmt-slice4.md) | [GAR-530](https://linear.app/chatgpt25/issue/GAR-530) | ✅ Merged 2026-05-07 via PR #181 (`b48a356`) |
+| 0077 | [GAR-533 — REST /v1 tasks slice 4: task assignees API (POST/GET/DELETE)](0077-gar-533-task-assignees-api.md) | [GAR-533](https://linear.app/chatgpt25/issue/GAR-533) | ⏳ In Progress |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

- **POST `/v1/groups/{group_id}/tasks/{task_id}/assignees`** — assign an active group member to a task; 409 on duplicate (SQLSTATE 23505), 404 on cross-group injection attempt.
- **GET `/v1/groups/{group_id}/tasks/{task_id}/assignees`** — list all assignees ordered by `assigned_at ASC`.
- **DELETE `/v1/groups/{group_id}/tasks/{task_id}/assignees/{user_id}`** — remove assignee; idempotent 204 whether row existed or not.
- **`garraia-auth`** — +2 `WorkspaceAuditAction` variants (`TaskAssigneeAdded`, `TaskAssigneeRemoved`) with `as_str()` entries and test assertions. Distinct-strings array now has 26 entries.
- **Integration tests** — 9 scenarios (A1–A9) in `tests/rest_v1_task_assignees.rs` covering happy path, 409 duplicate, 404 non-member, 404 cross-group task, GET list, DELETE, DELETE idempotent, 404 unknown task, 403 group mismatch.

## Design invariants enforced

- Both `app.current_user_id` and `app.current_group_id` set before any FORCE-RLS table access (`set_rls_context` pattern from plan 0056).
- Cross-group injection guard: `SELECT` from `group_members WHERE group_id = $1 AND user_id = $2 AND status = 'active'` before INSERT — 404 if not found (never 403, to avoid user-existence oracle).
- Duplicate assignee: SQLSTATE `23505` unique violation caught and mapped to `RestError::Conflict` (409).
- DELETE is idempotent: plain `DELETE` without existence check, always returns 204 (after verifying task is in group).
- Audit metadata carries only `assignee_user_id_len: 36` (structural) — never the UUID value itself.

## Test plan

- [x] `cargo check -p garraia-auth` green
- [x] `cargo check -p garraia-gateway --features test-helpers` green (0 warnings)
- [x] `cargo clippy -p garraia-gateway --features test-helpers -- -D warnings` clean
- [x] `cargo fmt` applied
- [x] 9 integration scenarios in `tests/rest_v1_task_assignees.rs` (A1–A9)
- [ ] CI green (all 18 checks)

## References

- Plan 0077 (`plans/0077-gar-533-task-assignees-api.md`)
- Linear: [GAR-533](https://linear.app/chatgpt25/issue/GAR-533)
- Builds on plan 0069 (GAR-520, task comments slice 3)
- `task_assignees` schema: migration 006 (`garraia-workspace`)

https://claude.ai/code/session_01ACzfagjjhR7WGm5sgX5kBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACzfagjjhR7WGm5sgX5kBr)_