### PR TITLE
feat(gateway): GAR-539 — task subscriptions REST API (plan 0079 slice 6)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -516,9 +516,12 @@ Módulo dentro de `garraia-workspace`. Schema entregue via migration 006 com **R
 - [x] `GET /v1/groups/{group_id}/tasks/{task_id}` — plan 0068 / GAR-518 ✅
 - [x] `PATCH /v1/groups/{group_id}/tasks/{task_id}` (status, priority, title, due_at) — plan 0068 / GAR-518 ✅
 - [x] `DELETE /v1/groups/{group_id}/tasks/{task_id}` (soft delete) — plan 0068 / GAR-518 ✅
-- [ ] `POST /v1/groups/{group_id}/tasks/{task_id}/comments` — plan 0069 / GAR-520 (em execução 2026-05-05)
-- [ ] `GET /v1/groups/{group_id}/tasks/{task_id}/comments?cursor=...` — plan 0069 / GAR-520 (em execução 2026-05-05)
-- [ ] `DELETE /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}` — plan 0069 / GAR-520 (em execução 2026-05-05)
+- [x] `POST /v1/groups/{group_id}/tasks/{task_id}/comments` — plan 0069 / [GAR-520](https://linear.app/chatgpt25/issue/GAR-520), implementado 2026-05-06 (Florida)
+- [x] `GET /v1/groups/{group_id}/tasks/{task_id}/comments?cursor=...` — plan 0069 / [GAR-520](https://linear.app/chatgpt25/issue/GAR-520), implementado 2026-05-06 (Florida)
+- [x] `DELETE /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}` — plan 0069 / [GAR-520](https://linear.app/chatgpt25/issue/GAR-520), implementado 2026-05-06 (Florida)
+- [x] `POST /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — plan 0079 / [GAR-539](https://linear.app/chatgpt25/issue/GAR-539), implementado 2026-05-07 (Florida)
+- [x] `DELETE /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — plan 0079 / [GAR-539](https://linear.app/chatgpt25/issue/GAR-539), implementado 2026-05-07 (Florida)
+- [x] `GET /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — plan 0079 / [GAR-539](https://linear.app/chatgpt25/issue/GAR-539), implementado 2026-05-07 (Florida)
 - [ ] `POST /v1/groups/{group_id}/tasks/{task_id}/attachments`
 - [ ] `POST /v1/groups/{group_id}/tasks/{task_id}:move` (reordenar/mudar lista)
 - [ ] WebSocket `/v1/groups/{group_id}/task-lists/{list_id}/stream` para updates em tempo real (kanban colaborativo)

--- a/crates/garraia-auth/src/audit_workspace.rs
+++ b/crates/garraia-auth/src/audit_workspace.rs
@@ -332,6 +332,22 @@ pub enum WorkspaceAuditAction {
     /// `resource_type = "task_label_assignments"`, `resource_id = "{task_id}"`.
     /// Metadata: `{ label_id_len: 36 }`.
     TaskLabelRemoved,
+
+    /// The calling user subscribed to task change notifications via
+    /// `POST /v1/groups/{group_id}/tasks/{task_id}/subscriptions` (plan 0079 / GAR-539,
+    /// epic GAR-WS-TASKS slice 6).
+    ///
+    /// `resource_type = "task_subscriptions"`, `resource_id = "{task_id}"`.
+    /// Metadata: `{ subscriber_user_id_len: 36 }`.
+    TaskSubscribed,
+
+    /// The calling user unsubscribed from task change notifications via
+    /// `DELETE /v1/groups/{group_id}/tasks/{task_id}/subscriptions` (plan 0079 / GAR-539,
+    /// epic GAR-WS-TASKS slice 6).
+    ///
+    /// `resource_type = "task_subscriptions"`, `resource_id = "{task_id}"`.
+    /// Metadata: `{ subscriber_user_id_len: 36 }`.
+    TaskUnsubscribed,
 }
 
 impl WorkspaceAuditAction {
@@ -369,6 +385,8 @@ impl WorkspaceAuditAction {
             WorkspaceAuditAction::TaskLabelDeleted => "task_label.deleted",
             WorkspaceAuditAction::TaskLabelAssigned => "task.label.assigned",
             WorkspaceAuditAction::TaskLabelRemoved => "task.label.removed",
+            WorkspaceAuditAction::TaskSubscribed => "task.subscribed",
+            WorkspaceAuditAction::TaskUnsubscribed => "task.unsubscribed",
         }
     }
 }
@@ -534,6 +552,14 @@ mod tests {
             WorkspaceAuditAction::TaskLabelRemoved.as_str(),
             "task.label.removed"
         );
+        assert_eq!(
+            WorkspaceAuditAction::TaskSubscribed.as_str(),
+            "task.subscribed"
+        );
+        assert_eq!(
+            WorkspaceAuditAction::TaskUnsubscribed.as_str(),
+            "task.unsubscribed"
+        );
     }
 
     #[test]
@@ -570,6 +596,8 @@ mod tests {
             WorkspaceAuditAction::TaskLabelDeleted.as_str(),
             WorkspaceAuditAction::TaskLabelAssigned.as_str(),
             WorkspaceAuditAction::TaskLabelRemoved.as_str(),
+            WorkspaceAuditAction::TaskSubscribed.as_str(),
+            WorkspaceAuditAction::TaskUnsubscribed.as_str(),
         ];
         let unique: std::collections::HashSet<_> = strings.iter().collect();
         assert_eq!(unique.len(), strings.len(), "duplicate action strings");

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -365,6 +365,13 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     "/v1/groups/{group_id}/tasks/{task_id}/labels/{label_id}",
                     delete(tasks::remove_task_label_from_task),
                 )
+                // Plan 0079 (GAR-539) — task subscriptions API slice 6.
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/subscriptions",
+                    post(tasks::subscribe_task)
+                        .delete(tasks::unsubscribe_task)
+                        .get(tasks::list_task_subscriptions),
+                )
                 // Plan 0070 (GAR-522) — audit API slice 1.
                 .route("/v1/groups/{group_id}/audit", get(audit::list_audit))
                 .merge(rate_limited_routes)

--- a/crates/garraia-gateway/src/rest_v1/tasks.rs
+++ b/crates/garraia-gateway/src/rest_v1/tasks.rs
@@ -2636,3 +2636,300 @@ fn is_valid_hex_color(color: &str) -> bool {
     }
     bytes[1..].iter().all(|b| b.is_ascii_hexdigit())
 }
+
+// ─── Slice 6 (plan 0079 / GAR-539): Task Subscriptions ───────────────────────
+
+/// DB row for a `task_subscriptions` entry.
+#[derive(sqlx::FromRow)]
+struct SubscriptionRow {
+    task_id: Uuid,
+    user_id: Uuid,
+    subscribed_at: DateTime<Utc>,
+    muted: bool,
+}
+
+/// Public response shape for a subscription record.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct SubscriptionResponse {
+    pub task_id: Uuid,
+    pub user_id: Uuid,
+    pub subscribed_at: DateTime<Utc>,
+    pub muted: bool,
+}
+
+impl From<SubscriptionRow> for SubscriptionResponse {
+    fn from(r: SubscriptionRow) -> Self {
+        Self {
+            task_id: r.task_id,
+            user_id: r.user_id,
+            subscribed_at: r.subscribed_at,
+            muted: r.muted,
+        }
+    }
+}
+
+/// `POST /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — subscribe caller to a task.
+///
+/// The calling user is subscribed to change notifications for the task.
+/// Returns 201 on success, 409 if already subscribed, 404 if task not found
+/// in this group. Authz: `Action::TasksRead` (watching requires only read access).
+///
+/// ## Error matrix
+///
+/// | Condition                          | Status |
+/// |------------------------------------|--------|
+/// | Missing/invalid JWT                | 401    |
+/// | Non-member of group                | 403    |
+/// | Path group_id ≠ principal group_id | 403    |
+/// | Task not found / cross-tenant      | 404    |
+/// | Already subscribed                 | 409    |
+/// | Happy path                         | 201    |
+#[utoipa::path(
+    post,
+    path = "/v1/groups/{group_id}/tasks/{task_id}/subscriptions",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("task_id" = Uuid, Path, description = "Task UUID."),
+    ),
+    responses(
+        (status = 201, description = "Subscribed to task.", body = SubscriptionResponse),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Task not found in this group.", body = super::problem::ProblemDetails),
+        (status = 409, description = "Already subscribed to this task.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn subscribe_task(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, task_id)): Path<(Uuid, Uuid)>,
+) -> Result<(StatusCode, Json<SubscriptionResponse>), RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksRead) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    let task_exists: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM tasks WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+    )
+    .bind(task_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if task_exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    let row: SubscriptionRow = sqlx::query_as(
+        "INSERT INTO task_subscriptions (task_id, user_id) \
+         VALUES ($1, $2) \
+         RETURNING task_id, user_id, subscribed_at, muted",
+    )
+    .bind(task_id)
+    .bind(principal.user_id)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| {
+        if let sqlx::Error::Database(ref db_err) = e
+            && db_err.code().as_deref() == Some("23505")
+        {
+            return RestError::Conflict("already subscribed to this task".into());
+        }
+        RestError::Internal(e.into())
+    })?;
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::TaskSubscribed,
+        principal.user_id,
+        group_id,
+        "task_subscriptions",
+        task_id.to_string(),
+        json!({ "subscriber_user_id_len": 36 }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok((StatusCode::CREATED, Json(SubscriptionResponse::from(row))))
+}
+
+/// `DELETE /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — unsubscribe caller from a task.
+///
+/// Idempotent: returns 204 whether or not the subscription existed.
+/// Returns 404 if the task is not found in this group. Authz: `Action::TasksRead`.
+///
+/// ## Error matrix
+///
+/// | Condition                          | Status |
+/// |------------------------------------|--------|
+/// | Missing/invalid JWT                | 401    |
+/// | Non-member of group                | 403    |
+/// | Path group_id ≠ principal group_id | 403    |
+/// | Task not found / cross-tenant      | 404    |
+/// | Happy path (was/wasn't subscribed) | 204    |
+#[utoipa::path(
+    delete,
+    path = "/v1/groups/{group_id}/tasks/{task_id}/subscriptions",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("task_id" = Uuid, Path, description = "Task UUID."),
+    ),
+    responses(
+        (status = 204, description = "Unsubscribed (or was not subscribed)."),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Task not found in this group.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn unsubscribe_task(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, task_id)): Path<(Uuid, Uuid)>,
+) -> Result<StatusCode, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksRead) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    let task_exists: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM tasks WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+    )
+    .bind(task_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if task_exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    sqlx::query(
+        "DELETE FROM task_subscriptions WHERE task_id = $1 AND user_id = $2",
+    )
+    .bind(task_id)
+    .bind(principal.user_id)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::TaskUnsubscribed,
+        principal.user_id,
+        group_id,
+        "task_subscriptions",
+        task_id.to_string(),
+        json!({ "subscriber_user_id_len": 36 }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `GET /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — list subscribers of a task.
+///
+/// Returns all current subscribers ordered by `subscribed_at ASC`.
+/// Authz: `Action::TasksRead`.
+///
+/// ## Error matrix
+///
+/// | Condition                          | Status |
+/// |------------------------------------|--------|
+/// | Missing/invalid JWT                | 401    |
+/// | Non-member of group                | 403    |
+/// | Path group_id ≠ principal group_id | 403    |
+/// | Task not found / cross-tenant      | 404    |
+/// | Happy path                         | 200    |
+#[utoipa::path(
+    get,
+    path = "/v1/groups/{group_id}/tasks/{task_id}/subscriptions",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("task_id" = Uuid, Path, description = "Task UUID."),
+    ),
+    responses(
+        (status = 200, description = "List of subscribers.", body = Vec<SubscriptionResponse>),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Task not found in this group.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn list_task_subscriptions(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, task_id)): Path<(Uuid, Uuid)>,
+) -> Result<Json<Vec<SubscriptionResponse>>, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksRead) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    let task_exists: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM tasks WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+    )
+    .bind(task_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if task_exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    let rows: Vec<SubscriptionRow> = sqlx::query_as(
+        "SELECT task_id, user_id, subscribed_at, muted \
+         FROM task_subscriptions \
+         WHERE task_id = $1 \
+         ORDER BY subscribed_at ASC",
+    )
+    .bind(task_id)
+    .fetch_all(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(Json(rows.into_iter().map(SubscriptionResponse::from).collect()))
+}

--- a/crates/garraia-gateway/tests/rest_v1_task_subscriptions.rs
+++ b/crates/garraia-gateway/tests/rest_v1_task_subscriptions.rs
@@ -1,0 +1,319 @@
+//! Integration tests for task subscriptions REST API (plan 0079, GAR-539).
+//!
+//! All scenarios bundled into ONE `#[tokio::test]` — same pattern as
+//! `rest_v1_task_assignees.rs`. Splitting triggers the sqlx runtime-teardown
+//! race documented in plan 0016 M3.
+//!
+//! Scenarios (8 total):
+//!
+//!   S1.  POST 201 — subscribe caller to task; assert response shape + audit row.
+//!   S2.  POST 409 — duplicate subscribe returns 409 Conflict.
+//!   S3.  GET 200 — list subscriptions; includes S1 entry.
+//!   S4.  DELETE 204 — unsubscribe; verify audit row emitted.
+//!   S5.  DELETE 204 — idempotent: user already unsubscribed; returns 204 again.
+//!   S6.  POST 404 — task not in group (cross-group task isolation).
+//!   S7.  GET 404 + DELETE 404 + POST 404 — unknown task_id returns 404.
+//!   S8.  POST 403 — path group_id ≠ principal group_id returns 403.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+
+use common::Harness;
+use common::fixtures::{fetch_audit_events_for_group, seed_user_with_group};
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect response body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("response body is not JSON")
+}
+
+fn auth_req(
+    method: &str,
+    uri: &str,
+    token: Option<&str>,
+    x_group_id: Option<&str>,
+    body: Option<serde_json::Value>,
+) -> Request<Body> {
+    let body_bytes = match body {
+        Some(v) => Body::from(v.to_string()),
+        None => Body::empty(),
+    };
+    let mut req = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(body_bytes)
+        .expect("request builder");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    if let Some(t) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {t}")).unwrap(),
+        );
+    }
+    if let Some(g) = x_group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    req
+}
+
+async fn create_task_list_and_task(h: &Harness, token: &str, gid: &str) -> (String, String) {
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{gid}/task-lists"),
+            Some(token),
+            Some(gid),
+            Some(json!({ "name": "Sub Test List", "type": "list" })),
+        ))
+        .await
+        .expect("create task-list");
+    assert_eq!(resp.status(), StatusCode::CREATED, "setup: task-list 201");
+    let tl_body = body_json(resp).await;
+    let list_id = tl_body["id"].as_str().expect("list id").to_string();
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{gid}/task-lists/{list_id}/tasks"),
+            Some(token),
+            Some(gid),
+            Some(json!({ "title": "Watch me", "status": "todo", "priority": "none" })),
+        ))
+        .await
+        .expect("create task");
+    assert_eq!(resp.status(), StatusCode::CREATED, "setup: task 201");
+    let t_body = body_json(resp).await;
+    let task_id = t_body["id"].as_str().expect("task id").to_string();
+
+    (list_id, task_id)
+}
+
+// ─── Test ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn task_subscriptions_api_all_scenarios() {
+    let h = Harness::get().await;
+
+    // Primary user (group owner).
+    let (_user_id, group_id, token) = seed_user_with_group(&h, "alice@subs.test")
+        .await
+        .expect("seed alice+group");
+
+    // Second user / group for cross-group isolation.
+    let (_user_id2, group_id2, token2) = seed_user_with_group(&h, "bob@subs.test")
+        .await
+        .expect("seed bob+group2");
+
+    let gid = group_id.to_string();
+    let g2id = group_id2.to_string();
+
+    let (_, task_id) = create_task_list_and_task(&h, &token, &gid).await;
+
+    // ── S1. POST 201 — subscribe caller ──────────────────────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/subscriptions"),
+            Some(&token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("S1");
+    assert_eq!(resp.status(), StatusCode::CREATED, "S1: 201 subscribe");
+    let s1_body = body_json(resp).await;
+    assert_eq!(s1_body["task_id"].as_str().unwrap(), task_id, "S1: task_id");
+    assert!(s1_body["user_id"].as_str().is_some(), "S1: user_id present");
+    assert!(s1_body["subscribed_at"].as_str().is_some(), "S1: subscribed_at present");
+    assert!(!s1_body["muted"].as_bool().unwrap(), "S1: muted defaults false");
+
+    // Verify audit row.
+    let audit = fetch_audit_events_for_group(&h, group_id)
+        .await
+        .expect("S1 fetch audit");
+    let s1_audit = audit
+        .iter()
+        .find(|e| e.0 == "task.subscribed")
+        .expect("S1: task.subscribed audit row");
+    let (_, _, s1_res_type, s1_res_id, s1_meta) = s1_audit;
+    assert_eq!(s1_res_type, "task_subscriptions", "S1: audit resource_type");
+    assert_eq!(s1_res_id, &task_id, "S1: audit resource_id = task_id");
+    assert!(
+        s1_meta["subscriber_user_id_len"].as_u64().is_some(),
+        "S1: metadata has subscriber_user_id_len"
+    );
+    assert!(
+        s1_meta.get("user_id").is_none(),
+        "S1: PII guard — user_id value absent from metadata"
+    );
+
+    // ── S2. POST 409 — duplicate subscribe ───────────────────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/subscriptions"),
+            Some(&token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("S2");
+    assert_eq!(resp.status(), StatusCode::CONFLICT, "S2: 409 duplicate");
+
+    // ── S3. GET 200 — list subscriptions includes S1 ─────────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "GET",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/subscriptions"),
+            Some(&token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("S3");
+    assert_eq!(resp.status(), StatusCode::OK, "S3: 200 list");
+    let s3_body = body_json(resp).await;
+    let items = s3_body.as_array().expect("S3: array response");
+    assert_eq!(items.len(), 1, "S3: exactly 1 subscriber");
+    assert_eq!(items[0]["task_id"].as_str().unwrap(), task_id, "S3: task_id matches");
+
+    // ── S4. DELETE 204 — unsubscribe + audit ─────────────────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "DELETE",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/subscriptions"),
+            Some(&token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("S4");
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT, "S4: 204 unsubscribe");
+
+    let audit2 = fetch_audit_events_for_group(&h, group_id)
+        .await
+        .expect("S4 fetch audit");
+    assert!(
+        audit2.iter().any(|e| e.0 == "task.unsubscribed"),
+        "S4: task.unsubscribed audit row present"
+    );
+
+    // ── S5. DELETE 204 — idempotent (already unsubscribed) ───────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "DELETE",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/subscriptions"),
+            Some(&token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("S5");
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT, "S5: 204 idempotent");
+
+    // GET returns empty list after unsubscribe.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "GET",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/subscriptions"),
+            Some(&token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("S5b");
+    assert_eq!(resp.status(), StatusCode::OK, "S5b: 200");
+    assert_eq!(
+        body_json(resp).await.as_array().unwrap().len(),
+        0,
+        "S5b: empty after unsubscribe"
+    );
+
+    // ── S6. POST 404 — task in group1, accessed via group2 creds ─────────────
+    // Bob (group2) tries to subscribe to task in group1 using group2 path.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{g2id}/tasks/{task_id}/subscriptions"),
+            Some(&token2),
+            Some(&g2id),
+            None,
+        ))
+        .await
+        .expect("S6");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND, "S6: 404 cross-group task");
+
+    // ── S7. GET 404 + DELETE 404 + POST 404 — unknown task_id ────────────────
+    let bad_id = uuid::Uuid::new_v4();
+    for method in ["GET", "DELETE", "POST"] {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(auth_req(
+                method,
+                &format!("/v1/groups/{gid}/tasks/{bad_id}/subscriptions"),
+                Some(&token),
+                Some(&gid),
+                None,
+            ))
+            .await
+            .unwrap_or_else(|_| panic!("S7 {method}"));
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "S7: {method} 404 unknown task"
+        );
+    }
+
+    // ── S8. POST 403 — path group_id ≠ principal group_id ───────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            // path says group2 but token/header says group1
+            &format!("/v1/groups/{g2id}/tasks/{task_id}/subscriptions"),
+            Some(&token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("S8");
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN, "S8: 403 group mismatch");
+}

--- a/plans/0079-gar-539-task-subscriptions-api.md
+++ b/plans/0079-gar-539-task-subscriptions-api.md
@@ -1,0 +1,106 @@
+# Plan 0079 — GAR-539: REST /v1 tasks slice 6: task subscriptions API
+
+## Goal
+
+Land three task-subscription endpoints on the `garraia_app` RLS-enforced pool,
+completing the self-service "watch/unwatch a task" surface. The `task_subscriptions`
+table already exists (migration 006, FORCE RLS via JOIN policy through `tasks`).
+
+## Endpoints delivered
+
+| Method | Path | Auth | Action |
+|--------|------|------|--------|
+| `POST` | `/v1/groups/{group_id}/tasks/{task_id}/subscriptions` | `TasksRead` | Subscribe caller to task (201 / 409 duplicate) |
+| `DELETE` | `/v1/groups/{group_id}/tasks/{task_id}/subscriptions` | `TasksRead` | Unsubscribe caller (204, idempotent) |
+| `GET` | `/v1/groups/{group_id}/tasks/{task_id}/subscriptions` | `TasksRead` | List subscribers |
+
+Note: subscribing/unsubscribing only requires `TasksRead` — no write permission needed
+to watch a task you can see. This matches the design intention that watching is low-privilege.
+
+## Architecture
+
+- **Crate:** `garraia-gateway` — `rest_v1/tasks.rs` (Slice 6 section)
+- **Crate:** `garraia-auth` — add `TaskSubscribed` + `TaskUnsubscribed` to `WorkspaceAuditAction`
+- **Router:** `rest_v1/mod.rs` — two new `.route()` calls
+- **Tests:** `crates/garraia-gateway/tests/rest_v1_task_subscriptions.rs`
+
+## Table schema (migration 006, already migrated)
+
+```sql
+CREATE TABLE task_subscriptions (
+    task_id       uuid        NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    user_id       uuid        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    subscribed_at timestamptz NOT NULL DEFAULT now(),
+    muted         boolean     NOT NULL DEFAULT false,
+    PRIMARY KEY (task_id, user_id)
+);
+-- RLS: task_subscriptions_through_tasks JOIN policy (group isolation via tasks.group_id)
+```
+
+## Tech stack
+
+- Rust + Axum 0.8 + SQLx 0.8 + Postgres 16 + pgvector (testcontainers)
+- `garraia-auth` for `Principal`, `can()`, `audit_workspace_event()`
+- Parameterized `set_config()` for RLS context (plan 0056 pattern)
+
+## Design invariants
+
+1. `set_rls_context` called before every query (both `user_id` and `group_id`).
+2. PK conflict on `(task_id, user_id)` → 409 Conflict (not 500).
+3. DELETE is idempotent — no row found returns 204, not 404.
+4. Audit: `task.subscribed` on POST, `task.unsubscribed` on DELETE (no audit for GET).
+5. PII-safe metadata: no user email/name in audit payload; `user_id_len: 36` only.
+6. App-layer group guard: `path_group_id == principal.group_id` or 403.
+7. Cross-group guard: task must exist in the caller's group (enforced by RLS + task existence check).
+
+## Out of scope
+
+- `muted` field management (PUT/PATCH subscription) — deferred to GAR-397 digest worker
+- Fan-out notifications — GAR-397
+- Batch subscribe — not in schema
+
+## Rollback
+
+Docs + code only; no schema change. Revert by dropping the 3 handler functions, 2 router entries, 1 test file, and the 2 audit variants.
+
+## File structure
+
+```
+crates/garraia-auth/src/audit_workspace.rs        ← +2 variants + 2 as_str() + 4 test rows
+crates/garraia-gateway/src/rest_v1/tasks.rs       ← +~120 LOC Slice 6 section
+crates/garraia-gateway/src/rest_v1/mod.rs         ← +2 route entries
+crates/garraia-gateway/tests/rest_v1_task_subscriptions.rs  ← new, 8 scenarios
+plans/0079-gar-539-task-subscriptions-api.md      ← this file
+plans/README.md                                   ← new row
+```
+
+## M1 tasks
+
+- [x] T1: Add `TaskSubscribed` + `TaskUnsubscribed` to `WorkspaceAuditAction` in `garraia-auth`
+- [x] T2: Add Slice 6 handlers (`subscribe_task`, `unsubscribe_task`, `list_task_subscriptions`) in `tasks.rs`
+- [x] T3: Wire routes in `mod.rs`
+- [x] T4: Write integration test `rest_v1_task_subscriptions.rs` (8 scenarios: S1–S8)
+- [x] T5: `cargo check -p garraia-gateway -p garraia-auth` green
+- [x] T6: `cargo test -p garraia-gateway --test rest_v1_task_subscriptions` green
+- [x] T7: `cargo clippy --workspace ...` green
+- [x] T8: Update `plans/README.md` + ROADMAP.md checklist
+
+## Acceptance criteria
+
+- POST 201 on fresh subscription; 409 on duplicate; 404 if task not in group.
+- DELETE 204 whether or not subscription existed.
+- GET 200 returns list ordered by `subscribed_at ASC`.
+- Cross-group injection: user from group B cannot subscribe to task in group A (403 path guard + RLS).
+- `cargo test -p garraia-gateway --test rest_v1_task_subscriptions` green (8 scenarios).
+- `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` green.
+
+## Cross-references
+
+- GAR-539 Linear issue
+- Plan 0077 (GAR-533) — task assignees (same pattern)
+- Plan 0078 (GAR-536) — task labels (same pattern)
+- Migration 006 — `task_subscriptions` table + RLS policy
+
+## Estimativa
+
+0.5 / 1 / 1.5 days

--- a/plans/README.md
+++ b/plans/README.md
@@ -102,6 +102,7 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0076 | [GAR-530 — Chat management slice 4: individual chat ops + member CRUD](0076-gar-530-chat-mgmt-slice4.md) | [GAR-530](https://linear.app/chatgpt25/issue/GAR-530) | ✅ Merged 2026-05-07 via PR #181 (`b48a356`) |
 | 0077 | [GAR-533 — REST /v1 tasks slice 4: task assignees API (POST/GET/DELETE)](0077-gar-533-task-assignees-api.md) | [GAR-533](https://linear.app/chatgpt25/issue/GAR-533) | ✅ Merged 2026-05-07 via PR #184 (`22c423c`) |
 | 0078 | [GAR-536 — REST /v1 tasks slice 5: task labels API (POST/GET/DELETE label CRUD + assignment)](0078-gar-536-task-labels-api.md) | [GAR-536](https://linear.app/chatgpt25/issue/GAR-536) | ✅ Merged 2026-05-07 via PR #189 (`7fc5cb3`) |
+| 0079 | [GAR-539 — REST /v1 tasks slice 6: task subscriptions API (POST/DELETE/GET)](0079-gar-539-task-subscriptions-api.md) | [GAR-539](https://linear.app/chatgpt25/issue/GAR-539) | ⏳ In Progress |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

- Implements `POST/DELETE/GET /v1/groups/{group_id}/tasks/{task_id}/subscriptions` (plan 0079, GAR-539)
- Adds `WorkspaceAuditAction::TaskSubscribed` / `TaskUnsubscribed` variants in `garraia-auth`
- 8-scenario integration test in `rest_v1_task_subscriptions.rs` (S1–S8: 201/409/200/204 idempotent/404 cross-group/404 unknown/403 group mismatch)
- PII-safe audit metadata: records `subscriber_user_id_len` (36), never raw user_id
- FORCE RLS isolation via `task_subscriptions_through_tasks` JOIN policy (migration 006)

## Test plan

- [ ] All 4 CI jobs pass (fmt / clippy / test / build)
- [ ] Integration test `task_subscriptions_api_all_scenarios` covers all 8 scenarios
- [ ] Cross-group isolation verified (S6: 404, S8: 403)
- [ ] Audit rows `task.subscribed` + `task.unsubscribed` emitted and PII-clean
- [ ] Idempotent DELETE (S5: 204 when already unsubscribed)

## References

- Plan: `plans/0079-gar-539-task-subscriptions-api.md`
- Linear: GAR-539
- Previous slice: PR #189 (task labels, plan 0078)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DxyWoSNsL1YnUPknLcQQSn)_