### PR TITLE
feat(tasks): GAR-544 — task move API slice 8 (plan 0082)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -532,7 +532,7 @@ Módulo dentro de `garraia-workspace`. Schema entregue via migration 006 com **R
 - [x] `DELETE /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — plan 0079 / GAR-539 ✅
 - [x] `GET /v1/groups/{group_id}/tasks/{task_id}/activity?cursor=...` — plan 0080 / GAR-541 ✅
 - [ ] `POST /v1/groups/{group_id}/tasks/{task_id}/attachments`
-- [ ] `POST /v1/groups/{group_id}/tasks/{task_id}:move` (reordenar/mudar lista)
+- [x] `POST /v1/groups/{group_id}/tasks/{task_id}/move` — plan 0082 / GAR-544 (path scheme amendado de `:move` para `/move` por limitação Axum 0.8 / matchit; reordenar dentro da lista deferido — coluna `position` ainda não existe) 🟡 Em execução
 - [ ] WebSocket `/v1/groups/{group_id}/task-lists/{list_id}/stream` para updates em tempo real (kanban colaborativo)
 
 **RBAC:**

--- a/crates/garraia-auth/src/audit_workspace.rs
+++ b/crates/garraia-auth/src/audit_workspace.rs
@@ -352,6 +352,16 @@ pub enum WorkspaceAuditAction {
     /// `resource_type = "task_subscriptions"`, `resource_id = "{task_id}"`.
     /// Metadata: `{ subscriber_user_id_len: 36 }`.
     TaskUnsubscribed,
+
+    /// A task was moved to a different list within the same group via
+    /// `POST /v1/groups/{group_id}/tasks/{task_id}/move` (plan 0082 / GAR-544,
+    /// epic GAR-WS-TASKS slice 8).
+    ///
+    /// Idempotent self-move (`target_list_id == current list_id`) does NOT
+    /// emit this event — only actual transitions are audited.
+    /// `resource_type = "tasks"`, `resource_id = "{task_id}"`.
+    /// Metadata: `{ from_list_id, to_list_id }` — UUIDs only, never list names.
+    TaskMoved,
 }
 
 impl WorkspaceAuditAction {
@@ -391,6 +401,7 @@ impl WorkspaceAuditAction {
             WorkspaceAuditAction::TaskLabelRemoved => "task.label.removed",
             WorkspaceAuditAction::TaskSubscribed => "task.subscribed",
             WorkspaceAuditAction::TaskUnsubscribed => "task.unsubscribed",
+            WorkspaceAuditAction::TaskMoved => "task.moved",
         }
     }
 }
@@ -564,6 +575,7 @@ mod tests {
             WorkspaceAuditAction::TaskUnsubscribed.as_str(),
             "task.unsubscribed"
         );
+        assert_eq!(WorkspaceAuditAction::TaskMoved.as_str(), "task.moved");
     }
 
     #[test]
@@ -602,6 +614,7 @@ mod tests {
             WorkspaceAuditAction::TaskLabelRemoved.as_str(),
             WorkspaceAuditAction::TaskSubscribed.as_str(),
             WorkspaceAuditAction::TaskUnsubscribed.as_str(),
+            WorkspaceAuditAction::TaskMoved.as_str(),
         ];
         let unique: std::collections::HashSet<_> = strings.iter().collect();
         assert_eq!(unique.len(), strings.len(), "duplicate action strings");

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -295,6 +295,17 @@ name = "rest_v1_task_activity"
 path = "tests/rest_v1_task_activity.rs"
 required-features = ["test-helpers"]
 
+# Plan 0082 (GAR-544): task move endpoint POST tasks/{id}/move.
+# 8 bundled scenarios (M1-M8). required-features gates the binary so
+# `cargo clippy --all-targets` without `--features test-helpers`
+# (CI's clippy invocation) skips compilation — otherwise the
+# `mod common` import would pull `JwtIssuer::new_for_test` /
+# `build_router_for_test` which only exist behind `test-helpers`.
+[[test]]
+name = "rest_v1_task_move"
+path = "tests/rest_v1_task_move.rs"
+required-features = ["test-helpers"]
+
 [dev-dependencies]
 # Plan 0024 T4 (GAR-412): metrics_exporter tests and the
 # metrics_auth_integration binary build a `PrometheusRecorder` directly

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -377,6 +377,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     "/v1/groups/{group_id}/tasks/{task_id}/activity",
                     get(tasks::list_task_activity),
                 )
+                // Plan 0082 (GAR-544) — task move API slice 8.
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/move",
+                    post(tasks::move_task),
+                )
                 // Plan 0070 (GAR-522) — audit API slice 1.
                 .route("/v1/groups/{group_id}/audit", get(audit::list_audit))
                 .merge(rate_limited_routes)
@@ -492,6 +497,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 .route(
                     "/v1/groups/{group_id}/tasks/{task_id}/activity",
                     get(unconfigured_handler),
+                )
+                // Plan 0082 (GAR-544) — task move API slice 8, fail-soft 503.
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/move",
+                    post(unconfigured_handler),
                 )
                 .route(
                     "/v1/uploads",
@@ -612,6 +622,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 .route(
                     "/v1/groups/{group_id}/tasks/{task_id}/activity",
                     get(unconfigured_handler),
+                )
+                // Plan 0082 (GAR-544) — task move API slice 8, no-auth stub.
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/move",
+                    post(unconfigured_handler),
                 )
                 .route(
                     "/v1/uploads",

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -33,8 +33,8 @@ use super::tasks::{
     AddAssigneeRequest, AssignTaskLabelRequest, AssigneeResponse, CommentResponse,
     CreateCommentRequest, CreateTaskLabelRequest, CreateTaskListRequest, CreateTaskRequest,
     LabelAssignmentResponse, ListCommentsResponse, ListTaskListsResponse, ListTasksResponse,
-    PatchTaskListRequest, PatchTaskRequest, SubscriptionResponse, TaskLabelResponse,
-    TaskListResponse, TaskListSummary, TaskResponse, TaskSummary,
+    MoveTaskRequest, PatchTaskListRequest, PatchTaskRequest, SubscriptionResponse,
+    TaskLabelResponse, TaskListResponse, TaskListSummary, TaskResponse, TaskSummary,
 };
 use super::uploads::{CreateUploadRequest, CreateUploadResponse};
 
@@ -126,6 +126,7 @@ impl Modify for SecurityAddon {
         super::tasks::subscribe_to_task,
         super::tasks::list_task_subscriptions,
         super::tasks::unsubscribe_from_task,
+        super::tasks::move_task,
         super::audit::list_audit,
     ),
     components(schemas(
@@ -178,6 +179,7 @@ impl Modify for SecurityAddon {
         AssignTaskLabelRequest,
         LabelAssignmentResponse,
         SubscriptionResponse,
+        MoveTaskRequest,
         AuditEventSummary,
         ListAuditResponse,
     )),

--- a/crates/garraia-gateway/src/rest_v1/tasks.rs
+++ b/crates/garraia-gateway/src/rest_v1/tasks.rs
@@ -3286,3 +3286,213 @@ pub async fn list_task_activity(
 
     Ok(Json(ListActivityResponse { items, next_cursor }))
 }
+
+// ─── Slice 8 — `POST tasks/{id}/move` (plan 0082 / GAR-544) ──────────────────
+
+/// Request body for `POST /v1/groups/{group_id}/tasks/{task_id}/move`.
+///
+/// Move semantics:
+/// - `target_list_id` MUST be a list in the same group, not archived.
+/// - If `target_list_id == current list_id`, the call is a no-op (200, no
+///   activity row, no audit row, `updated_at` unchanged).
+/// - Cross-group target → 404 (RLS filters lookup to 0 rows).
+/// - Schema-level compound FK `(list_id, group_id) → task_lists(id, group_id)`
+///   is the second line of defense if the §pre-validation SELECT is bypassed.
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct MoveTaskRequest {
+    /// Destination task list (must live in the caller's group).
+    pub target_list_id: Uuid,
+}
+
+/// `POST /v1/groups/{group_id}/tasks/{task_id}/move` — move task between lists.
+///
+/// Updates `tasks.list_id` to `target_list_id`. The new list MUST belong to
+/// the caller's group and MUST NOT be archived. On a real transition (target
+/// differs from current list) one `task_activity` row (kind=`'moved'`) and
+/// one `audit_events` row (`task.moved`) are written atomically inside the
+/// same transaction as the UPDATE; an idempotent self-move skips both writes.
+///
+/// Authz: `Action::TasksWrite`. Path `group_id` must equal `principal.group_id`.
+///
+/// Note on the path scheme: the GAR-544 spec used Google API verb-suffix
+/// `:move`, but Axum 0.8 / matchit 0.8 cannot route a literal segment-internal
+/// suffix after a named param. Plan 0082 §0 amends to `/move` sub-segment,
+/// matching the existing convention for sibling task routes.
+///
+/// ## Error matrix
+///
+/// | Condition                          | Status |
+/// |------------------------------------|--------|
+/// | Missing/invalid JWT                | 401    |
+/// | Non-member of group                | 403    |
+/// | Path group_id ≠ principal group_id | 403    |
+/// | Insufficient permission            | 403    |
+/// | Task not found / cross-tenant      | 404    |
+/// | Task soft-deleted                  | 404    |
+/// | Target list not found / cross-tenant | 404  |
+/// | Target list archived               | 404    |
+/// | Self-move (target == current)      | 200 (no-op) |
+/// | Happy path                         | 200    |
+#[utoipa::path(
+    post,
+    path = "/v1/groups/{group_id}/tasks/{task_id}/move",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("task_id" = Uuid, Path, description = "Task UUID."),
+    ),
+    request_body = MoveTaskRequest,
+    responses(
+        (status = 200, description = "Task moved (or self-move no-op).", body = TaskResponse),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member, group mismatch, or insufficient permission.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Task or target list not found / cross-tenant / archived / soft-deleted.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn move_task(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, task_id)): Path<(Uuid, Uuid)>,
+    Json(body): Json<MoveTaskRequest>,
+) -> Result<Json<TaskResponse>, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksWrite) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Fetch current list_id; 404 if task missing or soft-deleted.
+    let current: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT list_id FROM tasks \
+         WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+    )
+    .bind(task_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let from_list_id = match current {
+        Some((id,)) => id,
+        None => return Err(RestError::NotFound),
+    };
+
+    // Idempotent self-move: same list — return current task body unchanged.
+    if from_list_id == body.target_list_id {
+        let row: TaskRow = sqlx::query_as(
+            "SELECT id, list_id, group_id, parent_task_id, title, description_md, \
+                    status, priority, due_at, started_at, completed_at, \
+                    estimated_minutes, created_by, created_by_label, \
+                    created_at, updated_at, deleted_at \
+             FROM tasks \
+             WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+        )
+        .bind(task_id)
+        .bind(group_id)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+        tx.commit()
+            .await
+            .map_err(|e| RestError::Internal(e.into()))?;
+
+        return Ok(Json(TaskResponse::from(row)));
+    }
+
+    // Validate target list — must live in the same group and not be archived.
+    // Cross-group targets are filtered to 0 rows by RLS, so the cross-tenant
+    // case collapses into a clean 404.
+    let target_ok: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM task_lists \
+         WHERE id = $1 AND group_id = $2 AND archived_at IS NULL",
+    )
+    .bind(body.target_list_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if target_ok.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    // Cache actor display name for audit + activity payloads.
+    let (actor_label,): (String,) = sqlx::query_as("SELECT display_name FROM users WHERE id = $1")
+        .bind(principal.user_id)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    // Apply the move. Compound FK `(list_id, group_id) → task_lists(id, group_id)`
+    // re-validates same-group at the DB layer — even a buggy app layer cannot
+    // point list_id at a foreign-group list (would fail with SQLSTATE 23503).
+    let row: Option<TaskRow> = sqlx::query_as(
+        "UPDATE tasks \
+         SET list_id    = $1, \
+             updated_at = now() \
+         WHERE id = $2 \
+           AND group_id = $3 \
+           AND deleted_at IS NULL \
+         RETURNING id, list_id, group_id, parent_task_id, title, description_md, \
+                   status, priority, due_at, started_at, completed_at, \
+                   estimated_minutes, created_by, created_by_label, \
+                   created_at, updated_at, deleted_at",
+    )
+    .bind(body.target_list_id)
+    .bind(task_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let row = match row {
+        Some(r) => r,
+        None => return Err(RestError::NotFound),
+    };
+
+    // Activity timeline entry — kind `'moved'` introduced in migration 016.
+    insert_task_activity(
+        &mut tx,
+        task_id,
+        group_id,
+        principal.user_id,
+        &actor_label,
+        "moved",
+        json!({
+            "from_list_id": from_list_id.to_string(),
+            "to_list_id": body.target_list_id.to_string(),
+        }),
+    )
+    .await?;
+
+    // Compliance audit row. Metadata carries UUIDs only — never list names.
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::TaskMoved,
+        principal.user_id,
+        group_id,
+        "tasks",
+        task_id.to_string(),
+        json!({
+            "from_list_id": from_list_id.to_string(),
+            "to_list_id": body.target_list_id.to_string(),
+        }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(Json(TaskResponse::from(row)))
+}

--- a/crates/garraia-gateway/tests/rest_v1_task_move.rs
+++ b/crates/garraia-gateway/tests/rest_v1_task_move.rs
@@ -1,0 +1,387 @@
+//! Integration tests for the task-move REST endpoint (plan 0082, GAR-544, slice 8).
+//!
+//! All scenarios bundled into ONE `#[tokio::test]` — same pattern as previous
+//! task-slice tests. Splitting triggers the sqlx runtime-teardown race
+//! documented in plan 0016 M3.
+//!
+//! Scenarios (8 total):
+//!
+//!   M1. Happy path — Alice moves a task from list A to list B in her own
+//!       group; response carries the new `list_id`; `task_activity` has a
+//!       `moved` row with `{from_list_id, to_list_id}`; `audit_events` has a
+//!       `task.moved` row whose `metadata` carries both UUIDs.
+//!   M2. Idempotent self-move — `target_list_id == current` returns 200
+//!       with no new activity row, no new audit row, and `updated_at`
+//!       unchanged.
+//!   M3. Unknown `task_id` returns 404.
+//!   M4. Soft-deleted task returns 404.
+//!   M5. Unknown `target_list_id` returns 404.
+//!   M6. Archived target list returns 404 (archive via `DELETE` on the list).
+//!   M7. Cross-group `target_list_id` (list belongs to Bob's group) returns
+//!       404 from Alice's principal — RLS filter collapses the SELECT to 0
+//!       rows.
+//!   M8. Cross-group `task_id` (task in Bob's group, called with Alice's
+//!       principal + her own group header) returns 404.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use common::Harness;
+use common::fixtures::{fetch_audit_events_for_group, seed_user_with_group};
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect response body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("response body is not JSON")
+}
+
+fn auth_req(
+    method: &str,
+    uri: &str,
+    token: Option<&str>,
+    x_group_id: Option<&str>,
+    body: Option<serde_json::Value>,
+) -> Request<Body> {
+    let body_bytes = match body {
+        Some(v) => Body::from(v.to_string()),
+        None => Body::empty(),
+    };
+    let mut req = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(body_bytes)
+        .expect("request builder");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    if let Some(t) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {t}")).unwrap(),
+        );
+    }
+    if let Some(g) = x_group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    req
+}
+
+/// POST a task-list and return the new list_id.
+async fn create_task_list(h: &Harness, token: &str, group_id: &str, name: &str) -> String {
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{group_id}/task-lists"),
+            Some(token),
+            Some(group_id),
+            Some(json!({ "name": name, "type": "list" })),
+        ))
+        .await
+        .expect("POST task-list oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::CREATED,
+        "setup: task-list 201 ({name})"
+    );
+    let body = body_json(resp).await;
+    body["id"].as_str().expect("list id").to_string()
+}
+
+/// POST a task into the given list and return the new task_id.
+async fn create_task(h: &Harness, token: &str, group_id: &str, list_id: &str) -> String {
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{group_id}/task-lists/{list_id}/tasks"),
+            Some(token),
+            Some(group_id),
+            Some(json!({ "title": "Task for move tests" })),
+        ))
+        .await
+        .expect("POST task oneshot");
+    assert_eq!(resp.status(), StatusCode::CREATED, "setup: task 201");
+    let body = body_json(resp).await;
+    body["id"].as_str().expect("task id").to_string()
+}
+
+/// POST a move and return the response.
+async fn move_task(
+    h: &Harness,
+    token: &str,
+    group_id: &str,
+    task_id: &str,
+    target_list_id: &str,
+) -> axum::response::Response {
+    h.router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{group_id}/tasks/{task_id}/move"),
+            Some(token),
+            Some(group_id),
+            Some(json!({ "target_list_id": target_list_id })),
+        ))
+        .await
+        .expect("POST move oneshot")
+}
+
+/// SELECT the raw `tasks` row for the given task_id.
+/// Used to assert `updated_at` invariance in M2.
+async fn fetch_task_updated_at(h: &Harness, task_id: Uuid) -> chrono::DateTime<chrono::Utc> {
+    let (ts,): (chrono::DateTime<chrono::Utc>,) =
+        sqlx::query_as("SELECT updated_at FROM tasks WHERE id = $1")
+            .bind(task_id)
+            .fetch_one(&h.admin_pool)
+            .await
+            .expect("SELECT updated_at");
+    ts
+}
+
+/// SELECT all `task_activity` rows for the given task_id, newest first.
+async fn fetch_task_activity(h: &Harness, task_id: Uuid) -> Vec<(String, serde_json::Value)> {
+    sqlx::query_as(
+        "SELECT kind, payload FROM task_activity \
+         WHERE task_id = $1 \
+         ORDER BY created_at DESC, id DESC",
+    )
+    .bind(task_id)
+    .fetch_all(&h.admin_pool)
+    .await
+    .expect("SELECT task_activity")
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(feature = "test-helpers")]
+#[tokio::test]
+async fn rest_v1_task_move_scenarios() {
+    let h = Harness::get().await;
+
+    // Seed Alice (owner of group A) and Bob (owner of group B).
+    let (_alice_id, alice_group_id, alice_token) = seed_user_with_group(&h, "alice@move.test")
+        .await
+        .expect("seed alice+group");
+    let (_bob_id, bob_group_id, bob_token) = seed_user_with_group(&h, "bob@move.test")
+        .await
+        .expect("seed bob+group");
+
+    let agid = alice_group_id.to_string();
+    let bgid = bob_group_id.to_string();
+
+    // Two lists in Alice's group.
+    let list_a = create_task_list(&h, &alice_token, &agid, "List A — origin").await;
+    let list_b = create_task_list(&h, &alice_token, &agid, "List B — target").await;
+
+    // Task starts in list_a.
+    let task_id_str = create_task(&h, &alice_token, &agid, &list_a).await;
+    let task_id_uuid: Uuid = task_id_str.parse().expect("task uuid");
+
+    // ── M1. Happy path ─────────────────────────────────────────────────────
+    let resp = move_task(&h, &alice_token, &agid, &task_id_str, &list_b).await;
+    assert_eq!(resp.status(), StatusCode::OK, "M1 move 200");
+    let body = body_json(resp).await;
+    assert_eq!(
+        body["list_id"].as_str(),
+        Some(list_b.as_str()),
+        "M1 response carries the new list_id"
+    );
+    assert_eq!(
+        body["id"].as_str(),
+        Some(task_id_str.as_str()),
+        "M1 response is the same task"
+    );
+
+    // task_activity has a `moved` row with both UUIDs.
+    let activity = fetch_task_activity(&h, task_id_uuid).await;
+    let moved_row = activity
+        .iter()
+        .find(|(k, _)| k == "moved")
+        .expect("M1 task_activity has a `moved` row");
+    let moved_payload = &moved_row.1;
+    assert_eq!(
+        moved_payload["from_list_id"].as_str(),
+        Some(list_a.as_str()),
+        "M1 activity payload.from_list_id"
+    );
+    assert_eq!(
+        moved_payload["to_list_id"].as_str(),
+        Some(list_b.as_str()),
+        "M1 activity payload.to_list_id"
+    );
+
+    // audit_events has a `task.moved` row scoped to Alice's group.
+    let audit_rows = fetch_audit_events_for_group(&h, alice_group_id)
+        .await
+        .expect("M1 audit fetch");
+    let audit_moved = audit_rows
+        .iter()
+        .find(|(action, _, rt, rid, _)| {
+            action == "task.moved" && rt == "tasks" && rid == &task_id_str
+        })
+        .expect("M1 audit_events has task.moved row");
+    let audit_meta = &audit_moved.4;
+    assert_eq!(
+        audit_meta["from_list_id"].as_str(),
+        Some(list_a.as_str()),
+        "M1 audit metadata.from_list_id"
+    );
+    assert_eq!(
+        audit_meta["to_list_id"].as_str(),
+        Some(list_b.as_str()),
+        "M1 audit metadata.to_list_id"
+    );
+    // PII guard: no list names in metadata.
+    assert!(
+        audit_meta.get("from_name").is_none(),
+        "M1 audit metadata must not carry list names"
+    );
+    assert!(
+        audit_meta.get("to_name").is_none(),
+        "M1 audit metadata must not carry list names"
+    );
+
+    // ── M2. Idempotent self-move ────────────────────────────────────────────
+    // Task is now in list_b. Move it to list_b again — should be a no-op.
+    let updated_before = fetch_task_updated_at(&h, task_id_uuid).await;
+    let activity_before = fetch_task_activity(&h, task_id_uuid).await;
+    let audit_before = fetch_audit_events_for_group(&h, alice_group_id)
+        .await
+        .expect("M2 audit before");
+    let moved_count_before = audit_before
+        .iter()
+        .filter(|(action, _, _, rid, _)| action == "task.moved" && rid == &task_id_str)
+        .count();
+
+    let resp = move_task(&h, &alice_token, &agid, &task_id_str, &list_b).await;
+    assert_eq!(resp.status(), StatusCode::OK, "M2 self-move 200");
+
+    let updated_after = fetch_task_updated_at(&h, task_id_uuid).await;
+    assert_eq!(
+        updated_after, updated_before,
+        "M2 updated_at must NOT change on self-move"
+    );
+    let activity_after = fetch_task_activity(&h, task_id_uuid).await;
+    assert_eq!(
+        activity_after.len(),
+        activity_before.len(),
+        "M2 no new task_activity row on self-move"
+    );
+    let audit_after = fetch_audit_events_for_group(&h, alice_group_id)
+        .await
+        .expect("M2 audit after");
+    let moved_count_after = audit_after
+        .iter()
+        .filter(|(action, _, _, rid, _)| action == "task.moved" && rid == &task_id_str)
+        .count();
+    assert_eq!(
+        moved_count_after, moved_count_before,
+        "M2 no new task.moved audit row on self-move"
+    );
+
+    // ── M3. Unknown task_id → 404 ──────────────────────────────────────────
+    let unknown_task = Uuid::new_v4().to_string();
+    let resp = move_task(&h, &alice_token, &agid, &unknown_task, &list_a).await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND, "M3 unknown task 404");
+
+    // ── M4. Soft-deleted task → 404 ────────────────────────────────────────
+    // Create a fresh task in list_a, soft-delete it via DELETE, then attempt
+    // to move it.
+    let doomed_task = create_task(&h, &alice_token, &agid, &list_a).await;
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "DELETE",
+            &format!("/v1/groups/{agid}/tasks/{doomed_task}"),
+            Some(&alice_token),
+            Some(&agid),
+            None,
+        ))
+        .await
+        .expect("M4 DELETE task");
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT, "M4 DELETE 204");
+
+    let resp = move_task(&h, &alice_token, &agid, &doomed_task, &list_b).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "M4 soft-deleted task move 404"
+    );
+
+    // ── M5. Unknown target_list_id → 404 ───────────────────────────────────
+    let unknown_list = Uuid::new_v4().to_string();
+    let resp = move_task(&h, &alice_token, &agid, &task_id_str, &unknown_list).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "M5 unknown target_list_id 404"
+    );
+
+    // ── M6. Archived target list → 404 ─────────────────────────────────────
+    // Create a third list, archive it via DELETE on the list, then attempt
+    // to move our happy-path task into it.
+    let list_c_archived = create_task_list(&h, &alice_token, &agid, "List C — to archive").await;
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "DELETE",
+            &format!("/v1/groups/{agid}/task-lists/{list_c_archived}"),
+            Some(&alice_token),
+            Some(&agid),
+            None,
+        ))
+        .await
+        .expect("M6 archive list-c");
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT, "M6 archive list 204");
+
+    let resp = move_task(&h, &alice_token, &agid, &task_id_str, &list_c_archived).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "M6 archived target list 404"
+    );
+
+    // ── M7. Cross-group target_list_id → 404 ───────────────────────────────
+    // Bob owns a list in his group; Alice (with her own JWT + her own
+    // x-group-id) cannot use Bob's list_id as a target.
+    let bob_list = create_task_list(&h, &bob_token, &bgid, "Bob's list").await;
+    let resp = move_task(&h, &alice_token, &agid, &task_id_str, &bob_list).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "M7 cross-group target 404"
+    );
+
+    // ── M8. Cross-group task_id → 404 ──────────────────────────────────────
+    // Bob has a task in his own group. Alice attempts to move it using her
+    // own principal but Bob's task UUID — RLS filters the lookup to 0 rows.
+    let bob_task = create_task(&h, &bob_token, &bgid, &bob_list).await;
+    let resp = move_task(&h, &alice_token, &agid, &bob_task, &list_b).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "M8 cross-group task 404"
+    );
+}

--- a/crates/garraia-workspace/migrations/016_task_activity_moved_kind.sql
+++ b/crates/garraia-workspace/migrations/016_task_activity_moved_kind.sql
@@ -1,0 +1,44 @@
+-- 016_task_activity_moved_kind.sql
+-- GAR-544 — Migration 016: extend task_activity.kind CHECK with 'moved'.
+-- Plan:     plans/0082-gar-544-task-move-api.md
+-- Depends:  migration 006 (task_activity table + original CHECK constraint)
+-- Forward-only. The default Postgres-named constraint
+-- `task_activity_kind_check` was generated inline by migration 006
+-- (no `CONSTRAINT name` clause). If the runtime name differs we
+-- look it up via pg_constraint instead of failing.
+
+DO $$
+DECLARE
+    cname text;
+BEGIN
+    SELECT conname
+    INTO cname
+    FROM pg_constraint
+    WHERE conrelid = 'public.task_activity'::regclass
+      AND contype  = 'c'
+      AND pg_get_constraintdef(oid) ILIKE '%kind%';
+
+    IF cname IS NULL THEN
+        RAISE EXCEPTION 'task_activity kind CHECK constraint not found';
+    END IF;
+
+    EXECUTE format(
+        'ALTER TABLE task_activity DROP CONSTRAINT %I',
+        cname
+    );
+END
+$$;
+
+ALTER TABLE task_activity
+    ADD CONSTRAINT task_activity_kind_check
+    CHECK (kind IN (
+        'created', 'status_changed', 'priority_changed',
+        'assigned', 'unassigned', 'labeled', 'unlabeled',
+        'commented', 'due_changed', 'archived', 'deleted', 'restored',
+        'moved'
+    ));
+
+COMMENT ON CONSTRAINT task_activity_kind_check ON task_activity IS
+    'Closed set of activity event kinds. ''moved'' added in migration 016 '
+    '(GAR-544 task move endpoint). Extending requires a new forward-only '
+    'migration following the same DROP/ADD pattern.';

--- a/plans/0082-gar-544-task-move-api.md
+++ b/plans/0082-gar-544-task-move-api.md
@@ -1,0 +1,336 @@
+# Plan 0082 — GAR-544: REST /v1 tasks slice 8 (move task between lists)
+
+**Status:** Em execução
+**Autor:** Claude Opus 4.7 (garra-routine 2026-05-08, America/New_York)
+**Data:** 2026-05-08 (America/New_York)
+**Issue:** [GAR-544](https://linear.app/chatgpt25/issue/GAR-544)
+**Branch:** `routine/202605081115-task-move-api`
+**Epic:** `epic:ws-api`, `epic:ws-tasks`
+**Parent:** GAR-396
+
+---
+
+## §0 Path-scheme amendment
+
+GAR-544 spec wrote `POST /v1/groups/{group_id}/tasks/{task_id}:move`
+(Google API verb-suffix style). Axum 0.8 / matchit 0.8 routes named
+parameters `{name}` greedily over the entire URL segment between `/`
+delimiters — `:move` would be absorbed into `task_id` (ex.: `task_id =
+"<uuid>:move"`), so the literal Google-style suffix is unroutable
+without writing a custom router.
+
+**Decision:** use `POST /v1/groups/{group_id}/tasks/{task_id}/move`
+(action sub-segment), matching the existing convention for tasks-API
+sibling routes (`/comments`, `/assignees`, `/labels`, `/subscriptions`,
+`/activity`). Linear issue GAR-544 amended via comment with this rationale.
+
+## §1 Goal
+
+Land the task-move REST endpoint (ROADMAP §3.4 / §3.8 Tier 1):
+
+* `POST /v1/groups/{group_id}/tasks/{task_id}/move` — move a task to a
+  different task list within the same group. Returns `200` with the
+  updated task body (same shape as `GET /v1/groups/{group_id}/tasks/{task_id}`).
+
+The operation updates `tasks.list_id` to point to a new `task_lists.id`.
+No position/ordering column exists yet (migration 006 comment: "position
+column (kanban ordering) → out of scope, future migration"), so this
+slice only moves across lists, not within a list.
+
+**Request body:** `{ "target_list_id": "<uuid>" }`
+
+**Activity log entry:** kind = `'moved'` with payload
+`{ "from_list_id": "<uuid>", "to_list_id": "<uuid>" }`. The
+`task_activity.kind` CHECK constraint (migration 006) does not currently
+include `'moved'` — this slice ships migration 016 to extend it.
+
+**Audit event:** new `WorkspaceAuditAction::TaskMoved` → `"task.moved"`
+with metadata `{ "from_list_id": "<uuid>", "to_list_id": "<uuid>" }`
+(UUIDs are not PII).
+
+## §2 Architecture
+
+### Schema delta — migration 016
+
+Forward-only `ALTER TABLE` to extend the `task_activity.kind` CHECK
+constraint with `'moved'`:
+
+```sql
+ALTER TABLE task_activity DROP CONSTRAINT task_activity_kind_check;
+ALTER TABLE task_activity
+    ADD CONSTRAINT task_activity_kind_check
+    CHECK (kind IN (
+        'created', 'status_changed', 'priority_changed',
+        'assigned', 'unassigned', 'labeled', 'unlabeled',
+        'commented', 'due_changed', 'archived', 'deleted', 'restored',
+        'moved'
+    ));
+```
+
+The constraint name `task_activity_kind_check` is the Postgres default
+for inline `CHECK (...)` on column `kind`. Verified empirically against
+migration 006 (no explicit `CONSTRAINT name`). If the runtime name turns
+out to differ, migration 016 will look it up via `pg_constraint`.
+
+### Move handler (`move_task`)
+
+Location: `crates/garraia-gateway/src/rest_v1/tasks.rs` (single new pub
+async fn at the slice 8 section, mirroring `patch_task`'s shape).
+
+```text
+1. require_group_id(&principal) → group_id
+2. check_group_match(path_group_id, group_id)
+3. can(&principal, Action::TasksWrite) || 403
+4. Begin tx; set_rls_context(user_id, group_id)
+5. Pre-fetch current list_id:
+     SELECT list_id FROM tasks
+     WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL
+   → 404 if None
+6. Validate target list exists, same group, not archived:
+     SELECT 1 FROM task_lists
+     WHERE id = $1 AND group_id = $2 AND archived_at IS NULL
+   → 404 if None
+7. If old_list_id == target_list_id: skip UPDATE + activity (idempotent),
+   re-SELECT TaskRow, return 200.
+8. UPDATE tasks SET list_id = $1, updated_at = now()
+   WHERE id = $2 AND group_id = $3 AND deleted_at IS NULL
+   RETURNING <full TaskRow>
+9. Fetch actor_label (display_name)
+10. insert_task_activity(kind='moved',
+        payload={from_list_id, to_list_id})
+11. audit_workspace_event(TaskMoved, metadata={from_list_id, to_list_id})
+12. tx.commit()
+13. Return 200 + TaskResponse::from(row)
+```
+
+The compound FK `(list_id, group_id) → task_lists(id, group_id)`
+on `tasks` already enforces same-group at the DB layer — even if
+the app layer were buggy, attempting to point `list_id` at a
+list in another group would fail at INSERT/UPDATE time. The §2.6
+SELECT is a defense-in-depth check that returns the human-friendly
+`404` instead of a `23503` foreign-key error.
+
+### Idempotency
+
+If `target_list_id == current list_id`:
+
+* No `UPDATE` is issued (avoids spurious `updated_at` bumps).
+* No `task_activity` row is written (avoids polluting the timeline
+  with no-op events).
+* No audit event is logged.
+* Response is still `200` with the unchanged task body.
+
+This matches the convention from `delete_task` (already-deleted = 404)
+and `patch_task` (no-op fields are ignored), favoring **observable
+no-op** semantics over loud errors. Test M5 asserts this.
+
+### `WorkspaceAuditAction::TaskMoved`
+
+Add a new enum variant in
+`crates/garraia-auth/src/audit_workspace.rs`:
+
+```rust
+TaskMoved => "task.moved",
+```
+
+Plus the existing test in `as_str_returns_stable_strings` and
+`from_str_round_trips` gets an assertion line.
+
+## §3 Tech stack
+
+* Axum 0.8 + `RestV1FullState`
+* `sqlx::query` / `sqlx::query_as` (Postgres) — no SQL string concat
+* `serde_json::json!` macro for payload values
+* `utoipa::path` for OpenAPI doc
+
+## §4 Design invariants
+
+1. `group_id` in path MUST equal `principal.group_id` (403 otherwise).
+2. The handler MUST `set_rls_context` before any read or write — RLS
+   filter is the primary cross-group isolation, not the app-layer SELECT.
+3. The DB-layer compound FK `(list_id, group_id) → task_lists(id, group_id)`
+   is the secondary line of defense — even a buggy handler cannot point
+   `list_id` at a foreign-group list.
+4. Activity payload contains only UUIDs (`from_list_id`, `to_list_id`).
+   No PII (no list names, no task titles).
+5. Audit metadata contains only UUIDs (same rule).
+6. Idempotent self-move (target == current) returns 200 with no
+   side effects (no `updated_at` bump, no activity, no audit).
+7. Soft-deleted tasks return 404, not 200 (matches `delete_task` semantics).
+8. Archived target lists return 404 (cannot move into a hidden bucket).
+
+## §5 Validações pré-plano
+
+- [x] `task_activity.kind` CHECK lacks `'moved'` — migration 016 needed ✅
+  (verified `crates/garraia-workspace/migrations/006_tasks_with_rls.sql:204-208`).
+- [x] Migration sequence is forward-only — last is 015 ✅.
+- [x] `WorkspaceAuditAction` does NOT yet have `TaskMoved` ✅
+  (verified `crates/garraia-auth/src/audit_workspace.rs:375-393`).
+- [x] `set_rls_context`, `insert_task_activity`, `require_group_id`,
+  `check_group_match` helpers exist ✅
+  (`tasks.rs:490, 508, 534, 540`).
+- [x] `Action::TasksWrite` exists in `garraia-auth::Action` ✅.
+- [x] `TaskRow` / `TaskResponse` types reusable ✅
+  (`tasks.rs:118, 348`).
+- [x] Compound FK `(list_id, group_id) → task_lists(id, group_id)` on
+  `tasks` exists ✅ (`006_tasks_with_rls.sql:93`).
+- [x] Axum 0.8 / matchit 0.8 cannot route Google `:move` suffix —
+  decision in §0 ✅.
+
+## §6 Out of scope
+
+* In-list reordering (`position` column does not exist).
+* Moving across groups (forbidden by compound FK; out of scope for this
+  slice — `403/404` is acceptable).
+* Move between archived and unarchived state (use `PATCH` on
+  `task_lists`).
+* WebSocket fan-out for kanban UI (GAR-397 digest worker).
+* Bulk move (`POST /v1/groups/{group_id}/tasks:move-many`) — separate slice.
+* Subtask cascade (parent_task_id is preserved; subtasks keep their own
+  list_id) — already handled by schema (no cascade on list_id).
+
+## §7 Rollback
+
+* Migration 016 is forward-only. To revert, write a 017 that drops `'moved'`
+  from the CHECK *after* deleting any rows with that kind (the CHECK reject
+  on existing data otherwise).
+* Handler is additive (new pub fn + new route line). Removing the route
+  + deleting the fn is a clean revert.
+* Audit enum variant is additive. Removing it requires checking that no
+  persisted `audit_events.action_type = 'task.moved'` rows reference it,
+  but `WorkspaceAuditAction` enum is only used in writes — read paths
+  treat `action_type` as opaque text.
+
+## §8 File structure
+
+```
+crates/garraia-workspace/migrations/
+  016_task_activity_moved_kind.sql    — NEW
+
+crates/garraia-auth/src/
+  audit_workspace.rs                  — add TaskMoved variant + as_str + tests
+
+crates/garraia-gateway/src/rest_v1/
+  tasks.rs                            — add MoveTaskRequest + move_task fn (~120 LOC)
+  mod.rs                              — wire route in 3 blocks (full + 2 fail-soft)
+
+crates/garraia-gateway/tests/
+  rest_v1_task_move.rs                — NEW bundled test (~350 LOC, 8 scenarios)
+
+ROADMAP.md                            — flip slice 8 from [ ] → [x]
+plans/README.md                       — add row for plan 0082
+```
+
+## §9 Tasks
+
+### T1 — Migration 016 (`task_activity.kind` CHECK adds `'moved'`)
+
+- [ ] Create `crates/garraia-workspace/migrations/016_task_activity_moved_kind.sql`
+  with `ALTER TABLE task_activity DROP CONSTRAINT task_activity_kind_check;`
+  + recreate with `'moved'` appended.
+- [ ] Append migration 016 to the embed list (verify how 014/015 are referenced).
+- [ ] `cargo check -p garraia-workspace` green.
+
+### T2 — `WorkspaceAuditAction::TaskMoved`
+
+- [ ] Add variant + match arm in `audit_workspace.rs::as_str` →
+  `"task.moved"`.
+- [ ] Update `from_str` if it exists (round-trip).
+- [ ] Update `as_str_returns_stable_strings` test with the new assertion.
+- [ ] `cargo test -p garraia-auth` green.
+
+### T3 — `move_task` handler + route wiring
+
+- [ ] Add `MoveTaskRequest { target_list_id: Uuid }` struct with
+  `#[derive(Serialize, Deserialize, ToSchema)]`.
+- [ ] Add `pub async fn move_task(...)` in `tasks.rs` (~120 LOC) with
+  `#[utoipa::path]` doc.
+- [ ] Wire route `POST /v1/groups/{group_id}/tasks/{task_id}/move` in
+  `mod.rs` (full-state block + 2 fail-soft 503 stubs).
+- [ ] `cargo check -p garraia-gateway` green.
+
+### T4 — Integration tests
+
+- [ ] Create `tests/rest_v1_task_move.rs` with 8 scenarios in ONE
+  `#[tokio::test] async fn rest_v1_task_move_scenarios()` (sqlx
+  runtime-teardown rule from plan 0016 M3):
+
+  * **M1.** Happy path: 2 lists in same group → POST move → 200 + task
+    body shows new list_id; activity row kind=`moved` with
+    `{from_list_id, to_list_id}`; audit row `task.moved` present.
+  * **M2.** Idempotent self-move: target == current → 200, no new
+    activity row written, no new audit row, `updated_at` unchanged.
+  * **M3.** Unknown task_id → 404.
+  * **M4.** Soft-deleted task → 404.
+  * **M5.** Unknown target_list_id → 404.
+  * **M6.** Archived target_list_id → 404.
+  * **M7.** Cross-group target_list_id (list owned by group B) → 404
+    (RLS filters; same SELECT returns 0 rows).
+  * **M8.** Cross-group task (task in group B from group A's principal)
+    → 404 (existing isolation pattern; matches T7/T9 in `rest_v1_tasks.rs`).
+- [ ] `cargo test -p garraia-gateway --test rest_v1_task_move` green.
+
+### T5 — Clippy + fmt
+
+- [ ] `cargo fmt --all` clean.
+- [ ] `SWAGGER_UI_DOWNLOAD_URL=file:///tmp/swagger-ui-cache/v5.17.14.zip
+  cargo clippy --workspace --tests --exclude garraia-desktop
+  --features garraia-gateway/test-helpers --no-deps -- -D warnings` clean.
+
+### T6 — Update ROADMAP.md + plans/README.md
+
+- [ ] Mark slice 8 (`POST tasks/{id}/move`) as `[x]` in ROADMAP §3.4.
+- [ ] Add plan 0082 row to `plans/README.md` with status "Em execução".
+
+## §10 Risk register
+
+| Risk | Mitigation |
+|------|-----------|
+| Constraint name `task_activity_kind_check` not the Postgres default | If `ALTER TABLE … DROP CONSTRAINT` errors, fall back to `DO $$ DECLARE n text; BEGIN SELECT conname INTO n FROM pg_constraint WHERE conrelid = 'task_activity'::regclass AND contype = 'c' AND pg_get_constraintdef(oid) LIKE '%kind%'; EXECUTE 'ALTER TABLE task_activity DROP CONSTRAINT ' \|\| n; END $$;`. |
+| Compound FK rejects target_list_id before our SELECT | Keep the §2.6 SELECT — it gives a clean 404 instead of a 500-via-23503 leak. |
+| Migration 016 vs 015 race during deployment | Forward-only; migrations are sequential — 016 only runs after 015. |
+| Idempotent self-move masking bugs | Test M2 asserts no audit / no activity / no updated_at bump — bug-mask is detectable. |
+
+## §11 Acceptance criteria
+
+1. `POST /v1/groups/{gid}/tasks/{tid}/move` with valid `target_list_id`
+   returns `200` + updated task; `tasks.list_id` is the new value.
+2. Activity row kind=`'moved'` with payload
+   `{from_list_id, to_list_id}` recorded.
+3. Audit event `task.moved` with metadata
+   `{from_list_id, to_list_id}` recorded.
+4. Cross-group target → 404. Cross-group task → 404. Soft-deleted task → 404.
+   Archived target list → 404.
+5. Idempotent self-move → 200, no new activity, no new audit,
+   `updated_at` unchanged.
+6. All 17+ CI checks green on the PR.
+7. `task_activity.kind` CHECK constraint includes `'moved'` (migration 016
+   applied).
+
+## §12 Open questions
+
+* **Q1.** Should `move` allow targeting an archived list with an explicit
+  `--unarchive` flag? **Decided: no** — out of scope; user must unarchive
+  first via PATCH on `task_lists`.
+* **Q2.** Should the activity row include `from_list_label` / `to_list_label`
+  for display? **Decided: no** — UUIDs only; UI can JOIN against
+  `task_lists` for names. Avoids stale labels and keeps payload PII-free.
+* **Q3.** Should bulk move be in this slice? **Decided: no** — separate
+  slice; spec is single-task only. Bulk surface needs its own design
+  (atomicity, partial-failure semantics).
+* **Q4.** What about subtasks? **Decided:** the schema does NOT cascade
+  `list_id` from parent to children — moving the parent does not
+  reparent subtasks. Documented in §6 out of scope.
+
+## §13 Cross-references
+
+* ROADMAP §3.4 Fase 3.4 — Tasks API Tier 1.
+* Migration 006 (`crates/garraia-workspace/migrations/006_tasks_with_rls.sql`).
+* GAR-396 (parent epic: API REST Tasks + WebSocket kanban colaborativo).
+* Plans 0066/0068/0069/0077/0078/0079/0080 (previous tasks slices 1-7).
+* `crates/garraia-auth/src/audit_workspace.rs` (audit enum).
+
+## §14 Estimativa
+
+~500 LOC total (~50 LOC migration, ~10 LOC enum, ~120 LOC handler,
+~350 LOC tests). 1 sessão.

--- a/plans/README.md
+++ b/plans/README.md
@@ -105,6 +105,7 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0079 | [GAR-539 — REST /v1 tasks slice 6: task subscriptions API (POST/DELETE/GET)](0079-gar-539-task-subscriptions-api.md) | [GAR-539](https://linear.app/chatgpt25/issue/GAR-539) | ✅ Merged 2026-05-07 via PR #199 (`b6c60b0`) |
 | 0080 | [GAR-541 — REST /v1 tasks slice 7: task activity log (writes + GET)](0080-gar-541-task-activity-api.md) | [GAR-541](https://linear.app/chatgpt25/issue/GAR-541) | ✅ Merged 2026-05-07 via PR #204 (`e39a7e5`) |
 | 0081 | [GAR-466 — Q6.4: kill `is_unique_violation` constant-true mutant](0081-gar-466-q64-unique-violation-mutant.md) | [GAR-466](https://linear.app/chatgpt25/issue/GAR-466) | ✅ Merged 2026-05-07 via PR #206 (`48b55a2`) |
+| 0082 | [GAR-544 — REST `/v1` tasks slice 8 (move task between lists)](0082-gar-544-task-move-api.md) | [GAR-544](https://linear.app/chatgpt25/issue/GAR-544) | 🟡 Em execução (sessão garra-routine 2026-05-08) |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

Lands `POST /v1/groups/{group_id}/tasks/{task_id}/move` — move a task between lists within the same group. Returns `200` + updated task body. Slice 8 of the tasks API epic (GAR-396).

- Migration **016** extends `task_activity.kind` CHECK with `'moved'` (forward-only; uses `pg_constraint` lookup so the constraint name is resilient).
- `WorkspaceAuditAction::TaskMoved` → `"task.moved"`. Audit metadata carries `{from_list_id, to_list_id}` (UUIDs only — never list names).
- Idempotent self-move (`target == current`) returns 200 with **no** UPDATE, **no** activity row, **no** audit row, **no** `updated_at` bump (asserted in test M2).
- Cross-tenant isolation enforced by RLS on the SELECT lookups, defended at the DB layer by the existing compound FK `(list_id, group_id) → task_lists(id, group_id)`.
- Archived target list → `404`. Soft-deleted task → `404`. Unknown task or target → `404`.
- OpenAPI registered (`super::tasks::move_task` + `MoveTaskRequest` schema).
- 8 bundled integration scenarios in `tests/rest_v1_task_move.rs` (~350 LOC).

### Path-scheme deviation from spec

GAR-544 wrote the Google API verb suffix `:move`. Axum 0.8 / matchit 0.8 cannot terminate a named param mid-segment — `:move` would be absorbed into `{task_id}`. Plan 0082 §0 amends to `/move` sub-segment, matching the existing convention for sibling task routes (`/comments`, `/assignees`, `/labels`, `/subscriptions`, `/activity`) and the precedent set in plans 0019 (`/accept`) and 0020 (`/setRole`).

## Test plan

- [ ] Format Check passes (`cargo fmt --all --check`)
- [ ] Clippy Linting passes (`-D warnings`, workspace-wide, test-helpers feature)
- [ ] MSRV check (1.92) passes
- [ ] Test (ubuntu/macos/windows) — `rest_v1_task_move_scenarios` runs all 8 scenarios M1..M8 against pgvector testcontainer
- [ ] Coverage (cargo-llvm-cov) passes
- [ ] Build Check / Security Audit / cargo-deny / Secret Scan / Dependency Review pass
- [ ] Analyze (rust) + Analyze (javascript-typescript) pass
- [ ] Playwright E2E + E2E Tests pass
- [ ] M1 happy path: `tasks.list_id` updated; `task_activity` has `moved` row; `audit_events` has `task.moved` row
- [ ] M2 idempotent self-move: 200, no new audit, no new activity, `updated_at` unchanged
- [ ] M3-M8 negative scenarios: all return 404

Linear: [GAR-544](https://linear.app/chatgpt25/issue/GAR-544)
Plan:   `plans/0082-gar-544-task-move-api.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)