### PR TITLE
feat(tasks): GAR-539 — task subscriptions API slice 6 (plan 0079)

### DIFF
--- a/crates/garraia-auth/src/audit_workspace.rs
+++ b/crates/garraia-auth/src/audit_workspace.rs
@@ -332,6 +332,26 @@ pub enum WorkspaceAuditAction {
     /// `resource_type = "task_label_assignments"`, `resource_id = "{task_id}"`.
     /// Metadata: `{ label_id_len: 36 }`.
     TaskLabelRemoved,
+
+    /// The current user subscribed themselves to a task via
+    /// `POST /v1/groups/{group_id}/tasks/{task_id}/subscriptions`
+    /// (plan 0079 / GAR-539, epic GAR-WS-TASKS slice 6).
+    ///
+    /// `resource_type = "task_subscriptions"`, `resource_id = "{task_id}"`.
+    /// Metadata: `{ subscriber_user_id_len: 36 }` — never the subscriber's
+    /// email or display name.
+    TaskSubscribed,
+
+    /// The current user unsubscribed themselves from a task via
+    /// `DELETE /v1/groups/{group_id}/tasks/{task_id}/subscriptions`
+    /// (plan 0079 / GAR-539, epic GAR-WS-TASKS slice 6).
+    ///
+    /// Idempotent — emitted on every DELETE call, even when no row was
+    /// removed (the audit row is the receipt that the operation ran, not
+    /// proof that state changed).
+    /// `resource_type = "task_subscriptions"`, `resource_id = "{task_id}"`.
+    /// Metadata: `{ subscriber_user_id_len: 36 }`.
+    TaskUnsubscribed,
 }
 
 impl WorkspaceAuditAction {
@@ -369,6 +389,8 @@ impl WorkspaceAuditAction {
             WorkspaceAuditAction::TaskLabelDeleted => "task_label.deleted",
             WorkspaceAuditAction::TaskLabelAssigned => "task.label.assigned",
             WorkspaceAuditAction::TaskLabelRemoved => "task.label.removed",
+            WorkspaceAuditAction::TaskSubscribed => "task.subscribed",
+            WorkspaceAuditAction::TaskUnsubscribed => "task.unsubscribed",
         }
     }
 }
@@ -534,6 +556,14 @@ mod tests {
             WorkspaceAuditAction::TaskLabelRemoved.as_str(),
             "task.label.removed"
         );
+        assert_eq!(
+            WorkspaceAuditAction::TaskSubscribed.as_str(),
+            "task.subscribed"
+        );
+        assert_eq!(
+            WorkspaceAuditAction::TaskUnsubscribed.as_str(),
+            "task.unsubscribed"
+        );
     }
 
     #[test]
@@ -570,6 +600,8 @@ mod tests {
             WorkspaceAuditAction::TaskLabelDeleted.as_str(),
             WorkspaceAuditAction::TaskLabelAssigned.as_str(),
             WorkspaceAuditAction::TaskLabelRemoved.as_str(),
+            WorkspaceAuditAction::TaskSubscribed.as_str(),
+            WorkspaceAuditAction::TaskUnsubscribed.as_str(),
         ];
         let unique: std::collections::HashSet<_> = strings.iter().collect();
         assert_eq!(unique.len(), strings.len(), "duplicate action strings");

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -280,6 +280,14 @@ name = "rest_v1_task_labels"
 path = "tests/rest_v1_task_labels.rs"
 required-features = ["test-helpers"]
 
+# Plan 0079 (GAR-539) — tasks slice 6: task subscriptions API
+# (POST/GET/DELETE /v1/groups/{gid}/tasks/{tid}/subscriptions). Subject is
+# always principal.user_id; POST/DELETE take no body. 7 bundled scenarios.
+[[test]]
+name = "rest_v1_task_subscriptions"
+path = "tests/rest_v1_task_subscriptions.rs"
+required-features = ["test-helpers"]
+
 [dev-dependencies]
 # Plan 0024 T4 (GAR-412): metrics_exporter tests and the
 # metrics_auth_integration binary build a `PrometheusRecorder` directly

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -365,6 +365,13 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     "/v1/groups/{group_id}/tasks/{task_id}/labels/{label_id}",
                     delete(tasks::remove_task_label_from_task),
                 )
+                // Plan 0079 (GAR-539) — task subscriptions API slice 6.
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/subscriptions",
+                    post(tasks::subscribe_to_task)
+                        .get(tasks::list_task_subscriptions)
+                        .delete(tasks::unsubscribe_from_task),
+                )
                 // Plan 0070 (GAR-522) — audit API slice 1.
                 .route("/v1/groups/{group_id}/audit", get(audit::list_audit))
                 .merge(rate_limited_routes)

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -33,8 +33,8 @@ use super::tasks::{
     AddAssigneeRequest, AssignTaskLabelRequest, AssigneeResponse, CommentResponse,
     CreateCommentRequest, CreateTaskLabelRequest, CreateTaskListRequest, CreateTaskRequest,
     LabelAssignmentResponse, ListCommentsResponse, ListTaskListsResponse, ListTasksResponse,
-    PatchTaskListRequest, PatchTaskRequest, TaskLabelResponse, TaskListResponse, TaskListSummary,
-    TaskResponse, TaskSummary,
+    PatchTaskListRequest, PatchTaskRequest, SubscriptionResponse, TaskLabelResponse,
+    TaskListResponse, TaskListSummary, TaskResponse, TaskSummary,
 };
 use super::uploads::{CreateUploadRequest, CreateUploadResponse};
 
@@ -123,6 +123,9 @@ impl Modify for SecurityAddon {
         super::tasks::delete_task_label,
         super::tasks::assign_task_label,
         super::tasks::remove_task_label_from_task,
+        super::tasks::subscribe_to_task,
+        super::tasks::list_task_subscriptions,
+        super::tasks::unsubscribe_from_task,
         super::audit::list_audit,
     ),
     components(schemas(
@@ -174,6 +177,7 @@ impl Modify for SecurityAddon {
         TaskLabelResponse,
         AssignTaskLabelRequest,
         LabelAssignmentResponse,
+        SubscriptionResponse,
         AuditEventSummary,
         ListAuditResponse,
     )),

--- a/crates/garraia-gateway/src/rest_v1/tasks.rs
+++ b/crates/garraia-gateway/src/rest_v1/tasks.rs
@@ -1,7 +1,7 @@
-//! `/v1/groups/{group_id}/task-lists` and task/comment/assignee/label handlers
-//! (plan 0066/0067/0069/0077/0078, GAR-516/GAR-518/GAR-520/GAR-533/GAR-536).
+//! `/v1/groups/{group_id}/task-lists` and task/comment/assignee/label/subscription handlers
+//! (plan 0066/0067/0069/0077/0078/0079, GAR-516/GAR-518/GAR-520/GAR-533/GAR-536/GAR-539).
 //!
-//! Twenty endpoints on the `garraia_app` RLS-enforced pool:
+//! Twenty-three endpoints on the `garraia_app` RLS-enforced pool:
 //!
 //! **Slice 1 (plan 0066 / GAR-516):**
 //! - `POST /v1/groups/{group_id}/task-lists` — create task list
@@ -32,6 +32,11 @@
 //! - `DELETE /v1/groups/{group_id}/task-labels/{label_id}` — delete label (CASCADE assignments)
 //! - `POST /v1/groups/{group_id}/tasks/{task_id}/labels` — assign label to task
 //! - `DELETE /v1/groups/{group_id}/tasks/{task_id}/labels/{label_id}` — remove label assignment (idempotent)
+//!
+//! **Slice 6 (plan 0079 / GAR-539):**
+//! - `POST /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — current user subscribes
+//! - `GET /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — list subscribers
+//! - `DELETE /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — current user unsubscribes (idempotent)
 //!
 //! ## Tenant-context protocol
 //!
@@ -2635,4 +2640,284 @@ fn is_valid_hex_color(color: &str) -> bool {
         return false;
     }
     bytes[1..].iter().all(|b| b.is_ascii_hexdigit())
+}
+
+// ─── Plan 0079 (GAR-539) — task subscriptions API slice 6 ──────────────────
+//
+// Subject is always `principal.user_id`; POST/DELETE take no body. RLS class
+// is JOIN-via-tasks (same as task_assignees and task_label_assignments).
+
+/// DB row for a single task subscription, as fetched from `task_subscriptions`.
+#[derive(sqlx::FromRow)]
+struct SubscriptionRow {
+    user_id: Uuid,
+    subscribed_at: DateTime<Utc>,
+    muted: bool,
+}
+
+/// Public response shape for a task subscription.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct SubscriptionResponse {
+    pub task_id: Uuid,
+    pub user_id: Uuid,
+    pub subscribed_at: DateTime<Utc>,
+    pub muted: bool,
+}
+
+/// `POST /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — subscribe the
+/// current user to a task.
+///
+/// Returns 201 on success, 409 if already subscribed, 404 if task is not
+/// present in this group. Body is empty. Authz: `Action::TasksWrite`.
+#[utoipa::path(
+    post,
+    path = "/v1/groups/{group_id}/tasks/{task_id}/subscriptions",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("task_id" = Uuid, Path, description = "Task UUID."),
+    ),
+    responses(
+        (status = 201, description = "Subscribed.", body = SubscriptionResponse),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Task not found in this group.", body = super::problem::ProblemDetails),
+        (status = 409, description = "Already subscribed to this task.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn subscribe_to_task(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, task_id)): Path<(Uuid, Uuid)>,
+) -> Result<(StatusCode, Json<SubscriptionResponse>), RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksWrite) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Verify task exists in this group and is not soft-deleted.
+    let task_exists: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM tasks WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+    )
+    .bind(task_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if task_exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    let row: SubscriptionRow = sqlx::query_as(
+        "INSERT INTO task_subscriptions (task_id, user_id) \
+         VALUES ($1, $2) \
+         RETURNING user_id, subscribed_at, muted",
+    )
+    .bind(task_id)
+    .bind(principal.user_id)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| {
+        if let sqlx::Error::Database(ref db_err) = e
+            && db_err.code().as_deref() == Some("23505")
+        {
+            return RestError::Conflict("already subscribed to this task".into());
+        }
+        RestError::Internal(e.into())
+    })?;
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::TaskSubscribed,
+        principal.user_id,
+        group_id,
+        "task_subscriptions",
+        task_id.to_string(),
+        json!({ "subscriber_user_id_len": 36 }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(SubscriptionResponse {
+            task_id,
+            user_id: row.user_id,
+            subscribed_at: row.subscribed_at,
+            muted: row.muted,
+        }),
+    ))
+}
+
+/// `GET /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — list subscribers
+/// for a task.
+///
+/// Returns subscribers ordered by `subscribed_at ASC`, then `user_id ASC` as
+/// a stable tiebreaker for subsecond inserts. Authz: `Action::TasksRead`.
+#[utoipa::path(
+    get,
+    path = "/v1/groups/{group_id}/tasks/{task_id}/subscriptions",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("task_id" = Uuid, Path, description = "Task UUID."),
+    ),
+    responses(
+        (status = 200, description = "List of subscribers.", body = Vec<SubscriptionResponse>),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Task not found in this group.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn list_task_subscriptions(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, task_id)): Path<(Uuid, Uuid)>,
+) -> Result<Json<Vec<SubscriptionResponse>>, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksRead) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Explicit 404 if task not found (RLS would also filter, but the explicit
+    // check yields clear UX vs. silent empty list when the task is wrong).
+    let task_exists: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM tasks WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+    )
+    .bind(task_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if task_exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    let rows: Vec<SubscriptionRow> = sqlx::query_as(
+        "SELECT user_id, subscribed_at, muted \
+         FROM task_subscriptions \
+         WHERE task_id = $1 \
+         ORDER BY subscribed_at ASC, user_id ASC",
+    )
+    .bind(task_id)
+    .fetch_all(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    let items = rows
+        .into_iter()
+        .map(|r| SubscriptionResponse {
+            task_id,
+            user_id: r.user_id,
+            subscribed_at: r.subscribed_at,
+            muted: r.muted,
+        })
+        .collect();
+
+    Ok(Json(items))
+}
+
+/// `DELETE /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — unsubscribe
+/// the current user from a task.
+///
+/// Idempotent on the subscription row: returns 204 whether or not the user
+/// was previously subscribed. Returns 404 if the task itself is not present
+/// in this group. Authz: `Action::TasksWrite`.
+#[utoipa::path(
+    delete,
+    path = "/v1/groups/{group_id}/tasks/{task_id}/subscriptions",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("task_id" = Uuid, Path, description = "Task UUID."),
+    ),
+    responses(
+        (status = 204, description = "Unsubscribed (or was not subscribed)."),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Task not found in this group.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn unsubscribe_from_task(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, task_id)): Path<(Uuid, Uuid)>,
+) -> Result<StatusCode, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksWrite) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Verify task exists in this group before emitting audit.
+    let task_exists: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM tasks WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+    )
+    .bind(task_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if task_exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    sqlx::query("DELETE FROM task_subscriptions WHERE task_id = $1 AND user_id = $2")
+        .bind(task_id)
+        .bind(principal.user_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::TaskUnsubscribed,
+        principal.user_id,
+        group_id,
+        "task_subscriptions",
+        task_id.to_string(),
+        json!({ "subscriber_user_id_len": 36 }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/garraia-gateway/tests/rest_v1_task_subscriptions.rs
+++ b/crates/garraia-gateway/tests/rest_v1_task_subscriptions.rs
@@ -1,0 +1,337 @@
+//! Integration tests for task subscriptions REST API (plan 0079, GAR-539).
+//!
+//! All scenarios bundled into ONE `#[tokio::test]` — same pattern as
+//! `rest_v1_task_assignees.rs` and `rest_v1_task_labels.rs`. Splitting
+//! triggers the sqlx runtime-teardown race documented in plan 0016 M3.
+//!
+//! Scenarios (7 total):
+//!
+//!   S1. POST 201 — Alice subscribes herself; response shape + audit row
+//!       (`task.subscribed`, resource `task_subscriptions/{task_id}`,
+//!       metadata `subscriber_user_id_len: 36` and NO PII).
+//!   S2. POST 409 — second subscribe by same user.
+//!   S3. GET 200  — list returns 1 entry with Alice as subscriber.
+//!   S4. DELETE 204 — Alice unsubscribes; audit `task.unsubscribed`;
+//!       second DELETE on same task → 204 idempotent.
+//!   S5. POST 404 — Alice tries to subscribe to a task that lives in Bob's
+//!       group (cross-group `task_id` injection guard).
+//!   S6. POST 403 — path `group_id` ≠ principal `group_id`
+//!       (covered by `check_group_match`).
+//!   S7. GET 200  — empty array after the unsubscribe in S4.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+
+use common::Harness;
+use common::fixtures::{fetch_audit_events_for_group, seed_user_with_group};
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect response body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("response body is not JSON")
+}
+
+fn auth_req(
+    method: &str,
+    uri: &str,
+    token: Option<&str>,
+    x_group_id: Option<&str>,
+    body: Option<serde_json::Value>,
+) -> Request<Body> {
+    let body_bytes = match body {
+        Some(v) => Body::from(v.to_string()),
+        None => Body::empty(),
+    };
+    let mut req = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(body_bytes)
+        .expect("request builder");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    if let Some(t) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {t}")).unwrap(),
+        );
+    }
+    if let Some(g) = x_group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    req
+}
+
+async fn create_task_list_and_task(h: &Harness, token: &str, group_id: &str) -> (String, String) {
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{group_id}/task-lists"),
+            Some(token),
+            Some(group_id),
+            Some(json!({ "name": "Subscription Test List", "type": "list" })),
+        ))
+        .await
+        .expect("create task-list");
+    assert_eq!(resp.status(), StatusCode::CREATED, "setup: task-list 201");
+    let tl_body = body_json(resp).await;
+    let list_id = tl_body["id"].as_str().expect("list id").to_string();
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{group_id}/task-lists/{list_id}/tasks"),
+            Some(token),
+            Some(group_id),
+            Some(json!({ "title": "Task that gets subscribers" })),
+        ))
+        .await
+        .expect("create task");
+    assert_eq!(resp.status(), StatusCode::CREATED, "setup: task 201");
+    let task_body = body_json(resp).await;
+    let task_id = task_body["id"].as_str().expect("task id").to_string();
+
+    (list_id, task_id)
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(feature = "test-helpers")]
+#[tokio::test]
+async fn rest_v1_task_subscriptions_scenarios() {
+    let h = Harness::get().await;
+
+    // Seed Alice as group owner; Bob owns a separate group used by S5.
+    let (alice_id, group_id, alice_token) = seed_user_with_group(&h, "alice@subs.test")
+        .await
+        .expect("seed alice+group");
+    let (_bob_id, bob_group_id, bob_token) = seed_user_with_group(&h, "bob@subs.test")
+        .await
+        .expect("seed bob+group2");
+
+    let gid = group_id.to_string();
+    let g2id = bob_group_id.to_string();
+    let alice_id_s = alice_id.to_string();
+
+    // Set up a task under Alice's group (S1–S4, S6, S7 act on this one).
+    let (_list_id, task_id) = create_task_list_and_task(&h, &alice_token, &gid).await;
+
+    // Set up a task under Bob's group for the cross-group injection test (S5).
+    let (_b_list_id, bob_task_id) = create_task_list_and_task(&h, &bob_token, &g2id).await;
+
+    // ── S1. POST 201 — Alice subscribes herself; verify shape + audit ────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/subscriptions"),
+            Some(&alice_token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("S1 oneshot");
+    assert_eq!(resp.status(), StatusCode::CREATED, "S1 status");
+    let s1_body = body_json(resp).await;
+    assert_eq!(s1_body["task_id"], task_id, "S1 task_id");
+    assert_eq!(s1_body["user_id"], alice_id_s, "S1 user_id is principal");
+    assert_eq!(s1_body["muted"], false, "S1 muted defaults to false");
+    assert!(
+        s1_body.get("subscribed_at").is_some(),
+        "S1 subscribed_at present"
+    );
+
+    // Audit row.
+    let audit1 = fetch_audit_events_for_group(&h, group_id)
+        .await
+        .expect("S1 fetch audit");
+    let s1_audit = audit1
+        .iter()
+        .find(|e| e.0 == "task.subscribed" && e.3 == task_id)
+        .expect("S1 audit row task.subscribed");
+    let (_, _, s1_res_type, _, s1_meta) = s1_audit;
+    assert_eq!(s1_res_type, "task_subscriptions", "S1 resource_type");
+    assert_eq!(
+        s1_meta["subscriber_user_id_len"].as_u64(),
+        Some(36),
+        "S1 metadata has subscriber_user_id_len"
+    );
+    assert!(
+        s1_meta.get("user_id").is_none(),
+        "S1 audit must not contain raw user_id (PII guard)"
+    );
+    assert!(
+        s1_meta.get("email").is_none(),
+        "S1 audit must not contain email (PII guard)"
+    );
+
+    // ── S2. POST 409 — second subscribe by same user ─────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/subscriptions"),
+            Some(&alice_token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("S2 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::CONFLICT,
+        "S2 duplicate subscribe must be 409"
+    );
+
+    // ── S3. GET 200 — list returns Alice as subscriber ───────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "GET",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/subscriptions"),
+            Some(&alice_token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("S3 oneshot");
+    assert_eq!(resp.status(), StatusCode::OK, "S3 status");
+    let s3_body = body_json(resp).await;
+    let items = s3_body.as_array().expect("S3 response is array");
+    assert_eq!(items.len(), 1, "S3 list should have exactly 1 subscriber");
+    assert_eq!(items[0]["user_id"], alice_id_s, "S3 subscriber is alice");
+    assert_eq!(items[0]["task_id"], task_id, "S3 task_id");
+    assert_eq!(items[0]["muted"], false, "S3 muted defaults to false");
+
+    // ── S4. DELETE 204 — Alice unsubscribes (idempotent on second call) ──
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "DELETE",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/subscriptions"),
+            Some(&alice_token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("S4 first oneshot");
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT, "S4 first DELETE 204");
+
+    // Audit row for unsubscribe.
+    let audit4 = fetch_audit_events_for_group(&h, group_id)
+        .await
+        .expect("S4 fetch audit");
+    assert!(
+        audit4
+            .iter()
+            .any(|e| e.0 == "task.unsubscribed" && e.3 == task_id),
+        "S4 audit row task.unsubscribed must be present"
+    );
+
+    // Second DELETE → 204 idempotent.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "DELETE",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/subscriptions"),
+            Some(&alice_token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("S4 idempotent oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NO_CONTENT,
+        "S4 second DELETE must be 204 idempotent"
+    );
+
+    // ── S5. POST 404 — Alice subscribes to a task in Bob's group ─────────
+    // Even though Alice's principal carries her own group_id, the path is
+    // still under her group_id (since check_group_match enforces that).
+    // The task_id is from Bob's group — RLS + the explicit `group_id =`
+    // filter in the existence query should yield 404.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{gid}/tasks/{bob_task_id}/subscriptions"),
+            Some(&alice_token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("S5 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "S5 cross-group task_id must be 404"
+    );
+
+    // ── S6. POST 403 — path group_id ≠ principal group_id ────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{g2id}/tasks/{task_id}/subscriptions"),
+            Some(&alice_token),
+            Some(&gid), // X-Group-Id matches alice; path is bob's group.
+            None,
+        ))
+        .await
+        .expect("S6 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "S6 path group mismatch must be 403"
+    );
+
+    // ── S7. GET 200 — empty array after unsubscribe in S4 ────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "GET",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/subscriptions"),
+            Some(&alice_token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("S7 oneshot");
+    assert_eq!(resp.status(), StatusCode::OK, "S7 status");
+    let s7_body = body_json(resp).await;
+    let items = s7_body.as_array().expect("S7 response is array");
+    assert!(
+        items.is_empty(),
+        "S7 list must be empty after unsubscribe (got {})",
+        items.len()
+    );
+}

--- a/plans/0079-gar-539-task-subscriptions-api.md
+++ b/plans/0079-gar-539-task-subscriptions-api.md
@@ -1,0 +1,278 @@
+# Plan 0079 — GAR-539: REST /v1 tasks slice 6 (task subscriptions API)
+
+**Status:** Em execução
+**Autor:** Claude Opus 4.7 (garra-routine 2026-05-07, America/New_York)
+**Data:** 2026-05-07 (America/New_York)
+**Issue:** [GAR-539](https://linear.app/chatgpt25/issue/GAR-539)
+**Branch:** `routine/202605071835-task-subscriptions-api`
+**Epic:** `epic:ws-api`, `epic:ws-tasks`
+**Parent:** GAR-396
+
+---
+
+## §1 Goal
+
+Land the task subscriptions REST API (ROADMAP §3.8 Tier 1), delivering three
+endpoints on the `garraia_app` RLS-enforced pool — all keyed to the *current
+authenticated user* (no `user_id` body parameter):
+
+- `POST /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — current user
+  subscribes to the task (201 on success; 409 if already subscribed; 404 if
+  task not in this group).
+- `DELETE /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — current user
+  unsubscribes (204 idempotent; 404 if task not in this group).
+- `GET /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — list subscribers
+  for a task (200 with array; 404 if task not in this group).
+
+## §2 Architecture
+
+### Schema (migration 006)
+
+```sql
+CREATE TABLE task_subscriptions (
+    task_id       uuid        NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    user_id       uuid        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    subscribed_at timestamptz NOT NULL DEFAULT now(),
+    muted         boolean     NOT NULL DEFAULT false,
+    PRIMARY KEY (task_id, user_id)
+);
+```
+
+### RLS (migration 006)
+
+`task_subscriptions` — **JOIN via tasks** (FORCE RLS, same class as
+`task_assignees`, `task_label_assignments`):
+
+```sql
+CREATE POLICY task_subscriptions_through_tasks ON task_subscriptions
+    USING (task_id IN (SELECT id FROM tasks));
+```
+
+Because `tasks` is filtered by `app.current_group_id`, this transitively scopes
+subscriptions to the current group.
+
+### Subject = principal
+
+Unlike `task_assignees` (where any group member can be assigned by any other
+member) and `task_labels` (where the actor passes the `label_id`), subscription
+operations always act on the *current user*. POST and DELETE take no body, no
+`user_id` parameter. This keeps the wire surface minimal and avoids the
+question of "can Alice subscribe Bob to a task?".
+
+### Cross-group safety
+
+- POST and DELETE first verify `task_id` exists in the current group and is
+  not soft-deleted. Cross-group `task_id` returns 404 (RLS would also filter,
+  but the explicit check yields clear UX).
+- GET requires the same check.
+- 23505 unique violation on `(task_id, user_id)` PK on POST → 409.
+- DELETE is idempotent (no 404 on missing row, only 404 on missing task).
+
+### `muted` field
+
+Default `false`. Exposed in GET response. Mutation path (PATCH to flip muted)
+is **out of scope** for this slice — it's simple and can ship in a follow-up
+if the digest worker (GAR-397) needs it.
+
+## §3 Tech stack
+
+- Axum 0.8 + `RestV1FullState` (same as tasks.rs)
+- `sqlx::query` / `sqlx::query_as` — no SQL string concat
+- `garraia_auth::{Action, Principal, WorkspaceAuditAction, audit_workspace_event}`
+- 2 new `WorkspaceAuditAction` variants: `TaskSubscribed`, `TaskUnsubscribed`
+- `utoipa` OpenAPI annotations
+
+## §4 Design invariants
+
+1. SET LOCAL both `app.current_user_id` AND `app.current_group_id` in every tx.
+2. Audit metadata structural-only: `{ subscriber_user_id_len: 36 }` — never
+   the user's email or display name.
+3. Cross-group `task_id` returns 404 (explicit check + RLS).
+4. DELETE is idempotent on the subscription row (204 either way), but still
+   returns 404 if the task itself is missing from this group.
+5. POST 409 on SQLSTATE `23505` for the PK `(task_id, user_id)`.
+6. Subject is always `principal.user_id` — no `user_id` request body.
+7. `muted` defaults to `false` on insert (DB default); response exposes it
+   verbatim from the row.
+8. No `unwrap()` outside tests.
+9. GET response sorted by `subscribed_at ASC` for stable pagination.
+
+## §5 Validações pré-plano
+
+- [x] `task_subscriptions` schema in migration 006 (PK + ON DELETE CASCADE).
+- [x] `task_subscriptions_through_tasks` FORCE RLS JOIN policy.
+- [x] `Action::TasksWrite` / `Action::TasksRead` already in `action.rs`.
+- [x] `set_rls_context` parameterized SET LOCAL pattern (plan 0056).
+- [x] `audit_workspace_event` signature (plans 0077, 0078).
+- [x] 23505 unique violation catch pattern (plan 0078).
+- [x] No body for parameterless POST — Axum 0.8 accepts empty body when no
+  `Json<T>` extractor present.
+
+## §6 Scope
+
+**In scope:**
+
+- `POST /v1/groups/{group_id}/tasks/{task_id}/subscriptions`
+- `DELETE /v1/groups/{group_id}/tasks/{task_id}/subscriptions`
+- `GET /v1/groups/{group_id}/tasks/{task_id}/subscriptions`
+- `WorkspaceAuditAction::TaskSubscribed` + `WorkspaceAuditAction::TaskUnsubscribed`
+- 7 integration test scenarios (S1–S7)
+- OpenAPI registration for the 3 endpoints + the new `SubscriptionResponse`
+
+**Out of scope:**
+
+- `PATCH /v1/groups/{group_id}/tasks/{task_id}/subscriptions/me/mute` (toggle
+  `muted`) — separate slice, ships when digest worker (GAR-397) lands.
+- Subscribing other users on someone else's behalf — never, by design.
+- Bulk subscribe (subscribe-all-task-list) — separate slice.
+- Notification fan-out to channels — owned by GAR-397 digest worker.
+- WebSocket push of subscription events — GAR-396 parent scope.
+
+## §7 Rollback
+
+No schema changes. If the implementation is defective, revert the 3 route
+registrations in `rest_v1/mod.rs`, the 3 handler functions in `tasks.rs`, the
+2 audit variants in `audit_workspace.rs`, and the OpenAPI additions in
+`openapi.rs`. No migration rollback needed.
+
+## §8 Open questions
+
+None. All design decisions are direct echoes of plan 0078 (labels) and plan
+0077 (assignees), plus the design choice that subscription subject = principal.
+
+## §9 File structure
+
+```
+crates/
+  garraia-auth/
+    src/
+      audit_workspace.rs        ← +2 variants (TaskSubscribed, TaskUnsubscribed)
+                                   + as_str() entries
+                                   + matching distinct-strings test entries
+  garraia-gateway/
+    Cargo.toml                  ← [[test]] required-features for the new test
+    src/
+      rest_v1/
+        mod.rs                  ← +2 route registrations (1 path, GET+POST+DELETE
+                                   share the path, plus DELETE has same path)
+                                   in fact: 1 .route() entry with .post().get().delete()
+        tasks.rs                ← +3 handler functions + Subscription{Row,Response}
+        openapi.rs              ← +3 path entries + SubscriptionResponse schema
+    tests/
+      rest_v1_task_subscriptions.rs  ← NEW — 7 integration scenarios (S1–S7)
+plans/
+  README.md                     ← +1 row for plan 0079
+  0079-gar-539-task-subscriptions-api.md  ← THIS FILE
+```
+
+## §10 M1 tasks
+
+### T1 — Add 2 WorkspaceAuditAction variants
+
+- [ ] Add `TaskSubscribed`, `TaskUnsubscribed` to `audit_workspace.rs`.
+- [ ] Add `as_str()` entries: `"task.subscribed"`, `"task.unsubscribed"`.
+- [ ] Update the distinct-strings test (now 32 entries).
+- [ ] Update the per-variant `as_str()` assertion test (add 2 new asserts).
+- [ ] `cargo check -p garraia-auth` green.
+
+### T2 — Implement 3 handler functions in tasks.rs
+
+- [ ] `subscribe_to_task` (POST, 201 on success, 409 on 23505 PK violation,
+      404 if task not in group).
+- [ ] `unsubscribe_from_task` (DELETE, 204 idempotent on subscription row,
+      404 if task not in group).
+- [ ] `list_task_subscriptions` (GET, 200 with `Vec<SubscriptionResponse>`,
+      ordered by `subscribed_at ASC`, 404 if task not in group).
+- [ ] New types: `SubscriptionRow` (sqlx::FromRow) + `SubscriptionResponse`
+      (Serialize + utoipa::ToSchema) with fields
+      `{ task_id, user_id, subscribed_at, muted }`.
+- [ ] All 3 handlers call `set_rls_context(&mut tx, principal.user_id, group_id)`
+      before any FORCE-RLS table access.
+- [ ] Audit metadata uses `{ subscriber_user_id_len: 36 }` — PII-safe.
+- [ ] `cargo check -p garraia-gateway --features test-helpers` green.
+
+### T3 — Register routes in rest_v1/mod.rs
+
+- [ ] One `.route("/v1/groups/{group_id}/tasks/{task_id}/subscriptions", …)`
+      block with `.post(subscribe_to_task).get(list_task_subscriptions).delete(unsubscribe_from_task)`.
+- [ ] Marker comment: `// Plan 0079 (GAR-539) — task subscriptions API slice 6.`
+- [ ] `cargo check -p garraia-gateway --features test-helpers` green.
+
+### T4 — Register OpenAPI in openapi.rs
+
+- [ ] Add `super::tasks::subscribe_to_task`, `list_task_subscriptions`,
+      `unsubscribe_from_task` to the `paths(...)` macro arm.
+- [ ] Add `SubscriptionResponse` to the `components(...)` macro arm.
+- [ ] Add `SubscriptionResponse` to the `use super::tasks::{ ... }` import.
+- [ ] `cargo check -p garraia-gateway --features test-helpers` green.
+
+### T5 — Write integration tests (tests/rest_v1_task_subscriptions.rs)
+
+Single bundled `#[tokio::test]` (avoid sqlx runtime-teardown race per plan 0016 M3).
+
+- [ ] **S1.** POST 201 — Alice subscribes herself to her task; verify response
+      shape (`task_id`, `user_id`, `subscribed_at`, `muted=false`); audit row
+      `task.subscribed` with `resource_type=task_subscriptions`,
+      `resource_id={task_id}`, metadata has `subscriber_user_id_len: 36`,
+      no `user_id` value or PII.
+- [ ] **S2.** POST 409 — second subscribe by same user → 409 Conflict.
+- [ ] **S3.** GET 200 — list returns 1 entry with Alice as subscriber.
+- [ ] **S4.** DELETE 204 — Alice unsubscribes; audit row `task.unsubscribed`;
+      second DELETE on same task → 204 idempotent.
+- [ ] **S5.** POST 404 — Bob (different group) tries to subscribe to Alice's
+      task by passing the foreign `task_id` under his own group → 404.
+- [ ] **S6.** POST 403 — path `group_id` ≠ principal `group_id` (alice's token,
+      bob's group in path) → 403 (covered by `check_group_match`).
+- [ ] **S7.** GET 200 — empty array when no subscribers (re-list after the
+      unsubscribe in S4).
+- [ ] `cargo test -p garraia-gateway --features test-helpers --test rest_v1_task_subscriptions`
+      green against testcontainers Postgres.
+
+### T6 — Cargo.toml `[[test]]` gate
+
+- [ ] Add `[[test]] name = "rest_v1_task_subscriptions"` block with
+      `required-features = ["test-helpers"]`. Mirrors the existing entry
+      for `rest_v1_task_labels` / `rest_v1_task_assignees`.
+
+### T7 — Workspace-wide clippy + fmt
+
+- [ ] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` clean.
+- [ ] `cargo fmt --all -- --check` clean.
+
+### T8 — Update plans/README.md
+
+- [ ] Add row for plan 0079 (GAR-539, this plan) — initial state
+      `⏳ In Progress`. Will flip to `✅ Merged` post-merge in a follow-up
+      doc-only PR.
+
+## §11 Risk register
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Empty-body POST/DELETE rejected by Axum at 415 | Low | Don't include `Json<T>` extractor; Axum default body parser accepts empty body when no extractor demands it. Verified with `unsubscribe_from_task` (DELETE) which is parameter-only. |
+| Notification fan-out side-effects expected on subscribe | Out of scope | `task.subscribed` audit row only; no notification side effect this slice. |
+| GET ordering instability across subsecond subscribes | Low | Order by `subscribed_at ASC` then `user_id ASC` as tiebreaker. |
+| `muted` accidentally exposed and someone tries to set it on POST | Out of scope | POST takes no body; tests validate POST returns `muted=false`; mute toggle is a future PATCH. |
+
+## §12 Acceptance criteria
+
+- All ≥16 actual CI workflow checks green on the PR.
+- 7 integration scenarios pass against testcontainers Postgres.
+- Cross-group `task_id` returns 404 (S5).
+- Duplicate subscribe returns 409 (S2).
+- DELETE is idempotent — second DELETE returns 204 (S4 second call).
+- Path-vs-principal `group_id` mismatch returns 403 (S6).
+- Audit metadata never contains the subscriber email or display name.
+
+## §13 Cross-references
+
+- Plan 0078 (GAR-536, task labels) — same RLS class + 23505 + audit pattern.
+- Plan 0077 (GAR-533, task assignees) — same JOIN policy class.
+- Plan 0069 (GAR-520, task comments) — JOIN policy class.
+- ROADMAP §3.8 Tier 1 — task_subscriptions schema.
+- Migration 006 (`006_tasks_with_rls.sql`) — `task_subscriptions` definition.
+- GAR-397 — digest worker that fans out to subscribers (downstream consumer).
+
+## §14 Estimativa
+
+**Baixa:** 1.0h | **Provável:** 1.5h | **Alta:** 2.5h

--- a/plans/README.md
+++ b/plans/README.md
@@ -102,6 +102,7 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0076 | [GAR-530 — Chat management slice 4: individual chat ops + member CRUD](0076-gar-530-chat-mgmt-slice4.md) | [GAR-530](https://linear.app/chatgpt25/issue/GAR-530) | ✅ Merged 2026-05-07 via PR #181 (`b48a356`) |
 | 0077 | [GAR-533 — REST /v1 tasks slice 4: task assignees API (POST/GET/DELETE)](0077-gar-533-task-assignees-api.md) | [GAR-533](https://linear.app/chatgpt25/issue/GAR-533) | ✅ Merged 2026-05-07 via PR #184 (`22c423c`) |
 | 0078 | [GAR-536 — REST /v1 tasks slice 5: task labels API (POST/GET/DELETE label CRUD + assignment)](0078-gar-536-task-labels-api.md) | [GAR-536](https://linear.app/chatgpt25/issue/GAR-536) | ✅ Merged 2026-05-07 via PR #189 (`7fc5cb3`) |
+| 0079 | [GAR-539 — REST /v1 tasks slice 6: task subscriptions API (POST/DELETE/GET)](0079-gar-539-task-subscriptions-api.md) | [GAR-539](https://linear.app/chatgpt25/issue/GAR-539) | ⏳ In Progress |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

Adds 3 endpoints for task subscriptions under `/v1/groups/{group_id}/tasks/{task_id}/subscriptions` on the `garraia_app` RLS-enforced pool. The current authenticated user is the implicit subject — POST and DELETE take no body, no `user_id` parameter; the operation always acts on `principal.user_id`. This is a deliberate API design choice: ""can Alice subscribe Bob?"" is out of scope and never reachable.

- `POST   /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — subscribe current user (201; 409 on duplicate; 404 if task not in this group)
- `GET    /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — list subscribers (200; 404 if task not in this group); ordered by `subscribed_at ASC` then `user_id ASC` as stable tiebreaker
- `DELETE /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — unsubscribe current user (204 idempotent on the subscription row; 404 if task itself not in this group)

Adds 2 new `WorkspaceAuditAction` variants (`TaskSubscribed`, `TaskUnsubscribed`) with PII-safe metadata `{ subscriber_user_id_len: 36 }`. Adds `SubscriptionResponse` schema `{ task_id, user_id, subscribed_at, muted }` to OpenAPI.

RLS class is JOIN-via-tasks (same as `task_assignees` and `task_label_assignments`). Both `app.current_user_id` and `app.current_group_id` are SET LOCAL on every transaction.

## Test plan

- [x] `cargo check -p garraia-auth` — clean
- [x] `cargo check -p garraia-gateway --features test-helpers --tests` — clean
- [x] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` — 0 warnings
- [x] `cargo fmt --all -- --check` — no diff
- [ ] CI: Format, Clippy, Test (ubuntu/macos/windows), Build, MSRV, cargo-deny, Security Audit, Coverage, CodeQL (rust + js-ts), Playwright, E2E, Secret Scan, Dependency Review
- [ ] Integration test `rest_v1_task_subscriptions_scenarios` (7 scenarios S1–S7) — green on CI Postgres

## Cross-references

- Plan: `plans/0079-gar-539-task-subscriptions-api.md`
- Linear: GAR-539 (child of GAR-396 epic:ws-tasks)
- Schema: migration 006 (`task_subscriptions` table — already exists with FORCE RLS via `task_subscriptions_through_tasks` JOIN policy)
- Sibling slices: plan 0077 (assignees, GAR-533), plan 0078 (labels, GAR-536)

https://claude.ai/code/session_017hwE5qdTtj4jiF9b8nF6Ar

---
_Generated by [Claude Code](https://claude.ai/code/session_017hwE5qdTtj4jiF9b8nF6Ar)_