### PR TITLE
chore(health): ignore local audit and health-report directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,9 @@ quality-report.md
 
 # Local research / reference material (not committed)
 AI Quality Gates/
+
+# /github-health and /github-health-improve skill outputs — local audit
+# artifacts. Per the skill contract these are never auto-committed; they
+# persist on disk so iterations can read prior reports as input.
+.github-health-reports/
+audit/


### PR DESCRIPTION
## Summary

- Adds `.github-health-reports/` and `audit/` to `.gitignore` so the `/github-health` and `/github-health-improve` skill output stays out of version control while still persisting on disk for cross-iteration reads.
- No code, no CI workflow, no security setting changes.

## Why

The `/github-health-improve` skill aborts at procedure step 2 ("Confirm clean working tree") whenever those two directories are untracked, blocking every subsequent ratchet iteration. This commit unblocks the autonomous loop.

## Audit context

- Source report: `.github-health-reports/issues_05_07_26.md` (2026-05-07, mode `issues`, status YELLOW, 60/100 — Issues sub-area).
- Iteration: 1 of up to 3.
- Risk level: low.
- Improvement plan: `.github-health-reports/2026-05-07-improvement-gitignore-local-reports.md` (local, ignored).

## Test plan

- [x] `git status --short` shows only `.gitignore` modified.
- [x] After applying the diff, untracked report files no longer appear in `git status`.
- [ ] CI fmt / clippy / test / audit / deny / e2e / playwright / quality-ratchet all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)