### PR TITLE
docs(health): document milestones-out-of-scope in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -229,6 +229,20 @@ Comente em uma issue antes de começar a trabalhar para evitar esforço duplicad
 
 ---
 
+## Acompanhamento e milestones
+
+Planejamento de releases e ciclos vive no [Linear (time GAR)](https://linear.app/chatgpt25/team/GAR/projects), não em GitHub milestones. Por design, **milestones do GitHub não são utilizados** neste repositório — a ferramenta de prioridade, sequenciamento e alocação por ciclo é o Linear.
+
+GitHub Issues neste repositório serve a três propósitos restritos:
+
+1. Bugs reportados externamente pela comunidade.
+2. Issues de automação geradas por workflows (ex.: `garra-routine-trigger.yml`, rotuladas com `automation` + `garra-routine`).
+3. Discussões pontuais que precisem de threading público.
+
+Trabalho interno ativo (slices, planos, refactors, dependências) é rastreado em Linear e correlacionado com PRs por título / branch (`feat(...): GAR-XXX — ...`). Se você for um colaborador externo procurando saber o que está em andamento, prefira o link do Linear acima ou o `ROADMAP.md` na raiz do repositório.
+
+---
+
 ## Comunicação
 
 - **Discord:** [discord.gg/aEXGq5cS](https://discord.gg/aEXGq5cS)


### PR DESCRIPTION
## Summary

- Adds an "Acompanhamento e milestones" section to `CONTRIBUTING.md` documenting that GitHub milestones are intentionally not used and that release/cycle planning lives in Linear (team GAR).
- Documentation only — no code, no CI, no security setting changes.

## Why

`/github-health issues` on 2026-05-07 flagged the empty milestone list as `[MEDIUM] Milestones unused`. The audit's recommendation explicitly offered "declare milestones intentionally out-of-scope (Linear cycles handle this) and document it in `CONTRIBUTING.md`" as the lower-friction option. This PR takes that path.

## Audit context

- Source report: `.github-health-reports/issues_05_07_26.md` (mode `issues`, status YELLOW, 60/100).
- Iteration: 2 of up to 3.
- Risk level: low.
- Closes finding: `[MEDIUM] Milestones unused`.
- Predicted Issues sub-area score: 60 → 63–65.

## Test plan

- [x] `git status --short` shows only `CONTRIBUTING.md` modified.
- [x] Diff is +14 / -0 — pure addition between existing sections.
- [ ] CI fmt / clippy / test / audit / deny / e2e / playwright / quality-ratchet all green (docs-only diff; should pass cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)