### PR TITLE
feat(tasks): GAR-546 — subtasks API slice 9 (plan 0083)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -532,7 +532,9 @@ Módulo dentro de `garraia-workspace`. Schema entregue via migration 006 com **R
 - [x] `DELETE /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — plan 0079 / GAR-539 ✅
 - [x] `GET /v1/groups/{group_id}/tasks/{task_id}/activity?cursor=...` — plan 0080 / GAR-541 ✅
 - [ ] `POST /v1/groups/{group_id}/tasks/{task_id}/attachments`
-- [x] `POST /v1/groups/{group_id}/tasks/{task_id}/move` — plan 0082 / GAR-544 (path scheme amendado de `:move` para `/move` por limitação Axum 0.8 / matchit; reordenar dentro da lista deferido — coluna `position` ainda não existe) 🟡 Em execução
+- [x] `POST /v1/groups/{group_id}/tasks/{task_id}/move` — plan 0082 / GAR-544 (path scheme amendado de `:move` para `/move` por limitação Axum 0.8 / matchit; reordenar dentro da lista deferido — coluna `position` ainda não existe) ✅
+- [x] `parent_task_id` em `CreateTaskRequest` — plan 0083 / [GAR-546](https://linear.app/chatgpt25/issue/GAR-546), implementado 2026-05-08 (Florida). Depth limit = 1 (grandchild → 400).
+- [x] `GET /v1/groups/{group_id}/tasks/{task_id}/subtasks?cursor=&limit=&status=` — plan 0083 / GAR-546, implementado 2026-05-08 (Florida)
 - [ ] WebSocket `/v1/groups/{group_id}/task-lists/{list_id}/stream` para updates em tempo real (kanban colaborativo)
 
 **RBAC:**

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -382,6 +382,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     "/v1/groups/{group_id}/tasks/{task_id}/move",
                     post(tasks::move_task),
                 )
+                // Plan 0083 (GAR-546) — subtasks API slice 9.
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/subtasks",
+                    get(tasks::list_subtasks),
+                )
                 // Plan 0070 (GAR-522) — audit API slice 1.
                 .route("/v1/groups/{group_id}/audit", get(audit::list_audit))
                 .merge(rate_limited_routes)
@@ -502,6 +507,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 .route(
                     "/v1/groups/{group_id}/tasks/{task_id}/move",
                     post(unconfigured_handler),
+                )
+                // Plan 0083 (GAR-546) — subtasks API slice 9, fail-soft 503.
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/subtasks",
+                    get(unconfigured_handler),
                 )
                 .route(
                     "/v1/uploads",
@@ -627,6 +637,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 .route(
                     "/v1/groups/{group_id}/tasks/{task_id}/move",
                     post(unconfigured_handler),
+                )
+                // Plan 0083 (GAR-546) — subtasks API slice 9, no-auth stub.
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/subtasks",
+                    get(unconfigured_handler),
                 )
                 .route(
                     "/v1/uploads",

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -32,9 +32,10 @@ use super::problem::ProblemDetails;
 use super::tasks::{
     AddAssigneeRequest, AssignTaskLabelRequest, AssigneeResponse, CommentResponse,
     CreateCommentRequest, CreateTaskLabelRequest, CreateTaskListRequest, CreateTaskRequest,
-    LabelAssignmentResponse, ListCommentsResponse, ListTaskListsResponse, ListTasksResponse,
-    MoveTaskRequest, PatchTaskListRequest, PatchTaskRequest, SubscriptionResponse,
-    TaskLabelResponse, TaskListResponse, TaskListSummary, TaskResponse, TaskSummary,
+    LabelAssignmentResponse, ListCommentsResponse, ListSubtasksResponse, ListTaskListsResponse,
+    ListTasksResponse, MoveTaskRequest, PatchTaskListRequest, PatchTaskRequest,
+    SubscriptionResponse, TaskLabelResponse, TaskListResponse, TaskListSummary, TaskResponse,
+    TaskSummary,
 };
 use super::uploads::{CreateUploadRequest, CreateUploadResponse};
 
@@ -127,6 +128,7 @@ impl Modify for SecurityAddon {
         super::tasks::list_task_subscriptions,
         super::tasks::unsubscribe_from_task,
         super::tasks::move_task,
+        super::tasks::list_subtasks,
         super::audit::list_audit,
     ),
     components(schemas(
@@ -180,6 +182,7 @@ impl Modify for SecurityAddon {
         LabelAssignmentResponse,
         SubscriptionResponse,
         MoveTaskRequest,
+        ListSubtasksResponse,
         AuditEventSummary,
         ListAuditResponse,
     )),

--- a/crates/garraia-gateway/src/rest_v1/tasks.rs
+++ b/crates/garraia-gateway/src/rest_v1/tasks.rs
@@ -1,7 +1,7 @@
 //! `/v1/groups/{group_id}/task-lists` and task/comment/assignee/label/subscription handlers
-//! (plan 0066/0067/0069/0077/0078/0079, GAR-516/GAR-518/GAR-520/GAR-533/GAR-536/GAR-539).
+//! (plan 0066/0067/0069/0077/0078/0079/0083, GAR-516/GAR-518/GAR-520/GAR-533/GAR-536/GAR-539/GAR-546).
 //!
-//! Twenty-three endpoints on the `garraia_app` RLS-enforced pool:
+//! Twenty-four endpoints on the `garraia_app` RLS-enforced pool:
 //!
 //! **Slice 1 (plan 0066 / GAR-516):**
 //! - `POST /v1/groups/{group_id}/task-lists` — create task list
@@ -37,6 +37,11 @@
 //! - `POST /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — current user subscribes
 //! - `GET /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — list subscribers
 //! - `DELETE /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — current user unsubscribes (idempotent)
+//!
+//! **Slice 9 (plan 0083 / GAR-546):**
+//! - `GET /v1/groups/{group_id}/tasks/{task_id}/subtasks` — cursor-paginated direct children
+//!   (`parent_task_id = task_id AND deleted_at IS NULL`); also enables `parent_task_id`
+//!   in `CreateTaskRequest` so tasks can be created as children of an existing task.
 //!
 //! ## Tenant-context protocol
 //!
@@ -299,6 +304,10 @@ pub struct CreateTaskRequest {
     pub due_at: Option<DateTime<Utc>>,
     /// Optional time estimate in minutes. 0–100,000.
     pub estimated_minutes: Option<i32>,
+    /// Optional parent task UUID. When provided the new task becomes a direct child
+    /// of the parent (depth limit: max 1 level of nesting; the parent must itself
+    /// have no parent). The parent must be in the same group and not soft-deleted.
+    pub parent_task_id: Option<Uuid>,
 }
 
 fn default_status() -> String {
@@ -820,11 +829,35 @@ pub async fn create_task(
 
     let title_trimmed = body.title.trim().to_string();
 
+    // Validate parent_task_id if provided.
+    if let Some(parent_id) = body.parent_task_id {
+        // Parent must exist in this group and not be soft-deleted.
+        let parent_row: Option<(Option<Uuid>,)> = sqlx::query_as(
+            "SELECT parent_task_id FROM tasks \
+             WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+        )
+        .bind(parent_id)
+        .bind(group_id)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+        match parent_row {
+            None => return Err(RestError::NotFound),
+            Some((Some(_),)) => {
+                return Err(RestError::BadRequest(
+                    "max nesting depth exceeded: parent task already has a parent".into(),
+                ));
+            }
+            Some((None,)) => {} // parent is a root task — allowed
+        }
+    }
+
     let row: TaskRow = sqlx::query_as(
         "INSERT INTO tasks \
-             (list_id, group_id, title, description_md, status, priority, \
+             (list_id, group_id, parent_task_id, title, description_md, status, priority, \
               due_at, estimated_minutes, created_by, created_by_label) \
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) \
          RETURNING id, list_id, group_id, parent_task_id, title, description_md, \
                    status, priority, due_at, started_at, completed_at, \
                    estimated_minutes, created_by, created_by_label, \
@@ -832,6 +865,7 @@ pub async fn create_task(
     )
     .bind(list_id)
     .bind(group_id)
+    .bind(body.parent_task_id)
     .bind(&title_trimmed)
     .bind(&body.description_md)
     .bind(&body.status)
@@ -859,6 +893,10 @@ pub async fn create_task(
     .await
     .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
 
+    let activity_payload = match body.parent_task_id {
+        Some(pid) => json!({ "parent_task_id": pid.to_string() }),
+        None => json!({}),
+    };
     insert_task_activity(
         &mut tx,
         task_id,
@@ -866,7 +904,7 @@ pub async fn create_task(
         principal.user_id,
         &created_by_label,
         "created",
-        json!({}),
+        activity_payload,
     )
     .await?;
 
@@ -3285,6 +3323,221 @@ pub async fn list_task_activity(
     };
 
     Ok(Json(ListActivityResponse { items, next_cursor }))
+}
+
+// ─── Slice 9 — `GET tasks/{id}/subtasks` (plan 0083 / GAR-546) ───────────────
+
+/// Query parameters for `GET /v1/groups/{group_id}/tasks/{task_id}/subtasks`.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ListSubtasksQuery {
+    /// Optional status filter.
+    pub status: Option<String>,
+    /// Keyset cursor — UUID of the last item received.
+    pub cursor: Option<Uuid>,
+    /// Page size. Default 50, max 100.
+    pub limit: Option<u32>,
+}
+
+/// Response body for `GET /v1/groups/{group_id}/tasks/{task_id}/subtasks`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ListSubtasksResponse {
+    pub items: Vec<TaskSummary>,
+    pub next_cursor: Option<Uuid>,
+}
+
+/// `GET /v1/groups/{group_id}/tasks/{task_id}/subtasks` — cursor-paginated direct children.
+///
+/// Returns tasks whose `parent_task_id = task_id` and `deleted_at IS NULL`.
+/// Only direct children are listed (depth = 1). Cross-group parent task → 404.
+/// Authz: `Action::TasksRead`.
+///
+/// ## Error matrix
+///
+/// | Condition                          | Status |
+/// |------------------------------------|--------|
+/// | Missing/invalid JWT                | 401    |
+/// | Non-member of group                | 403    |
+/// | Path group_id ≠ principal group_id | 403    |
+/// | Invalid status filter              | 400    |
+/// | Parent task not found              | 404    |
+/// | Happy path                         | 200    |
+#[utoipa::path(
+    get,
+    path = "/v1/groups/{group_id}/tasks/{task_id}/subtasks",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("task_id" = Uuid, Path, description = "Parent task UUID."),
+        ListSubtasksQuery,
+    ),
+    responses(
+        (status = 200, description = "Direct child tasks.", body = ListSubtasksResponse),
+        (status = 400, description = "Invalid status filter.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Parent task not found or cross-tenant.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn list_subtasks(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, task_id)): Path<(Uuid, Uuid)>,
+    Query(params): Query<ListSubtasksQuery>,
+) -> Result<Json<ListSubtasksResponse>, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksRead) {
+        return Err(RestError::Forbidden);
+    }
+
+    if params
+        .status
+        .as_deref()
+        .is_some_and(|s| !ALLOWED_STATUSES.contains(&s))
+    {
+        return Err(RestError::BadRequest(
+            "status must be one of: backlog, todo, in_progress, review, done, canceled".into(),
+        ));
+    }
+
+    let effective_limit = params.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+    let fetch_limit = i64::from(effective_limit + 1);
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Verify parent task exists in this group and is not soft-deleted.
+    let parent_exists: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM tasks WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+    )
+    .bind(task_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if parent_exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    let rows: Vec<TaskRow> = match (params.cursor, &params.status) {
+        (Some(cursor_id), Some(status)) => sqlx::query_as(
+            "SELECT id, list_id, group_id, parent_task_id, title, description_md, \
+                    status, priority, due_at, started_at, completed_at, \
+                    estimated_minutes, created_by, created_by_label, \
+                    created_at, updated_at, deleted_at \
+             FROM tasks \
+             WHERE parent_task_id = $1 \
+               AND group_id = $2 \
+               AND deleted_at IS NULL \
+               AND status = $3 \
+               AND (created_at, id) < ( \
+                   SELECT created_at, id FROM tasks WHERE id = $4 \
+               ) \
+             ORDER BY created_at DESC, id DESC \
+             LIMIT $5",
+        )
+        .bind(task_id)
+        .bind(group_id)
+        .bind(status)
+        .bind(cursor_id)
+        .bind(fetch_limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?,
+        (Some(cursor_id), None) => sqlx::query_as(
+            "SELECT id, list_id, group_id, parent_task_id, title, description_md, \
+                    status, priority, due_at, started_at, completed_at, \
+                    estimated_minutes, created_by, created_by_label, \
+                    created_at, updated_at, deleted_at \
+             FROM tasks \
+             WHERE parent_task_id = $1 \
+               AND group_id = $2 \
+               AND deleted_at IS NULL \
+               AND (created_at, id) < ( \
+                   SELECT created_at, id FROM tasks WHERE id = $3 \
+               ) \
+             ORDER BY created_at DESC, id DESC \
+             LIMIT $4",
+        )
+        .bind(task_id)
+        .bind(group_id)
+        .bind(cursor_id)
+        .bind(fetch_limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?,
+        (None, Some(status)) => sqlx::query_as(
+            "SELECT id, list_id, group_id, parent_task_id, title, description_md, \
+                    status, priority, due_at, started_at, completed_at, \
+                    estimated_minutes, created_by, created_by_label, \
+                    created_at, updated_at, deleted_at \
+             FROM tasks \
+             WHERE parent_task_id = $1 \
+               AND group_id = $2 \
+               AND deleted_at IS NULL \
+               AND status = $3 \
+             ORDER BY created_at DESC, id DESC \
+             LIMIT $4",
+        )
+        .bind(task_id)
+        .bind(group_id)
+        .bind(status)
+        .bind(fetch_limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?,
+        (None, None) => sqlx::query_as(
+            "SELECT id, list_id, group_id, parent_task_id, title, description_md, \
+                    status, priority, due_at, started_at, completed_at, \
+                    estimated_minutes, created_by, created_by_label, \
+                    created_at, updated_at, deleted_at \
+             FROM tasks \
+             WHERE parent_task_id = $1 \
+               AND group_id = $2 \
+               AND deleted_at IS NULL \
+             ORDER BY created_at DESC, id DESC \
+             LIMIT $3",
+        )
+        .bind(task_id)
+        .bind(group_id)
+        .bind(fetch_limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?,
+    };
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    let has_more = rows.len() as u32 > effective_limit;
+    let items: Vec<TaskSummary> = rows
+        .into_iter()
+        .take(effective_limit as usize)
+        .map(|r| TaskSummary {
+            id: r.id,
+            list_id: r.list_id,
+            group_id: r.group_id,
+            title: r.title,
+            status: r.status,
+            priority: r.priority,
+            due_at: r.due_at,
+            created_at: r.created_at,
+            updated_at: r.updated_at,
+        })
+        .collect();
+    let next_cursor = if has_more {
+        items.last().map(|it| it.id)
+    } else {
+        None
+    };
+
+    Ok(Json(ListSubtasksResponse { items, next_cursor }))
 }
 
 // ─── Slice 8 — `POST tasks/{id}/move` (plan 0082 / GAR-544) ──────────────────

--- a/crates/garraia-gateway/tests/rest_v1_task_subtasks.rs
+++ b/crates/garraia-gateway/tests/rest_v1_task_subtasks.rs
@@ -1,0 +1,420 @@
+//! Integration tests for the subtasks REST API (plan 0083, GAR-546, slice 9).
+//!
+//! All scenarios bundled into ONE `#[tokio::test]` — same pattern as previous
+//! task-slice tests. Splitting triggers the sqlx runtime-teardown race
+//! documented in plan 0016 M3.
+//!
+//! Scenarios (8 total):
+//!
+//!   S1. Happy path — create a subtask with `parent_task_id`; response includes
+//!       `parent_task_id`; `task_activity` has a `created` row with the parent ID.
+//!   S2. GET /subtasks — returns the child created in S1; `parent_task_id` absent
+//!       from `TaskSummary` items (compact shape).
+//!   S3. GET /subtasks — unknown parent task → 404.
+//!   S4. GET /subtasks — soft-deleted parent → 404.
+//!   S5. POST create with parent_task_id from Bob's group → 404
+//!       (RLS + group_id check: cross-group injection).
+//!   S6. POST create with depth > 1 (grandchild) → 400 "max nesting depth exceeded".
+//!   S7. GET /subtasks — cursor pagination: 3 subtasks, limit=2, cursor page returns remaining.
+//!   S8. GET /subtasks — status filter: only matching subtasks returned.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use common::Harness;
+use common::fixtures::seed_user_with_group;
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect response body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("response body is not JSON")
+}
+
+fn auth_req(
+    method: &str,
+    uri: &str,
+    token: Option<&str>,
+    x_group_id: Option<&str>,
+    body: Option<serde_json::Value>,
+) -> Request<Body> {
+    let body_bytes = match body {
+        Some(v) => Body::from(v.to_string()),
+        None => Body::empty(),
+    };
+    let mut req = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(body_bytes)
+        .expect("request builder");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    if let Some(t) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {t}")).unwrap(),
+        );
+    }
+    if let Some(g) = x_group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    req
+}
+
+/// POST a task-list and return the new list_id string.
+async fn create_task_list(h: &Harness, token: &str, group_id: &str, name: &str) -> String {
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{group_id}/task-lists"),
+            Some(token),
+            Some(group_id),
+            Some(json!({ "name": name, "type": "list" })),
+        ))
+        .await
+        .expect("POST task-list oneshot");
+    assert_eq!(resp.status(), StatusCode::CREATED, "setup: task-list 201");
+    body_json(resp).await["id"]
+        .as_str()
+        .expect("list id")
+        .to_string()
+}
+
+/// POST a task (no parent) and return the task_id string.
+async fn create_root_task(
+    h: &Harness,
+    token: &str,
+    group_id: &str,
+    list_id: &str,
+    title: &str,
+) -> String {
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{group_id}/task-lists/{list_id}/tasks"),
+            Some(token),
+            Some(group_id),
+            Some(json!({ "title": title })),
+        ))
+        .await
+        .expect("POST task oneshot");
+    assert_eq!(resp.status(), StatusCode::CREATED, "setup: root task 201");
+    body_json(resp).await["id"]
+        .as_str()
+        .expect("task id")
+        .to_string()
+}
+
+/// POST a task with a parent and return the full response body.
+async fn create_subtask(
+    h: &Harness,
+    token: &str,
+    group_id: &str,
+    list_id: &str,
+    title: &str,
+    parent_task_id: &str,
+    expected_status: StatusCode,
+) -> serde_json::Value {
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{group_id}/task-lists/{list_id}/tasks"),
+            Some(token),
+            Some(group_id),
+            Some(json!({ "title": title, "parent_task_id": parent_task_id })),
+        ))
+        .await
+        .expect("POST subtask oneshot");
+    assert_eq!(
+        resp.status(),
+        expected_status,
+        "create_subtask {expected_status}"
+    );
+    body_json(resp).await
+}
+
+/// GET /subtasks and return the full response body.
+async fn get_subtasks(
+    h: &Harness,
+    token: &str,
+    group_id: &str,
+    task_id: &str,
+    query: &str,
+) -> axum::response::Response {
+    h.router
+        .clone()
+        .oneshot(auth_req(
+            "GET",
+            &format!("/v1/groups/{group_id}/tasks/{task_id}/subtasks{query}"),
+            Some(token),
+            Some(group_id),
+            None,
+        ))
+        .await
+        .expect("GET subtasks oneshot")
+}
+
+/// Soft-delete a task via DELETE endpoint.
+async fn delete_task(h: &Harness, token: &str, group_id: &str, task_id: &str) {
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "DELETE",
+            &format!("/v1/groups/{group_id}/tasks/{task_id}"),
+            Some(token),
+            Some(group_id),
+            None,
+        ))
+        .await
+        .expect("DELETE task oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NO_CONTENT,
+        "setup: delete task 204"
+    );
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(feature = "test-helpers")]
+#[tokio::test]
+async fn rest_v1_task_subtasks_scenarios() {
+    let h = Harness::get().await;
+
+    // Seed Alice (owner of group A) and Bob (owner of group B).
+    let (_alice_id, alice_group_id, alice_token) = seed_user_with_group(&h, "alice@subtasks.test")
+        .await
+        .expect("seed alice+group");
+    let (_bob_id, bob_group_id, bob_token) = seed_user_with_group(&h, "bob@subtasks.test")
+        .await
+        .expect("seed bob+group");
+
+    let agid = alice_group_id.to_string();
+    let bgid = bob_group_id.to_string();
+
+    // Setup: one task list for Alice and one for Bob.
+    let alice_list = create_task_list(&h, &alice_token, &agid, "Alice's List").await;
+    let bob_list = create_task_list(&h, &bob_token, &bgid, "Bob's List").await;
+
+    // Setup: a root task in Alice's list (will be the parent).
+    let parent_id = create_root_task(&h, &alice_token, &agid, &alice_list, "Parent Task").await;
+
+    // ── S1. Happy path — create subtask ────────────────────────────────────
+    let body = create_subtask(
+        &h,
+        &alice_token,
+        &agid,
+        &alice_list,
+        "Child Task 1",
+        &parent_id,
+        StatusCode::CREATED,
+    )
+    .await;
+
+    assert_eq!(
+        body["parent_task_id"].as_str(),
+        Some(parent_id.as_str()),
+        "S1 parent_task_id in response"
+    );
+    let child1_id = body["id"].as_str().expect("child1 id").to_string();
+
+    // Verify task_activity has a `created` row with parent_task_id.
+    let child1_uuid: Uuid = child1_id.parse().expect("child1 uuid");
+    let activity: Vec<(String, serde_json::Value)> = sqlx::query_as(
+        "SELECT kind, payload FROM task_activity WHERE task_id = $1 ORDER BY created_at DESC",
+    )
+    .bind(child1_uuid)
+    .fetch_all(&h.admin_pool)
+    .await
+    .expect("SELECT task_activity");
+    assert!(!activity.is_empty(), "S1 activity row exists");
+    assert_eq!(activity[0].0, "created", "S1 activity kind=created");
+    assert_eq!(
+        activity[0].1["parent_task_id"].as_str(),
+        Some(parent_id.as_str()),
+        "S1 activity payload has parent_task_id"
+    );
+
+    // ── S2. GET /subtasks — returns child created in S1 ────────────────────
+    let resp = get_subtasks(&h, &alice_token, &agid, &parent_id, "").await;
+    assert_eq!(resp.status(), StatusCode::OK, "S2 GET subtasks 200");
+    let body = body_json(resp).await;
+    let items = body["items"].as_array().expect("items array");
+    assert_eq!(items.len(), 1, "S2 one subtask returned");
+    assert_eq!(
+        items[0]["id"].as_str(),
+        Some(child1_id.as_str()),
+        "S2 correct child id"
+    );
+
+    // ── S3. GET /subtasks — unknown parent task → 404 ──────────────────────
+    let unknown_id = Uuid::new_v4().to_string();
+    let resp = get_subtasks(&h, &alice_token, &agid, &unknown_id, "").await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "S3 unknown parent 404"
+    );
+
+    // ── S4. GET /subtasks — soft-deleted parent → 404 ──────────────────────
+    let to_delete = create_root_task(&h, &alice_token, &agid, &alice_list, "Task to delete").await;
+    delete_task(&h, &alice_token, &agid, &to_delete).await;
+    let resp = get_subtasks(&h, &alice_token, &agid, &to_delete, "").await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "S4 deleted parent 404"
+    );
+
+    // ── S5. Cross-group parent injection — Bob's parent_task_id in Alice's request ──
+    let bob_root = create_root_task(&h, &bob_token, &bgid, &bob_list, "Bob's Root Task").await;
+    let body = create_subtask(
+        &h,
+        &alice_token,
+        &agid,
+        &alice_list,
+        "Injected child",
+        &bob_root, // parent in Bob's group — should fail
+        StatusCode::NOT_FOUND,
+    )
+    .await;
+    // 404 because parent lookup is scoped to Alice's group_id via RLS
+    let _ = body;
+
+    // ── S6. Depth > 1 (grandchild) → 400 ──────────────────────────────────
+    // child1 already has a parent (parent_id) → child1.parent_task_id IS NOT NULL
+    let body = create_subtask(
+        &h,
+        &alice_token,
+        &agid,
+        &alice_list,
+        "Grandchild Task",
+        &child1_id, // child1 is not a root task
+        StatusCode::BAD_REQUEST,
+    )
+    .await;
+    let detail = body["detail"].as_str().unwrap_or("");
+    assert!(
+        detail.contains("nesting depth"),
+        "S6 error mentions nesting depth, got: {detail}"
+    );
+
+    // ── S7. Cursor pagination — 3 subtasks, limit=2 ────────────────────────
+    // child1 already exists; create two more.
+    let _child2_id = {
+        let b = create_subtask(
+            &h,
+            &alice_token,
+            &agid,
+            &alice_list,
+            "Child Task 2",
+            &parent_id,
+            StatusCode::CREATED,
+        )
+        .await;
+        b["id"].as_str().expect("child2").to_string()
+    };
+    let _child3_id = {
+        let b = create_subtask(
+            &h,
+            &alice_token,
+            &agid,
+            &alice_list,
+            "Child Task 3",
+            &parent_id,
+            StatusCode::CREATED,
+        )
+        .await;
+        b["id"].as_str().expect("child3").to_string()
+    };
+
+    // Page 1: limit=2, newest first.
+    let resp = get_subtasks(&h, &alice_token, &agid, &parent_id, "?limit=2").await;
+    assert_eq!(resp.status(), StatusCode::OK, "S7 page1 200");
+    let body = body_json(resp).await;
+    let page1 = body["items"].as_array().expect("page1 items");
+    assert_eq!(page1.len(), 2, "S7 page1 has 2 items");
+    let cursor = body["next_cursor"]
+        .as_str()
+        .expect("S7 next_cursor present");
+
+    // Page 2: use cursor.
+    let resp = get_subtasks(
+        &h,
+        &alice_token,
+        &agid,
+        &parent_id,
+        &format!("?limit=2&cursor={cursor}"),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK, "S7 page2 200");
+    let body = body_json(resp).await;
+    let page2 = body["items"].as_array().expect("page2 items");
+    assert_eq!(page2.len(), 1, "S7 page2 has 1 remaining item");
+    assert!(body["next_cursor"].is_null(), "S7 page2 no more cursor");
+
+    // ── S8. Status filter ──────────────────────────────────────────────────
+    // Patch child1 to status=done.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "PATCH",
+            &format!("/v1/groups/{agid}/tasks/{child1_id}"),
+            Some(&alice_token),
+            Some(&agid),
+            Some(json!({ "status": "done" })),
+        ))
+        .await
+        .expect("PATCH task oneshot");
+    assert_eq!(resp.status(), StatusCode::OK, "S8 patch to done 200");
+
+    // Filter by status=done — should return only child1.
+    let resp = get_subtasks(&h, &alice_token, &agid, &parent_id, "?status=done").await;
+    assert_eq!(resp.status(), StatusCode::OK, "S8 filter=done 200");
+    let body = body_json(resp).await;
+    let done_items = body["items"].as_array().expect("done items");
+    assert_eq!(done_items.len(), 1, "S8 only one done subtask");
+    assert_eq!(
+        done_items[0]["id"].as_str(),
+        Some(child1_id.as_str()),
+        "S8 correct done subtask"
+    );
+
+    // Filter by status=todo — should NOT include child1.
+    let resp = get_subtasks(&h, &alice_token, &agid, &parent_id, "?status=todo").await;
+    assert_eq!(resp.status(), StatusCode::OK, "S8 filter=todo 200");
+    let body = body_json(resp).await;
+    let todo_items = body["items"].as_array().expect("todo items");
+    for item in todo_items {
+        assert_ne!(
+            item["id"].as_str(),
+            Some(child1_id.as_str()),
+            "S8 done child not in todo filter"
+        );
+    }
+}

--- a/plans/0083-gar-546-task-subtasks-api.md
+++ b/plans/0083-gar-546-task-subtasks-api.md
@@ -1,0 +1,166 @@
+# Plan 0083 — GAR-546: REST /v1 tasks slice 9 (subtasks API)
+
+**Status:** Em execução
+**Autor:** Claude Sonnet 4.6 (garra-routine 2026-05-08, America/New_York)
+**Data:** 2026-05-08 (America/New_York)
+**Issue:** [GAR-546](https://linear.app/chatgpt25/issue/GAR-546)
+**Branch:** `routine/202605081215-task-subtasks-slice9`
+**Epic:** `epic:ws-api`, `epic:ws-tasks`
+**Parent:** GAR-396
+
+---
+
+## §1 Goal
+
+Expose the subtask relationship already modelled in the DB (`tasks.parent_task_id UUID REFERENCES tasks(id)`) through the REST API:
+
+1. **`parent_task_id` in `CreateTaskRequest`** — callers can create a task as a child of an existing task in the same group.
+2. **`GET /v1/groups/{group_id}/tasks/{task_id}/subtasks`** — cursor-paginated list of direct children.
+
+No schema migration required; `parent_task_id` is already in migration 006 and is already returned by every `TaskResponse`.
+
+---
+
+## §2 Architecture
+
+```
+crates/garraia-gateway/src/
+  rest_v1/
+    tasks.rs           — add parent_task_id to CreateTaskRequest + validate +
+                         update INSERT + new list_subtasks handler
+    mod.rs             — register GET /v1/groups/{group_id}/tasks/{task_id}/subtasks
+    openapi.rs         — add list_subtasks to OpenAPI doc
+tests/
+  rest_v1_tasks_integration.rs  — integration tests S1–S8
+ROADMAP.md             — add two new ✅ checkboxes under §3.8 Task API
+plans/README.md        — add row 0083
+```
+
+---
+
+## §3 Tech stack
+
+- Rust / Axum 0.8, sqlx Postgres (query string, not macro — consistent with existing task handlers)
+- Testcontainers pgvector/pgvector:pg16 (existing integration test harness)
+
+---
+
+## §4 Design invariants
+
+1. **Same group enforcement**: parent task must belong to `path_group_id` (checked via RLS + explicit query on `group_id` column).
+2. **Depth limit = 1**: parent task must have `parent_task_id IS NULL` — nesting beyond one level returns 400 `"max nesting depth exceeded"` (simple MVP; unlimited depth deferred).
+3. **Not-deleted parent**: parent must have `deleted_at IS NULL`; if soft-deleted → 404.
+4. **RLS context**: every DB transaction sets `app.current_user_id` + `app.current_group_id` via existing `set_rls_context()`.
+5. **PII-free audit**: `task_activity` payload carries `{ "parent_task_id": "<uuid>" }` — UUIDs are not PII.
+6. **Idempotent read**: `GET /subtasks` is a pure read, no side effects.
+7. `TaskSummary` already lacks `parent_task_id` (compact view) — `list_subtasks` reuses it for response items.
+
+---
+
+## §5 Validações pré-plano
+
+- [x] `parent_task_id` column exists: `migration 006` has `parent_task_id UUID REFERENCES tasks(id) ON DELETE CASCADE`
+- [x] `TaskRow` already selects `parent_task_id`
+- [x] `TaskResponse` already exposes `parent_task_id: Option<Uuid>`
+- [x] `CreateTaskRequest` does NOT have `parent_task_id` (gap to close)
+- [x] No existing `list_subtasks` handler or route (gap to close)
+- [x] Existing integration test harness in `tests/rest_v1_tasks_integration.rs`
+
+---
+
+## §6 Out of scope
+
+- Unlimited nesting depth (deferred)
+- `PATCH` to reparent a task (separate slice)
+- Subtask ordering / position column (deferred — doesn't exist yet)
+- WebSocket live subtask updates
+
+---
+
+## §7 Rollback
+
+Pure additive changes: new optional field in request, new endpoint, new route. Rollback = revert the commits. No DB migration to undo.
+
+---
+
+## §8 Rollback plan
+
+`git revert <commit-sha>` on the implementation commit. No migration involved.
+
+---
+
+## §9 File structure (changes)
+
+```
+crates/garraia-gateway/src/rest_v1/tasks.rs
+  + parent_task_id: Option<Uuid> in CreateTaskRequest
+  + validate() addition: parent_task_id cross-group check
+  + create_task() INSERT includes parent_task_id
+  + pub async fn list_subtasks(...)
+
+crates/garraia-gateway/src/rest_v1/mod.rs
+  + route GET /v1/groups/{group_id}/tasks/{task_id}/subtasks
+
+crates/garraia-gateway/src/rest_v1/openapi.rs
+  + list_subtasks in paths!()
+
+tests/rest_v1_tasks_integration.rs
+  + tests S1–S8 (subtask create, list, cross-group, depth limit, pagination)
+
+ROADMAP.md §3.8
+  + [x] parent_task_id in CreateTaskRequest
+  + [x] GET /v1/groups/{group_id}/tasks/{task_id}/subtasks
+```
+
+---
+
+## §10 M1 tasks
+
+- [x] T1 — Add `parent_task_id: Option<Uuid>` to `CreateTaskRequest`; validate in `validate()`; update `create_task` INSERT + `task_activity` payload
+- [x] T2 — Implement `list_subtasks` handler: `GET /v1/groups/{group_id}/tasks/{task_id}/subtasks?cursor=&limit=&status=`
+- [x] T3 — Register route in `rest_v1/mod.rs` + `openapi.rs`; add integration tests S1–S8
+- [x] T4 — Update `ROADMAP.md` §3.8 + `plans/README.md` row 0083
+
+---
+
+## §11 Risk register
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| Depth check misses edge case (task is its own ancestor) | Low | Explicit `WHERE parent_task_id = $id AND id != $id` not needed; depth=1 check (`parent IS NULL`) covers it |
+| Cross-group injection via `parent_task_id` | Medium | Explicit SELECT on `group_id` column + RLS blocks it |
+| Existing tests broken by new field in request | Low | `parent_task_id` is optional with serde default `None`; `deny_unknown_fields` only rejects unknown keys, not missing optional ones |
+
+---
+
+## §12 Open questions
+
+None — design settled.
+
+---
+
+## §13 Acceptance criteria
+
+- `POST /v1/groups/{group_id}/task-lists/{list_id}/tasks` with valid `parent_task_id` → 201 with `parent_task_id` in response body.
+- `POST` with `parent_task_id` belonging to different group → 400.
+- `POST` with `parent_task_id` of a soft-deleted task → 404.
+- `POST` with `parent_task_id` that itself has a parent → 400 "max nesting depth exceeded".
+- `GET /v1/groups/{group_id}/tasks/{task_id}/subtasks` returns only direct children with `deleted_at IS NULL`.
+- Cursor pagination works (S7 test with 3 subtasks, limit=2).
+- All 8 existing task integration test scenarios remain green.
+
+---
+
+## §14 Cross-references
+
+- ROADMAP.md §3.8 Tier 1 Tasks API
+- Migration 006 (schema — `parent_task_id` column)
+- Plan 0082 (GAR-544, task move — sibling slice)
+- GAR-396 (epic parent)
+
+---
+
+## §15 Estimativa
+
+- LOC: ~280 (tasks.rs +180, mod.rs +8, openapi.rs +2, tests +90)
+- Time: ~2h implementation + CI wait

--- a/plans/README.md
+++ b/plans/README.md
@@ -105,7 +105,8 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0079 | [GAR-539 — REST /v1 tasks slice 6: task subscriptions API (POST/DELETE/GET)](0079-gar-539-task-subscriptions-api.md) | [GAR-539](https://linear.app/chatgpt25/issue/GAR-539) | ✅ Merged 2026-05-07 via PR #199 (`b6c60b0`) |
 | 0080 | [GAR-541 — REST /v1 tasks slice 7: task activity log (writes + GET)](0080-gar-541-task-activity-api.md) | [GAR-541](https://linear.app/chatgpt25/issue/GAR-541) | ✅ Merged 2026-05-07 via PR #204 (`e39a7e5`) |
 | 0081 | [GAR-466 — Q6.4: kill `is_unique_violation` constant-true mutant](0081-gar-466-q64-unique-violation-mutant.md) | [GAR-466](https://linear.app/chatgpt25/issue/GAR-466) | ✅ Merged 2026-05-07 via PR #206 (`48b55a2`) |
-| 0082 | [GAR-544 — REST `/v1` tasks slice 8 (move task between lists)](0082-gar-544-task-move-api.md) | [GAR-544](https://linear.app/chatgpt25/issue/GAR-544) | 🟡 Em execução (sessão garra-routine 2026-05-08) |
+| 0082 | [GAR-544 — REST `/v1` tasks slice 8 (move task between lists)](0082-gar-544-task-move-api.md) | [GAR-544](https://linear.app/chatgpt25/issue/GAR-544) | ✅ Merged 2026-05-08 via PR #214 (6232ec1) |
+| 0083 | [GAR-546 — REST `/v1` tasks slice 9 (subtasks API)](0083-gar-546-task-subtasks-api.md) | [GAR-546](https://linear.app/chatgpt25/issue/GAR-546) | 🟡 Em execução (sessão garra-routine 2026-05-08) |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

Closes [GAR-546](https://linear.app/chatgpt25/issue/GAR-546) — tasks slice 9 (plan 0083).

- **`parent_task_id` in `CreateTaskRequest`** — tasks can be created as direct children of an existing root task in the same group. Depth limit = 1 (grandchild → 400). Cross-group parent → 404. Deleted parent → 404.
- **`GET /v1/groups/{group_id}/tasks/{task_id}/subtasks`** — cursor-paginated listing of direct children (`parent_task_id = task_id AND deleted_at IS NULL`), with optional `status` filter and `limit`/`cursor` params.
- Route registered in all 3 router modes (full / auth-only / no-auth stubs).
- OpenAPI spec updated (`list_subtasks` path + `ListSubtasksResponse` schema).
- 8-scenario integration test (`rest_v1_task_subtasks.rs`): S1 happy path, S2 list subtasks, S3 unknown parent → 404, S4 deleted parent → 404, S5 cross-group injection → 404, S6 depth > 1 → 400, S7 cursor pagination, S8 status filter.

No schema migration required — `parent_task_id` column and FK already exist from migration 006.

## Test plan

- [x] `cargo check -p garraia-gateway` — clean
- [x] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] CI: Format Check ✅
- [ ] CI: Clippy Linting ✅
- [ ] CI: Test (ubuntu-latest) ✅
- [ ] CI: Test (macos-latest) ✅
- [ ] CI: Test (windows-latest) ✅
- [ ] CI: Build Check ✅
- [ ] CI: MSRV check ✅
- [ ] CI: cargo-deny ✅
- [ ] CI: Security Audit ✅
- [ ] CI: Coverage ✅
- [ ] CI: Analyze (rust) ✅
- [ ] CI: Analyze (javascript-typescript) ✅
- [ ] CI: Playwright E2E ✅
- [ ] CI: E2E Tests ✅
- [ ] CI: Secret Scan ✅
- [ ] CI: Dependency Review ✅

## References

- Plan: `plans/0083-gar-546-task-subtasks-api.md`
- ROADMAP: §3.8 Tier 1 Tasks API (two new ✅ entries)
- Parent PR chain: #214 (slice 8 move) → this PR (slice 9 subtasks)
- Schema: migration 006 `parent_task_id UUID REFERENCES tasks(id) ON DELETE CASCADE`

https://claude.ai/code/session_01MMdXczbkauv2KNLvqet2Zw

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMdXczbkauv2KNLvqet2Zw)_