### PR TITLE
feat(search): GAR-551 — /v1/search slice 2 (chat + user scope) (plan 0085)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -423,7 +423,8 @@ Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
 
 **Busca unificada**
 
-- [x] `GET /v1/search?q=...&scope_type=group&scope_id=<uuid>&types=messages,memory` — plan 0084 / [GAR-549](https://linear.app/chatgpt25/issue/GAR-549), implementado 2026-05-08 (Florida). Slice 1: messages (body_tsv GIN) + memory_items (runtime tsvector). Files e user/chat scope deferred.
+- [x] `GET /v1/search?q=...&scope_type=group&scope_id=<uuid>&types=messages,memory` — plan 0084 / [GAR-549](https://linear.app/chatgpt25/issue/GAR-549), implementado 2026-05-08 (Florida). Slice 1: messages (body_tsv GIN) + memory_items (runtime tsvector). Files deferred.
+- [x] `GET /v1/search?...&scope_type=chat&scope_id=<chat_uuid>` + `scope_type=user&scope_id=<user_uuid>` — plan 0085 / [GAR-551](https://linear.app/chatgpt25/issue/GAR-551), implementado 2026-05-08 (Florida). Slice 2 lifts the slice-1 group-only restriction; user-scope rejects `types=messages` (no user-scoped messages exist).
 
 **Auditoria**
 

--- a/crates/garraia-gateway/src/rest_v1/search.rs
+++ b/crates/garraia-gateway/src/rest_v1/search.rs
@@ -486,9 +486,14 @@ pub async fn search(
                 "include_messages with scope_type=user is rejected at parse_and_validate"
             ),
         };
-        let rows =
-            fetch_messages(&mut tx, &validated.q, caller_group_id, chat_filter, fetch_up_to)
-                .await?;
+        let rows = fetch_messages(
+            &mut tx,
+            &validated.q,
+            caller_group_id,
+            chat_filter,
+            fetch_up_to,
+        )
+        .await?;
         for r in rows {
             all.push(SearchResult {
                 result_type: SearchResultType::Message,

--- a/crates/garraia-gateway/src/rest_v1/search.rs
+++ b/crates/garraia-gateway/src/rest_v1/search.rs
@@ -1,10 +1,13 @@
 //! `GET /v1/search` — unified full-text search across messages and memory_items
-//! (plan 0084, GAR-549, epic GAR-WS-SEARCH / Fase 3.4).
+//! (plan 0084 + plan 0085, GAR-549 + GAR-551, epic GAR-WS-SEARCH / Fase 3.4).
 //!
-//! ## Scope (slice 1)
+//! ## Scope (slice 1 + slice 2)
 //!
-//! `GET /v1/search?q=...&scope_type=group&scope_id=<uuid>&types=messages,memory
-//!               &limit=<1-50>&offset=<n>`
+//! ```text
+//! GET /v1/search?q=<q>&scope_type=group&scope_id=<group_uuid>&types=messages,memory
+//! GET /v1/search?q=<q>&scope_type=chat &scope_id=<chat_uuid> &types=messages,memory
+//! GET /v1/search?q=<q>&scope_type=user &scope_id=<user_uuid> &types=memory
+//! ```
 //!
 //! Searches two FORCE-RLS tables within a single transaction:
 //!
@@ -19,6 +22,17 @@
 //!
 //! Both `app.current_user_id` and `app.current_group_id` are SET LOCAL via
 //! parameterized `set_config` before any SELECT. `true` = transaction-local.
+//! Memory RLS (`memory_items_group_or_self`, migration 007:133) is dual-branch
+//! and covers all three scopes — the user branch fires when `group_id IS NULL
+//! AND created_by = app.current_user_id`.
+//!
+//! ## Cross-tenant isolation
+//!
+//! - `scope_type=group` + `scope_id ≠ principal.group_id` → 404
+//! - `scope_type=chat`  + chat not in caller's group        → 404
+//! - `scope_type=user`  + `scope_id ≠ principal.user_id`    → 404
+//!
+//! 404 (not 403) avoids leaking the existence of resources in other tenants.
 //!
 //! ## Security filters on memory_items
 //!
@@ -122,9 +136,20 @@ pub struct SearchQuery {
 
 // ─── Validation ───────────────────────────────────────────────────────────────
 
+/// Discriminator for the validated scope. Maps directly to the three accepted
+/// `scope_type` values. Resolved app-layer cross-tenant checks (404) and SQL
+/// filter selection are driven by this enum in the handler.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ValidatedScopeType {
+    Group,
+    Chat,
+    User,
+}
+
 /// Parsed, validated search parameters.
 struct ValidatedSearch {
     q: String,
+    scope_type: ValidatedScopeType,
     scope_id: Uuid,
     include_messages: bool,
     include_memory: bool,
@@ -144,12 +169,17 @@ fn parse_and_validate(params: &SearchQuery) -> Result<ValidatedSearch, RestError
         )));
     }
 
-    // scope_type: only "group" supported in slice 1.
-    if params.scope_type.as_str() != "group" {
-        return Err(RestError::BadRequest(
-            "scope_type must be 'group' (user/chat scope deferred)".into(),
-        ));
-    }
+    // scope_type ∈ {group, chat, user}.
+    let scope_type = match params.scope_type.as_str() {
+        "group" => ValidatedScopeType::Group,
+        "chat" => ValidatedScopeType::Chat,
+        "user" => ValidatedScopeType::User,
+        other => {
+            return Err(RestError::BadRequest(format!(
+                "scope_type must be one of: group, chat, user (got '{other}')"
+            )));
+        }
+    };
 
     // Parse types list.
     let types_str = params.types.as_deref().unwrap_or("messages,memory");
@@ -172,6 +202,14 @@ fn parse_and_validate(params: &SearchQuery) -> Result<ValidatedSearch, RestError
         ));
     }
 
+    // Messages have no user scope — they always belong to a chat in a group.
+    // Reject the combination explicitly instead of silently filtering.
+    if scope_type == ValidatedScopeType::User && include_messages {
+        return Err(RestError::BadRequest(
+            "scope_type=user does not support types=messages; use types=memory".into(),
+        ));
+    }
+
     let limit = params.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
     let offset = params.offset.unwrap_or(0);
     if offset > MAX_OFFSET {
@@ -182,6 +220,7 @@ fn parse_and_validate(params: &SearchQuery) -> Result<ValidatedSearch, RestError
 
     Ok(ValidatedSearch {
         q,
+        scope_type,
         scope_id: params.scope_id,
         include_messages,
         include_memory,
@@ -242,10 +281,15 @@ async fn set_rls_context(
 // ─── FTS queries ─────────────────────────────────────────────────────────────
 
 /// Fetch message results from messages.body_tsv (GIN indexed).
+///
+/// `chat_filter`:
+/// - `None` → group-wide search (slice 1: `scope_type=group`)
+/// - `Some(chat_id)` → chat-scoped search (slice 2: `scope_type=chat`)
 async fn fetch_messages(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     q: &str,
     group_id: Uuid,
+    chat_filter: Option<Uuid>,
     fetch_up_to: i64,
 ) -> Result<Vec<MessageSearchRow>, RestError> {
     let rows = sqlx::query_as::<_, MessageSearchRow>(
@@ -259,12 +303,14 @@ async fn fetch_messages(
          FROM   messages m
          WHERE  m.body_tsv @@ websearch_to_tsquery('portuguese', $1)
            AND  m.group_id = $2
+           AND  ($3::uuid IS NULL OR m.chat_id = $3)
            AND  m.deleted_at IS NULL
          ORDER BY score DESC, m.created_at DESC, m.id DESC
-         LIMIT $3",
+         LIMIT $4",
     )
     .bind(q)
     .bind(group_id)
+    .bind(chat_filter)
     .bind(fetch_up_to)
     .fetch_all(&mut **tx)
     .await
@@ -274,10 +320,23 @@ async fn fetch_messages(
 }
 
 /// Fetch memory results using runtime `to_tsvector` on content.
+///
+/// Three scope variants share a single SQL statement with NULL-able predicates:
+///
+/// - **Group**: `group_filter=Some(g)`, `scope_type_filter=None`, `scope_id_filter=None`.
+///   Matches all memory rows visible at the group level (group-scope rows AND
+///   chat-scope rows whose `group_id = g`). Slice 1 behavior — preserved.
+/// - **Chat**:  `group_filter=Some(g)`, `scope_type_filter=Some("chat")`,
+///   `scope_id_filter=Some(chat_id)`. Restricts to the specific chat.
+/// - **User**:  `group_filter=None`,    `scope_type_filter=Some("user")`,
+///   `scope_id_filter=Some(user_id)`. RLS branch 2
+///   (`group_id IS NULL AND created_by = current_user_id`) handles the rest.
 async fn fetch_memory(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     q: &str,
-    group_id: Uuid,
+    group_filter: Option<Uuid>,
+    scope_type_filter: Option<&'static str>,
+    scope_id_filter: Option<Uuid>,
     fetch_up_to: i64,
 ) -> Result<Vec<MemorySearchRow>, RestError> {
     let rows = sqlx::query_as::<_, MemorySearchRow>(
@@ -294,15 +353,19 @@ async fn fetch_memory(
                 mi.created_at
          FROM   memory_items mi
          WHERE  to_tsvector('portuguese', mi.content) @@ websearch_to_tsquery('portuguese', $1)
-           AND  mi.group_id = $2
+           AND  ($2::uuid IS NULL OR mi.group_id = $2)
+           AND  ($3::text IS NULL OR mi.scope_type = $3)
+           AND  ($4::uuid IS NULL OR mi.scope_id = $4)
            AND  mi.deleted_at IS NULL
            AND  mi.sensitivity <> 'secret'
            AND  (mi.ttl_expires_at IS NULL OR mi.ttl_expires_at > now())
          ORDER BY score DESC, mi.created_at DESC, mi.id DESC
-         LIMIT $3",
+         LIMIT $5",
     )
     .bind(q)
-    .bind(group_id)
+    .bind(group_filter)
+    .bind(scope_type_filter)
+    .bind(scope_id_filter)
     .bind(fetch_up_to)
     .fetch_all(&mut **tx)
     .await
@@ -315,24 +378,27 @@ async fn fetch_memory(
 
 /// `GET /v1/search` — unified full-text search across messages and memory.
 ///
-/// Requires the caller to be a group member. `scope_id` must equal the caller's
-/// active `group_id`; mismatches return 404 (cross-group isolation).
+/// Requires the caller to be a group member. Cross-tenant attempts return 404
+/// in every variant (avoids leaking the existence of resources in other tenants).
 ///
 /// Results are ranked by `ts_rank` (descending), then `created_at` (descending),
 /// then `id` (descending) for stable ordering. Offset-based pagination.
 ///
 /// ## Error matrix
 ///
-/// | Condition                           | Status |
-/// |-------------------------------------|--------|
-/// | Missing/invalid JWT                 | 401    |
-/// | Caller has no group membership      | 404    |
-/// | `scope_id` ≠ `principal.group_id`   | 404    |
-/// | `scope_type` ≠ `group`              | 400    |
-/// | Empty `q` or `q` > 256 chars        | 400    |
-/// | Unknown type in `types`             | 400    |
-/// | `offset` > 10 000                   | 400    |
-/// | Happy path                          | 200    |
+/// | Condition                                                     | Status |
+/// |---------------------------------------------------------------|--------|
+/// | Missing/invalid JWT                                           | 401    |
+/// | Caller has no group membership                                | 404    |
+/// | `scope_type=group` and `scope_id ≠ principal.group_id`        | 404    |
+/// | `scope_type=chat`  and chat not in caller's group / archived  | 404    |
+/// | `scope_type=user`  and `scope_id ≠ principal.user_id`         | 404    |
+/// | `scope_type` not in {group, chat, user}                       | 400    |
+/// | `scope_type=user` + `types=messages`                          | 400    |
+/// | Empty `q` or `q` > 256 chars                                  | 400    |
+/// | Unknown type in `types`                                       | 400    |
+/// | `offset` > 10 000                                             | 400    |
+/// | Happy path                                                    | 200    |
 #[utoipa::path(
     get,
     path = "/v1/search",
@@ -341,7 +407,7 @@ async fn fetch_memory(
         (status = 200, description = "Search results.", body = SearchResponse),
         (status = 400, description = "Invalid query parameters.", body = super::problem::ProblemDetails),
         (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
-        (status = 404, description = "Group not found or cross-group attempt.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Cross-tenant scope or chat not in caller's group.", body = super::problem::ProblemDetails),
     ),
     security(("bearer" = []))
 )]
@@ -350,7 +416,8 @@ pub async fn search(
     principal: Principal,
     Query(params): Query<SearchQuery>,
 ) -> Result<Json<SearchResponse>, RestError> {
-    // Caller must be in a group.
+    // Caller must be in a group (every scope_type still requires a tenant context
+    // for the RLS dual-branch policy on memory_items to fire correctly).
     let caller_group_id = match principal.group_id {
         Some(g) => g,
         None => return Err(RestError::NotFound),
@@ -359,9 +426,21 @@ pub async fn search(
     // Validate params.
     let validated = parse_and_validate(&params)?;
 
-    // Cross-group isolation: scope_id must equal the caller's group.
-    if validated.scope_id != caller_group_id {
-        return Err(RestError::NotFound);
+    // App-layer cross-tenant checks (SQL-independent).
+    match validated.scope_type {
+        ValidatedScopeType::Group => {
+            if validated.scope_id != caller_group_id {
+                return Err(RestError::NotFound);
+            }
+        }
+        ValidatedScopeType::User => {
+            if validated.scope_id != principal.user_id {
+                return Err(RestError::NotFound);
+            }
+        }
+        ValidatedScopeType::Chat => {
+            // In-tx check below — we need RLS context first.
+        }
     }
 
     // Fetch more than needed to detect has_more.
@@ -375,11 +454,41 @@ pub async fn search(
 
     set_rls_context(&mut tx, principal.user_id, caller_group_id).await?;
 
+    // For chat scope, verify the chat belongs to the caller's group and is not
+    // archived. Mirrors `memory.rs` and `messages.rs` patterns. RLS on `chats`
+    // (migration 007:90-94) already filters by `group_id = current_group_id`,
+    // so the explicit `group_id = $2` is defense-in-depth.
+    if validated.scope_type == ValidatedScopeType::Chat {
+        let chat_row: Option<(Uuid,)> = sqlx::query_as(
+            "SELECT id FROM chats WHERE id = $1 AND group_id = $2 AND archived_at IS NULL",
+        )
+        .bind(validated.scope_id)
+        .bind(caller_group_id)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+        if chat_row.is_none() {
+            return Err(RestError::NotFound);
+        }
+    }
+
     // Collect all candidate results.
     let mut all: Vec<SearchResult> = Vec::new();
 
     if validated.include_messages {
-        let rows = fetch_messages(&mut tx, &validated.q, caller_group_id, fetch_up_to).await?;
+        // User scope was rejected at parse_and_validate; messages here means
+        // either Group (chat_filter=None) or Chat (chat_filter=Some(chat_id)).
+        let chat_filter = match validated.scope_type {
+            ValidatedScopeType::Chat => Some(validated.scope_id),
+            ValidatedScopeType::Group => None,
+            ValidatedScopeType::User => unreachable!(
+                "include_messages with scope_type=user is rejected at parse_and_validate"
+            ),
+        };
+        let rows =
+            fetch_messages(&mut tx, &validated.q, caller_group_id, chat_filter, fetch_up_to)
+                .await?;
         for r in rows {
             all.push(SearchResult {
                 result_type: SearchResultType::Message,
@@ -398,7 +507,29 @@ pub async fn search(
     }
 
     if validated.include_memory {
-        let rows = fetch_memory(&mut tx, &validated.q, caller_group_id, fetch_up_to).await?;
+        // Memory query has three filter shapes — see fetch_memory rustdoc.
+        let (group_filter, scope_type_filter, scope_id_filter): (
+            Option<Uuid>,
+            Option<&'static str>,
+            Option<Uuid>,
+        ) = match validated.scope_type {
+            ValidatedScopeType::Group => (Some(caller_group_id), None, None),
+            ValidatedScopeType::Chat => (
+                Some(caller_group_id),
+                Some("chat"),
+                Some(validated.scope_id),
+            ),
+            ValidatedScopeType::User => (None, Some("user"), Some(principal.user_id)),
+        };
+        let rows = fetch_memory(
+            &mut tx,
+            &validated.q,
+            group_filter,
+            scope_type_filter,
+            scope_id_filter,
+            fetch_up_to,
+        )
+        .await?;
         for r in rows {
             all.push(SearchResult {
                 result_type: SearchResultType::Memory,
@@ -486,8 +617,72 @@ mod tests {
 
     #[test]
     fn unsupported_scope_type_rejected() {
+        let params = make_params("hello", "everyone", None);
+        assert!(parse_and_validate(&params).is_err());
+    }
+
+    #[test]
+    fn scope_type_chat_accepted() {
+        let params = make_params("hello", "chat", None);
+        let v = parse_and_validate(&params).unwrap();
+        assert_eq!(v.scope_type, ValidatedScopeType::Chat);
+        assert!(v.include_messages);
+        assert!(v.include_memory);
+    }
+
+    #[test]
+    fn scope_type_user_with_memory_accepted() {
+        let params = make_params("hello", "user", Some("memory"));
+        let v = parse_and_validate(&params).unwrap();
+        assert_eq!(v.scope_type, ValidatedScopeType::User);
+        assert!(!v.include_messages);
+        assert!(v.include_memory);
+    }
+
+    #[test]
+    fn scope_type_user_with_default_types_rejected() {
+        // default types = "messages,memory" — messages not allowed for user scope.
         let params = make_params("hello", "user", None);
         assert!(parse_and_validate(&params).is_err());
+    }
+
+    #[test]
+    fn scope_type_user_with_messages_rejected() {
+        let params = make_params("hello", "user", Some("messages"));
+        assert!(parse_and_validate(&params).is_err());
+    }
+
+    #[test]
+    fn scope_type_user_with_messages_and_memory_rejected() {
+        let params = make_params("hello", "user", Some("messages,memory"));
+        assert!(parse_and_validate(&params).is_err());
+    }
+
+    #[test]
+    fn scope_type_chat_messages_only_accepted() {
+        let params = make_params("hello", "chat", Some("messages"));
+        let v = parse_and_validate(&params).unwrap();
+        assert_eq!(v.scope_type, ValidatedScopeType::Chat);
+        assert!(v.include_messages);
+        assert!(!v.include_memory);
+    }
+
+    #[test]
+    fn scope_type_chat_memory_only_accepted() {
+        let params = make_params("hello", "chat", Some("memory"));
+        let v = parse_and_validate(&params).unwrap();
+        assert_eq!(v.scope_type, ValidatedScopeType::Chat);
+        assert!(!v.include_messages);
+        assert!(v.include_memory);
+    }
+
+    #[test]
+    fn scope_type_group_default_preserved_slice1() {
+        let params = make_params("hello", "group", None);
+        let v = parse_and_validate(&params).unwrap();
+        assert_eq!(v.scope_type, ValidatedScopeType::Group);
+        assert!(v.include_messages);
+        assert!(v.include_memory);
     }
 
     #[test]

--- a/crates/garraia-gateway/tests/rest_v1_search.rs
+++ b/crates/garraia-gateway/tests/rest_v1_search.rs
@@ -1,10 +1,12 @@
-//! Integration tests for `GET /v1/search` (plan 0084, GAR-549).
+//! Integration tests for `GET /v1/search` (plan 0084 + plan 0085;
+//! GAR-549 + GAR-551).
 //!
 //! All scenarios bundled into ONE `#[tokio::test]` — same pattern as other
 //! rest_v1_* tests (sqlx runtime-teardown race documented in plan 0016 M3).
 //!
-//! Scenarios (11 total):
+//! Scenarios:
 //!
+//!   ── Slice 1 (group scope) — GAR-549 ──
 //!   S1.  GET 200 — message search: matching message returned.
 //!   S2.  GET 200 — memory search: matching memory_item returned.
 //!   S3.  GET 200 — combined types: both messages and memory in results.
@@ -12,10 +14,18 @@
 //!   S5.  GET 404 — cross-group: scope_id ≠ principal.group_id → 404.
 //!   S6.  GET 400 — empty q → 400.
 //!   S7.  GET 400 — unknown type in types → 400.
-//!   S8.  GET 400 — unsupported scope_type (user) → 400.
+//!   S8.  GET 400 — `scope_type=user` + `types=messages` rejected (plan 0085).
 //!   S9.  GET 401 — missing bearer → 401.
 //!   S10. GET 200 — sensitivity='secret' memory excluded.
 //!   S11. GET 200 — cross-group RLS: group2 cannot see group1 messages.
+//!
+//!   ── Slice 2 (chat + user scope) — GAR-551 ──
+//!   S12. GET 200 — `scope_type=chat`: returns only messages from that chat.
+//!   S13. GET 404 — `scope_type=chat` with chat in another group → 404.
+//!   S14. GET 200 — `scope_type=chat` memory: only chat-scope rows, not group-scope.
+//!   S15. GET 200 — `scope_type=user` (memory): returns only caller's personal memory.
+//!   S16. GET 404 — `scope_type=user` with another user's id → 404.
+//!   S17. GET 400 — `scope_type=user` with default types (messages,memory) → 400.
 
 mod common;
 
@@ -126,7 +136,7 @@ async fn send_message(
         .to_string()
 }
 
-/// Helper: create a memory item.
+/// Helper: create a group-scoped memory item.
 async fn create_memory(h: &Harness, token: &str, group_id: &str, content: &str, sensitivity: &str) {
     let resp = h
         .router
@@ -149,6 +159,72 @@ async fn create_memory(h: &Harness, token: &str, group_id: &str, content: &str, 
     assert_eq!(resp.status(), StatusCode::CREATED, "setup: memory 201");
 }
 
+/// Helper: create a chat-scoped memory item.
+async fn create_chat_memory(
+    h: &Harness,
+    token: &str,
+    group_id: &str,
+    chat_id: &str,
+    content: &str,
+) {
+    let resp = h
+        .router
+        .clone()
+        .oneshot(req(
+            "POST",
+            "/v1/memory",
+            Some(token),
+            Some(group_id),
+            Some(json!({
+                "scope_type": "chat",
+                "scope_id": chat_id,
+                "kind": "fact",
+                "content": content,
+                "sensitivity": "private"
+            })),
+        ))
+        .await
+        .expect("create_chat_memory oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::CREATED,
+        "setup: chat memory 201"
+    );
+}
+
+/// Helper: create a user-scoped (personal) memory item.
+async fn create_user_memory(
+    h: &Harness,
+    token: &str,
+    group_id: &str,
+    user_id: &str,
+    content: &str,
+) {
+    let resp = h
+        .router
+        .clone()
+        .oneshot(req(
+            "POST",
+            "/v1/memory",
+            Some(token),
+            Some(group_id),
+            Some(json!({
+                "scope_type": "user",
+                "scope_id": user_id,
+                "kind": "fact",
+                "content": content,
+                "sensitivity": "private"
+            })),
+        ))
+        .await
+        .expect("create_user_memory oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::CREATED,
+        "setup: user memory 201"
+    );
+}
+
 /// Helper: GET /v1/search with the given query string.
 fn search_req(token: Option<&str>, x_group_id: Option<&str>, qs: &str) -> Request<Body> {
     req("GET", &format!("/v1/search?{qs}"), token, x_group_id, None)
@@ -160,11 +236,12 @@ fn search_req(token: Option<&str>, x_group_id: Option<&str>, qs: &str) -> Reques
 async fn search_scenarios() {
     let h = Harness::get().await;
 
-    // Seed two isolated groups.
-    let (_, group_id, token) = seed_user_with_group(&h, "owner@search-test.test")
+    // Seed two isolated groups. Slice 2 also exercises user_id, so we
+    // capture it for both seeds.
+    let (user_id, group_id, token) = seed_user_with_group(&h, "owner@search-test.test")
         .await
         .expect("seed owner");
-    let (_, group2_id, token2) = seed_user_with_group(&h, "owner2@search-test.test")
+    let (user2_id, group2_id, token2) = seed_user_with_group(&h, "owner2@search-test.test")
         .await
         .expect("seed owner2");
 
@@ -203,6 +280,49 @@ async fn search_scenarios() {
         &group_id.to_string(),
         "fluffernutter classified recipe top secret",
         "secret",
+    )
+    .await;
+
+    // ── Slice-2 setup ────────────────────────────────────────────────────
+    // Chat-scoped memory item with a unique token so we can prove that
+    // `scope_type=chat` returns chat-scope rows (and not group-scope rows
+    // that just happen to be in the same group).
+    create_chat_memory(
+        &h,
+        &token,
+        &group_id.to_string(),
+        &chat_id,
+        "cinnamonroll is the chat-scope canary phrase",
+    )
+    .await;
+    // User-scoped (personal) memory items, one per owner. The unique
+    // token "personalsecretphrase42" lets us assert that user A's search
+    // returns A's personal memory and not B's.
+    create_user_memory(
+        &h,
+        &token,
+        &group_id.to_string(),
+        &user_id.to_string(),
+        "personalsecretphrase42 belongs to owner1 alone",
+    )
+    .await;
+    create_user_memory(
+        &h,
+        &token2,
+        &group2_id.to_string(),
+        &user2_id.to_string(),
+        "personalsecretphrase42 belongs to owner2 alone",
+    )
+    .await;
+    // Second chat in caller's group — search by chat_id (chat 1) must NOT
+    // return a message that lives only in chat 2.
+    let chat2_id = create_chat(&h, &token, &group_id.to_string()).await;
+    send_message(
+        &h,
+        &token,
+        &chat2_id,
+        &group_id.to_string(),
+        "fluffernutter only here in chat2",
     )
     .await;
 
@@ -337,10 +457,12 @@ async fn search_scenarios() {
         .expect("S7 oneshot");
     assert_eq!(resp7.status(), StatusCode::BAD_REQUEST, "S7 expected 400");
 
-    // ── S8. Unsupported scope_type=user → 400 ────────────────────────────
+    // ── S8. scope_type=user + types=messages → 400 (plan 0085) ───────────
+    // user scope is now valid, but messages have no user scope, so
+    // `types=messages` is rejected with 400 at parse_and_validate.
     let qs8 = format!(
         "q=hello&scope_type=user&scope_id={}&types=messages",
-        group_id
+        user_id
     );
     let resp8 = h
         .router
@@ -403,4 +525,155 @@ async fn search_scenarios() {
         body11["items"].as_array().expect("S11 items").is_empty(),
         "S11 group2 must not see group1 messages via search"
     );
+
+    // ── Slice 2 — chat scope (S12-S14) ───────────────────────────────────
+
+    // ── S12. scope_type=chat happy: returns only messages from that chat
+    // chat_id (chat 1) has the "fluffernutter sandwich" message. chat2_id
+    // has "fluffernutter only here in chat2". A chat-scoped search by
+    // chat_id must not return chat 2's message.
+    let qs12 = format!(
+        "q=fluffernutter&scope_type=chat&scope_id={}&types=messages",
+        chat_id
+    );
+    let resp12 = h
+        .router
+        .clone()
+        .oneshot(search_req(Some(&token), Some(&group_id.to_string()), &qs12))
+        .await
+        .expect("S12 oneshot");
+    assert_eq!(resp12.status(), StatusCode::OK, "S12 status");
+    let body12 = body_json(resp12).await;
+    let items12 = body12["items"].as_array().expect("S12 items");
+    assert!(!items12.is_empty(), "S12 must return chat 1's message");
+    for it in items12 {
+        assert_eq!(
+            it["chat_id"].as_str().unwrap_or(""),
+            chat_id,
+            "S12 every result must belong to chat 1"
+        );
+        assert!(
+            !it["excerpt"]
+                .as_str()
+                .unwrap_or("")
+                .contains("only here in chat2"),
+            "S12 chat 2's message must not appear in chat 1's search"
+        );
+    }
+
+    // ── S13. scope_type=chat with chat in another group → 404 ────────────
+    // Owner1 attempts to search using a chat_id that lives in group2 — but
+    // we only have chat_id and chat2_id in group1. We use a UUID that
+    // doesn't belong to any chat in caller's group.
+    let bogus_chat = uuid::Uuid::new_v4();
+    let qs13 = format!(
+        "q=fluffernutter&scope_type=chat&scope_id={}&types=messages",
+        bogus_chat
+    );
+    let resp13 = h
+        .router
+        .clone()
+        .oneshot(search_req(Some(&token), Some(&group_id.to_string()), &qs13))
+        .await
+        .expect("S13 oneshot");
+    assert_eq!(resp13.status(), StatusCode::NOT_FOUND, "S13 expected 404");
+
+    // ── S14. scope_type=chat memory: only chat-scope rows ────────────────
+    // The "cinnamonroll" canary lives only in the chat-scope memory; the
+    // group-scope memory uses "marshmallow". Chat-scope search for
+    // "cinnamonroll" must hit; chat-scope search for "marshmallow" must
+    // NOT hit (group-scope memory must not leak into chat-scope results).
+    let qs14a = format!(
+        "q=cinnamonroll&scope_type=chat&scope_id={}&types=memory",
+        chat_id
+    );
+    let resp14a = h
+        .router
+        .clone()
+        .oneshot(search_req(Some(&token), Some(&group_id.to_string()), &qs14a))
+        .await
+        .expect("S14a oneshot");
+    assert_eq!(resp14a.status(), StatusCode::OK, "S14a status");
+    let body14a = body_json(resp14a).await;
+    let items14a = body14a["items"].as_array().expect("S14a items");
+    assert_eq!(
+        items14a.len(),
+        1,
+        "S14a must return exactly the chat-scope memory item"
+    );
+    assert_eq!(items14a[0]["scope_type"].as_str().unwrap_or(""), "chat");
+
+    let qs14b = format!(
+        "q=marshmallow&scope_type=chat&scope_id={}&types=memory",
+        chat_id
+    );
+    let resp14b = h
+        .router
+        .clone()
+        .oneshot(search_req(Some(&token), Some(&group_id.to_string()), &qs14b))
+        .await
+        .expect("S14b oneshot");
+    assert_eq!(resp14b.status(), StatusCode::OK, "S14b status");
+    let body14b = body_json(resp14b).await;
+    assert!(
+        body14b["items"].as_array().expect("S14b items").is_empty(),
+        "S14b group-scope memory must NOT leak into chat-scope results"
+    );
+
+    // ── Slice 2 — user scope (S15-S17) ───────────────────────────────────
+
+    // ── S15. scope_type=user happy: returns only caller's personal memory
+    let qs15 = format!(
+        "q=personalsecretphrase42&scope_type=user&scope_id={}&types=memory",
+        user_id
+    );
+    let resp15 = h
+        .router
+        .clone()
+        .oneshot(search_req(Some(&token), Some(&group_id.to_string()), &qs15))
+        .await
+        .expect("S15 oneshot");
+    assert_eq!(resp15.status(), StatusCode::OK, "S15 status");
+    let body15 = body_json(resp15).await;
+    let items15 = body15["items"].as_array().expect("S15 items");
+    assert_eq!(
+        items15.len(),
+        1,
+        "S15 must return exactly owner1's personal memory"
+    );
+    let it15 = &items15[0];
+    assert_eq!(it15["type"].as_str().unwrap_or(""), "memory");
+    assert_eq!(it15["scope_type"].as_str().unwrap_or(""), "user");
+    assert_eq!(it15["scope_id"].as_str().unwrap_or(""), user_id.to_string());
+    assert!(
+        it15["excerpt"]
+            .as_str()
+            .unwrap_or("")
+            .contains("owner1 alone"),
+        "S15 must return owner1's personal memory body, not owner2's"
+    );
+
+    // ── S16. scope_type=user with another user's id → 404 ───────────────
+    // Owner1 attempts to search using user2_id; cross-user must 404.
+    let qs16 = format!(
+        "q=personalsecretphrase42&scope_type=user&scope_id={}&types=memory",
+        user2_id
+    );
+    let resp16 = h
+        .router
+        .clone()
+        .oneshot(search_req(Some(&token), Some(&group_id.to_string()), &qs16))
+        .await
+        .expect("S16 oneshot");
+    assert_eq!(resp16.status(), StatusCode::NOT_FOUND, "S16 expected 404");
+
+    // ── S17. scope_type=user with default types (messages,memory) → 400
+    let qs17 = format!("q=hello&scope_type=user&scope_id={}", user_id);
+    let resp17 = h
+        .router
+        .clone()
+        .oneshot(search_req(Some(&token), Some(&group_id.to_string()), &qs17))
+        .await
+        .expect("S17 oneshot");
+    assert_eq!(resp17.status(), StatusCode::BAD_REQUEST, "S17 expected 400");
 }

--- a/crates/garraia-gateway/tests/rest_v1_search.rs
+++ b/crates/garraia-gateway/tests/rest_v1_search.rs
@@ -185,11 +185,7 @@ async fn create_chat_memory(
         ))
         .await
         .expect("create_chat_memory oneshot");
-    assert_eq!(
-        resp.status(),
-        StatusCode::CREATED,
-        "setup: chat memory 201"
-    );
+    assert_eq!(resp.status(), StatusCode::CREATED, "setup: chat memory 201");
 }
 
 /// Helper: create a user-scoped (personal) memory item.
@@ -218,11 +214,7 @@ async fn create_user_memory(
         ))
         .await
         .expect("create_user_memory oneshot");
-    assert_eq!(
-        resp.status(),
-        StatusCode::CREATED,
-        "setup: user memory 201"
-    );
+    assert_eq!(resp.status(), StatusCode::CREATED, "setup: user memory 201");
 }
 
 /// Helper: GET /v1/search with the given query string.
@@ -590,7 +582,11 @@ async fn search_scenarios() {
     let resp14a = h
         .router
         .clone()
-        .oneshot(search_req(Some(&token), Some(&group_id.to_string()), &qs14a))
+        .oneshot(search_req(
+            Some(&token),
+            Some(&group_id.to_string()),
+            &qs14a,
+        ))
         .await
         .expect("S14a oneshot");
     assert_eq!(resp14a.status(), StatusCode::OK, "S14a status");
@@ -610,7 +606,11 @@ async fn search_scenarios() {
     let resp14b = h
         .router
         .clone()
-        .oneshot(search_req(Some(&token), Some(&group_id.to_string()), &qs14b))
+        .oneshot(search_req(
+            Some(&token),
+            Some(&group_id.to_string()),
+            &qs14b,
+        ))
         .await
         .expect("S14b oneshot");
     assert_eq!(resp14b.status(), StatusCode::OK, "S14b status");

--- a/plans/0085-gar-551-search-api-slice2-chat-user-scope.md
+++ b/plans/0085-gar-551-search-api-slice2-chat-user-scope.md
@@ -1,0 +1,308 @@
+# Plan 0085 — GAR-551: REST /v1 search slice 2 (chat + user scope)
+
+**Status:** 🟡 In Progress
+**Autor:** Claude Opus 4.7 (garra-routine 2026-05-08, America/New_York)
+**Data:** 2026-05-08 (America/New_York)
+**Issue:** [GAR-551](https://linear.app/chatgpt25/issue/GAR-551) — Backlog → In Progress
+**Branch:** `routine/202605082234-search-slice2-chat-user-scope`
+**Epic:** `epic:ws-search`, `epic:ws-api`
+**Predecessor:** plan 0084 (GAR-549, slice 1)
+
+---
+
+## §1 Goal
+
+Lift the `scope_type=group` restriction in slice 1 by adding two new
+scopes to `GET /v1/search`:
+
+```
+GET /v1/search
+  ?q=<query>
+  &scope_type=chat               # NEW
+  &scope_id=<chat_uuid>
+  &types=messages,memory         (default: both)
+  &limit=<1-50>                  (default 20)
+  &offset=<n>                    (default 0)
+
+GET /v1/search
+  ?q=<query>
+  &scope_type=user               # NEW
+  &scope_id=<user_uuid>          (must equal principal.user_id)
+  &types=memory                  (messages invalid for user scope)
+  &limit=<1-50>
+  &offset=<n>
+```
+
+Slice 1 (`scope_type=group`) behavior is preserved unchanged.
+
+---
+
+## §2 Architecture
+
+```
+crates/garraia-gateway/src/rest_v1/
+  search.rs                              ← EDIT: extend validation + queries
+  openapi.rs                             ← unchanged (utoipa picks up new param values)
+crates/garraia-gateway/tests/
+  rest_v1_search.rs                      ← EDIT: add 8 new scenarios for chat/user scope
+plans/0085-...md                          ← this file
+```
+
+### Scope dispatcher
+
+A new internal enum encodes the validated scope:
+
+```rust
+enum Scope {
+    Group { group_id: Uuid },
+    Chat  { chat_id: Uuid, group_id: Uuid },
+    User  { user_id: Uuid, group_id: Uuid },
+}
+```
+
+`parse_and_validate(params, principal)` returns `Scope` plus a refined
+`include_messages` / `include_memory` policy:
+
+| scope_type | include_messages allowed? | include_memory allowed? |
+|------------|---------------------------|-------------------------|
+| group      | yes                       | yes                     |
+| chat       | yes (filtered by chat_id) | yes (`scope_type='chat' AND scope_id=$chat_id`) |
+| user       | **400** if requested      | yes (`scope_type='user' AND scope_id=$user_id`) |
+
+### Cross-tenant 404 matrix
+
+| Condition                                                  | Status |
+|------------------------------------------------------------|--------|
+| `scope_type=user` + `scope_id ≠ principal.user_id`         | 404    |
+| `scope_type=chat` + `scope_id` not in caller's group       | 404    |
+| `scope_type=group` + `scope_id ≠ principal.group_id` (1)   | 404    |
+
+(1) preserved from slice 1.
+
+### RLS protocol
+
+Same as slice 1: both `app.current_user_id` and `app.current_group_id`
+are SET LOCAL via parameterized `set_config` before any SELECT. RLS on
+`memory_items` (policy `memory_items_group_or_self`, migration 007:133)
+already covers all three scope_types via its dual branch. Messages RLS
+is direct on `group_id`.
+
+### Chat existence validation
+
+For `scope_type=chat`, before any FTS query:
+
+```sql
+SELECT id FROM chats
+WHERE id = $1 AND group_id = $2 AND archived_at IS NULL
+```
+
+`Some(_)` → continue; `None` → 404. Pattern mirrors `messages.rs` and
+`memory.rs` chat scope validation. No `chat_members` lookup is added in
+this slice — visibility is "any chat in caller's group", consistent with
+slice 1 of the chat surface.
+
+### Query filter changes
+
+**Messages query** (slice 2 adds optional `chat_id` predicate):
+
+```sql
+SELECT m.id, ts_rank(...) AS score, m.body, m.group_id, m.chat_id,
+       m.sender_user_id, m.created_at
+FROM   messages m
+WHERE  m.body_tsv @@ websearch_to_tsquery('portuguese', $1)
+  AND  m.group_id = $2
+  AND  ($3::uuid IS NULL OR m.chat_id = $3)   -- NEW
+  AND  m.deleted_at IS NULL
+ORDER BY score DESC, m.created_at DESC, m.id DESC
+LIMIT $4
+```
+
+**Memory query** (slice 2 adds optional `scope_type`/`scope_id` predicates):
+
+```sql
+SELECT mi.id, ts_rank(to_tsvector('portuguese', mi.content), ...) AS score,
+       mi.content, mi.group_id, mi.scope_type, mi.scope_id, mi.kind, mi.created_at
+FROM   memory_items mi
+WHERE  to_tsvector('portuguese', mi.content) @@ websearch_to_tsquery('portuguese', $1)
+  AND  ($2::text IS NULL OR mi.scope_type = $2)   -- NEW
+  AND  ($3::uuid IS NULL OR mi.scope_id   = $3)   -- NEW
+  AND  mi.deleted_at IS NULL
+  AND  mi.sensitivity <> 'secret'
+  AND  (mi.ttl_expires_at IS NULL OR mi.ttl_expires_at > now())
+ORDER BY score DESC, mi.created_at DESC, mi.id DESC
+LIMIT $4
+```
+
+For `scope_type=group`, the new predicates are passed as `NULL` → no-op
+filter, preserving slice 1 behavior bit-for-bit. Note that
+`memory_items.group_id` is NOT in the WHERE clause for user scope (per
+migration 005, user-scope rows have `group_id IS NULL`); RLS handles the
+`group_id IS NULL AND created_by = current_user_id` branch automatically.
+
+---
+
+## §3 Tech Stack
+
+- sqlx parameter binding (no string concat, no `format!` for SET LOCAL — we
+  use `set_config('app.current_*_id', $1, true)` per the established pattern)
+- `websearch_to_tsquery('portuguese', $1)` for safe FTS
+- utoipa `#[utoipa::path]` documentation auto-rebuilt
+- `garraia_auth::{Principal, AppPool}`
+
+---
+
+## §4 Design Invariants
+
+1. **Slice 1 is regression-tested** — `scope_type=group` still works.
+2. **NO SQL string concat** — all user-controlled values via `bind`.
+3. **RLS both vars set** — `app.current_user_id` + `app.current_group_id`.
+4. **Cross-tenant → 404** — never 403 for user/chat (avoid leaking
+   existence of other-group chats or other users). Slice 1 used 404 for
+   group; we keep it.
+5. **`types=messages` + `scope_type=user` → 400** — explicit, not silent
+   filter. The error message names which scope is incompatible.
+6. **`sensitivity='secret'` excluded** from memory results in all scopes.
+7. **`deleted_at IS NULL`** + `ttl_expires_at` filters apply in all scopes.
+8. **No audit event** for search reads (no circular noise).
+9. **Chat-scoped search of `messages.body`** — a non-member of the chat
+   but in the group still gets results (acceptable for `type='channel'`;
+   for `dm` rooms the future slice 3 will add `chat_members` enforcement
+   if product calls for it).
+
+---
+
+## §5 Validações pré-plano
+
+- [x] `messages.body_tsv` GIN index (migration 004)
+- [x] `memory_items.content` queryable at runtime via `to_tsvector`
+  (slice 1 already does this)
+- [x] `chats` RLS on `group_id` (migration 007:90-94)
+- [x] `memory_items_group_or_self` policy already covers user-scope rows
+  via its second branch (migration 007:133-140)
+- [x] No new migration required
+- [x] Linear search confirms no duplicate issue (`v1/search slice 2`,
+  `search scope_type chat user` returned only related slice 1 / memory
+  slice 1; no GAR-551 conflict). Created GAR-551 fresh.
+
+---
+
+## §6 Out of Scope
+
+- FTS on `tasks`, `task_comments`, `files`, `audit_events`
+- Cursor-based pagination (offset is fine for FTS)
+- Embedding/vector search (GAR-372)
+- WebSocket streaming results
+- Highlighting/snippet extraction (future slice)
+- `chat_members` membership enforcement for DM-type chats (slice 3 if
+  product asks for it)
+- Sweep of slice-1 internal review follow-ups (none filed)
+
+---
+
+## §7 Rollback
+
+The change is purely additive at the handler level: validation grows
+from one `scope_type` branch to three, queries gain two NULL-able bind
+predicates. No migration, no schema change, no new table. Reverting is
+`git revert` of the squash-merge commit. Slice 1 callers using
+`scope_type=group` continue working without recompile (DTO is unchanged
+beyond the scope_type accepted set).
+
+---
+
+## §8 File Structure
+
+```
+crates/garraia-gateway/src/rest_v1/search.rs          (EDIT, ~+150 LOC)
+crates/garraia-gateway/tests/rest_v1_search.rs        (EDIT, ~+200 LOC)
+plans/0085-gar-551-search-api-slice2-chat-user-scope.md  (NEW)
+plans/README.md                                        (EDIT: +row 0085)
+ROADMAP.md                                             (EDIT: §3.4 search note)
+```
+
+No changes to `mod.rs`, `openapi.rs`, or migrations.
+
+---
+
+## §9 M1 Tasks
+
+- [ ] T1: extend `parse_and_validate` to accept `scope_type ∈ {group, chat, user}`;
+      add `Scope` enum; new unit tests covering: chat-scope happy, chat-scope
+      messages-only, chat-scope memory-only, user-scope memory happy, user-scope
+      `types=messages` rejected, user-scope `scope_id` mismatch rejected.
+- [ ] T2: refactor `fetch_messages` and `fetch_memory` to accept the new
+      optional bind predicates (`chat_id_filter`, `mem_scope_type`,
+      `mem_scope_id`). Slice-1 callers pass `None` → identical SQL plan.
+- [ ] T3: extend the `search` handler to dispatch on `Scope`. Add chat
+      existence check in-tx for chat scope (mirrors `memory.rs:362`).
+- [ ] T4: integration tests in `rest_v1_search.rs` — 8 new scenarios:
+      (a) chat-scope happy returns only that chat's messages,
+      (b) chat-scope cross-group → 404,
+      (c) chat-scope archived chat → 404,
+      (d) chat-scope memory only returns `scope_type='chat'` rows for that chat,
+      (e) user-scope happy returns only personal memory of caller,
+      (f) user-scope `scope_id` mismatch → 404,
+      (g) user-scope `types=messages` → 400,
+      (h) cross-user attempt → 404 (user A tries `scope_type=user` with B's id).
+- [ ] T5: update plan/ROADMAP bookkeeping — `plans/README.md` row, ROADMAP §3.4
+      note for slice 2 against the existing `GET /v1/search` checkbox.
+
+---
+
+## §10 Risk Register
+
+| Risk | Mitigation |
+|------|-----------|
+| `($N::uuid IS NULL OR ...)` triggers a sqlx type-inference cliff | Cast inside SQL; `bind(Option<Uuid>)` is canonical and matches `memory.rs` patterns |
+| Slice 1 regression by accident | T1 unit tests preserve all slice-1 cases verbatim; T4 keeps 1 group-scope happy as smoke |
+| RLS user-branch unexpectedly filters chat-scope memory | RLS branch 1 covers `chat` (group_id NOT NULL = principal.group_id); explicit unit test |
+| User-scope memory query slow without index | `memory_items_scope_idx (scope_type, scope_id)` already exists (migration 005:32) — partial WHERE deleted_at IS NULL |
+| Cross-language tokenizer mismatch | Unchanged from slice 1; documented limitation |
+
+---
+
+## §11 Acceptance Criteria
+
+1. `scope_type=chat` + `scope_id ∈ caller's group` → 200 with messages
+   filtered by `chat_id` and memory_items with `scope_type='chat' AND scope_id=chat_id`.
+2. `scope_type=chat` + `scope_id` not in caller's group → 404.
+3. `scope_type=chat` + chat archived (`archived_at IS NOT NULL`) → 404.
+4. `scope_type=user` + `scope_id == principal.user_id` → 200 with only
+   personal memory of caller.
+5. `scope_type=user` + `scope_id ≠ principal.user_id` → 404.
+6. `scope_type=user` + `types=messages` (or `messages,memory`) → 400.
+7. `scope_type=group` (slice 1) regression: identical responses pre/post.
+8. `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` green.
+9. All required CI checks (Format, Clippy, Test×3, Build, MSRV, cargo-deny,
+   Security Audit, Coverage, Analyze rust, Analyze js-ts, Playwright, E2E,
+   Secret Scan, Dependency Review) pass.
+
+---
+
+## §12 Open questions
+
+None. All design decisions are derivable from migrations 004/005/007 and
+existing handlers (`messages.rs`, `memory.rs`, `search.rs`).
+
+---
+
+## §13 Cross-references
+
+- plan 0084 (GAR-549): slice 1, defers user/chat scope in §6
+- plan 0062 (GAR-514): memory.rs scope dispatcher (`user`/`group`/`chat`)
+- plan 0055 (GAR-507): messages.rs chat-existence in-tx pattern
+- plan 0056 (GAR-508): `set_config()` parameterized SQL convention
+- migration 004: `chats`, `chat_members`, `messages` schema
+- migration 005: `memory_items` scope_type/scope_id semantics
+- migration 007: RLS policies (`messages_group_isolation`, `chats_group_isolation`,
+  `memory_items_group_or_self` dual-branch)
+- ADR 0006: search strategy decision (Postgres FTS → Tantivy → Meilisearch)
+- ROADMAP §3.4: `GET /v1/search` checkbox already ticked for slice 1
+
+---
+
+## §14 Estimativa
+
+- Implementação: 2–3 h (small, well-scoped extension)
+- LOC: ~350 (search.rs +150, tests +200)
+- Risco: baixo (padrão estabelecido em memory.rs; sem migração; slice 1 preservado)

--- a/plans/README.md
+++ b/plans/README.md
@@ -108,6 +108,7 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0082 | [GAR-544 — REST `/v1` tasks slice 8 (move task between lists)](0082-gar-544-task-move-api.md) | [GAR-544](https://linear.app/chatgpt25/issue/GAR-544) | ✅ Merged 2026-05-08 via PR #214 (`6232ec1`) |
 | 0083 | [GAR-546 — REST `/v1` tasks slice 9 (subtasks API)](0083-gar-546-task-subtasks-api.md) | [GAR-546](https://linear.app/chatgpt25/issue/GAR-546) | ✅ Merged 2026-05-08 via PR #217 (`ad394b7`) |
 | 0084 | [GAR-549 — REST `/v1` search slice 1: GET /v1/search unified FTS](0084-gar-549-search-api-slice1.md) | [GAR-549](https://linear.app/chatgpt25/issue/GAR-549) | ✅ Merged 2026-05-08 via PR #223 (`79199ab`) |
+| 0085 | [GAR-551 — REST `/v1` search slice 2: chat + user scope](0085-gar-551-search-api-slice2-chat-user-scope.md) | [GAR-551](https://linear.app/chatgpt25/issue/GAR-551) | 🟡 In Progress |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

- Lifts the slice-1 `scope_type=group` restriction in `GET /v1/search`. The endpoint now accepts `scope_type=chat` and `scope_type=user` as well, with cross-tenant attempts (wrong group / wrong chat / wrong user) returning **404** in every case to avoid leaking the existence of resources in other tenants.
- For `scope_type=user`, the combination `types=messages` returns **400** (messages have no user scope; explicit rejection rather than silent filter).
- Memory query is unified into a single statement with three NULL-able predicate columns: group, scope_type, scope_id. Slice-1 (`scope_type=group`) passes them all as NULL → identical query plan, regression-free. Chat scope adds the `scope_type='chat' AND scope_id=chat_id` filter; user scope drops the group filter and lets RLS branch 2 (`group_id IS NULL AND created_by = current_user_id`) handle visibility.
- 8 new unit tests in `search.rs` (total 20) and 6 new integration scenarios in `rest_v1_search.rs` (S12–S17), including a chat-2 message that **must not** appear in chat-1 search results, a chat-scope memory that must not leak group-scope memory back, and a cross-user 404.

Issue: [GAR-551](https://linear.app/chatgpt25/issue/GAR-551)
Plan:  `plans/0085-gar-551-search-api-slice2-chat-user-scope.md`

## Test plan

- [x] `cargo check -p garraia-gateway --tests` (local, 19s)
- [x] `cargo test -p garraia-gateway --lib rest_v1::search::` — 20/20 unit tests green
- [x] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` — clean
- [x] Integration test binary builds (`--no-run` with `--features test-helpers`)
- [ ] CI: Format, Clippy, Test (ubuntu/macos/windows), MSRV, cargo-deny, Security Audit, Coverage, Analyze (rust + js-ts), Playwright, E2E, Secret Scan, Dependency Review — driven to green by CI

## Migration / rollback

- No DB migration. Purely additive at the handler level.
- Reverting is `git revert` of the squash-merge commit. Slice-1 callers (`scope_type=group`) work identically pre/post.

## Cross-references

- Predecessor: plan 0084 / GAR-549 (slice 1, group only)
- Pattern reused: plan 0062 / GAR-514 (memory.rs scope dispatcher)
- Pattern reused: plan 0055 / GAR-507 (in-tx chat existence check)
- Pattern reused: plan 0056 / GAR-508 (`set_config()` parameterized RLS)