### PR TITLE
feat(search): GAR-552 — GET /v1/search slice 3: from_date/to_date/author_id filters (plan 0086)

### DIFF
--- a/crates/garraia-gateway/src/rest_v1/search.rs
+++ b/crates/garraia-gateway/src/rest_v1/search.rs
@@ -1,7 +1,7 @@
 //! `GET /v1/search` — unified full-text search across messages and memory_items
-//! (plan 0084 + plan 0085, GAR-549 + GAR-551, epic GAR-WS-SEARCH / Fase 3.4).
+//! (plan 0084 + plan 0085 + plan 0086, GAR-549 + GAR-551 + GAR-552, epic GAR-WS-SEARCH / Fase 3.4).
 //!
-//! ## Scope (slice 1 + slice 2)
+//! ## Scope (slice 1 + slice 2 + slice 3)
 //!
 //! ```text
 //! GET /v1/search?q=<q>&scope_type=group&scope_id=<group_uuid>&types=messages,memory
@@ -128,6 +128,12 @@ pub struct SearchQuery {
     /// Comma-separated list of resource types to search.
     /// Supported: `messages`, `memory`. Default: `messages,memory`.
     pub types: Option<String>,
+    /// Filter: only results created at or after this timestamp (ISO 8601 UTC). Optional.
+    pub from_date: Option<DateTime<Utc>>,
+    /// Filter: only results created at or before this timestamp (ISO 8601 UTC). Optional.
+    pub to_date: Option<DateTime<Utc>>,
+    /// Filter: for message results only, restrict to this sender UUID. Rejected for `scope_type=user`.
+    pub author_id: Option<Uuid>,
     /// Page size. Default 20, max 50.
     pub limit: Option<u32>,
     /// Offset for pagination. Default 0, max 10 000.
@@ -153,6 +159,9 @@ struct ValidatedSearch {
     scope_id: Uuid,
     include_messages: bool,
     include_memory: bool,
+    from_date: Option<DateTime<Utc>>,
+    to_date: Option<DateTime<Utc>>,
+    author_id: Option<Uuid>,
     limit: u32,
     offset: u32,
 }
@@ -210,6 +219,23 @@ fn parse_and_validate(params: &SearchQuery) -> Result<ValidatedSearch, RestError
         ));
     }
 
+    // author_id is only meaningful for message results; user scope never has messages.
+    if params.author_id.is_some() && scope_type == ValidatedScopeType::User {
+        return Err(RestError::BadRequest(
+            "author_id is not supported for scope_type=user (user scope only searches memory)"
+                .into(),
+        ));
+    }
+
+    // When both dates are provided, from_date must not exceed to_date.
+    if let (Some(from), Some(to)) = (params.from_date, params.to_date)
+        && from > to
+    {
+        return Err(RestError::BadRequest(
+            "from_date must not be later than to_date".into(),
+        ));
+    }
+
     let limit = params.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
     let offset = params.offset.unwrap_or(0);
     if offset > MAX_OFFSET {
@@ -224,6 +250,9 @@ fn parse_and_validate(params: &SearchQuery) -> Result<ValidatedSearch, RestError
         scope_id: params.scope_id,
         include_messages,
         include_memory,
+        from_date: params.from_date,
+        to_date: params.to_date,
+        author_id: params.author_id,
         limit,
         offset,
     })
@@ -285,11 +314,16 @@ async fn set_rls_context(
 /// `chat_filter`:
 /// - `None` → group-wide search (slice 1: `scope_type=group`)
 /// - `Some(chat_id)` → chat-scoped search (slice 2: `scope_type=chat`)
+///
+/// `from_date` / `to_date` / `author_id` are all optional; `NULL` binds skip the predicate.
 async fn fetch_messages(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     q: &str,
     group_id: Uuid,
     chat_filter: Option<Uuid>,
+    from_date: Option<DateTime<Utc>>,
+    to_date: Option<DateTime<Utc>>,
+    author_id: Option<Uuid>,
     fetch_up_to: i64,
 ) -> Result<Vec<MessageSearchRow>, RestError> {
     let rows = sqlx::query_as::<_, MessageSearchRow>(
@@ -305,12 +339,18 @@ async fn fetch_messages(
            AND  m.group_id = $2
            AND  ($3::uuid IS NULL OR m.chat_id = $3)
            AND  m.deleted_at IS NULL
+           AND  ($4::timestamptz IS NULL OR m.created_at >= $4)
+           AND  ($5::timestamptz IS NULL OR m.created_at <= $5)
+           AND  ($6::uuid IS NULL OR m.sender_user_id = $6)
          ORDER BY score DESC, m.created_at DESC, m.id DESC
-         LIMIT $4",
+         LIMIT $7",
     )
     .bind(q)
     .bind(group_id)
     .bind(chat_filter)
+    .bind(from_date)
+    .bind(to_date)
+    .bind(author_id)
     .bind(fetch_up_to)
     .fetch_all(&mut **tx)
     .await
@@ -331,12 +371,16 @@ async fn fetch_messages(
 /// - **User**:  `group_filter=None`,    `scope_type_filter=Some("user")`,
 ///   `scope_id_filter=Some(user_id)`. RLS branch 2
 ///   (`group_id IS NULL AND created_by = current_user_id`) handles the rest.
+///
+/// `from_date` / `to_date` are optional date filters (slice 3).
 async fn fetch_memory(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     q: &str,
     group_filter: Option<Uuid>,
     scope_type_filter: Option<&'static str>,
     scope_id_filter: Option<Uuid>,
+    from_date: Option<DateTime<Utc>>,
+    to_date: Option<DateTime<Utc>>,
     fetch_up_to: i64,
 ) -> Result<Vec<MemorySearchRow>, RestError> {
     let rows = sqlx::query_as::<_, MemorySearchRow>(
@@ -359,13 +403,17 @@ async fn fetch_memory(
            AND  mi.deleted_at IS NULL
            AND  mi.sensitivity <> 'secret'
            AND  (mi.ttl_expires_at IS NULL OR mi.ttl_expires_at > now())
+           AND  ($5::timestamptz IS NULL OR mi.created_at >= $5)
+           AND  ($6::timestamptz IS NULL OR mi.created_at <= $6)
          ORDER BY score DESC, mi.created_at DESC, mi.id DESC
-         LIMIT $5",
+         LIMIT $7",
     )
     .bind(q)
     .bind(group_filter)
     .bind(scope_type_filter)
     .bind(scope_id_filter)
+    .bind(from_date)
+    .bind(to_date)
     .bind(fetch_up_to)
     .fetch_all(&mut **tx)
     .await
@@ -491,6 +539,9 @@ pub async fn search(
             &validated.q,
             caller_group_id,
             chat_filter,
+            validated.from_date,
+            validated.to_date,
+            validated.author_id,
             fetch_up_to,
         )
         .await?;
@@ -532,6 +583,8 @@ pub async fn search(
             group_filter,
             scope_type_filter,
             scope_id_filter,
+            validated.from_date,
+            validated.to_date,
             fetch_up_to,
         )
         .await?;
@@ -589,6 +642,9 @@ mod tests {
             scope_type: scope_type.to_owned(),
             scope_id: Uuid::new_v4(),
             types: types.map(|s| s.to_owned()),
+            from_date: None,
+            to_date: None,
+            author_id: None,
             limit: None,
             offset: None,
         }
@@ -727,6 +783,9 @@ mod tests {
             scope_type: "group".to_owned(),
             scope_id: Uuid::new_v4(),
             types: None,
+            from_date: None,
+            to_date: None,
+            author_id: None,
             limit: None,
             offset: Some(10_001),
         };
@@ -740,6 +799,9 @@ mod tests {
             scope_type: "group".to_owned(),
             scope_id: Uuid::new_v4(),
             types: None,
+            from_date: None,
+            to_date: None,
+            author_id: None,
             limit: Some(999),
             offset: None,
         };
@@ -756,5 +818,123 @@ mod tests {
         assert!(v.include_memory);
         assert_eq!(v.limit, DEFAULT_LIMIT);
         assert_eq!(v.offset, 0);
+    }
+
+    // ─── Slice 3: date-range + author_id filter tests ─────────────────────────
+
+    fn make_params_full(
+        q: &str,
+        scope_type: &str,
+        from_date: Option<DateTime<Utc>>,
+        to_date: Option<DateTime<Utc>>,
+        author_id: Option<Uuid>,
+    ) -> SearchQuery {
+        SearchQuery {
+            q: q.to_owned(),
+            scope_type: scope_type.to_owned(),
+            scope_id: Uuid::new_v4(),
+            types: None,
+            from_date,
+            to_date,
+            author_id,
+            limit: None,
+            offset: None,
+        }
+    }
+
+    #[test]
+    fn from_date_only_accepted() {
+        let from = "2026-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let params = make_params_full("hello", "group", Some(from), None, None);
+        let v = parse_and_validate(&params).unwrap();
+        assert_eq!(v.from_date, Some(from));
+        assert_eq!(v.to_date, None);
+    }
+
+    #[test]
+    fn to_date_only_accepted() {
+        let to = "2026-06-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let params = make_params_full("hello", "group", None, Some(to), None);
+        let v = parse_and_validate(&params).unwrap();
+        assert_eq!(v.from_date, None);
+        assert_eq!(v.to_date, Some(to));
+    }
+
+    #[test]
+    fn from_date_equal_to_date_accepted() {
+        let ts = "2026-03-15T12:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let params = make_params_full("hello", "group", Some(ts), Some(ts), None);
+        assert!(parse_and_validate(&params).is_ok());
+    }
+
+    #[test]
+    fn from_date_before_to_date_accepted() {
+        let from = "2026-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let to = "2026-06-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let params = make_params_full("hello", "group", Some(from), Some(to), None);
+        assert!(parse_and_validate(&params).is_ok());
+    }
+
+    #[test]
+    fn from_date_after_to_date_rejected() {
+        let from = "2026-06-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let to = "2026-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let params = make_params_full("hello", "group", Some(from), Some(to), None);
+        assert!(parse_and_validate(&params).is_err());
+    }
+
+    #[test]
+    fn author_id_with_group_scope_accepted() {
+        let author = Uuid::new_v4();
+        let params = make_params_full("hello", "group", None, None, Some(author));
+        let v = parse_and_validate(&params).unwrap();
+        assert_eq!(v.author_id, Some(author));
+    }
+
+    #[test]
+    fn author_id_with_chat_scope_accepted() {
+        let author = Uuid::new_v4();
+        let params = make_params_full("hello", "chat", None, None, Some(author));
+        let v = parse_and_validate(&params).unwrap();
+        assert_eq!(v.author_id, Some(author));
+    }
+
+    #[test]
+    fn author_id_with_user_scope_rejected() {
+        let author = Uuid::new_v4();
+        // user scope does not support messages, so author_id is rejected.
+        let params = SearchQuery {
+            q: "hello".to_owned(),
+            scope_type: "user".to_owned(),
+            scope_id: Uuid::new_v4(),
+            types: Some("memory".to_owned()),
+            from_date: None,
+            to_date: None,
+            author_id: Some(author),
+            limit: None,
+            offset: None,
+        };
+        assert!(parse_and_validate(&params).is_err());
+    }
+
+    #[test]
+    fn all_three_filters_together_accepted() {
+        let from = "2026-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let to = "2026-06-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let author = Uuid::new_v4();
+        let params = make_params_full("hello", "group", Some(from), Some(to), Some(author));
+        let v = parse_and_validate(&params).unwrap();
+        assert_eq!(v.from_date, Some(from));
+        assert_eq!(v.to_date, Some(to));
+        assert_eq!(v.author_id, Some(author));
+    }
+
+    #[test]
+    fn no_filter_params_has_none_defaults() {
+        let params = make_params("hello", "group", None);
+        let v = parse_and_validate(&params).unwrap();
+        assert_eq!(v.from_date, None);
+        assert_eq!(v.to_date, None);
+        assert_eq!(v.author_id, None);
     }
 }

--- a/plans/0086-gar-552-search-api-slice3-date-author-filters.md
+++ b/plans/0086-gar-552-search-api-slice3-date-author-filters.md
@@ -1,0 +1,186 @@
+# Plan 0086 — GAR-552: REST /v1 search slice 3 (date-range + author_id filters)
+
+**Status:** 🔵 In Progress
+**Autor:** Claude Sonnet 4.6 (garra-routine 2026-05-09, America/New_York)
+**Data:** 2026-05-09 (America/New_York)
+**Issue:** [GAR-552](https://linear.app/chatgpt25/issue/GAR-552) — In Progress
+**Branch:** `routine/202605090015-search-slice3-date-author-filters`
+**Epic:** `epic:ws-search`, `epic:ws-api`
+**Predecessor:** plan 0085 (GAR-551, slice 2)
+
+---
+
+## §1 Goal
+
+Extend `GET /v1/search` with three optional filter parameters that implement
+part of the ROADMAP §3.9 checklist ("Filtros: scope, types, from_date, author,
+has_attachment"):
+
+```
+GET /v1/search
+  ?q=<query>
+  &scope_type=group|chat|user
+  &scope_id=<uuid>
+  &from_date=2026-01-01T00:00:00Z   # NEW — created_at >= from_date
+  &to_date=2026-06-01T00:00:00Z     # NEW — created_at <= to_date
+  &author_id=<uuid>                 # NEW — message sender_user_id (not user scope)
+```
+
+All three parameters are optional and additive with existing slice 1+2 filters.
+
+---
+
+## §2 Architecture
+
+```
+crates/garraia-gateway/src/rest_v1/
+  search.rs   ← EDIT only: extend SearchQuery, ValidatedSearch,
+                parse_and_validate, fetch_messages, fetch_memory
+plans/
+  0086-...md  ← this file
+plans/README.md ← add row
+```
+
+No schema changes, no new migrations, no new crates. Pure Rust extension.
+
+### Validation rules
+
+| Condition | Response |
+|-----------|----------|
+| `from_date > to_date` (both present) | 400 |
+| `author_id` + `scope_type=user` | 400 (user scope has no messages) |
+| `from_date` or `to_date` alone | valid |
+| `author_id` with `scope_type=group` or `=chat` | valid |
+
+### SQL strategy
+
+Both queries use nullable predicates via sqlx bind:
+
+```sql
+-- messages
+AND ($N::timestamptz IS NULL OR m.created_at >= $N)
+AND ($M::timestamptz IS NULL OR m.created_at <= $M)
+AND ($P::uuid IS NULL OR m.sender_user_id = $P)
+
+-- memory_items
+AND ($N::timestamptz IS NULL OR mi.created_at >= $N)
+AND ($M::timestamptz IS NULL OR mi.created_at <= $M)
+```
+
+The `author_id` filter is NOT applied to memory results (no author concept there).
+
+---
+
+## §3 Tech stack
+
+- Rust / Axum 0.8 / sqlx 0.8
+- `chrono::DateTime<Utc>` — already in workspace with `serde` feature, parsed
+  automatically by Axum's `Query<T>` deserializer from ISO 8601 strings
+- No new dependencies
+
+---
+
+## §4 Design invariants
+
+- `author_id` on user-scope is rejected (400) even though it's technically harmless
+  (no messages to filter): fail loudly to avoid misleading callers.
+- Date filters apply to BOTH messages and memory rows — consistent `created_at`
+  semantics across types.
+- Offset pagination semantics unchanged: `fetch_up_to = offset + limit + 1` still
+  drives `has_more` detection after Rust-side sort.
+
+---
+
+## §5 Validações pré-plano
+
+- [x] chrono serde feature enabled in workspace (`Cargo.toml:chrono = { version = "0.4", features = ["serde"] }`)
+- [x] `DateTime<Utc>` already imported and used in `search.rs`
+- [x] `fetch_messages` and `fetch_memory` use sqlx positional params — safe to extend
+- [x] No integration tests for search (unit tests only so far) — unit test coverage is the target
+- [x] GAR-552 created in Linear, no duplicate found
+
+---
+
+## §6 Out of scope
+
+- `has_attachment` filter — requires schema change (attachments column on messages)
+- Hybrid BM25 + ANN vector re-ranking
+- Cursor-based pagination
+- `author_id` filter on memory results
+
+---
+
+## §7 Rollback
+
+Pure extension to existing module — removing the 3 new params from `SearchQuery`
+and reverting the SQL predicates restores slice 2 behavior exactly. No migration
+needed to rollback.
+
+---
+
+## §8 Open questions
+
+None. Approach is directly analogous to existing nullable-predicate pattern already
+in `fetch_messages` (`$3::uuid IS NULL OR m.chat_id = $3`).
+
+---
+
+## §9 File structure
+
+```
+crates/garraia-gateway/src/rest_v1/search.rs   (edit)
+plans/0086-gar-552-search-api-slice3-date-author-filters.md  (this)
+plans/README.md                                               (edit: add row)
+```
+
+---
+
+## §10 M1 tasks
+
+- [ ] T1: Extend `SearchQuery` + `ValidatedSearch` with 3 new fields; update `parse_and_validate`
+- [ ] T2: Update `fetch_messages` SQL + signature for date + author params
+- [ ] T3: Update `fetch_memory` SQL + signature for date params
+- [ ] T4: Wire new params through handler
+- [ ] T5: Add ≥ 10 unit tests for new validation branches
+- [ ] T6: `cargo check -p garraia-gateway` + `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings`
+- [ ] T7: Commit + push; open PR
+- [ ] T8: Update plans/README.md + ROADMAP checklist after merge
+
+---
+
+## §11 Risk register
+
+| Risk | Probability | Impact | Mitigation |
+|------|-------------|--------|------------|
+| chrono serde parse fails on non-UTC input | Low | Low | Serde rejects non-UTC automatically; caller gets 422 |
+| Nullable predicate `$N::timestamptz IS NULL` rejected by sqlx macro | Low | Low | Using `sqlx::query_as` (not `query!` macro) — dynamic bind is fine |
+| Offset-based pagination over filtered results differs from caller expectation | Low | Low | Documented in §4: offset applied after Rust sort, consistent with slices 1+2 |
+
+---
+
+## §12 Acceptance criteria
+
+- [ ] `?from_date=2026-01-01T00:00:00Z` filters results to `created_at >= 2026-01-01`
+- [ ] `?to_date=2026-06-01T00:00:00Z` filters results to `created_at <= 2026-06-01`
+- [ ] `from_date > to_date` → 400 with descriptive message
+- [ ] `?author_id=<uuid>` on group/chat scope → filters messages to that sender
+- [ ] `?author_id=<uuid>` on user scope → 400
+- [ ] All slice 1 + slice 2 unit tests pass unchanged
+- [ ] `cargo clippy` clean, no warnings
+
+---
+
+## Cross-references
+
+- ROADMAP §3.9 "Busca unificada" `[ ] Filtros: scope, types, from_date, author, has_attachment`
+- plan 0084 (GAR-549) — slice 1 (group scope)
+- plan 0085 (GAR-551) — slice 2 (chat + user scope)
+- plan 0056 (GAR-508) — set_config RLS pattern used throughout
+
+---
+
+## Estimativa
+
+- T1–T5: ~2h (extension of existing code, no new concepts)
+- T6–T7: ~30min (CI run time)
+- Total: ~3h calendar

--- a/plans/README.md
+++ b/plans/README.md
@@ -109,6 +109,7 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0083 | [GAR-546 — REST `/v1` tasks slice 9 (subtasks API)](0083-gar-546-task-subtasks-api.md) | [GAR-546](https://linear.app/chatgpt25/issue/GAR-546) | ✅ Merged 2026-05-08 via PR #217 (`ad394b7`) |
 | 0084 | [GAR-549 — REST `/v1` search slice 1: GET /v1/search unified FTS](0084-gar-549-search-api-slice1.md) | [GAR-549](https://linear.app/chatgpt25/issue/GAR-549) | ✅ Merged 2026-05-08 via PR #223 (`79199ab`) |
 | 0085 | [GAR-551 — REST `/v1` search slice 2: chat + user scope](0085-gar-551-search-api-slice2-chat-user-scope.md) | [GAR-551](https://linear.app/chatgpt25/issue/GAR-551) | ✅ Merged 2026-05-08 via PR #228 (`fdef9bc`) |
+| 0086 | [GAR-552 — REST `/v1` search slice 3: from_date/to_date/author_id filters](0086-gar-552-search-api-slice3-date-author-filters.md) | [GAR-552](https://linear.app/chatgpt25/issue/GAR-552) | 🔵 In Progress |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

- Extends `GET /v1/search` with three optional filter params, implementing ROADMAP §3.9 "Filtros: scope, types, **from_date**, **author**, has_attachment" (partial — excludes `has_attachment` which requires schema change).
- `from_date` / `to_date`: ISO 8601 UTC timestamps filtered via nullable `timestamptz` predicates (`$N::timestamptz IS NULL OR ...`) in both `messages` and `memory_items` queries.
- `author_id`: filters message results by `sender_user_id`; rejected with 400 for `scope_type=user` (user scope only searches memory, which has no author concept).
- `from_date > to_date` → 400 with descriptive message.
- All three params are additive with existing slice 1+2 filters (scope, types, limit, offset).

## Closes

[GAR-552](https://linear.app/chatgpt25/issue/GAR-552) — REST /v1 search slice 3: from_date / to_date / author_id filters

## Plan

`plans/0086-gar-552-search-api-slice3-date-author-filters.md`

## Files changed

- `crates/garraia-gateway/src/rest_v1/search.rs` — extend `SearchQuery`, `ValidatedSearch`, `parse_and_validate`, `fetch_messages`, `fetch_memory`; 10 new unit tests
- `plans/0086-gar-552-search-api-slice3-date-author-filters.md` — plan file
- `plans/README.md` — new row

## Test plan

- [x] 30/30 unit tests pass (`cargo test -p garraia-gateway --lib rest_v1::search`)
- [x] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` clean
- [x] `cargo check -p garraia-gateway` clean
- [ ] CI Format Check green
- [ ] CI Clippy Linting green
- [ ] CI Test (ubuntu/macos/windows) green
- [ ] CI Build Check green
- [ ] CI Security Audit green
- [ ] CI E2E Tests green

## Out of scope

- `has_attachment` filter (deferred — requires `messages` schema change for attachments column)
- Hybrid BM25 + ANN vector re-ranking (plan 0087+)

https://claude.ai/code/session_01LembDeKRZaEteaQpiXwyKm

---
_Generated by [Claude Code](https://claude.ai/code/session_01LembDeKRZaEteaQpiXwyKm)_