### PR TITLE
chore(deps): GAR-534 — upgrade rmcp 0.16 → 1.6 (supersedes Dependabot PR #185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1655,7 +1655,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6306,7 +6306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7051,7 +7051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -7064,7 +7064,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -7668,9 +7668,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.16.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c9c94680f75470ee8083a0667988b5d7b5beb70b9f998a8e51de7c682ce60"
+checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7695,9 +7695,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.16.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c23c8f26cae4da838fbc3eadfaecf2d549d97c04b558e7bd90526a9c28b42a"
+checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -11707,7 +11707,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ teloxide = { version = "0.17", default-features = false, features = ["rustls", "
 tokio-tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots"] }
 
 # MCP (Model Context Protocol)
-rmcp = { version = "0.16" }
+rmcp = { version = "1.6" }
 
 # System / OS interop
 libc = "0.2"

--- a/crates/garraia-agents/src/mcp/manager.rs
+++ b/crates/garraia-agents/src/mcp/manager.rs
@@ -461,10 +461,7 @@ impl McpManager {
             .get(name)
             .ok_or_else(|| Error::Mcp(format!("MCP server '{name}' not connected")))?;
 
-        let params = rmcp::model::ReadResourceRequestParams {
-            meta: None,
-            uri: uri.to_string(),
-        };
+        let params = rmcp::model::ReadResourceRequestParams::new(uri.to_string());
 
         let result = conn.service.read_resource(params).await.map_err(|e| {
             Error::Mcp(format!(
@@ -528,11 +525,10 @@ impl McpManager {
             .get(name)
             .ok_or_else(|| Error::Mcp(format!("MCP server '{name}' not connected")))?;
 
-        let params = rmcp::model::GetPromptRequestParams {
-            meta: None,
-            name: prompt_name.to_string(),
-            arguments: args,
-        };
+        let mut params = rmcp::model::GetPromptRequestParams::new(prompt_name.to_string());
+        if let Some(a) = args {
+            params = params.with_arguments(a);
+        }
 
         let result = conn.service.get_prompt(params).await.map_err(|e| {
             Error::Mcp(format!(

--- a/crates/garraia-agents/src/mcp/tool_bridge.rs
+++ b/crates/garraia-agents/src/mcp/tool_bridge.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -95,12 +94,10 @@ impl Tool for McpTool {
             }
         };
 
-        let params = CallToolRequestParams {
-            name: Cow::Owned(self.nome_original.clone()),
-            arguments: argumentos,
-            meta: None,
-            task: None,
-        };
+        let mut params = CallToolRequestParams::new(self.nome_original.clone());
+        if let Some(a) = argumentos {
+            params = params.with_arguments(a);
+        }
 
         // Executa com timeout
         let resultado = tokio::time::timeout(self.timeout, self.peer.call_tool(params))


### PR DESCRIPTION
## Summary

Upgrades `rmcp` from `0.16.0` to `1.6.0` (latest), fixing the Dependabot PR #185 which failed CI due to breaking API changes in rmcp 1.x.

**Root cause of CI failures in #185:** Three structs became `#[non_exhaustive]` in rmcp 1.x — `ReadResourceRequestParams`, `GetPromptRequestParams`, `CallToolRequestParams` — preventing external crates from using struct literal syntax to construct them.

**Fix:** Replace each struct expression with the `::new()` constructors + builder methods provided by rmcp 1.x API:
- `ReadResourceRequestParams::new(uri)` (no `Default` impl)
- `GetPromptRequestParams::new(name).with_arguments(args)` 
- `CallToolRequestParams::new(name).with_arguments(args)`

Also removes the now-unused `std::borrow::Cow` import from `tool_bridge.rs`.

**Verified:** `cargo check --workspace --exclude garraia-desktop` and `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` both clean.

Closes #185 (Dependabot PR superseded by this one).
Resolves GAR-534.

## Test plan

- [ ] Build Check passes
- [ ] Clippy Linting passes (no warnings)
- [ ] MSRV check (1.92) passes
- [ ] Test (ubuntu/macos/windows) passes
- [ ] Security Audit + cargo-deny pass
- [ ] `rmcp` version in Cargo.lock is ≥ 1.6.0

https://claude.ai/code/session_01MgfxySB47FeaHNcdSUVVTo

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgfxySB47FeaHNcdSUVVTo)_