### PR TITLE
docs(plans): mark plan 0081 merged — GAR-466 (PR #206, 48b55a2)

### DIFF
--- a/plans/README.md
+++ b/plans/README.md
@@ -104,7 +104,7 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0078 | [GAR-536 — REST /v1 tasks slice 5: task labels API (POST/GET/DELETE label CRUD + assignment)](0078-gar-536-task-labels-api.md) | [GAR-536](https://linear.app/chatgpt25/issue/GAR-536) | ✅ Merged 2026-05-07 via PR #189 (`7fc5cb3`) |
 | 0079 | [GAR-539 — REST /v1 tasks slice 6: task subscriptions API (POST/DELETE/GET)](0079-gar-539-task-subscriptions-api.md) | [GAR-539](https://linear.app/chatgpt25/issue/GAR-539) | ✅ Merged 2026-05-07 via PR #199 (`b6c60b0`) |
 | 0080 | [GAR-541 — REST /v1 tasks slice 7: task activity log (writes + GET)](0080-gar-541-task-activity-api.md) | [GAR-541](https://linear.app/chatgpt25/issue/GAR-541) | ✅ Merged 2026-05-07 via PR #204 (`e39a7e5`) |
-| 0081 | [GAR-466 — Q6.4: kill `is_unique_violation` constant-true mutant](0081-gar-466-q64-unique-violation-mutant.md) | [GAR-466](https://linear.app/chatgpt25/issue/GAR-466) | ⏳ Draft 2026-05-07 |
+| 0081 | [GAR-466 — Q6.4: kill `is_unique_violation` constant-true mutant](0081-gar-466-q64-unique-violation-mutant.md) | [GAR-466](https://linear.app/chatgpt25/issue/GAR-466) | ✅ Merged 2026-05-07 via PR #206 (`48b55a2`) |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
Bookkeeping doc-only follow-up to PR #206 (squash-merged at `48b55a2` on 2026-05-07 23:25 ET / 2026-05-08T03:25:03Z UTC). Flips the plan 0081 row in `plans/README.md` from `⏳ Draft` to `✅ Merged`.