### PR TITLE
docs(plans): mark plan 0080 merged — GAR-541 (PR #204, e39a7e5)

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -103,7 +103,7 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0077 | [GAR-533 — REST /v1 tasks slice 4: task assignees API (POST/GET/DELETE)](0077-gar-533-task-assignees-api.md) | [GAR-533](https://linear.app/chatgpt25/issue/GAR-533) | ✅ Merged 2026-05-07 via PR #184 (`22c423c`) |
 | 0078 | [GAR-536 — REST /v1 tasks slice 5: task labels API (POST/GET/DELETE label CRUD + assignment)](0078-gar-536-task-labels-api.md) | [GAR-536](https://linear.app/chatgpt25/issue/GAR-536) | ✅ Merged 2026-05-07 via PR #189 (`7fc5cb3`) |
 | 0079 | [GAR-539 — REST /v1 tasks slice 6: task subscriptions API (POST/DELETE/GET)](0079-gar-539-task-subscriptions-api.md) | [GAR-539](https://linear.app/chatgpt25/issue/GAR-539) | ✅ Merged 2026-05-07 via PR #199 (`b6c60b0`) |
-| 0080 | [GAR-541 — REST /v1 tasks slice 7: task activity log (writes + GET)](0080-gar-541-task-activity-api.md) | [GAR-541](https://linear.app/chatgpt25/issue/GAR-541) | 🔄 Em execução |
+| 0080 | [GAR-541 — REST /v1 tasks slice 7: task activity log (writes + GET)](0080-gar-541-task-activity-api.md) | [GAR-541](https://linear.app/chatgpt25/issue/GAR-541) | ✅ Merged 2026-05-07 via PR #204 (`e39a7e5`) |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
Docs-only: updates `plans/README.md` row for plan 0080 from 🔄 Em execução → ✅ Merged 2026-05-08 via PR #204 (`e39a7e5`).

No code changes.

https://claude.ai/code/session_01RgPq6MNRQBtEUJFLXiG2Ph

---
_Generated by [Claude Code](https://claude.ai/code/session_01RgPq6MNRQBtEUJFLXiG2Ph)_