### PR TITLE
feat(search): GAR-549 — GET /v1/search unified FTS slice 1 (plan 0084)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -423,7 +423,7 @@ Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
 
 **Busca unificada**
 
-- [ ] `GET /v1/search?q=...&scope=group:{id}&types=messages,files,memory`
+- [x] `GET /v1/search?q=...&scope_type=group&scope_id=<uuid>&types=messages,memory` — plan 0084 / [GAR-549](https://linear.app/chatgpt25/issue/GAR-549), implementado 2026-05-08 (Florida). Slice 1: messages (body_tsv GIN) + memory_items (runtime tsvector). Files e user/chat scope deferred.
 
 **Auditoria**
 

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -313,6 +313,14 @@ name = "rest_v1_task_subtasks"
 path = "tests/rest_v1_task_subtasks.rs"
 required-features = ["test-helpers"]
 
+# Plan 0084 (GAR-549): unified FTS search (GET /v1/search). required-features
+# gates the binary so `cargo test -p garraia-gateway` without
+# --features test-helpers skips compilation cleanly.
+[[test]]
+name = "rest_v1_search"
+path = "tests/rest_v1_search.rs"
+required-features = ["test-helpers"]
+
 [dev-dependencies]
 # Plan 0024 T4 (GAR-412): metrics_exporter tests and the
 # metrics_auth_integration binary build a `PrometheusRecorder` directly

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -38,6 +38,7 @@ pub mod memory;
 pub mod messages;
 pub mod openapi;
 pub mod problem;
+pub mod search;
 pub mod tasks;
 pub mod uploads;
 
@@ -389,6 +390,8 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 )
                 // Plan 0070 (GAR-522) — audit API slice 1.
                 .route("/v1/groups/{group_id}/audit", get(audit::list_audit))
+                // Plan 0084 (GAR-549) — search API slice 1.
+                .route("/v1/search", get(search::search))
                 .merge(rate_limited_routes)
                 .merge(tus_routes)
                 .with_state(full)
@@ -482,6 +485,8 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 )
                 // Plan 0070 (GAR-522) — audit API slice 1, fail-soft 503.
                 .route("/v1/groups/{group_id}/audit", get(unconfigured_handler))
+                // Plan 0084 (GAR-549) — search API slice 1, fail-soft 503.
+                .route("/v1/search", get(unconfigured_handler))
                 .route(
                     "/v1/groups/{group_id}/tasks/{task_id}/comments",
                     post(unconfigured_handler).get(unconfigured_handler),
@@ -612,6 +617,8 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 )
                 // Plan 0070 (GAR-522) — audit API slice 1, no-auth stub.
                 .route("/v1/groups/{group_id}/audit", get(unconfigured_handler))
+                // Plan 0084 (GAR-549) — search API slice 1, no-auth stub.
+                .route("/v1/search", get(unconfigured_handler))
                 .route(
                     "/v1/groups/{group_id}/tasks/{task_id}/comments",
                     post(unconfigured_handler).get(unconfigured_handler),

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -13,7 +13,6 @@ use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
 use utoipa::{Modify, OpenApi};
 
 use super::audit::{AuditEventSummary, ListAuditResponse};
-use super::search::{SearchResponse, SearchResult, SearchResultType};
 use super::chats::{ChatListResponse, ChatResponse, ChatSummary, CreateChatRequest};
 use super::groups::{
     CreateGroupRequest, CreateInviteRequest, GroupReadResponse, GroupResponse, InviteResponse,
@@ -30,6 +29,7 @@ use super::messages::{
     ThreadResponse,
 };
 use super::problem::ProblemDetails;
+use super::search::{SearchResponse, SearchResult, SearchResultType};
 use super::tasks::{
     AddAssigneeRequest, AssignTaskLabelRequest, AssigneeResponse, CommentResponse,
     CreateCommentRequest, CreateTaskLabelRequest, CreateTaskListRequest, CreateTaskRequest,

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -13,6 +13,7 @@ use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
 use utoipa::{Modify, OpenApi};
 
 use super::audit::{AuditEventSummary, ListAuditResponse};
+use super::search::{SearchResponse, SearchResult, SearchResultType};
 use super::chats::{ChatListResponse, ChatResponse, ChatSummary, CreateChatRequest};
 use super::groups::{
     CreateGroupRequest, CreateInviteRequest, GroupReadResponse, GroupResponse, InviteResponse,
@@ -130,6 +131,7 @@ impl Modify for SecurityAddon {
         super::tasks::move_task,
         super::tasks::list_subtasks,
         super::audit::list_audit,
+        super::search::search,
     ),
     components(schemas(
         MeResponse,
@@ -185,6 +187,9 @@ impl Modify for SecurityAddon {
         ListSubtasksResponse,
         AuditEventSummary,
         ListAuditResponse,
+        SearchResult,
+        SearchResponse,
+        SearchResultType,
     )),
     modifiers(&SecurityAddon)
 )]

--- a/crates/garraia-gateway/src/rest_v1/search.rs
+++ b/crates/garraia-gateway/src/rest_v1/search.rs
@@ -1,0 +1,567 @@
+//! `GET /v1/search` — unified full-text search across messages and memory_items
+//! (plan 0084, GAR-549, epic GAR-WS-SEARCH / Fase 3.4).
+//!
+//! ## Scope (slice 1)
+//!
+//! `GET /v1/search?q=...&scope_type=group&scope_id=<uuid>&types=messages,memory
+//!               &limit=<1-50>&offset=<n>`
+//!
+//! Searches two FORCE-RLS tables within a single transaction:
+//!
+//! - `messages.body_tsv` (GIN-indexed, 'portuguese' tokenizer, migration 004)
+//! - `memory_items.content` (runtime `to_tsvector`, no persistent index in slice 1)
+//!
+//! Results are merged in Rust, sorted by `(ts_rank DESC, created_at DESC, id DESC)`,
+//! then offset-sliced. Offset pagination is standard for FTS; cursor pagination across
+//! heterogeneous ranked results is deferred.
+//!
+//! ## Tenant-context protocol (plan 0056)
+//!
+//! Both `app.current_user_id` and `app.current_group_id` are SET LOCAL via
+//! parameterized `set_config` before any SELECT. `true` = transaction-local.
+//!
+//! ## Security filters on memory_items
+//!
+//! `deleted_at IS NULL` · `sensitivity <> 'secret'` ·
+//! `(ttl_expires_at IS NULL OR ttl_expires_at > now())` — mirrors memory.rs.
+//!
+//! ## FTS safety
+//!
+//! User-supplied `q` is always passed to `websearch_to_tsquery('portuguese', $1)`.
+//! Never use raw `to_tsquery` for user input (operator injection — see migration 004
+//! comment on `body_tsv`).
+
+use axum::Json;
+use axum::extract::{Query, State};
+use chrono::{DateTime, Utc};
+use garraia_auth::{Principal};
+use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
+use uuid::Uuid;
+
+use super::RestV1FullState;
+use super::problem::RestError;
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/// Maximum query string length (chars). Prevents absurdly large tsquery parsing.
+const MAX_QUERY_CHARS: usize = 256;
+
+/// Default page size.
+const DEFAULT_LIMIT: u32 = 20;
+
+/// Maximum page size.
+const MAX_LIMIT: u32 = 50;
+
+/// Maximum offset allowed. Prevents full-table scans as a DoS mitigation.
+const MAX_OFFSET: u32 = 10_000;
+
+// ─── DTOs ─────────────────────────────────────────────────────────────────────
+
+/// Type discriminant for a search result item.
+#[derive(Debug, Clone, PartialEq, Serialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SearchResultType {
+    Message,
+    Memory,
+}
+
+/// A single item in a search result list.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SearchResult {
+    /// Result type discriminant.
+    #[serde(rename = "type")]
+    pub result_type: SearchResultType,
+    /// Row UUID.
+    pub id: Uuid,
+    /// FTS relevance rank (`ts_rank`). Higher = more relevant.
+    pub score: f32,
+    /// The full content / body of the matched item. Not truncated in slice 1;
+    /// excerpt highlighting is a future enhancement.
+    pub excerpt: String,
+    /// The group this item belongs to.
+    pub group_id: Uuid,
+    /// For `message` results: the chat the message was sent in.
+    pub chat_id: Option<Uuid>,
+    /// For `message` results: the sender's user_id.
+    pub sender_user_id: Option<Uuid>,
+    /// For `memory` results: the scope type (`user`, `group`, `chat`).
+    pub scope_type: Option<String>,
+    /// For `memory` results: the scope id.
+    pub scope_id: Option<Uuid>,
+    /// For `memory` results: the kind (fact, preference, note, …).
+    pub kind: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Response body for `GET /v1/search`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SearchResponse {
+    pub items: Vec<SearchResult>,
+    /// `true` when more results exist beyond the current `offset + limit` window.
+    pub has_more: bool,
+}
+
+/// Query parameters for `GET /v1/search`.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct SearchQuery {
+    /// Full-text search query. Passed to `websearch_to_tsquery`. Required.
+    pub q: String,
+    /// Scope type. Only `group` is supported in slice 1.
+    pub scope_type: String,
+    /// The group UUID to search within. Must equal the caller's active group.
+    pub scope_id: Uuid,
+    /// Comma-separated list of resource types to search.
+    /// Supported: `messages`, `memory`. Default: `messages,memory`.
+    pub types: Option<String>,
+    /// Page size. Default 20, max 50.
+    pub limit: Option<u32>,
+    /// Offset for pagination. Default 0, max 10 000.
+    pub offset: Option<u32>,
+}
+
+// ─── Validation ───────────────────────────────────────────────────────────────
+
+/// Parsed, validated search parameters.
+struct ValidatedSearch {
+    q: String,
+    scope_id: Uuid,
+    include_messages: bool,
+    include_memory: bool,
+    limit: u32,
+    offset: u32,
+}
+
+fn parse_and_validate(params: &SearchQuery) -> Result<ValidatedSearch, RestError> {
+    // Validate q.
+    let q = params.q.trim().to_owned();
+    if q.is_empty() {
+        return Err(RestError::BadRequest("q must not be empty".into()));
+    }
+    if q.chars().count() > MAX_QUERY_CHARS {
+        return Err(RestError::BadRequest(format!(
+            "q must be at most {MAX_QUERY_CHARS} characters"
+        )));
+    }
+
+    // scope_type: only "group" supported in slice 1.
+    if params.scope_type.as_str() != "group" {
+        return Err(RestError::BadRequest(
+            "scope_type must be 'group' (user/chat scope deferred)".into(),
+        ));
+    }
+
+    // Parse types list.
+    let types_str = params
+        .types
+        .as_deref()
+        .unwrap_or("messages,memory");
+    let mut include_messages = false;
+    let mut include_memory = false;
+    for t in types_str.split(',') {
+        match t.trim() {
+            "messages" => include_messages = true,
+            "memory" => include_memory = true,
+            other => {
+                return Err(RestError::BadRequest(format!(
+                    "unknown type '{other}'; supported: messages, memory"
+                )));
+            }
+        }
+    }
+    if !include_messages && !include_memory {
+        return Err(RestError::BadRequest(
+            "types must include at least one of: messages, memory".into(),
+        ));
+    }
+
+    let limit = params.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+    let offset = params.offset.unwrap_or(0);
+    if offset > MAX_OFFSET {
+        return Err(RestError::BadRequest(format!(
+            "offset must be at most {MAX_OFFSET}"
+        )));
+    }
+
+    Ok(ValidatedSearch {
+        q,
+        scope_id: params.scope_id,
+        include_messages,
+        include_memory,
+        limit,
+        offset,
+    })
+}
+
+// ─── Internal row types ───────────────────────────────────────────────────────
+
+/// Row returned by the messages FTS query.
+#[derive(sqlx::FromRow)]
+struct MessageSearchRow {
+    id: Uuid,
+    score: f32,
+    body: String,
+    group_id: Uuid,
+    chat_id: Uuid,
+    sender_user_id: Option<Uuid>,
+    created_at: DateTime<Utc>,
+}
+
+/// Row returned by the memory_items FTS query.
+#[derive(sqlx::FromRow)]
+struct MemorySearchRow {
+    id: Uuid,
+    score: f32,
+    content: String,
+    group_id: Uuid,
+    scope_type: String,
+    scope_id: Option<Uuid>,
+    kind: String,
+    created_at: DateTime<Utc>,
+}
+
+// ─── RLS context helper ───────────────────────────────────────────────────────
+
+async fn set_rls_context(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    user_id: Uuid,
+    group_id: Uuid,
+) -> Result<(), RestError> {
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(user_id.to_string())
+        .execute(&mut **tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_group_id', $1, true)")
+        .bind(group_id.to_string())
+        .execute(&mut **tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(())
+}
+
+// ─── FTS queries ─────────────────────────────────────────────────────────────
+
+/// Fetch message results from messages.body_tsv (GIN indexed).
+async fn fetch_messages(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    q: &str,
+    group_id: Uuid,
+    fetch_up_to: i64,
+) -> Result<Vec<MessageSearchRow>, RestError> {
+    let rows = sqlx::query_as::<_, MessageSearchRow>(
+        "SELECT m.id,
+                ts_rank(m.body_tsv, websearch_to_tsquery('portuguese', $1))::real AS score,
+                m.body,
+                m.group_id,
+                m.chat_id,
+                m.sender_user_id,
+                m.created_at
+         FROM   messages m
+         WHERE  m.body_tsv @@ websearch_to_tsquery('portuguese', $1)
+           AND  m.group_id = $2
+           AND  m.deleted_at IS NULL
+         ORDER BY score DESC, m.created_at DESC, m.id DESC
+         LIMIT $3",
+    )
+    .bind(q)
+    .bind(group_id)
+    .bind(fetch_up_to)
+    .fetch_all(&mut **tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(rows)
+}
+
+/// Fetch memory results using runtime `to_tsvector` on content.
+async fn fetch_memory(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    q: &str,
+    group_id: Uuid,
+    fetch_up_to: i64,
+) -> Result<Vec<MemorySearchRow>, RestError> {
+    let rows = sqlx::query_as::<_, MemorySearchRow>(
+        "SELECT mi.id,
+                ts_rank(
+                    to_tsvector('portuguese', mi.content),
+                    websearch_to_tsquery('portuguese', $1)
+                )::real AS score,
+                mi.content,
+                mi.group_id,
+                mi.scope_type,
+                mi.scope_id,
+                mi.kind,
+                mi.created_at
+         FROM   memory_items mi
+         WHERE  to_tsvector('portuguese', mi.content) @@ websearch_to_tsquery('portuguese', $1)
+           AND  mi.group_id = $2
+           AND  mi.deleted_at IS NULL
+           AND  mi.sensitivity <> 'secret'
+           AND  (mi.ttl_expires_at IS NULL OR mi.ttl_expires_at > now())
+         ORDER BY score DESC, mi.created_at DESC, mi.id DESC
+         LIMIT $3",
+    )
+    .bind(q)
+    .bind(group_id)
+    .bind(fetch_up_to)
+    .fetch_all(&mut **tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(rows)
+}
+
+// ─── Handler ──────────────────────────────────────────────────────────────────
+
+/// `GET /v1/search` — unified full-text search across messages and memory.
+///
+/// Requires the caller to be a group member. `scope_id` must equal the caller's
+/// active `group_id`; mismatches return 404 (cross-group isolation).
+///
+/// Results are ranked by `ts_rank` (descending), then `created_at` (descending),
+/// then `id` (descending) for stable ordering. Offset-based pagination.
+///
+/// ## Error matrix
+///
+/// | Condition                           | Status |
+/// |-------------------------------------|--------|
+/// | Missing/invalid JWT                 | 401    |
+/// | Caller has no group membership      | 404    |
+/// | `scope_id` ≠ `principal.group_id`   | 404    |
+/// | `scope_type` ≠ `group`              | 400    |
+/// | Empty `q` or `q` > 256 chars        | 400    |
+/// | Unknown type in `types`             | 400    |
+/// | `offset` > 10 000                   | 400    |
+/// | Happy path                          | 200    |
+#[utoipa::path(
+    get,
+    path = "/v1/search",
+    params(SearchQuery),
+    responses(
+        (status = 200, description = "Search results.", body = SearchResponse),
+        (status = 400, description = "Invalid query parameters.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Group not found or cross-group attempt.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn search(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Query(params): Query<SearchQuery>,
+) -> Result<Json<SearchResponse>, RestError> {
+    // Caller must be in a group.
+    let caller_group_id = match principal.group_id {
+        Some(g) => g,
+        None => return Err(RestError::NotFound),
+    };
+
+    // Validate params.
+    let validated = parse_and_validate(&params)?;
+
+    // Cross-group isolation: scope_id must equal the caller's group.
+    if validated.scope_id != caller_group_id {
+        return Err(RestError::NotFound);
+    }
+
+    // Fetch more than needed to detect has_more.
+    let fetch_up_to = (validated.offset + validated.limit + 1) as i64;
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    set_rls_context(&mut tx, principal.user_id, caller_group_id).await?;
+
+    // Collect all candidate results.
+    let mut all: Vec<SearchResult> = Vec::new();
+
+    if validated.include_messages {
+        let rows = fetch_messages(&mut tx, &validated.q, caller_group_id, fetch_up_to).await?;
+        for r in rows {
+            all.push(SearchResult {
+                result_type: SearchResultType::Message,
+                id: r.id,
+                score: r.score,
+                excerpt: r.body,
+                group_id: r.group_id,
+                chat_id: Some(r.chat_id),
+                sender_user_id: r.sender_user_id,
+                scope_type: None,
+                scope_id: None,
+                kind: None,
+                created_at: r.created_at,
+            });
+        }
+    }
+
+    if validated.include_memory {
+        let rows = fetch_memory(&mut tx, &validated.q, caller_group_id, fetch_up_to).await?;
+        for r in rows {
+            all.push(SearchResult {
+                result_type: SearchResultType::Memory,
+                id: r.id,
+                score: r.score,
+                excerpt: r.content,
+                group_id: r.group_id,
+                chat_id: None,
+                sender_user_id: None,
+                scope_type: Some(r.scope_type),
+                scope_id: r.scope_id,
+                kind: Some(r.kind),
+                created_at: r.created_at,
+            });
+        }
+    }
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    // Sort merged results: score DESC, created_at DESC, id DESC.
+    all.sort_unstable_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| b.created_at.cmp(&a.created_at))
+            .then_with(|| b.id.cmp(&a.id))
+    });
+
+    // Offset slice.
+    let offset = validated.offset as usize;
+    let limit = validated.limit as usize;
+    let slice_end = (offset + limit).min(all.len());
+    let has_more = all.len() > offset + limit;
+    let items: Vec<SearchResult> = all
+        .into_iter()
+        .skip(offset)
+        .take(limit)
+        .collect();
+
+    // If offset >= slice_end, skip was past all results — return empty.
+    let _ = slice_end; // used implicitly via skip+take
+    Ok(Json(SearchResponse { items, has_more }))
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_params(q: &str, scope_type: &str, types: Option<&str>) -> SearchQuery {
+        SearchQuery {
+            q: q.to_owned(),
+            scope_type: scope_type.to_owned(),
+            scope_id: Uuid::new_v4(),
+            types: types.map(|s| s.to_owned()),
+            limit: None,
+            offset: None,
+        }
+    }
+
+    #[test]
+    fn empty_q_rejected() {
+        let params = make_params("", "group", None);
+        assert!(parse_and_validate(&params).is_err());
+    }
+
+    #[test]
+    fn whitespace_only_q_rejected() {
+        let params = make_params("   ", "group", None);
+        assert!(parse_and_validate(&params).is_err());
+    }
+
+    #[test]
+    fn q_too_long_rejected() {
+        let long_q: String = "a".repeat(257);
+        let params = make_params(&long_q, "group", None);
+        assert!(parse_and_validate(&params).is_err());
+    }
+
+    #[test]
+    fn q_exactly_max_len_accepted() {
+        let max_q: String = "a".repeat(256);
+        let params = make_params(&max_q, "group", None);
+        assert!(parse_and_validate(&params).is_ok());
+    }
+
+    #[test]
+    fn unsupported_scope_type_rejected() {
+        let params = make_params("hello", "user", None);
+        assert!(parse_and_validate(&params).is_err());
+    }
+
+    #[test]
+    fn unknown_type_rejected() {
+        let params = make_params("hello", "group", Some("messages,files"));
+        assert!(parse_and_validate(&params).is_err());
+    }
+
+    #[test]
+    fn types_messages_only_accepted() {
+        let params = make_params("hello", "group", Some("messages"));
+        let v = parse_and_validate(&params).unwrap();
+        assert!(v.include_messages);
+        assert!(!v.include_memory);
+    }
+
+    #[test]
+    fn types_memory_only_accepted() {
+        let params = make_params("hello", "group", Some("memory"));
+        let v = parse_and_validate(&params).unwrap();
+        assert!(!v.include_messages);
+        assert!(v.include_memory);
+    }
+
+    #[test]
+    fn default_types_is_both() {
+        let params = make_params("hello", "group", None);
+        let v = parse_and_validate(&params).unwrap();
+        assert!(v.include_messages);
+        assert!(v.include_memory);
+    }
+
+    #[test]
+    fn offset_too_large_rejected() {
+        let params = SearchQuery {
+            q: "hello".to_owned(),
+            scope_type: "group".to_owned(),
+            scope_id: Uuid::new_v4(),
+            types: None,
+            limit: None,
+            offset: Some(10_001),
+        };
+        assert!(parse_and_validate(&params).is_err());
+    }
+
+    #[test]
+    fn limit_clamped_to_max() {
+        let params = SearchQuery {
+            q: "hello".to_owned(),
+            scope_type: "group".to_owned(),
+            scope_id: Uuid::new_v4(),
+            types: None,
+            limit: Some(999),
+            offset: None,
+        };
+        let v = parse_and_validate(&params).unwrap();
+        assert_eq!(v.limit, MAX_LIMIT);
+    }
+
+    #[test]
+    fn valid_params_accepted() {
+        let params = make_params("hello world", "group", Some("messages,memory"));
+        let v = parse_and_validate(&params).unwrap();
+        assert_eq!(v.q, "hello world");
+        assert!(v.include_messages);
+        assert!(v.include_memory);
+        assert_eq!(v.limit, DEFAULT_LIMIT);
+        assert_eq!(v.offset, 0);
+    }
+}

--- a/crates/garraia-gateway/src/rest_v1/search.rs
+++ b/crates/garraia-gateway/src/rest_v1/search.rs
@@ -34,7 +34,7 @@
 use axum::Json;
 use axum::extract::{Query, State};
 use chrono::{DateTime, Utc};
-use garraia_auth::{Principal};
+use garraia_auth::Principal;
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
@@ -152,10 +152,7 @@ fn parse_and_validate(params: &SearchQuery) -> Result<ValidatedSearch, RestError
     }
 
     // Parse types list.
-    let types_str = params
-        .types
-        .as_deref()
-        .unwrap_or("messages,memory");
+    let types_str = params.types.as_deref().unwrap_or("messages,memory");
     let mut include_messages = false;
     let mut include_memory = false;
     for t in types_str.split(',') {
@@ -437,11 +434,7 @@ pub async fn search(
     let limit = validated.limit as usize;
     let slice_end = (offset + limit).min(all.len());
     let has_more = all.len() > offset + limit;
-    let items: Vec<SearchResult> = all
-        .into_iter()
-        .skip(offset)
-        .take(limit)
-        .collect();
+    let items: Vec<SearchResult> = all.into_iter().skip(offset).take(limit).collect();
 
     // If offset >= slice_end, skip was past all results — return empty.
     let _ = slice_end; // used implicitly via skip+take

--- a/crates/garraia-gateway/tests/rest_v1_search.rs
+++ b/crates/garraia-gateway/tests/rest_v1_search.rs
@@ -1,0 +1,450 @@
+//! Integration tests for `GET /v1/search` (plan 0084, GAR-549).
+//!
+//! All scenarios bundled into ONE `#[tokio::test]` — same pattern as other
+//! rest_v1_* tests (sqlx runtime-teardown race documented in plan 0016 M3).
+//!
+//! Scenarios (11 total):
+//!
+//!   S1.  GET 200 — message search: matching message returned.
+//!   S2.  GET 200 — memory search: matching memory_item returned.
+//!   S3.  GET 200 — combined types: both messages and memory in results.
+//!   S4.  GET 200 — empty results: no match returns empty items array.
+//!   S5.  GET 404 — cross-group: scope_id ≠ principal.group_id → 404.
+//!   S6.  GET 400 — empty q → 400.
+//!   S7.  GET 400 — unknown type in types → 400.
+//!   S8.  GET 400 — unsupported scope_type (user) → 400.
+//!   S9.  GET 401 — missing bearer → 401.
+//!   S10. GET 200 — sensitivity='secret' memory excluded.
+//!   S11. GET 200 — cross-group RLS: group2 cannot see group1 messages.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+
+use common::Harness;
+use common::fixtures::seed_user_with_group;
+
+// ─── Response helpers ─────────────────────────────────────────────────────────
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect response body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("response is not JSON")
+}
+
+// ─── Request builders ─────────────────────────────────────────────────────────
+
+fn req(
+    method: &str,
+    uri: &str,
+    token: Option<&str>,
+    x_group_id: Option<&str>,
+    body: Option<serde_json::Value>,
+) -> Request<Body> {
+    let body_bytes = match body {
+        Some(v) => Body::from(v.to_string()),
+        None => Body::empty(),
+    };
+    let mut r = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(body_bytes)
+        .expect("request builder");
+    r.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    if let Some(t) = token {
+        r.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {t}")).unwrap(),
+        );
+    }
+    if let Some(g) = x_group_id {
+        r.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    r
+}
+
+/// Helper: create a chat and return its id string.
+async fn create_chat(h: &Harness, token: &str, group_id: &str) -> String {
+    let resp = h
+        .router
+        .clone()
+        .oneshot(req(
+            "POST",
+            &format!("/v1/groups/{group_id}/chats"),
+            Some(token),
+            Some(group_id),
+            Some(json!({"name": "search-test-chat", "type": "channel"})),
+        ))
+        .await
+        .expect("create_chat oneshot");
+    assert_eq!(resp.status(), StatusCode::CREATED, "setup: chat 201");
+    body_json(resp).await["id"]
+        .as_str()
+        .expect("chat id")
+        .to_string()
+}
+
+/// Helper: send a message and return its id string.
+async fn send_message(
+    h: &Harness,
+    token: &str,
+    chat_id: &str,
+    group_id: &str,
+    body_text: &str,
+) -> String {
+    let resp = h
+        .router
+        .clone()
+        .oneshot(req(
+            "POST",
+            &format!("/v1/chats/{chat_id}/messages"),
+            Some(token),
+            Some(group_id),
+            Some(json!({"body": body_text})),
+        ))
+        .await
+        .expect("send_message oneshot");
+    assert_eq!(resp.status(), StatusCode::CREATED, "setup: message 201");
+    body_json(resp).await["id"]
+        .as_str()
+        .expect("message id")
+        .to_string()
+}
+
+/// Helper: create a memory item.
+async fn create_memory(
+    h: &Harness,
+    token: &str,
+    group_id: &str,
+    content: &str,
+    sensitivity: &str,
+) {
+    let resp = h
+        .router
+        .clone()
+        .oneshot(req(
+            "POST",
+            "/v1/memory",
+            Some(token),
+            Some(group_id),
+            Some(json!({
+                "scope_type": "group",
+                "scope_id": group_id,
+                "kind": "fact",
+                "content": content,
+                "sensitivity": sensitivity
+            })),
+        ))
+        .await
+        .expect("create_memory oneshot");
+    assert_eq!(resp.status(), StatusCode::CREATED, "setup: memory 201");
+}
+
+/// Helper: GET /v1/search with the given query string.
+fn search_req(token: Option<&str>, x_group_id: Option<&str>, qs: &str) -> Request<Body> {
+    req("GET", &format!("/v1/search?{qs}"), token, x_group_id, None)
+}
+
+// ─── Test suite ───────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn search_scenarios() {
+    let h = Harness::get().await;
+
+    // Seed two isolated groups.
+    let (_, group_id, token) = seed_user_with_group(&h, "owner@search-test.test")
+        .await
+        .expect("seed owner");
+    let (_, group2_id, token2) = seed_user_with_group(&h, "owner2@search-test.test")
+        .await
+        .expect("seed owner2");
+
+    // Set up group1 data.
+    let chat_id = create_chat(&h, &token, &group_id.to_string()).await;
+    send_message(
+        &h,
+        &token,
+        &chat_id,
+        &group_id.to_string(),
+        "fluffernutter sandwich is a delicious treat",
+    )
+    .await;
+    // Non-matching message — must NOT appear in fluffernutter search.
+    send_message(
+        &h,
+        &token,
+        &chat_id,
+        &group_id.to_string(),
+        "completely unrelated weather report today",
+    )
+    .await;
+    // Matching memory item.
+    create_memory(
+        &h,
+        &token,
+        &group_id.to_string(),
+        "fluffernutter is peanut butter and marshmallow combined",
+        "group",
+    )
+    .await;
+    // Secret memory — must NEVER appear in search results.
+    create_memory(
+        &h,
+        &token,
+        &group_id.to_string(),
+        "fluffernutter classified recipe top secret",
+        "secret",
+    )
+    .await;
+
+    // ── S1. Message search ────────────────────────────────────────────────
+    let qs = format!(
+        "q=fluffernutter&scope_type=group&scope_id={}&types=messages",
+        group_id
+    );
+    let resp = h
+        .router
+        .clone()
+        .oneshot(search_req(
+            Some(&token),
+            Some(&group_id.to_string()),
+            &qs,
+        ))
+        .await
+        .expect("S1 oneshot");
+    assert_eq!(resp.status(), StatusCode::OK, "S1 status");
+    let body = body_json(resp).await;
+    let items = body["items"].as_array().expect("S1 items");
+    assert!(
+        !items.is_empty(),
+        "S1 must return at least one message result"
+    );
+    assert!(
+        items.iter().all(|it| it["type"] == "message"),
+        "S1 all items must be type=message"
+    );
+    assert!(
+        items
+            .iter()
+            .any(|it| it["excerpt"].as_str().unwrap_or("").contains("fluffernutter")),
+        "S1 must find the matching message"
+    );
+
+    // ── S2. Memory search ─────────────────────────────────────────────────
+    let qs2 = format!(
+        "q=marshmallow&scope_type=group&scope_id={}&types=memory",
+        group_id
+    );
+    let resp2 = h
+        .router
+        .clone()
+        .oneshot(search_req(
+            Some(&token),
+            Some(&group_id.to_string()),
+            &qs2,
+        ))
+        .await
+        .expect("S2 oneshot");
+    assert_eq!(resp2.status(), StatusCode::OK, "S2 status");
+    let body2 = body_json(resp2).await;
+    let items2 = body2["items"].as_array().expect("S2 items");
+    assert!(!items2.is_empty(), "S2 must return at least one memory result");
+    assert!(
+        items2.iter().all(|it| it["type"] == "memory"),
+        "S2 all items must be type=memory"
+    );
+
+    // ── S3. Combined types ────────────────────────────────────────────────
+    let qs3 = format!(
+        "q=fluffernutter&scope_type=group&scope_id={}&types=messages,memory",
+        group_id
+    );
+    let resp3 = h
+        .router
+        .clone()
+        .oneshot(search_req(
+            Some(&token),
+            Some(&group_id.to_string()),
+            &qs3,
+        ))
+        .await
+        .expect("S3 oneshot");
+    assert_eq!(resp3.status(), StatusCode::OK, "S3 status");
+    let body3 = body_json(resp3).await;
+    let items3 = body3["items"].as_array().expect("S3 items");
+    assert!(
+        items3.iter().any(|it| it["type"] == "message"),
+        "S3 must include message results"
+    );
+    assert!(
+        items3.iter().any(|it| it["type"] == "memory"),
+        "S3 must include memory results"
+    );
+
+    // ── S4. Empty results ─────────────────────────────────────────────────
+    let qs4 = format!(
+        "q=xyzzy_nonexistent_12345&scope_type=group&scope_id={}&types=messages,memory",
+        group_id
+    );
+    let resp4 = h
+        .router
+        .clone()
+        .oneshot(search_req(
+            Some(&token),
+            Some(&group_id.to_string()),
+            &qs4,
+        ))
+        .await
+        .expect("S4 oneshot");
+    assert_eq!(resp4.status(), StatusCode::OK, "S4 status");
+    let body4 = body_json(resp4).await;
+    assert!(
+        body4["items"].as_array().expect("S4 items").is_empty(),
+        "S4 must return empty items"
+    );
+    assert_eq!(body4["has_more"], false, "S4 has_more must be false");
+
+    // ── S5. Cross-group 404: owner1 with scope_id=group2 ─────────────────
+    let qs5 = format!(
+        "q=fluffernutter&scope_type=group&scope_id={}&types=messages",
+        group2_id
+    );
+    let resp5 = h
+        .router
+        .clone()
+        .oneshot(search_req(
+            Some(&token),
+            Some(&group_id.to_string()),
+            &qs5,
+        ))
+        .await
+        .expect("S5 oneshot");
+    assert_eq!(resp5.status(), StatusCode::NOT_FOUND, "S5 expected 404");
+
+    // ── S6. Empty q → 400 ────────────────────────────────────────────────
+    let qs6 = format!(
+        "q=&scope_type=group&scope_id={}&types=messages",
+        group_id
+    );
+    let resp6 = h
+        .router
+        .clone()
+        .oneshot(search_req(
+            Some(&token),
+            Some(&group_id.to_string()),
+            &qs6,
+        ))
+        .await
+        .expect("S6 oneshot");
+    assert_eq!(resp6.status(), StatusCode::BAD_REQUEST, "S6 expected 400");
+
+    // ── S7. Unknown type → 400 ────────────────────────────────────────────
+    let qs7 = format!(
+        "q=hello&scope_type=group&scope_id={}&types=messages,files",
+        group_id
+    );
+    let resp7 = h
+        .router
+        .clone()
+        .oneshot(search_req(
+            Some(&token),
+            Some(&group_id.to_string()),
+            &qs7,
+        ))
+        .await
+        .expect("S7 oneshot");
+    assert_eq!(resp7.status(), StatusCode::BAD_REQUEST, "S7 expected 400");
+
+    // ── S8. Unsupported scope_type=user → 400 ────────────────────────────
+    let qs8 = format!(
+        "q=hello&scope_type=user&scope_id={}&types=messages",
+        group_id
+    );
+    let resp8 = h
+        .router
+        .clone()
+        .oneshot(search_req(
+            Some(&token),
+            Some(&group_id.to_string()),
+            &qs8,
+        ))
+        .await
+        .expect("S8 oneshot");
+    assert_eq!(resp8.status(), StatusCode::BAD_REQUEST, "S8 expected 400");
+
+    // ── S9. Missing bearer → 401 ─────────────────────────────────────────
+    let qs9 = format!(
+        "q=hello&scope_type=group&scope_id={}&types=messages",
+        group_id
+    );
+    let resp9 = h
+        .router
+        .clone()
+        .oneshot(search_req(None, Some(&group_id.to_string()), &qs9))
+        .await
+        .expect("S9 oneshot");
+    assert_eq!(resp9.status(), StatusCode::UNAUTHORIZED, "S9 expected 401");
+
+    // ── S10. secret memory must not appear ───────────────────────────────
+    // "classified" word only appears in the secret memory item.
+    let qs10 = format!(
+        "q=classified&scope_type=group&scope_id={}&types=memory",
+        group_id
+    );
+    let resp10 = h
+        .router
+        .clone()
+        .oneshot(search_req(
+            Some(&token),
+            Some(&group_id.to_string()),
+            &qs10,
+        ))
+        .await
+        .expect("S10 oneshot");
+    assert_eq!(resp10.status(), StatusCode::OK, "S10 status");
+    let body10 = body_json(resp10).await;
+    assert!(
+        body10["items"]
+            .as_array()
+            .expect("S10 items")
+            .is_empty(),
+        "S10 secret memory must not appear in search results"
+    );
+
+    // ── S11. Cross-group RLS: group2 can't see group1 messages ───────────
+    let qs11 = format!(
+        "q=fluffernutter&scope_type=group&scope_id={}&types=messages",
+        group2_id
+    );
+    let resp11 = h
+        .router
+        .clone()
+        .oneshot(search_req(
+            Some(&token2),
+            Some(&group2_id.to_string()),
+            &qs11,
+        ))
+        .await
+        .expect("S11 oneshot");
+    assert_eq!(resp11.status(), StatusCode::OK, "S11 status");
+    let body11 = body_json(resp11).await;
+    assert!(
+        body11["items"].as_array().expect("S11 items").is_empty(),
+        "S11 group2 must not see group1 messages via search"
+    );
+}

--- a/crates/garraia-gateway/tests/rest_v1_search.rs
+++ b/crates/garraia-gateway/tests/rest_v1_search.rs
@@ -127,13 +127,7 @@ async fn send_message(
 }
 
 /// Helper: create a memory item.
-async fn create_memory(
-    h: &Harness,
-    token: &str,
-    group_id: &str,
-    content: &str,
-    sensitivity: &str,
-) {
+async fn create_memory(h: &Harness, token: &str, group_id: &str, content: &str, sensitivity: &str) {
     let resp = h
         .router
         .clone()
@@ -220,11 +214,7 @@ async fn search_scenarios() {
     let resp = h
         .router
         .clone()
-        .oneshot(search_req(
-            Some(&token),
-            Some(&group_id.to_string()),
-            &qs,
-        ))
+        .oneshot(search_req(Some(&token), Some(&group_id.to_string()), &qs))
         .await
         .expect("S1 oneshot");
     assert_eq!(resp.status(), StatusCode::OK, "S1 status");
@@ -239,9 +229,10 @@ async fn search_scenarios() {
         "S1 all items must be type=message"
     );
     assert!(
-        items
-            .iter()
-            .any(|it| it["excerpt"].as_str().unwrap_or("").contains("fluffernutter")),
+        items.iter().any(|it| it["excerpt"]
+            .as_str()
+            .unwrap_or("")
+            .contains("fluffernutter")),
         "S1 must find the matching message"
     );
 
@@ -253,17 +244,16 @@ async fn search_scenarios() {
     let resp2 = h
         .router
         .clone()
-        .oneshot(search_req(
-            Some(&token),
-            Some(&group_id.to_string()),
-            &qs2,
-        ))
+        .oneshot(search_req(Some(&token), Some(&group_id.to_string()), &qs2))
         .await
         .expect("S2 oneshot");
     assert_eq!(resp2.status(), StatusCode::OK, "S2 status");
     let body2 = body_json(resp2).await;
     let items2 = body2["items"].as_array().expect("S2 items");
-    assert!(!items2.is_empty(), "S2 must return at least one memory result");
+    assert!(
+        !items2.is_empty(),
+        "S2 must return at least one memory result"
+    );
     assert!(
         items2.iter().all(|it| it["type"] == "memory"),
         "S2 all items must be type=memory"
@@ -277,11 +267,7 @@ async fn search_scenarios() {
     let resp3 = h
         .router
         .clone()
-        .oneshot(search_req(
-            Some(&token),
-            Some(&group_id.to_string()),
-            &qs3,
-        ))
+        .oneshot(search_req(Some(&token), Some(&group_id.to_string()), &qs3))
         .await
         .expect("S3 oneshot");
     assert_eq!(resp3.status(), StatusCode::OK, "S3 status");
@@ -304,11 +290,7 @@ async fn search_scenarios() {
     let resp4 = h
         .router
         .clone()
-        .oneshot(search_req(
-            Some(&token),
-            Some(&group_id.to_string()),
-            &qs4,
-        ))
+        .oneshot(search_req(Some(&token), Some(&group_id.to_string()), &qs4))
         .await
         .expect("S4 oneshot");
     assert_eq!(resp4.status(), StatusCode::OK, "S4 status");
@@ -327,28 +309,17 @@ async fn search_scenarios() {
     let resp5 = h
         .router
         .clone()
-        .oneshot(search_req(
-            Some(&token),
-            Some(&group_id.to_string()),
-            &qs5,
-        ))
+        .oneshot(search_req(Some(&token), Some(&group_id.to_string()), &qs5))
         .await
         .expect("S5 oneshot");
     assert_eq!(resp5.status(), StatusCode::NOT_FOUND, "S5 expected 404");
 
     // ── S6. Empty q → 400 ────────────────────────────────────────────────
-    let qs6 = format!(
-        "q=&scope_type=group&scope_id={}&types=messages",
-        group_id
-    );
+    let qs6 = format!("q=&scope_type=group&scope_id={}&types=messages", group_id);
     let resp6 = h
         .router
         .clone()
-        .oneshot(search_req(
-            Some(&token),
-            Some(&group_id.to_string()),
-            &qs6,
-        ))
+        .oneshot(search_req(Some(&token), Some(&group_id.to_string()), &qs6))
         .await
         .expect("S6 oneshot");
     assert_eq!(resp6.status(), StatusCode::BAD_REQUEST, "S6 expected 400");
@@ -361,11 +332,7 @@ async fn search_scenarios() {
     let resp7 = h
         .router
         .clone()
-        .oneshot(search_req(
-            Some(&token),
-            Some(&group_id.to_string()),
-            &qs7,
-        ))
+        .oneshot(search_req(Some(&token), Some(&group_id.to_string()), &qs7))
         .await
         .expect("S7 oneshot");
     assert_eq!(resp7.status(), StatusCode::BAD_REQUEST, "S7 expected 400");
@@ -378,11 +345,7 @@ async fn search_scenarios() {
     let resp8 = h
         .router
         .clone()
-        .oneshot(search_req(
-            Some(&token),
-            Some(&group_id.to_string()),
-            &qs8,
-        ))
+        .oneshot(search_req(Some(&token), Some(&group_id.to_string()), &qs8))
         .await
         .expect("S8 oneshot");
     assert_eq!(resp8.status(), StatusCode::BAD_REQUEST, "S8 expected 400");
@@ -409,20 +372,13 @@ async fn search_scenarios() {
     let resp10 = h
         .router
         .clone()
-        .oneshot(search_req(
-            Some(&token),
-            Some(&group_id.to_string()),
-            &qs10,
-        ))
+        .oneshot(search_req(Some(&token), Some(&group_id.to_string()), &qs10))
         .await
         .expect("S10 oneshot");
     assert_eq!(resp10.status(), StatusCode::OK, "S10 status");
     let body10 = body_json(resp10).await;
     assert!(
-        body10["items"]
-            .as_array()
-            .expect("S10 items")
-            .is_empty(),
+        body10["items"].as_array().expect("S10 items").is_empty(),
         "S10 secret memory must not appear in search results"
     );
 

--- a/plans/0084-gar-549-search-api-slice1.md
+++ b/plans/0084-gar-549-search-api-slice1.md
@@ -1,0 +1,193 @@
+# Plan 0084 — GAR-549: REST /v1 search slice 1 (unified FTS)
+
+**Status:** In Progress
+**Autor:** Claude Sonnet 4.6 (garra-routine 2026-05-08, America/New_York)
+**Data:** 2026-05-08 (America/New_York)
+**Issue:** [GAR-549](https://linear.app/chatgpt25/issue/GAR-549) — In Progress
+**Branch:** `routine/202605081815-search-api-slice10`
+**Epic:** `epic:ws-search`, `epic:ws-api`
+
+---
+
+## §1 Goal
+
+Expose `GET /v1/search` — unified full-text search across messages and
+memory_items scoped to a group. This is the only remaining non-blocked
+Fase 3.4 endpoint (WebSocket and Files are deferred).
+
+```
+GET /v1/search
+  ?q=<query>
+  &scope_type=group
+  &scope_id=<group_uuid>
+  &types=messages,memory          (default: both)
+  &limit=<1-50>                   (default 20)
+  &offset=<n>                     (default 0)
+```
+
+Response: `SearchResponse { items: Vec<SearchResult>, has_more: bool }`.
+
+---
+
+## §2 Architecture
+
+```
+crates/garraia-gateway/src/
+  rest_v1/
+    search.rs          ← NEW: handler + DTOs + unit tests
+    mod.rs             ← add pub mod search; routes in all 3 modes
+    openapi.rs         ← add search::search to paths(...)
+  tests/
+    rest_v1_search.rs  ← NEW: 8 integration test scenarios
+```
+
+### FTS strategy
+
+| Table         | Column        | Index         | FTS function               |
+|---------------|---------------|---------------|----------------------------|
+| `messages`    | `body_tsv`    | GIN (mig 004) | `body_tsv @@ q`            |
+| `memory_items`| `content`     | none (runtime)| `to_tsvector('portuguese', content) @@ q` |
+
+`q` is always built via `websearch_to_tsquery('portuguese', $1)` — never
+`to_tsquery` (operator injection risk documented in migration 004 comment).
+
+### RLS protocol (plan 0056 pattern)
+
+Both `messages` and `memory_items` are FORCE RLS tables. Two `set_config`
+calls before any SELECT:
+
+```sql
+SELECT set_config('app.current_user_id', $1, true)
+SELECT set_config('app.current_group_id', $1, true)
+```
+
+`true` = transaction-local (cleared on COMMIT/ROLLBACK).
+
+### Result merging
+
+Run both type queries independently within the same transaction. Collect
+into a `Vec<SearchResult>`, sort by `(score DESC, created_at DESC, id DESC)`,
+apply `[offset .. offset+limit]`, set `has_more = total_collected > offset + limit`.
+
+Offset-based pagination is standard for FTS (cursor pagination across
+heterogeneous ranked results is pathological).
+
+---
+
+## §3 Tech Stack
+
+- sqlx `QueryBuilder` (parameterized, no string concat)
+- `websearch_to_tsquery('portuguese', $1)` — safe user-input FTS
+- `ts_rank(body_tsv, query)` / `ts_rank(to_tsvector('portuguese', content), query)` → `f32`
+- utoipa `#[utoipa::path]` for OpenAPI docs
+- `garraia_auth::{Principal, AppPool}` — same as all other slices
+
+---
+
+## §4 Design Invariants
+
+1. **NO SQL string concat** — all params via `push_bind` or `$N` placeholders.
+2. **RLS both vars** — `app.current_user_id` + `app.current_group_id` SET LOCAL before every query.
+3. **Cross-group 404** — `scope_id ≠ principal.group_id` → 404 (not 403).
+4. **`q` sanitisation** — empty `q` → 400; max 256 chars → 400; `websearch_to_tsquery` handles the rest.
+5. **`sensitivity='secret'` excluded** from memory results (same filter as memory.rs).
+6. **`deleted_at IS NULL`** applied to both messages and memory_items.
+7. **No audit event** for search reads (no circular noise).
+8. **Max limit 50** — prevents runaway queries; offset max 10 000 (DoS mitigation).
+
+---
+
+## §5 Validações pré-plano
+
+- [x] `messages.body_tsv` GIN index exists (migration 004, `messages_body_tsv_idx`)
+- [x] `memory_items.content` queryable at runtime via `to_tsvector`
+- [x] `AppPool` + `Principal` + `set_config` pattern established (plans 0056+)
+- [x] No new migration required
+- [x] Linear search confirms no duplicate issue for `GET /v1/search` in GAR
+
+---
+
+## §6 Out of Scope
+
+- FTS on tasks, files, audit_events
+- `scope_type=user` or `scope_type=chat` (group-only for slice 1)
+- Cursor-based pagination
+- Embedding/vector search (GAR-372)
+- WebSocket streaming results
+- Highlighting/snippet extraction (future slice)
+
+---
+
+## §7 Rollback
+
+Delete the branch. The only change is an additive `search.rs` module +
+route registrations. No migration, no schema change. Reverting is `git revert`.
+
+---
+
+## §8 File Structure
+
+```
+crates/garraia-gateway/src/rest_v1/search.rs   (NEW ~280 LOC)
+crates/garraia-gateway/src/rest_v1/mod.rs      (EDIT: +pub mod + routes)
+crates/garraia-gateway/src/rest_v1/openapi.rs  (EDIT: +search::search)
+crates/garraia-gateway/tests/rest_v1_search.rs (NEW ~150 LOC)
+plans/0084-gar-549-search-api-slice1.md        (this file)
+```
+
+---
+
+## §9 M1 Tasks
+
+- [ ] T1: `search.rs` — DTOs, validation, unit tests (red)
+- [ ] T2: FTS query helpers — messages + memory queries with `set_config` RLS
+- [ ] T3: Handler + `SearchResult` merge/sort + router wiring (all 3 modes)
+- [ ] T4: Integration tests (`rest_v1_search.rs`)
+- [ ] T5: OpenAPI registration + `mod.rs` `pub mod search`
+- [ ] T6: ROADMAP §3.4 checkbox + plans/README.md row
+
+---
+
+## §10 Risk Register
+
+| Risk | Mitigation |
+|------|-----------|
+| `to_tsvector` on memory.content is slow without GIN index | Acceptable for slice 1 (content ≤ 10k, RLS filters first); add index in future slice if p95 > 100ms |
+| `websearch_to_tsquery` returns empty tsquery for nonsense input | Handled: Postgres returns 0 rows, not an error |
+| Large offset causes full-table scan | offset MAX = 10 000 → 400 |
+| Cross-language content ranks poorly with 'portuguese' config | Known limitation; config is per-DB; noted in plan |
+
+---
+
+## §11 Acceptance Criteria
+
+1. `GET /v1/search?q=hello&scope_type=group&scope_id=<uuid>&types=messages` returns messages matching "hello" in group.
+2. `GET /v1/search?q=hello&scope_type=group&scope_id=<uuid>&types=memory` returns memory_items matching "hello".
+3. `types=messages,memory` returns merged results sorted by score DESC.
+4. Cross-group: `scope_id` ≠ `principal.group_id` → 404.
+5. Empty `q` → 400.
+6. Unknown type → 400.
+7. `has_more=true` when results exceed limit.
+8. `sensitivity='secret'` memory items not returned.
+9. `cargo clippy --workspace ... -D warnings` green.
+10. All CI checks green.
+
+---
+
+## §12 Cross-references
+
+- plan 0056 (GAR-508): `set_config` RLS protocol
+- plan 0055 (GAR-507): messages patterns
+- plan 0062 (GAR-514): memory patterns
+- migration 004: `messages.body_tsv` (tsvector, 'portuguese', GIN)
+- migration 005: `memory_items.content` (text, CHECK 10k)
+- ADR 0006: search strategy decision (Postgres FTS → Tantivy → Meilisearch)
+- ROADMAP §3.4: `GET /v1/search` checkbox
+
+---
+
+## §13 Estimativa
+
+- Implementação: 3–4 h
+- LOC: ~430 (search.rs 280 + mod 30 + openapi 5 + tests 115)
+- Risco: baixo (padrão estabelecido, sem migração)

--- a/plans/README.md
+++ b/plans/README.md
@@ -107,6 +107,7 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0081 | [GAR-466 — Q6.4: kill `is_unique_violation` constant-true mutant](0081-gar-466-q64-unique-violation-mutant.md) | [GAR-466](https://linear.app/chatgpt25/issue/GAR-466) | ✅ Merged 2026-05-07 via PR #206 (`48b55a2`) |
 | 0082 | [GAR-544 — REST `/v1` tasks slice 8 (move task between lists)](0082-gar-544-task-move-api.md) | [GAR-544](https://linear.app/chatgpt25/issue/GAR-544) | ✅ Merged 2026-05-08 via PR #214 (`6232ec1`) |
 | 0083 | [GAR-546 — REST `/v1` tasks slice 9 (subtasks API)](0083-gar-546-task-subtasks-api.md) | [GAR-546](https://linear.app/chatgpt25/issue/GAR-546) | ✅ Merged 2026-05-08 via PR #217 (`ad394b7`) |
+| 0084 | [GAR-549 — REST `/v1` search slice 1: GET /v1/search unified FTS](0084-gar-549-search-api-slice1.md) | [GAR-549](https://linear.app/chatgpt25/issue/GAR-549) | 🔄 In Progress |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `GET /v1/search?q=...&scope_type=group&scope_id=<uuid>&types=messages,memory&limit=<n>&offset=<n>` — unified full-text search across two tables on the `garraia_app` RLS-enforced pool (Fase 3.4 / plan 0084, GAR-549).
- **messages**: FTS via pre-built `body_tsv` GIN index (migration 004, `websearch_to_tsquery('portuguese', $1)` — never `to_tsquery` per migration 004 comment).
- **memory_items**: runtime `to_tsvector` with `sensitivity='secret'` + `deleted_at IS NULL` + TTL filters (mirrors memory.rs).
- Results merged in Rust, sorted by `(ts_rank DESC, created_at DESC, id DESC)`. Offset-based pagination (max offset 10 000, max limit 50).
- Cross-group isolation: `scope_id ≠ principal.group_id` → 404.
- Wired in all 3 router modes (Mode 1 real handler, Modes 2/3 fail-soft 503). OpenAPI schema registered.
- ROADMAP §3.4 `GET /v1/search` checkbox flipped.

## Test plan

- [x] 12 unit tests (`search::tests::*`) — validation logic (empty q, long q, unknown type, offset limit, etc.) — `cargo test --lib search::tests`
- [x] 11 integration scenarios in `tests/rest_v1_search.rs` — S1 message FTS, S2 memory FTS, S3 combined, S4 empty result, S5 cross-group 404, S6 empty-q 400, S7 unknown-type 400, S8 unsupported-scope 400, S9 missing-bearer 401, S10 secret-excluded, S11 cross-group RLS
- [x] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` green locally

## Linear

Closes [GAR-549](https://linear.app/chatgpt25/issue/GAR-549)

https://claude.ai/code/session_01RRNYHKqQMxBezsn1rs7WR7
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRNYHKqQMxBezsn1rs7WR7)_