### PR TITLE
feat(tasks): GAR-544 — POST /v1/groups/{gid}/tasks/{tid}:move (plan 0082)

### DIFF
--- a/crates/garraia-auth/src/audit_workspace.rs
+++ b/crates/garraia-auth/src/audit_workspace.rs
@@ -352,6 +352,15 @@ pub enum WorkspaceAuditAction {
     /// `resource_type = "task_subscriptions"`, `resource_id = "{task_id}"`.
     /// Metadata: `{ subscriber_user_id_len: 36 }`.
     TaskUnsubscribed,
+
+    /// A task was moved to a different list via
+    /// `POST /v1/groups/{group_id}/tasks/{task_id}:move`
+    /// (plan 0082 / GAR-544, epic GAR-WS-TASKS slice 8).
+    ///
+    /// `resource_type = "tasks"`, `resource_id = "{task_id}"`.
+    /// Metadata: `{ from_list_id, to_list_id }`. Both are UUIDs — structural,
+    /// not PII.
+    TaskMoved,
 }
 
 impl WorkspaceAuditAction {
@@ -391,6 +400,7 @@ impl WorkspaceAuditAction {
             WorkspaceAuditAction::TaskLabelRemoved => "task.label.removed",
             WorkspaceAuditAction::TaskSubscribed => "task.subscribed",
             WorkspaceAuditAction::TaskUnsubscribed => "task.unsubscribed",
+            WorkspaceAuditAction::TaskMoved => "task.moved",
         }
     }
 }

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -377,6 +377,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     "/v1/groups/{group_id}/tasks/{task_id}/activity",
                     get(tasks::list_task_activity),
                 )
+                // Plan 0082 (GAR-544) — task move API slice 8.
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}:move",
+                    post(tasks::move_task),
+                )
                 // Plan 0070 (GAR-522) — audit API slice 1.
                 .route("/v1/groups/{group_id}/audit", get(audit::list_audit))
                 .merge(rate_limited_routes)

--- a/crates/garraia-gateway/src/rest_v1/tasks.rs
+++ b/crates/garraia-gateway/src/rest_v1/tasks.rs
@@ -1,5 +1,5 @@
 //! `/v1/groups/{group_id}/task-lists` and task/comment/assignee/label/subscription handlers
-//! (plan 0066/0067/0069/0077/0078/0079, GAR-516/GAR-518/GAR-520/GAR-533/GAR-536/GAR-539).
+//! (plan 0066/0067/0069/0077/0078/0079/0082, GAR-516/GAR-518/GAR-520/GAR-533/GAR-536/GAR-539/GAR-544).
 //!
 //! Twenty-three endpoints on the `garraia_app` RLS-enforced pool:
 //!
@@ -37,6 +37,12 @@
 //! - `POST /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — current user subscribes
 //! - `GET /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — list subscribers
 //! - `DELETE /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — current user unsubscribes (idempotent)
+//!
+//! **Slice 7 (plan 0080 / GAR-541):**
+//! - `GET /v1/groups/{group_id}/tasks/{task_id}/activity` — cursor-paginated activity log
+//!
+//! **Slice 8 (plan 0082 / GAR-544):**
+//! - `POST /v1/groups/{group_id}/tasks/{task_id}:move` — move task to a different list
 //!
 //! ## Tenant-context protocol
 //!
@@ -483,6 +489,14 @@ impl PatchTaskRequest {
         }
         Ok(())
     }
+}
+
+/// Request body for `POST /v1/groups/{group_id}/tasks/{task_id}:move`.
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct MoveTaskRequest {
+    /// UUID of the destination task list (must belong to the same group and not be archived).
+    pub target_list_id: Uuid,
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -3285,4 +3299,148 @@ pub async fn list_task_activity(
     };
 
     Ok(Json(ListActivityResponse { items, next_cursor }))
+}
+
+// ─── Handlers — slice 8 (plan 0082 / GAR-544) ────────────────────────────────
+
+/// `POST /v1/groups/{group_id}/tasks/{task_id}:move` — move a task to a different list.
+///
+/// Atomically reassigns `tasks.list_id` to `target_list_id`. The compound FK
+/// `(list_id, group_id) → task_lists(id, group_id)` enforces same-group
+/// invariant at the DB layer; Step 1 SELECT catches cross-group/archived targets
+/// first so the client receives a 404 rather than a FK violation.
+///
+/// ## Error matrix
+///
+/// | Condition                                | Status |
+/// |------------------------------------------|--------|
+/// | Missing/invalid JWT                      | 401    |
+/// | Non-member or path group ≠ principal     | 403    |
+/// | Task soft-deleted or not in group        | 404    |
+/// | Target list archived, missing, or cross-group | 404 |
+/// | Malformed body (missing target_list_id)  | 422    |
+/// | Happy path                               | 200    |
+#[utoipa::path(
+    post,
+    path = "/v1/groups/{group_id}/tasks/{task_id}:move",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("task_id" = Uuid, Path, description = "Task UUID to move."),
+    ),
+    request_body = MoveTaskRequest,
+    responses(
+        (status = 200, description = "Task moved; returns updated task.", body = TaskResponse),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Task or target list not found / archived / cross-group.", body = super::problem::ProblemDetails),
+        (status = 422, description = "Malformed request body.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn move_task(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, task_id)): Path<(Uuid, Uuid)>,
+    Json(body): Json<MoveTaskRequest>,
+) -> Result<Json<TaskResponse>, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksWrite) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Fetch current list_id (also verifies task is in group and not deleted).
+    let current: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT list_id FROM tasks WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+    )
+    .bind(task_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let (from_list_id,) = match current {
+        Some(row) => row,
+        None => return Err(RestError::NotFound),
+    };
+
+    // Verify target list belongs to the group and is not archived.
+    let target_exists: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM task_lists \
+         WHERE id = $1 AND group_id = $2 AND archived_at IS NULL",
+    )
+    .bind(body.target_list_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if target_exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    // Update task and return the full row.
+    let updated: Option<TaskRow> = sqlx::query_as(
+        "UPDATE tasks \
+         SET list_id = $1, updated_at = now() \
+         WHERE id = $2 AND group_id = $3 AND deleted_at IS NULL \
+         RETURNING id, list_id, group_id, parent_task_id, title, description_md, \
+                   status, priority, due_at, started_at, completed_at, \
+                   estimated_minutes, created_by, created_by_label, \
+                   created_at, updated_at, deleted_at",
+    )
+    .bind(body.target_list_id)
+    .bind(task_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let task_row = match updated {
+        Some(r) => r,
+        None => return Err(RestError::NotFound),
+    };
+
+    let (actor_label,): (String,) =
+        sqlx::query_as("SELECT display_name FROM users WHERE id = $1")
+            .bind(principal.user_id)
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(|e| RestError::Internal(e.into()))?;
+
+    insert_task_activity(
+        &mut tx,
+        task_id,
+        group_id,
+        principal.user_id,
+        &actor_label,
+        "moved",
+        json!({ "from_list_id": from_list_id, "to_list_id": body.target_list_id }),
+    )
+    .await?;
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::TaskMoved,
+        principal.user_id,
+        group_id,
+        "tasks",
+        task_id.to_string(),
+        json!({ "from_list_id": from_list_id, "to_list_id": body.target_list_id }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(Json(TaskResponse::from(task_row)))
 }

--- a/crates/garraia-gateway/src/rest_v1/tasks.rs
+++ b/crates/garraia-gateway/src/rest_v1/tasks.rs
@@ -3408,12 +3408,11 @@ pub async fn move_task(
         None => return Err(RestError::NotFound),
     };
 
-    let (actor_label,): (String,) =
-        sqlx::query_as("SELECT display_name FROM users WHERE id = $1")
-            .bind(principal.user_id)
-            .fetch_one(&mut *tx)
-            .await
-            .map_err(|e| RestError::Internal(e.into()))?;
+    let (actor_label,): (String,) = sqlx::query_as("SELECT display_name FROM users WHERE id = $1")
+        .bind(principal.user_id)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
 
     insert_task_activity(
         &mut tx,

--- a/plans/0082-gar-544-task-move-api.md
+++ b/plans/0082-gar-544-task-move-api.md
@@ -1,0 +1,155 @@
+# Plan 0082 — GAR-544: REST /v1 tasks slice 8 (task:move endpoint)
+
+**Status:** Em execução
+**Autor:** Claude Sonnet 4.6 (garra-routine 2026-05-08, America/New_York)
+**Data:** 2026-05-08 (America/New_York)
+**Issue:** [GAR-544](https://linear.app/chatgpt25/issue/GAR-544)
+**Branch:** `routine/202605080615-task-move-api` (off `main` after PR #210 merges)
+**Epic:** `epic:ws-api`, `epic:ws-tasks`
+**Parent:** GAR-396
+
+---
+
+## §1 Goal
+
+Land `POST /v1/groups/{group_id}/tasks/{task_id}:move` — the endpoint that
+moves a task from one task list to another within the same group. This is the
+last remaining non-WebSocket, non-attachment endpoint in ROADMAP §3.8 Tier 1.
+
+**Request body:** `{ "target_list_id": "<uuid>" }`
+**Response:** 200 + full task JSON (same shape as `GET …/tasks/{task_id}`).
+
+No new migration needed. `tasks.list_id` and the compound FK
+`(list_id, group_id) → task_lists(id, group_id)` already enforce the
+same-group invariant at the DB layer.
+
+---
+
+## §2 Architecture
+
+### Tenant context protocol
+
+Same as all task handlers:
+1. `SET LOCAL app.current_user_id = $1` + `SET LOCAL app.current_group_id = $2`
+   via parameterised `set_config` (migration 007 FORCE RLS pattern).
+2. Path `group_id` must equal `principal.group_id` → 403 otherwise.
+
+### DB query (2-step, single transaction)
+
+```sql
+-- Step 1: verify target list exists in group and is not archived
+SELECT id
+FROM task_lists
+WHERE id = $1
+  AND group_id = $2
+  AND archived_at IS NULL;
+
+-- Step 2: update task, return full row
+UPDATE tasks
+SET    list_id    = $1,     -- target_list_id
+       updated_at = now()
+WHERE  id         = $3      -- task_id
+  AND  group_id   = $2
+  AND  deleted_at IS NULL
+RETURNING id, list_id, group_id, parent_task_id, title, description_md,
+          status, priority, due_at, started_at, completed_at,
+          estimated_minutes, recurrence_rrule,
+          created_by, created_by_label, deleted_at, created_at, updated_at;
+```
+
+The compound FK guarantees the update cannot silently move the task to a
+cross-group list. If `target_list_id` is not in the group, Step 1's SELECT
+returns 0 rows → 404 before the UPDATE runs.
+
+### Activity log
+
+After the UPDATE, INSERT one `task_activity` row with:
+- `kind = 'moved'`
+- `payload = { "from_list_id": "<old>", "to_list_id": "<new>" }`
+- `actor_user_id` and `actor_label` from `principal`.
+
+Uses the existing `insert_task_activity` helper (plan 0080 §3).
+
+### Audit event
+
+`audit_workspace_event` call with `WorkspaceAuditAction::TaskUpdated` after the
+transaction commits.
+
+---
+
+## §3 Scope
+
+**In scope:**
+- Single handler `move_task` registered as `POST /v1/groups/{group_id}/tasks/{task_id}:move`
+- Request/response types: `MoveTaskRequest`, response reuses `TaskRow` → `serde_json::Value`
+- Activity log (`moved` kind)
+- Audit event
+- Integration tests (see §T tasks below)
+
+**Out of scope:**
+- Position/ordering column — migration 006 explicitly defers this
+- Moving subtasks (parent → different list): allowed implicitly; schema has no cross-list subtask constraint
+- WebSocket push on move — deferred to WS slice
+
+---
+
+## §4 Acceptance criteria
+
+- [ ] `POST /v1/groups/{gid}/tasks/{tid}:move` with valid `target_list_id` returns 200 + task JSON with updated `list_id`
+- [ ] Returns 404 when `target_list_id` is archived or non-existent in the group
+- [ ] Returns 404 when `task_id` is soft-deleted or non-existent in the group
+- [ ] Returns 403 when path `group_id` ≠ `principal.group_id`
+- [ ] Returns 422 when request body is malformed (missing `target_list_id`)
+- [ ] Activity entry with `kind='moved'` written atomically
+- [ ] Audit event emitted
+- [ ] Cross-group isolation test: user of group A cannot move task of group B (Rule 10 CLAUDE.md)
+- [ ] `cargo check --workspace` and `cargo clippy --workspace -- -D warnings` green
+
+---
+
+## §5 File structure
+
+Only one file changes:
+```
+crates/garraia-gateway/src/rest_v1/tasks.rs   — add handler + types + route
+```
+
+The handler is added at the bottom of `tasks.rs` (after `list_task_activity`).
+Route registration in `tasks_router()` at the top of the file.
+
+---
+
+## §6 Task list (M-tasks)
+
+- [ ] **T1 — Tests first (red):** add failing integration tests for:
+  - happy path (200 + updated list_id)
+  - archived target list → 404
+  - cross-group attempt → 403/404
+- [ ] **T2 — Implement `move_task` handler** (handler + `MoveTaskRequest` + route registration)
+- [ ] **T3 — Verify tests green** + clippy clean + `cargo fmt`
+- [ ] **T4 — Commit + push + PR**
+
+---
+
+## §7 Risk register
+
+| Risk | Mitigation |
+|------|-----------|
+| Compound FK might reject the UPDATE silently | Step 1 SELECT catches it first → 404 |
+| `task_activity.kind` CHECK constraint doesn't include `moved` | Already includes 12 values; `moved` IS one of them (verified in migration 006) |
+| MSRV issue from new syntax | No new syntax; same patterns as slices 1-7 |
+
+---
+
+## §8 Rollback plan
+
+Reversible: route can be removed without schema change. No migration to roll back.
+
+---
+
+## §9 Cross-references
+
+- ROADMAP §3.8 Tier 1: `POST /v1/groups/{group_id}/tasks/{task_id}:move`
+- Migration 006 (`crates/garraia-workspace/migrations/006_tasks_with_rls.sql`) — schema
+- Plan 0080 (GAR-541) — `insert_task_activity` helper to reuse
+- Plan 0066 (GAR-516) — `tasks_router()` and `TaskRow` patterns to follow

--- a/plans/README.md
+++ b/plans/README.md
@@ -105,6 +105,7 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0079 | [GAR-539 — REST /v1 tasks slice 6: task subscriptions API (POST/DELETE/GET)](0079-gar-539-task-subscriptions-api.md) | [GAR-539](https://linear.app/chatgpt25/issue/GAR-539) | ✅ Merged 2026-05-07 via PR #199 (`b6c60b0`) |
 | 0080 | [GAR-541 — REST /v1 tasks slice 7: task activity log (writes + GET)](0080-gar-541-task-activity-api.md) | [GAR-541](https://linear.app/chatgpt25/issue/GAR-541) | ✅ Merged 2026-05-07 via PR #204 (`e39a7e5`) |
 | 0081 | [GAR-466 — Q6.4: kill `is_unique_violation` constant-true mutant](0081-gar-466-q64-unique-violation-mutant.md) | [GAR-466](https://linear.app/chatgpt25/issue/GAR-466) | ✅ Merged 2026-05-07 via PR #206 (`48b55a2`) |
+| 0082 | [GAR-544 — REST /v1 tasks slice 8: POST /v1/groups/{group_id}/tasks/{task_id}:move](0082-gar-544-task-move-api.md) | [GAR-544](https://linear.app/chatgpt25/issue/GAR-544) | ⏳ In Progress |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

- Adds `POST /v1/groups/{group_id}/tasks/{task_id}:move` — the last remaining non-WS, non-attachment Tier 1 endpoint in ROADMAP §3.8
- `MoveTaskRequest { target_list_id: Uuid }` request body; returns 200 + full task JSON with updated `list_id`
- 2-step atomic transaction: verify target list exists in group and is not archived → `UPDATE tasks SET list_id` RETURNING full row → `insert_task_activity(kind='moved')` → `audit_workspace_event(TaskMoved)`
- New `WorkspaceAuditAction::TaskMoved` variant (`"task.moved"`) added to `garraia-auth`
- 404 when task is soft-deleted or not in group; 404 when target list is archived, missing, or cross-group; 403 when path `group_id ≠ principal.group_id`
- Plan: [0082-gar-544-task-move-api.md](plans/0082-gar-544-task-move-api.md)

## Test plan

- [ ] `POST` with valid `target_list_id` → 200 + task JSON with updated `list_id`
- [ ] `POST` with archived target list → 404
- [ ] `POST` with non-existent target list → 404
- [ ] `POST` with soft-deleted task → 404
- [ ] `POST` with path `group_id ≠ principal.group_id` → 403
- [ ] `POST` with missing `target_list_id` body → 422
- [ ] `task_activity` row with `kind='moved'` and `payload.from_list_id` / `payload.to_list_id` written
- [ ] `audit_events` row with `action='task.moved'` written
- [ ] Cross-group isolation: user of group A cannot move task of group B
- [ ] `cargo check --workspace` + `cargo clippy --workspace -- -D warnings` green

https://claude.ai/code/session_01MgfxySB47FeaHNcdSUVVTo

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgfxySB47FeaHNcdSUVVTo)_