### PR TITLE
feat(tasks): GAR-536 — task labels API slice 5 (plan 0078)

### DIFF
--- a/crates/garraia-auth/src/audit_workspace.rs
+++ b/crates/garraia-auth/src/audit_workspace.rs
@@ -282,6 +282,39 @@ pub enum WorkspaceAuditAction {
     /// `resource_type = "chat_members"`, `resource_id = "{user_id}"`.
     /// Metadata: `{ role }`.
     ChatMemberRemoved,
+
+    /// A task label was created via
+    /// `POST /v1/groups/{group_id}/task-labels` (plan 0078 / GAR-536,
+    /// epic GAR-WS-TASKS slice 5).
+    ///
+    /// `resource_type = "task_labels"`, `resource_id = "{label_id}"`.
+    /// Metadata: `{ name_len: N, color }` — no user-visible label name.
+    TaskLabelCreated,
+
+    /// A task label was deleted via
+    /// `DELETE /v1/groups/{group_id}/task-labels/{label_id}` (plan 0078 / GAR-536,
+    /// epic GAR-WS-TASKS slice 5).
+    ///
+    /// CASCADE removes all `task_label_assignments` referencing this label.
+    /// `resource_type = "task_labels"`, `resource_id = "{label_id}"`.
+    /// Metadata: `{ assignments_cascade: true }`.
+    TaskLabelDeleted,
+
+    /// A label was assigned to a task via
+    /// `POST /v1/groups/{group_id}/tasks/{task_id}/labels` (plan 0078 / GAR-536,
+    /// epic GAR-WS-TASKS slice 5).
+    ///
+    /// `resource_type = "task_label_assignments"`, `resource_id = "{task_id}"`.
+    /// Metadata: `{ label_id_len: 36 }`.
+    TaskLabelAssigned,
+
+    /// A label was removed from a task via
+    /// `DELETE /v1/groups/{group_id}/tasks/{task_id}/labels/{label_id}` (plan 0078 / GAR-536,
+    /// epic GAR-WS-TASKS slice 5).
+    ///
+    /// `resource_type = "task_label_assignments"`, `resource_id = "{task_id}"`.
+    /// Metadata: `{ label_id_len: 36 }`.
+    TaskLabelRemoved,
 }
 
 impl WorkspaceAuditAction {
@@ -313,6 +346,10 @@ impl WorkspaceAuditAction {
             WorkspaceAuditAction::ChatArchived => "chat.archived",
             WorkspaceAuditAction::ChatMemberAdded => "chat.member.added",
             WorkspaceAuditAction::ChatMemberRemoved => "chat.member.removed",
+            WorkspaceAuditAction::TaskLabelCreated => "task_label.created",
+            WorkspaceAuditAction::TaskLabelDeleted => "task_label.deleted",
+            WorkspaceAuditAction::TaskLabelAssigned => "task.label.assigned",
+            WorkspaceAuditAction::TaskLabelRemoved => "task.label.removed",
         }
     }
 }
@@ -454,6 +491,22 @@ mod tests {
             WorkspaceAuditAction::ChatMemberRemoved.as_str(),
             "chat.member.removed"
         );
+        assert_eq!(
+            WorkspaceAuditAction::TaskLabelCreated.as_str(),
+            "task_label.created"
+        );
+        assert_eq!(
+            WorkspaceAuditAction::TaskLabelDeleted.as_str(),
+            "task_label.deleted"
+        );
+        assert_eq!(
+            WorkspaceAuditAction::TaskLabelAssigned.as_str(),
+            "task.label.assigned"
+        );
+        assert_eq!(
+            WorkspaceAuditAction::TaskLabelRemoved.as_str(),
+            "task.label.removed"
+        );
     }
 
     #[test]
@@ -484,6 +537,10 @@ mod tests {
             WorkspaceAuditAction::ChatArchived.as_str(),
             WorkspaceAuditAction::ChatMemberAdded.as_str(),
             WorkspaceAuditAction::ChatMemberRemoved.as_str(),
+            WorkspaceAuditAction::TaskLabelCreated.as_str(),
+            WorkspaceAuditAction::TaskLabelDeleted.as_str(),
+            WorkspaceAuditAction::TaskLabelAssigned.as_str(),
+            WorkspaceAuditAction::TaskLabelRemoved.as_str(),
         ];
         let unique: std::collections::HashSet<_> = strings.iter().collect();
         assert_eq!(unique.len(), strings.len(), "duplicate action strings");

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -275,6 +275,11 @@ name = "rest_v1_task_assignees"
 path = "tests/rest_v1_task_assignees.rs"
 required-features = ["test-helpers"]
 
+[[test]]
+name = "rest_v1_task_labels"
+path = "tests/rest_v1_task_labels.rs"
+required-features = ["test-helpers"]
+
 [dev-dependencies]
 # Plan 0024 T4 (GAR-412): metrics_exporter tests and the
 # metrics_auth_integration binary build a `PrometheusRecorder` directly

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -339,6 +339,23 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     "/v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}",
                     delete(tasks::delete_task_comment),
                 )
+                // Plan 0078 (GAR-536) — task labels API slice 5.
+                .route(
+                    "/v1/groups/{group_id}/task-labels",
+                    post(tasks::create_task_label).get(tasks::list_task_labels),
+                )
+                .route(
+                    "/v1/groups/{group_id}/task-labels/{label_id}",
+                    delete(tasks::delete_task_label),
+                )
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/labels",
+                    post(tasks::assign_task_label),
+                )
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/labels/{label_id}",
+                    delete(tasks::remove_task_label_from_task),
+                )
                 // Plan 0070 (GAR-522) — audit API slice 1.
                 .route("/v1/groups/{group_id}/audit", get(audit::list_audit))
                 .merge(rate_limited_routes)

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -30,9 +30,10 @@ use super::messages::{
 };
 use super::problem::ProblemDetails;
 use super::tasks::{
-    CommentResponse, CreateCommentRequest, CreateTaskListRequest, CreateTaskRequest,
-    ListCommentsResponse, ListTaskListsResponse, ListTasksResponse, PatchTaskListRequest,
-    PatchTaskRequest, TaskListResponse, TaskListSummary, TaskResponse, TaskSummary,
+    AssignTaskLabelRequest, CommentResponse, CreateCommentRequest, CreateTaskLabelRequest,
+    CreateTaskListRequest, CreateTaskRequest, LabelAssignmentResponse, ListCommentsResponse,
+    ListTaskListsResponse, ListTasksResponse, PatchTaskListRequest, PatchTaskRequest,
+    TaskLabelResponse, TaskListResponse, TaskListSummary, TaskResponse, TaskSummary,
 };
 use super::uploads::{CreateUploadRequest, CreateUploadResponse};
 
@@ -113,6 +114,11 @@ impl Modify for SecurityAddon {
         super::tasks::create_task_comment,
         super::tasks::list_task_comments,
         super::tasks::delete_task_comment,
+        super::tasks::create_task_label,
+        super::tasks::list_task_labels,
+        super::tasks::delete_task_label,
+        super::tasks::assign_task_label,
+        super::tasks::remove_task_label_from_task,
         super::audit::list_audit,
     ),
     components(schemas(
@@ -158,6 +164,10 @@ impl Modify for SecurityAddon {
         CreateCommentRequest,
         CommentResponse,
         ListCommentsResponse,
+        CreateTaskLabelRequest,
+        TaskLabelResponse,
+        AssignTaskLabelRequest,
+        LabelAssignmentResponse,
         AuditEventSummary,
         ListAuditResponse,
     )),

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -30,7 +30,7 @@ use super::messages::{
 };
 use super::problem::ProblemDetails;
 use super::tasks::{
-    AddAssigneeRequest, AssigneeResponse, AssignTaskLabelRequest, CommentResponse,
+    AddAssigneeRequest, AssignTaskLabelRequest, AssigneeResponse, CommentResponse,
     CreateCommentRequest, CreateTaskLabelRequest, CreateTaskListRequest, CreateTaskRequest,
     LabelAssignmentResponse, ListCommentsResponse, ListTaskListsResponse, ListTasksResponse,
     PatchTaskListRequest, PatchTaskRequest, TaskLabelResponse, TaskListResponse, TaskListSummary,

--- a/crates/garraia-gateway/src/rest_v1/tasks.rs
+++ b/crates/garraia-gateway/src/rest_v1/tasks.rs
@@ -1,7 +1,7 @@
-//! `/v1/groups/{group_id}/task-lists` and task/comment/assignee handlers
-//! (plan 0066/0067/0069/0077, GAR-516/GAR-518/GAR-520/GAR-533).
+//! `/v1/groups/{group_id}/task-lists` and task/comment/assignee/label handlers
+//! (plan 0066/0067/0069/0077/0078, GAR-516/GAR-518/GAR-520/GAR-533/GAR-536).
 //!
-//! Fifteen endpoints on the `garraia_app` RLS-enforced pool:
+//! Twenty endpoints on the `garraia_app` RLS-enforced pool:
 //!
 //! **Slice 1 (plan 0066 / GAR-516):**
 //! - `POST /v1/groups/{group_id}/task-lists` — create task list
@@ -25,6 +25,13 @@
 //! - `POST /v1/groups/{group_id}/tasks/{task_id}/assignees` — assign group member
 //! - `GET /v1/groups/{group_id}/tasks/{task_id}/assignees` — list assignees
 //! - `DELETE /v1/groups/{group_id}/tasks/{task_id}/assignees/{user_id}` — remove assignee (idempotent)
+//!
+//! **Slice 5 (plan 0078 / GAR-536):**
+//! - `POST /v1/groups/{group_id}/task-labels` — create task label
+//! - `GET /v1/groups/{group_id}/task-labels` — list task labels
+//! - `DELETE /v1/groups/{group_id}/task-labels/{label_id}` — delete label (CASCADE assignments)
+//! - `POST /v1/groups/{group_id}/tasks/{task_id}/labels` — assign label to task
+//! - `DELETE /v1/groups/{group_id}/tasks/{task_id}/labels/{label_id}` — remove label assignment (idempotent)
 //!
 //! ## Tenant-context protocol
 //!
@@ -1840,7 +1847,6 @@ pub async fn delete_task_comment(
     Ok(StatusCode::NO_CONTENT)
 }
 
-
 // ─── Slice 4 (plan 0077 / GAR-533): Task Assignees ───────────────────────────
 
 /// DB row returned from `task_assignees`.
@@ -2340,7 +2346,9 @@ pub async fn list_task_labels(
         .await
         .map_err(|e| RestError::Internal(e.into()))?;
 
-    Ok(Json(rows.into_iter().map(TaskLabelResponse::from).collect()))
+    Ok(Json(
+        rows.into_iter().map(TaskLabelResponse::from).collect(),
+    ))
 }
 
 /// `DELETE /v1/groups/{group_id}/task-labels/{label_id}` — delete a task label.
@@ -2483,14 +2491,13 @@ pub async fn assign_task_label(
     }
 
     // Verify label belongs to this group (cross-group injection guard).
-    let label_exists: Option<(Uuid,)> = sqlx::query_as(
-        "SELECT id FROM task_labels WHERE id = $1 AND group_id = $2",
-    )
-    .bind(body.label_id)
-    .bind(group_id)
-    .fetch_optional(&mut *tx)
-    .await
-    .map_err(|e| RestError::Internal(e.into()))?;
+    let label_exists: Option<(Uuid,)> =
+        sqlx::query_as("SELECT id FROM task_labels WHERE id = $1 AND group_id = $2")
+            .bind(body.label_id)
+            .bind(group_id)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(|e| RestError::Internal(e.into()))?;
 
     if label_exists.is_none() {
         return Err(RestError::NotFound);

--- a/crates/garraia-gateway/src/rest_v1/tasks.rs
+++ b/crates/garraia-gateway/src/rest_v1/tasks.rs
@@ -1833,3 +1833,492 @@ pub async fn delete_task_comment(
 
     Ok(StatusCode::NO_CONTENT)
 }
+
+// ─── Task labels (plan 0078 / GAR-536, slice 5) ──────────────────────────────
+
+/// DB row returned from `task_labels`.
+#[derive(sqlx::FromRow)]
+struct TaskLabelRow {
+    id: Uuid,
+    group_id: Uuid,
+    name: String,
+    color: String,
+    created_by: Option<Uuid>,
+    created_by_label: String,
+    created_at: DateTime<Utc>,
+}
+
+/// Public response shape for a single task label.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct TaskLabelResponse {
+    pub id: Uuid,
+    pub group_id: Uuid,
+    pub name: String,
+    pub color: String,
+    pub created_by: Option<Uuid>,
+    pub created_by_label: String,
+    pub created_at: DateTime<Utc>,
+}
+
+impl From<TaskLabelRow> for TaskLabelResponse {
+    fn from(r: TaskLabelRow) -> Self {
+        Self {
+            id: r.id,
+            group_id: r.group_id,
+            name: r.name,
+            color: r.color,
+            created_by: r.created_by,
+            created_by_label: r.created_by_label,
+            created_at: r.created_at,
+        }
+    }
+}
+
+/// Request body for `POST /v1/groups/{group_id}/task-labels`.
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct CreateTaskLabelRequest {
+    pub name: String,
+    pub color: String,
+}
+
+/// `POST /v1/groups/{group_id}/task-labels` — create a task label for a group.
+///
+/// Returns 201 on success, 409 if a label with the same name already exists
+/// in this group (`UNIQUE (group_id, name)`). Both `app.current_user_id` and
+/// `app.current_group_id` are set before accessing any FORCE-RLS table.
+/// Authz: `Action::TasksWrite`.
+#[utoipa::path(
+    post,
+    path = "/v1/groups/{group_id}/task-labels",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+    ),
+    request_body = CreateTaskLabelRequest,
+    responses(
+        (status = 201, description = "Label created.", body = TaskLabelResponse),
+        (status = 400, description = "Validation error.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 409, description = "Label name already exists in this group.", body = super::problem::ProblemDetails),
+        (status = 422, description = "Invalid color format (expected #RRGGBB).", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn create_task_label(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(path_group_id): Path<Uuid>,
+    Json(body): Json<CreateTaskLabelRequest>,
+) -> Result<(StatusCode, Json<TaskLabelResponse>), RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksWrite) {
+        return Err(RestError::Forbidden);
+    }
+
+    let color = body.color.trim().to_string();
+    if !is_valid_hex_color(&color) {
+        return Err(RestError::BadRequest(
+            "color must be in #RRGGBB format".into(),
+        ));
+    }
+    let name = body.name.trim().to_string();
+    if name.is_empty() || name.len() > 80 {
+        return Err(RestError::BadRequest(
+            "name must be 1–80 characters".into(),
+        ));
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    let (created_by_label,): (String,) =
+        sqlx::query_as("SELECT display_name FROM users WHERE id = $1")
+            .bind(principal.user_id)
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(|e| RestError::Internal(e.into()))?;
+
+    let row: TaskLabelRow = sqlx::query_as(
+        "INSERT INTO task_labels (group_id, name, color, created_by, created_by_label) \
+         VALUES ($1, $2, $3, $4, $5) \
+         RETURNING id, group_id, name, color, created_by, created_by_label, created_at",
+    )
+    .bind(group_id)
+    .bind(&name)
+    .bind(&color)
+    .bind(principal.user_id)
+    .bind(&created_by_label)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| {
+        if let sqlx::Error::Database(ref db_err) = e
+            && db_err.code().as_deref() == Some("23505")
+        {
+            return RestError::Conflict("label name already exists in this group".into());
+        }
+        RestError::Internal(e.into())
+    })?;
+
+    let label_id = row.id;
+    let name_len = name.len();
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::TaskLabelCreated,
+        principal.user_id,
+        group_id,
+        "task_labels",
+        label_id.to_string(),
+        json!({ "name_len": name_len, "color": color }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok((StatusCode::CREATED, Json(TaskLabelResponse::from(row))))
+}
+
+/// `GET /v1/groups/{group_id}/task-labels` — list all labels for a group.
+///
+/// Returns labels ordered by `created_at ASC`. Authz: `Action::TasksRead`.
+#[utoipa::path(
+    get,
+    path = "/v1/groups/{group_id}/task-labels",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+    ),
+    responses(
+        (status = 200, description = "List of task labels.", body = Vec<TaskLabelResponse>),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn list_task_labels(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(path_group_id): Path<Uuid>,
+) -> Result<Json<Vec<TaskLabelResponse>>, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksRead) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    let rows: Vec<TaskLabelRow> = sqlx::query_as(
+        "SELECT id, group_id, name, color, created_by, created_by_label, created_at \
+         FROM task_labels \
+         ORDER BY created_at ASC",
+    )
+    .fetch_all(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(Json(rows.into_iter().map(TaskLabelResponse::from).collect()))
+}
+
+/// `DELETE /v1/groups/{group_id}/task-labels/{label_id}` — delete a task label.
+///
+/// Idempotent: returns 204 whether or not the label existed. The DB CASCADE
+/// removes all `task_label_assignments` referencing this label automatically.
+/// Authz: `Action::TasksWrite`.
+#[utoipa::path(
+    delete,
+    path = "/v1/groups/{group_id}/task-labels/{label_id}",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("label_id" = Uuid, Path, description = "Label UUID."),
+    ),
+    responses(
+        (status = 204, description = "Label deleted (or did not exist)."),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn delete_task_label(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, label_id)): Path<(Uuid, Uuid)>,
+) -> Result<StatusCode, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksWrite) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    sqlx::query("DELETE FROM task_labels WHERE id = $1 AND group_id = $2")
+        .bind(label_id)
+        .bind(group_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::TaskLabelDeleted,
+        principal.user_id,
+        group_id,
+        "task_labels",
+        label_id.to_string(),
+        json!({ "assignments_cascade": true }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// DB row for a label assignment.
+#[derive(sqlx::FromRow)]
+struct LabelAssignmentRow {
+    task_id: Uuid,
+    label_id: Uuid,
+    assigned_at: DateTime<Utc>,
+}
+
+/// Public response for a label assignment.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct LabelAssignmentResponse {
+    pub task_id: Uuid,
+    pub label_id: Uuid,
+    pub assigned_at: DateTime<Utc>,
+}
+
+/// Request body for `POST /v1/groups/{group_id}/tasks/{task_id}/labels`.
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct AssignTaskLabelRequest {
+    pub label_id: Uuid,
+}
+
+/// `POST /v1/groups/{group_id}/tasks/{task_id}/labels` — assign a label to a task.
+///
+/// Returns 201 on success, 409 if already assigned, 404 if task or label not
+/// found in this group. Authz: `Action::TasksWrite`.
+#[utoipa::path(
+    post,
+    path = "/v1/groups/{group_id}/tasks/{task_id}/labels",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("task_id" = Uuid, Path, description = "Task UUID."),
+    ),
+    request_body = AssignTaskLabelRequest,
+    responses(
+        (status = 201, description = "Label assigned.", body = LabelAssignmentResponse),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Task or label not found in this group.", body = super::problem::ProblemDetails),
+        (status = 409, description = "Label already assigned to this task.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn assign_task_label(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, task_id)): Path<(Uuid, Uuid)>,
+    Json(body): Json<AssignTaskLabelRequest>,
+) -> Result<(StatusCode, Json<LabelAssignmentResponse>), RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksWrite) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Verify task exists in this group and is not soft-deleted.
+    let task_exists: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM tasks WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+    )
+    .bind(task_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if task_exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    // Verify label belongs to this group (cross-group injection guard).
+    let label_exists: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM task_labels WHERE id = $1 AND group_id = $2",
+    )
+    .bind(body.label_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if label_exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    let row: LabelAssignmentRow = sqlx::query_as(
+        "INSERT INTO task_label_assignments (task_id, label_id) \
+         VALUES ($1, $2) \
+         RETURNING task_id, label_id, assigned_at",
+    )
+    .bind(task_id)
+    .bind(body.label_id)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| {
+        if let sqlx::Error::Database(ref db_err) = e
+            && db_err.code().as_deref() == Some("23505")
+        {
+            return RestError::Conflict("label already assigned to this task".into());
+        }
+        RestError::Internal(e.into())
+    })?;
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::TaskLabelAssigned,
+        principal.user_id,
+        group_id,
+        "task_label_assignments",
+        task_id.to_string(),
+        json!({ "label_id_len": 36 }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(LabelAssignmentResponse {
+            task_id: row.task_id,
+            label_id: row.label_id,
+            assigned_at: row.assigned_at,
+        }),
+    ))
+}
+
+/// `DELETE /v1/groups/{group_id}/tasks/{task_id}/labels/{label_id}` — remove a label from a task.
+///
+/// Idempotent: returns 204 whether or not the assignment existed.
+/// Returns 404 if the task is not found in this group. Authz: `Action::TasksWrite`.
+#[utoipa::path(
+    delete,
+    path = "/v1/groups/{group_id}/tasks/{task_id}/labels/{label_id}",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("task_id" = Uuid, Path, description = "Task UUID."),
+        ("label_id" = Uuid, Path, description = "Label UUID."),
+    ),
+    responses(
+        (status = 204, description = "Label removed from task (or was not assigned)."),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Task not found in this group.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn remove_task_label_from_task(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, task_id, label_id)): Path<(Uuid, Uuid, Uuid)>,
+) -> Result<StatusCode, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksWrite) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Verify task exists in this group before emitting audit.
+    let task_exists: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM tasks WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+    )
+    .bind(task_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if task_exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    sqlx::query("DELETE FROM task_label_assignments WHERE task_id = $1 AND label_id = $2")
+        .bind(task_id)
+        .bind(label_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::TaskLabelRemoved,
+        principal.user_id,
+        group_id,
+        "task_label_assignments",
+        task_id.to_string(),
+        json!({ "label_id_len": 36 }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// Validates that a color string is in `#RRGGBB` hex format.
+fn is_valid_hex_color(color: &str) -> bool {
+    if color.len() != 7 {
+        return false;
+    }
+    let bytes = color.as_bytes();
+    if bytes[0] != b'#' {
+        return false;
+    }
+    bytes[1..].iter().all(|b| b.is_ascii_hexdigit())
+}

--- a/crates/garraia-gateway/tests/rest_v1_task_labels.rs
+++ b/crates/garraia-gateway/tests/rest_v1_task_labels.rs
@@ -1,0 +1,455 @@
+//! Integration tests for task labels REST API (plan 0078, GAR-536).
+//!
+//! All scenarios bundled into ONE `#[tokio::test]` — same pattern as
+//! `rest_v1_task_assignees.rs`. Splitting triggers the sqlx runtime-teardown
+//! race documented in plan 0016 M3.
+//!
+//! Scenarios (10 total):
+//!
+//!   L1.  POST /task-labels 201 — create label; assert response shape + audit row.
+//!   L2.  POST /task-labels 409 — duplicate name in same group returns 409.
+//!   L3.  POST /task-labels 400 — invalid color format (not #RRGGBB) returns 400.
+//!   L4.  GET /task-labels 200 — list labels; includes L1 entry.
+//!   L5.  POST .../labels 201 — assign label to task; audit row emitted.
+//!   L6.  POST .../labels 409 — same label assigned again returns 409.
+//!   L7.  POST .../labels 404 — label from another group returns 404 (cross-group guard).
+//!   L8.  DELETE .../labels/{label_id} 204 — remove label from task (idempotent).
+//!   L9.  DELETE /task-labels/{label_id} 204 — delete label (idempotent, CASCADE).
+//!   L10. POST /task-labels 403 — path group_id ≠ principal group_id returns 403.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+
+use common::Harness;
+use common::fixtures::{fetch_audit_events_for_group, seed_user_with_group};
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect response body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("response body is not JSON")
+}
+
+fn auth_req(
+    method: &str,
+    uri: &str,
+    token: Option<&str>,
+    x_group_id: Option<&str>,
+    body: Option<serde_json::Value>,
+) -> Request<Body> {
+    let body_bytes = match body {
+        Some(v) => Body::from(v.to_string()),
+        None => Body::empty(),
+    };
+    let mut req = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(body_bytes)
+        .expect("request builder");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    if let Some(t) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {t}")).unwrap(),
+        );
+    }
+    if let Some(g) = x_group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    req
+}
+
+async fn create_task_list_and_task(h: &Harness, token: &str, group_id: &str) -> (String, String) {
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{group_id}/task-lists"),
+            Some(token),
+            Some(group_id),
+            Some(json!({ "name": "Label Test List", "type": "list" })),
+        ))
+        .await
+        .expect("create task-list");
+    assert_eq!(resp.status(), StatusCode::CREATED, "setup: task-list 201");
+    let tl_body = body_json(resp).await;
+    let list_id = tl_body["id"].as_str().expect("list id").to_string();
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{group_id}/task-lists/{list_id}/tasks"),
+            Some(token),
+            Some(group_id),
+            Some(json!({ "title": "Task for label assignment" })),
+        ))
+        .await
+        .expect("create task");
+    assert_eq!(resp.status(), StatusCode::CREATED, "setup: task 201");
+    let task_body = body_json(resp).await;
+    let task_id = task_body["id"].as_str().expect("task id").to_string();
+
+    (list_id, task_id)
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(feature = "test-helpers")]
+#[tokio::test]
+async fn rest_v1_task_labels_scenarios() {
+    let h = Harness::get().await;
+
+    // Seed Alice as group owner, Bob owns a separate group for isolation tests.
+    let (_alice_id, group_id, alice_token) = seed_user_with_group(&h, "alice@labels.test")
+        .await
+        .expect("seed alice+group");
+    let (_, bob_group_id, bob_token) = seed_user_with_group(&h, "bob@labels.test")
+        .await
+        .expect("seed bob+group2");
+
+    let gid = group_id.to_string();
+    let g2id = bob_group_id.to_string();
+
+    // Set up a task under Alice's group.
+    let (_list_id, task_id) = create_task_list_and_task(&h, &alice_token, &gid).await;
+
+    // ── L1. POST /task-labels 201 — create label; response shape + audit ──
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{gid}/task-labels"),
+            Some(&alice_token),
+            Some(&gid),
+            Some(json!({ "name": "Bug", "color": "#ff0000" })),
+        ))
+        .await
+        .expect("L1 oneshot");
+    assert_eq!(resp.status(), StatusCode::CREATED, "L1 status");
+    let l1_body = body_json(resp).await;
+    let label_id = l1_body["id"].as_str().expect("L1 label id").to_string();
+    assert_eq!(l1_body["name"], "Bug", "L1 name");
+    assert_eq!(l1_body["color"], "#ff0000", "L1 color");
+    assert_eq!(l1_body["group_id"], gid, "L1 group_id");
+    assert!(l1_body.get("created_at").is_some(), "L1 created_at present");
+
+    // Verify audit row.
+    let audit = fetch_audit_events_for_group(&h, group_id)
+        .await
+        .expect("L1 fetch audit");
+    let l1_audit = audit
+        .iter()
+        .find(|e| e.0 == "task_label.created")
+        .expect("L1 audit row task_label.created");
+    let (_, _, l1_res_type, l1_res_id, l1_meta) = l1_audit;
+    assert_eq!(l1_res_type, "task_labels", "L1 audit resource_type");
+    assert_eq!(l1_res_id, &label_id, "L1 audit resource_id is label_id");
+    assert!(
+        l1_meta["name_len"].as_u64().is_some(),
+        "L1 audit metadata has name_len (PII-safe)"
+    );
+    assert!(
+        l1_meta.get("name").is_none(),
+        "L1 audit must not contain label name value (PII guard)"
+    );
+
+    // ── L2. POST /task-labels 409 — duplicate name ───────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{gid}/task-labels"),
+            Some(&alice_token),
+            Some(&gid),
+            Some(json!({ "name": "Bug", "color": "#00ff00" })),
+        ))
+        .await
+        .expect("L2 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::CONFLICT,
+        "L2 duplicate label name must be 409"
+    );
+
+    // ── L3. POST /task-labels 400 — invalid color ────────────────────────
+    for bad_color in &["red", "#gg0000", "#ff00", "#FF0000aa", ""] {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(auth_req(
+                "POST",
+                &format!("/v1/groups/{gid}/task-labels"),
+                Some(&alice_token),
+                Some(&gid),
+                Some(json!({ "name": "Color Test", "color": bad_color })),
+            ))
+            .await
+            .expect("L3 oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "L3 invalid color '{bad_color}' must be 400"
+        );
+    }
+
+    // ── L4. GET /task-labels 200 — list includes L1 entry ────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "GET",
+            &format!("/v1/groups/{gid}/task-labels"),
+            Some(&alice_token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("L4 oneshot");
+    assert_eq!(resp.status(), StatusCode::OK, "L4 status");
+    let l4_body = body_json(resp).await;
+    let items = l4_body.as_array().expect("L4 response is array");
+    assert!(
+        items.iter().any(|it| it["id"] == label_id),
+        "L4 list must contain the created label"
+    );
+
+    // ── L5. POST .../labels 201 — assign label to task; audit row ─────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/labels"),
+            Some(&alice_token),
+            Some(&gid),
+            Some(json!({ "label_id": label_id })),
+        ))
+        .await
+        .expect("L5 oneshot");
+    assert_eq!(resp.status(), StatusCode::CREATED, "L5 status");
+    let l5_body = body_json(resp).await;
+    assert_eq!(l5_body["task_id"], task_id, "L5 task_id");
+    assert_eq!(l5_body["label_id"], label_id, "L5 label_id");
+    assert!(
+        l5_body.get("assigned_at").is_some(),
+        "L5 assigned_at present"
+    );
+
+    // Verify audit row.
+    let audit2 = fetch_audit_events_for_group(&h, group_id)
+        .await
+        .expect("L5 fetch audit");
+    assert!(
+        audit2
+            .iter()
+            .any(|e| e.0 == "task.label.assigned" && e.3 == task_id),
+        "L5 audit row task.label.assigned must be present"
+    );
+
+    // ── L6. POST .../labels 409 — same label assigned again ───────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/labels"),
+            Some(&alice_token),
+            Some(&gid),
+            Some(json!({ "label_id": label_id })),
+        ))
+        .await
+        .expect("L6 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::CONFLICT,
+        "L6 duplicate assignment must be 409"
+    );
+
+    // ── L7. POST .../labels 404 — label from another group ────────────────
+    // Create a label in Bob's group; try to assign it to Alice's task.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{g2id}/task-labels"),
+            Some(&bob_token),
+            Some(&g2id),
+            Some(json!({ "name": "Bob Label", "color": "#0000ff" })),
+        ))
+        .await
+        .expect("L7 bob label create");
+    assert_eq!(resp.status(), StatusCode::CREATED, "L7 bob label 201");
+    let bob_label_body = body_json(resp).await;
+    let bob_label_id = bob_label_body["id"].as_str().expect("bob label id");
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/labels"),
+            Some(&alice_token),
+            Some(&gid),
+            Some(json!({ "label_id": bob_label_id })),
+        ))
+        .await
+        .expect("L7 cross-group assign oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "L7 cross-group label must be 404"
+    );
+
+    // ── L8. DELETE .../labels/{label_id} 204 — remove label from task ─────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "DELETE",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/labels/{label_id}"),
+            Some(&alice_token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("L8 oneshot");
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT, "L8 status");
+
+    // Audit row for removal.
+    let audit3 = fetch_audit_events_for_group(&h, group_id)
+        .await
+        .expect("L8 fetch audit");
+    assert!(
+        audit3
+            .iter()
+            .any(|e| e.0 == "task.label.removed" && e.3 == task_id),
+        "L8 audit row task.label.removed must be present"
+    );
+
+    // Idempotent: second DELETE on same assignment also returns 204.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "DELETE",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/labels/{label_id}"),
+            Some(&alice_token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("L8 idempotent oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NO_CONTENT,
+        "L8 idempotent delete must return 204"
+    );
+
+    // ── L9. DELETE /task-labels/{label_id} 204 — delete the label itself ──
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "DELETE",
+            &format!("/v1/groups/{gid}/task-labels/{label_id}"),
+            Some(&alice_token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("L9 oneshot");
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT, "L9 status");
+
+    // Audit row for label deletion.
+    let audit4 = fetch_audit_events_for_group(&h, group_id)
+        .await
+        .expect("L9 fetch audit");
+    assert!(
+        audit4
+            .iter()
+            .any(|e| e.0 == "task_label.deleted" && e.3 == label_id),
+        "L9 audit row task_label.deleted must be present"
+    );
+
+    // Idempotent: delete again → 204.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "DELETE",
+            &format!("/v1/groups/{gid}/task-labels/{label_id}"),
+            Some(&alice_token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("L9 idempotent oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NO_CONTENT,
+        "L9 idempotent delete label must return 204"
+    );
+
+    // GET list after deletion: label no longer present.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "GET",
+            &format!("/v1/groups/{gid}/task-labels"),
+            Some(&alice_token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("L9 list after delete");
+    assert_eq!(resp.status(), StatusCode::OK, "L9 list status");
+    let l9_list = body_json(resp).await;
+    let after_del = l9_list.as_array().expect("L9 items array");
+    assert!(
+        !after_del.iter().any(|it| it["id"] == label_id),
+        "L9 deleted label must not appear in GET list"
+    );
+
+    // ── L10. POST 403 — path group_id ≠ principal group_id ───────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{g2id}/task-labels"),
+            Some(&alice_token),
+            Some(&gid), // X-Group-Id = alice's group, path = bob's group
+            Some(json!({ "name": "Forbidden Label", "color": "#ffffff" })),
+        ))
+        .await
+        .expect("L10 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "L10 path group_id mismatch must return 403"
+    );
+}

--- a/plans/0078-gar-536-task-labels-api.md
+++ b/plans/0078-gar-536-task-labels-api.md
@@ -1,0 +1,204 @@
+# Plan 0078 — GAR-536: REST /v1 tasks slice 5 (task labels API)
+
+**Status:** Em execução
+**Autor:** Claude Sonnet 4.6 (garra-routine 2026-05-07, America/New_York)
+**Data:** 2026-05-07 (America/New_York)
+**Issue:** [GAR-536](https://linear.app/chatgpt25/issue/GAR-536)
+**Branch:** `routine/202505071223-task-labels-api`
+**Epic:** `epic:ws-api`, `epic:ws-tasks`
+**Parent:** GAR-396
+
+---
+
+## §1 Goal
+
+Land the task labels REST API (ROADMAP §3.8 Tier 1), delivering five endpoints
+on the `garraia_app` RLS-enforced pool:
+
+**Group-level label management:**
+- `POST /v1/groups/{group_id}/task-labels` — create label (201, 409 on duplicate name)
+- `GET /v1/groups/{group_id}/task-labels` — list all labels for the group (200)
+- `DELETE /v1/groups/{group_id}/task-labels/{label_id}` — delete label (204, idempotent; CASCADE removes assignments)
+
+**Task-level label assignment:**
+- `POST /v1/groups/{group_id}/tasks/{task_id}/labels` — assign label to task (201, 409 if already assigned)
+- `DELETE /v1/groups/{group_id}/tasks/{task_id}/labels/{label_id}` — remove label from task (204, idempotent)
+
+## §2 Architecture
+
+### RLS patterns (both from migration 006)
+
+`task_labels` — **direct group_id** isolation (same class as `tasks`, `task_lists`):
+```sql
+CREATE POLICY task_labels_group_isolation ON task_labels
+    USING (group_id = NULLIF(current_setting('app.current_group_id', TRUE), '')::uuid);
+```
+
+`task_label_assignments` — **JOIN via tasks** (same class as `task_assignees`, `task_comments`):
+```sql
+CREATE POLICY task_label_assignments_through_tasks ON task_label_assignments
+    USING (task_id IN (SELECT id FROM tasks));
+```
+Since `tasks` is filtered by `app.current_group_id`, this transitively scopes
+label assignments to the current group.
+
+### Cross-group safety
+
+- `POST task-labels/{label_id}/task-labels` verifies `label.group_id = path_group_id` (RLS alone handles isolation, but explicit check gives clear 404 vs silent RLS filter).
+- `POST tasks/{task_id}/labels` verifies the label belongs to the same group before INSERT.
+- Both DELETE operations are idempotent (no 404 if row absent).
+
+### Unique violation handling
+
+- `task_labels.UNIQUE (group_id, name)` → SQLSTATE `23505` → 409 Conflict.
+- `task_label_assignments.PRIMARY KEY (task_id, label_id)` → SQLSTATE `23505` → 409 Conflict.
+
+### CASCADE behavior
+
+`DELETE /v1/groups/{group_id}/task-labels/{label_id}` issues `DELETE FROM task_labels WHERE id=$1 AND group_id=$2`. Postgres CASCADE removes all `task_label_assignments` rows referencing this label automatically — no extra DELETE needed.
+
+## §3 Tech stack
+
+- Axum 0.8 + `RestV1FullState` (same as tasks.rs)
+- `sqlx::query` / `sqlx::query_as` (no SQL string concat)
+- `garraia_auth::{Action, Principal, WorkspaceAuditAction, audit_workspace_event}`
+- New `WorkspaceAuditAction` variants: `TaskLabelCreated`, `TaskLabelDeleted`, `TaskLabelAssigned`, `TaskLabelRemoved`
+- `utoipa` OpenAPI annotations
+
+## §4 Design invariants
+
+1. SET LOCAL both `app.current_user_id` AND `app.current_group_id` in every tx.
+2. Audit metadata is STRUCTURAL: `{ name_len: N, color }` for label create — no display names or content.
+3. Cross-group label injection returns 404 (RLS + explicit label.group_id check).
+4. DELETE operations are always 204 (idempotent — no 404 for already-removed rows).
+5. POST label 409 on SQLSTATE `23505` duplicate name within group.
+6. POST assignment 409 on SQLSTATE `23505` duplicate (task_id, label_id).
+7. No `unwrap()` in production code.
+8. `color` stored as-is; validated by DB CHECK `#RRGGBB`; any invalid value returns 422 via `RestError::UnprocessableEntity`.
+
+## §5 Validações pré-plano
+
+- [x] `task_labels` schema in migration 006 ✅
+- [x] `task_label_assignments` schema in migration 006 ✅
+- [x] `task_labels_group_isolation` FORCE RLS direct policy ✅
+- [x] `task_label_assignments_through_tasks` FORCE RLS JOIN policy ✅
+- [x] `Action::TasksWrite` / `Action::TasksRead` in action.rs ✅
+- [x] `set_rls_context` parameterized SQL pattern (plan 0056) ✅
+- [x] `audit_workspace_event` function signature confirmed ✅
+- [x] 23505 unique violation catch pattern (plan 0077 / assignees) ✅
+- [x] `created_by_label` cache pattern (same as task_lists, task_comments) ✅
+
+## §6 Scope
+
+**In scope:**
+- `POST /v1/groups/{group_id}/task-labels`
+- `GET /v1/groups/{group_id}/task-labels`
+- `DELETE /v1/groups/{group_id}/task-labels/{label_id}`
+- `POST /v1/groups/{group_id}/tasks/{task_id}/labels`
+- `DELETE /v1/groups/{group_id}/tasks/{task_id}/labels/{label_id}`
+- `WorkspaceAuditAction::TaskLabelCreated` + `TaskLabelDeleted` + `TaskLabelAssigned` + `TaskLabelRemoved`
+- 10 integration test scenarios (L1–L10)
+
+**Out of scope:**
+- `PATCH /v1/groups/{group_id}/task-labels/{label_id}` (rename/recolor) — deferred
+- `GET /v1/groups/{group_id}/tasks/{task_id}/labels` (list task's labels) — can add later; label list endpoint covers this via join
+- task_subscriptions API — separate slice
+- task_activity API — separate slice
+- WebSocket kanban stream — GAR-396 parent scope
+
+## §7 Rollback
+
+No schema changes. If implementation is defective, revert handler registrations in `rest_v1/mod.rs` and remove the 5 handler functions from `tasks.rs`. No migration rollback needed.
+
+## §8 Open questions
+
+None. All design decisions confirmed by existing patterns in plans 0069 (comments) and 0077 (assignees).
+
+## §9 File structure
+
+```
+crates/
+  garraia-auth/
+    src/
+      audit_workspace.rs        ← +4 variants (TaskLabelCreated/Deleted/Assigned/Removed)
+  garraia-gateway/
+    src/
+      rest_v1/
+        mod.rs                  ← +5 route registrations
+        tasks.rs                ← +5 handler functions + structs
+    tests/
+      rest_v1_task_labels.rs    ← NEW — 10 integration scenarios (L1–L10)
+plans/
+  README.md                     ← new row for 0078
+```
+
+## §10 M1 tasks
+
+### T1 — Add 4 WorkspaceAuditAction variants to garraia-auth
+- [ ] Add `TaskLabelCreated`, `TaskLabelDeleted`, `TaskLabelAssigned`, `TaskLabelRemoved` to `audit_workspace.rs`
+- [ ] Add `as_str()` entries: `"task_label.created"`, `"task_label.deleted"`, `"task.label.assigned"`, `"task.label.removed"`
+- [ ] Verify distinct-strings test still passes (now 30 entries)
+- [ ] `cargo check -p garraia-auth` green
+
+### T2 — Implement 5 handler functions in tasks.rs
+- [ ] `create_task_label` (POST, 201, 409 on 23505 UNIQUE name)
+- [ ] `list_task_labels` (GET, 200, ordered by `created_at ASC`)
+- [ ] `delete_task_label` (DELETE, 204, idempotent; verify label.group_id = path_group_id first)
+- [ ] `assign_task_label` (POST, 201, 409 on 23505 PK; verify label.group_id = task.group_id before INSERT)
+- [ ] `remove_task_label_from_task` (DELETE, 204, idempotent; verify task in group first)
+- [ ] `cargo check -p garraia-gateway --features test-helpers` green
+
+### T3 — Register 5 routes in rest_v1/mod.rs
+- [ ] `POST/GET /v1/groups/{group_id}/task-labels`
+- [ ] `DELETE /v1/groups/{group_id}/task-labels/{label_id}`
+- [ ] `POST /v1/groups/{group_id}/tasks/{task_id}/labels`
+- [ ] `DELETE /v1/groups/{group_id}/tasks/{task_id}/labels/{label_id}`
+- [ ] `cargo check -p garraia-gateway --features test-helpers` green
+
+### T4 — Write integration tests (tests/rest_v1_task_labels.rs)
+- [ ] L1 — create label 201
+- [ ] L2 — create label 409 duplicate name
+- [ ] L3 — list labels returns created label
+- [ ] L4 — delete label 204 idempotent
+- [ ] L5 — assign label to task 201
+- [ ] L6 — assign label 409 duplicate
+- [ ] L7 — assign label cross-group (label from group B → task in group A) → 404
+- [ ] L8 — remove label from task 204 idempotent
+- [ ] L9 — list labels empty when none created
+- [ ] L10 — create label cross-group path mismatch → 403
+
+### T5 — Workspace-wide clippy + fmt
+- [ ] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` clean
+- [ ] `cargo fmt --check` clean
+
+### T6 — Update plans/README.md
+- [ ] Add row for plan 0078 (GAR-536, this plan)
+- [ ] Update tasks.rs module doc comment (add Slice 5 mention)
+
+## §11 Risk register
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| `created_by_label` lookup fails if user has no display_name | Low | Use `COALESCE(display_name, email)` same as task_lists.rs |
+| color validation: DB CHECK fires as internal 500 | Medium | Validate hex format in handler before INSERT; return 422 |
+| DELETE cascade surprise (all assignments gone) | Design intent | Documented; audit `task_label.deleted` includes `assignments_cascade: true` |
+
+## §12 Acceptance criteria
+
+- `cargo test --workspace --exclude garraia-desktop` all green including L1–L10
+- `cargo clippy --workspace ... -- -D warnings` clean
+- 10 integration scenarios pass against testcontainers Postgres
+- Cross-group label assignment returns 404 (L7)
+- Duplicate label name returns 409 (L2)
+- DELETE label is idempotent 204 (L4)
+
+## §13 Cross-references
+
+- Plan 0077 (GAR-533, task assignees) — identical RLS + 23505 pattern
+- Plan 0069 (GAR-520, task comments) — JOIN RLS pattern
+- ROADMAP §3.8 Tier 1 — task labels schema
+- Migration 006 (`006_tasks_with_rls.sql`) — `task_labels`, `task_label_assignments`
+
+## §14 Estimativa
+
+**Baixa:** 1.5h | **Provável:** 2.5h | **Alta:** 4h

--- a/plans/README.md
+++ b/plans/README.md
@@ -100,6 +100,8 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0074 | [GAR-528 — REST /v1 memory slice 3: GET + PATCH /v1/memory/{id}](0074-gar-528-memory-slice3-get-patch.md) | [GAR-528](https://linear.app/chatgpt25/issue/GAR-528) | ✅ Merged 2026-05-06 via PR #171 (`63cec45`) |
 | 0075 | [GAR-529 — tauri 2.10.3→2.11.1 security upgrade (ACL enforcement for remote origins)](0075-gar-529-tauri-2.11.1-acl-enforcement.md) | [GAR-529](https://linear.app/chatgpt25/issue/GAR-529) | ✅ Merged 2026-05-07 via PR #177 (`ba76287`) |
 | 0076 | [GAR-530 — Chat management slice 4: individual chat ops + member CRUD](0076-gar-530-chat-mgmt-slice4.md) | [GAR-530](https://linear.app/chatgpt25/issue/GAR-530) | ✅ Merged 2026-05-07 via PR #181 (`b48a356`) |
+| 0077 | [GAR-533 — REST /v1 tasks slice 4: task assignees API (POST/GET/DELETE)](0077-gar-533-task-assignees-api.md) | [GAR-533](https://linear.app/chatgpt25/issue/GAR-533) | ⏳ In Progress (PR #184) |
+| 0078 | [GAR-536 — REST /v1 tasks slice 5: task labels API (POST/GET/DELETE label CRUD + assignment)](0078-gar-536-task-labels-api.md) | [GAR-536](https://linear.app/chatgpt25/issue/GAR-536) | ⏳ In Progress |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

- Adds 5 new endpoints for task label CRUD + label assignment under `/v1/groups/{group_id}/`:
  - `POST /task-labels` — create label (name + `#RRGGBB` color, 409 on duplicate name per group)
  - `GET /task-labels` — list labels ordered by `created_at ASC`
  - `DELETE /task-labels/{label_id}` — delete label, CASCADE removes all assignments (idempotent 204)
  - `POST /tasks/{task_id}/labels` — assign label to task (cross-group injection guard, 409 on dup)
  - `DELETE /tasks/{task_id}/labels/{label_id}` — remove label from task (idempotent 204)
- Adds 4 new `WorkspaceAuditAction` variants: `TaskLabelCreated`, `TaskLabelDeleted`, `TaskLabelAssigned`, `TaskLabelRemoved`
- Extends OpenAPI spec (`openapi.rs`) with 5 paths + 4 schemas
- Registers all routes in `mod.rs`
- `is_valid_hex_color()` helper validates `#RRGGBB` format at the handler boundary

## Test plan

- [x] `cargo check -p garraia-gateway --features test-helpers` — clean
- [x] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` — 0 warnings
- [x] `cargo fmt --all -- --check` — no diff
- [ ] CI: Format, Clippy, Test (ubuntu/macos/windows), Build, MSRV, cargo-deny, Security Audit, Coverage, CodeQL, Playwright, E2E, Secret Scan, Dependency Review
- [ ] Integration test `rest_v1_task_labels_scenarios` (10 scenarios L1–L10) — green on CI Postgres

## Cross-references

- Plan: `plans/0078-gar-536-task-labels-api.md`
- Linear: GAR-536 (child of GAR-396 epic:ws-tasks)
- Schema: migration 006 (`task_labels` + `task_label_assignments` tables already exist)
- Includes additive merge from PR #184 (GAR-533 task assignees) — both slices coexist cleanly

https://claude.ai/code/session_017hwE5qdTtj4jiF9b8nF6Ar

---
_Generated by [Claude Code](https://claude.ai/code/session_017hwE5qdTtj4jiF9b8nF6Ar)_