### PR TITLE
docs(plans): mark plan 0085 merged — GAR-551 (PR #228, fdef9bc)

### DIFF
--- a/plans/0085-gar-551-search-api-slice2-chat-user-scope.md
+++ b/plans/0085-gar-551-search-api-slice2-chat-user-scope.md
@@ -1,9 +1,9 @@
 # Plan 0085 — GAR-551: REST /v1 search slice 2 (chat + user scope)
 
-**Status:** 🟡 In Progress
+**Status:** ✅ Merged 2026-05-08 via PR #228 (`fdef9bc`)
 **Autor:** Claude Opus 4.7 (garra-routine 2026-05-08, America/New_York)
 **Data:** 2026-05-08 (America/New_York)
-**Issue:** [GAR-551](https://linear.app/chatgpt25/issue/GAR-551) — Backlog → In Progress
+**Issue:** [GAR-551](https://linear.app/chatgpt25/issue/GAR-551) — Done
 **Branch:** `routine/202605082234-search-slice2-chat-user-scope`
 **Epic:** `epic:ws-search`, `epic:ws-api`
 **Predecessor:** plan 0084 (GAR-549, slice 1)

--- a/plans/README.md
+++ b/plans/README.md
@@ -108,7 +108,7 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0082 | [GAR-544 — REST `/v1` tasks slice 8 (move task between lists)](0082-gar-544-task-move-api.md) | [GAR-544](https://linear.app/chatgpt25/issue/GAR-544) | ✅ Merged 2026-05-08 via PR #214 (`6232ec1`) |
 | 0083 | [GAR-546 — REST `/v1` tasks slice 9 (subtasks API)](0083-gar-546-task-subtasks-api.md) | [GAR-546](https://linear.app/chatgpt25/issue/GAR-546) | ✅ Merged 2026-05-08 via PR #217 (`ad394b7`) |
 | 0084 | [GAR-549 — REST `/v1` search slice 1: GET /v1/search unified FTS](0084-gar-549-search-api-slice1.md) | [GAR-549](https://linear.app/chatgpt25/issue/GAR-549) | ✅ Merged 2026-05-08 via PR #223 (`79199ab`) |
-| 0085 | [GAR-551 — REST `/v1` search slice 2: chat + user scope](0085-gar-551-search-api-slice2-chat-user-scope.md) | [GAR-551](https://linear.app/chatgpt25/issue/GAR-551) | 🟡 In Progress |
+| 0085 | [GAR-551 — REST `/v1` search slice 2: chat + user scope](0085-gar-551-search-api-slice2-chat-user-scope.md) | [GAR-551](https://linear.app/chatgpt25/issue/GAR-551) | ✅ Merged 2026-05-08 via PR #228 (`fdef9bc`) |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
Bookkeeping: flips plan 0085 status header and the plans/README.md row from In Progress to Merged with the merge sha and PR number, per garra-routine §6.

Closes the row for [GAR-551](https://linear.app/chatgpt25/issue/GAR-551). The substantive change (search slice 2 — chat + user scope) shipped in #228 (`fdef9bc`).