### PR TITLE
docs(plans): mark plan 0083 merged — GAR-546 (PR #217, ad394b7)

### DIFF
--- a/plans/0083-gar-546-task-subtasks-api.md
+++ b/plans/0083-gar-546-task-subtasks-api.md
@@ -1,10 +1,10 @@
 # Plan 0083 — GAR-546: REST /v1 tasks slice 9 (subtasks API)
 
-**Status:** Em execução
+**Status:** ✅ Merged 2026-05-08 via PR #217 (`ad394b7`)
 **Autor:** Claude Sonnet 4.6 (garra-routine 2026-05-08, America/New_York)
 **Data:** 2026-05-08 (America/New_York)
-**Issue:** [GAR-546](https://linear.app/chatgpt25/issue/GAR-546)
-**Branch:** `routine/202605081215-task-subtasks-slice9`
+**Issue:** [GAR-546](https://linear.app/chatgpt25/issue/GAR-546) — Done
+**Branch:** `routine/202605081215-task-subtasks-slice9` (deletada após merge)
 **Epic:** `epic:ws-api`, `epic:ws-tasks`
 **Parent:** GAR-396
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -106,7 +106,7 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0080 | [GAR-541 — REST /v1 tasks slice 7: task activity log (writes + GET)](0080-gar-541-task-activity-api.md) | [GAR-541](https://linear.app/chatgpt25/issue/GAR-541) | ✅ Merged 2026-05-07 via PR #204 (`e39a7e5`) |
 | 0081 | [GAR-466 — Q6.4: kill `is_unique_violation` constant-true mutant](0081-gar-466-q64-unique-violation-mutant.md) | [GAR-466](https://linear.app/chatgpt25/issue/GAR-466) | ✅ Merged 2026-05-07 via PR #206 (`48b55a2`) |
 | 0082 | [GAR-544 — REST `/v1` tasks slice 8 (move task between lists)](0082-gar-544-task-move-api.md) | [GAR-544](https://linear.app/chatgpt25/issue/GAR-544) | ✅ Merged 2026-05-08 via PR #214 (`6232ec1`) |
-| 0083 | [GAR-546 — REST `/v1` tasks slice 9 (subtasks API)](0083-gar-546-task-subtasks-api.md) | [GAR-546](https://linear.app/chatgpt25/issue/GAR-546) | 🟡 Em execução (sessão garra-routine 2026-05-08) |
+| 0083 | [GAR-546 — REST `/v1` tasks slice 9 (subtasks API)](0083-gar-546-task-subtasks-api.md) | [GAR-546](https://linear.app/chatgpt25/issue/GAR-546) | ✅ Merged 2026-05-08 via PR #217 (`ad394b7`) |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
Doc-only follow-up to PR #217. Flips plan 0083 status badges (header + plans/README.md row) to Merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)