### PR TITLE
feat(files): GAR-555 — Files REST API slice 1 (GET files + GET folders + DELETE file)

### DIFF
--- a/crates/garraia-auth/src/audit_workspace.rs
+++ b/crates/garraia-auth/src/audit_workspace.rs
@@ -362,6 +362,15 @@ pub enum WorkspaceAuditAction {
     /// `resource_type = "tasks"`, `resource_id = "{task_id}"`.
     /// Metadata: `{ from_list_id, to_list_id }` — UUIDs only, never list names.
     TaskMoved,
+
+    /// A file was soft-deleted via `DELETE /v1/files/{file_id}`
+    /// (plan 0088 / GAR-555, Fase 3.4 files slice 1).
+    ///
+    /// Idempotent — emitted only when `deleted_at` transitions from NULL
+    /// (first soft-delete). Already-deleted files return 204 without emitting.
+    /// `resource_type = "files"`, `resource_id = "{file_id}"`.
+    /// Metadata: `{ name_len, group_id }` — never the raw file name.
+    FileDeleted,
 }
 
 impl WorkspaceAuditAction {
@@ -402,6 +411,7 @@ impl WorkspaceAuditAction {
             WorkspaceAuditAction::TaskSubscribed => "task.subscribed",
             WorkspaceAuditAction::TaskUnsubscribed => "task.unsubscribed",
             WorkspaceAuditAction::TaskMoved => "task.moved",
+            WorkspaceAuditAction::FileDeleted => "file.deleted",
         }
     }
 }
@@ -576,6 +586,7 @@ mod tests {
             "task.unsubscribed"
         );
         assert_eq!(WorkspaceAuditAction::TaskMoved.as_str(), "task.moved");
+        assert_eq!(WorkspaceAuditAction::FileDeleted.as_str(), "file.deleted");
     }
 
     #[test]

--- a/crates/garraia-gateway/src/rest_v1/files.rs
+++ b/crates/garraia-gateway/src/rest_v1/files.rs
@@ -260,9 +260,8 @@ pub async fn list_files(
     set_rls_context(&mut tx, principal.user_id, group_id).await?;
 
     let rows: Vec<FileRow> = match params.cursor {
-        Some(cursor_id) => {
-            sqlx::query_as(
-                "SELECT f.id, f.name, f.mime_type, f.size_bytes, \
+        Some(cursor_id) => sqlx::query_as(
+            "SELECT f.id, f.name, f.mime_type, f.size_bytes, \
                          f.current_version, f.total_versions, f.folder_id, \
                          f.created_by, f.created_by_label, f.created_at, f.updated_at \
                   FROM files f \
@@ -273,17 +272,15 @@ pub async fn list_files(
                     ) \
                   ORDER BY f.created_at DESC, f.id DESC \
                   LIMIT $3",
-            )
-            .bind(params.folder_id)
-            .bind(cursor_id)
-            .bind(fetch_limit)
-            .fetch_all(&mut *tx)
-            .await
-            .map_err(|e| RestError::Internal(e.into()))?
-        }
-        None => {
-            sqlx::query_as(
-                "SELECT f.id, f.name, f.mime_type, f.size_bytes, \
+        )
+        .bind(params.folder_id)
+        .bind(cursor_id)
+        .bind(fetch_limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?,
+        None => sqlx::query_as(
+            "SELECT f.id, f.name, f.mime_type, f.size_bytes, \
                          f.current_version, f.total_versions, f.folder_id, \
                          f.created_by, f.created_by_label, f.created_at, f.updated_at \
                   FROM files f \
@@ -291,13 +288,12 @@ pub async fn list_files(
                     AND ($1::uuid IS NULL OR f.folder_id = $1::uuid) \
                   ORDER BY f.created_at DESC, f.id DESC \
                   LIMIT $2",
-            )
-            .bind(params.folder_id)
-            .bind(fetch_limit)
-            .fetch_all(&mut *tx)
-            .await
-            .map_err(|e| RestError::Internal(e.into()))?
-        }
+        )
+        .bind(params.folder_id)
+        .bind(fetch_limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?,
     };
 
     tx.commit()
@@ -310,7 +306,11 @@ pub async fn list_files(
         .take(effective_limit as usize)
         .map(FileSummary::from)
         .collect();
-    let next_cursor = if has_next { items.last().map(|f| f.id) } else { None };
+    let next_cursor = if has_next {
+        items.last().map(|f| f.id)
+    } else {
+        None
+    };
     if has_next {
         items.pop();
     }
@@ -371,9 +371,8 @@ pub async fn list_folders(
     set_rls_context(&mut tx, principal.user_id, group_id).await?;
 
     let rows: Vec<FolderRow> = match params.cursor {
-        Some(cursor_id) => {
-            sqlx::query_as(
-                "SELECT f.id, f.name, f.parent_id, \
+        Some(cursor_id) => sqlx::query_as(
+            "SELECT f.id, f.name, f.parent_id, \
                          f.created_by, f.created_by_label, f.created_at, f.updated_at \
                   FROM folders f \
                   WHERE f.deleted_at IS NULL \
@@ -383,30 +382,27 @@ pub async fn list_folders(
                     ) \
                   ORDER BY f.created_at DESC, f.id DESC \
                   LIMIT $3",
-            )
-            .bind(params.parent_id)
-            .bind(cursor_id)
-            .bind(fetch_limit)
-            .fetch_all(&mut *tx)
-            .await
-            .map_err(|e| RestError::Internal(e.into()))?
-        }
-        None => {
-            sqlx::query_as(
-                "SELECT f.id, f.name, f.parent_id, \
+        )
+        .bind(params.parent_id)
+        .bind(cursor_id)
+        .bind(fetch_limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?,
+        None => sqlx::query_as(
+            "SELECT f.id, f.name, f.parent_id, \
                          f.created_by, f.created_by_label, f.created_at, f.updated_at \
                   FROM folders f \
                   WHERE f.deleted_at IS NULL \
                     AND f.parent_id IS NOT DISTINCT FROM $1::uuid \
                   ORDER BY f.created_at DESC, f.id DESC \
                   LIMIT $2",
-            )
-            .bind(params.parent_id)
-            .bind(fetch_limit)
-            .fetch_all(&mut *tx)
-            .await
-            .map_err(|e| RestError::Internal(e.into()))?
-        }
+        )
+        .bind(params.parent_id)
+        .bind(fetch_limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?,
     };
 
     tx.commit()
@@ -419,7 +415,11 @@ pub async fn list_folders(
         .take(effective_limit as usize)
         .map(FolderSummary::from)
         .collect();
-    let next_cursor = if has_next { items.last().map(|f| f.id) } else { None };
+    let next_cursor = if has_next {
+        items.last().map(|f| f.id)
+    } else {
+        None
+    };
     if has_next {
         items.pop();
     }
@@ -480,14 +480,13 @@ pub async fn delete_file(
     //   - not found / cross-group (0 rows) → 404
     //   - already deleted (deleted_at IS NOT NULL) → 204 idempotent, no audit
     //   - live file (deleted_at IS NULL) → UPDATE + audit + 204
-    let existing: Option<(Option<DateTime<Utc>>, String)> = sqlx::query_as(
-        "SELECT deleted_at, name FROM files WHERE id = $1 AND group_id = $2",
-    )
-    .bind(file_id)
-    .bind(group_id)
-    .fetch_optional(&mut *tx)
-    .await
-    .map_err(|e| RestError::Internal(e.into()))?;
+    let existing: Option<(Option<DateTime<Utc>>, String)> =
+        sqlx::query_as("SELECT deleted_at, name FROM files WHERE id = $1 AND group_id = $2")
+            .bind(file_id)
+            .bind(group_id)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(|e| RestError::Internal(e.into()))?;
 
     let (deleted_at, name) = match existing {
         Some(row) => row,

--- a/crates/garraia-gateway/src/rest_v1/files.rs
+++ b/crates/garraia-gateway/src/rest_v1/files.rs
@@ -1,0 +1,802 @@
+//! `/v1/groups/{group_id}/files`, `/v1/groups/{group_id}/folders`,
+//! and `DELETE /v1/files/{file_id}` handlers
+//! (plan 0088, GAR-555, Fase 3.4 files slice 1).
+//!
+//! Three endpoints on the `garraia_app` RLS-enforced pool:
+//! - `GET /v1/groups/{group_id}/files?folder_id=&cursor=&limit=` — cursor-paginated list
+//! - `GET /v1/groups/{group_id}/folders?parent_id=&cursor=&limit=` — cursor-paginated list
+//! - `DELETE /v1/files/{file_id}` — idempotent soft-delete
+//!
+//! ## Tenant-context protocol
+//!
+//! `files` and `folders` use FORCE RLS via `app.current_group_id` (migration 003).
+//! Both RLS vars set via parameterized `set_config` (plan 0056 pattern).
+//!
+//! ## Cross-group protection
+//!
+//! For group-path endpoints: `path_group_id` must equal `principal.group_id` → 403.
+//! For `DELETE /v1/files/{file_id}`: no group_id in path; RLS filters silently → 404.
+
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use chrono::{DateTime, Utc};
+use garraia_auth::{Action, Principal, WorkspaceAuditAction, audit_workspace_event, can};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use utoipa::{IntoParams, ToSchema};
+use uuid::Uuid;
+
+use super::RestV1FullState;
+use super::problem::RestError;
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const DEFAULT_LIMIT: u32 = 50;
+const MAX_LIMIT: u32 = 100;
+
+// ─── Private row types ────────────────────────────────────────────────────────
+
+/// Row for file list queries.
+#[derive(sqlx::FromRow)]
+struct FileRow {
+    id: Uuid,
+    name: String,
+    mime_type: String,
+    size_bytes: i64,
+    current_version: i32,
+    total_versions: i32,
+    folder_id: Option<Uuid>,
+    created_by: Option<Uuid>,
+    created_by_label: String,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+/// Row for folder list queries.
+#[derive(sqlx::FromRow)]
+struct FolderRow {
+    id: Uuid,
+    name: String,
+    parent_id: Option<Uuid>,
+    created_by: Option<Uuid>,
+    created_by_label: String,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+// ─── DTOs ─────────────────────────────────────────────────────────────────────
+
+/// File metadata returned in list responses.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct FileSummary {
+    pub id: Uuid,
+    pub name: String,
+    pub mime_type: String,
+    pub size_bytes: i64,
+    pub current_version: i32,
+    pub total_versions: i32,
+    /// `null` for root-level files (no folder).
+    pub folder_id: Option<Uuid>,
+    pub created_by: Option<Uuid>,
+    pub created_by_label: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl From<FileRow> for FileSummary {
+    fn from(r: FileRow) -> Self {
+        Self {
+            id: r.id,
+            name: r.name,
+            mime_type: r.mime_type,
+            size_bytes: r.size_bytes,
+            current_version: r.current_version,
+            total_versions: r.total_versions,
+            folder_id: r.folder_id,
+            created_by: r.created_by,
+            created_by_label: r.created_by_label,
+            created_at: r.created_at,
+            updated_at: r.updated_at,
+        }
+    }
+}
+
+/// Folder metadata returned in list responses.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct FolderSummary {
+    pub id: Uuid,
+    pub name: String,
+    /// `null` for root folders.
+    pub parent_id: Option<Uuid>,
+    pub created_by: Option<Uuid>,
+    pub created_by_label: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl From<FolderRow> for FolderSummary {
+    fn from(r: FolderRow) -> Self {
+        Self {
+            id: r.id,
+            name: r.name,
+            parent_id: r.parent_id,
+            created_by: r.created_by,
+            created_by_label: r.created_by_label,
+            created_at: r.created_at,
+            updated_at: r.updated_at,
+        }
+    }
+}
+
+/// Response body for `GET /v1/groups/{group_id}/files`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct FileListResponse {
+    pub items: Vec<FileSummary>,
+    /// Opaque cursor for the next page. `null` when the list is exhausted.
+    pub next_cursor: Option<Uuid>,
+}
+
+/// Response body for `GET /v1/groups/{group_id}/folders`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct FolderListResponse {
+    pub items: Vec<FolderSummary>,
+    /// Opaque cursor for the next page. `null` when the list is exhausted.
+    pub next_cursor: Option<Uuid>,
+}
+
+/// Query parameters for `GET /v1/groups/{group_id}/files`.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ListFilesQuery {
+    /// Filter to a specific folder UUID. Omit to list all files in the group.
+    pub folder_id: Option<Uuid>,
+    /// Cursor UUID (last seen file id). Omit for the first page.
+    pub cursor: Option<Uuid>,
+    /// Page size. Default 50, max 100.
+    pub limit: Option<u32>,
+}
+
+/// Query parameters for `GET /v1/groups/{group_id}/folders`.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ListFoldersQuery {
+    /// Parent folder UUID. Omit (or `null`) to list root-level folders.
+    pub parent_id: Option<Uuid>,
+    /// Cursor UUID (last seen folder id). Omit for the first page.
+    pub cursor: Option<Uuid>,
+    /// Page size. Default 50, max 100.
+    pub limit: Option<u32>,
+}
+
+// ─── Helper ───────────────────────────────────────────────────────────────────
+
+/// Set RLS GUCs for the transaction (plan 0056 pattern).
+async fn set_rls_context(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    user_id: Uuid,
+    group_id: Uuid,
+) -> Result<(), RestError> {
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(user_id.to_string())
+        .execute(&mut **tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_group_id', $1, true)")
+        .bind(group_id.to_string())
+        .execute(&mut **tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(())
+}
+
+/// Extract and validate `principal.group_id`. Returns 400 if missing.
+fn require_group_id(principal: &Principal) -> Result<Uuid, RestError> {
+    principal
+        .group_id
+        .ok_or_else(|| RestError::BadRequest("X-Group-Id header is required".into()))
+}
+
+/// Verify path group_id matches principal's group. Returns 403 on mismatch.
+fn check_group_match(path_group_id: Uuid, principal_group_id: Uuid) -> Result<(), RestError> {
+    if path_group_id != principal_group_id {
+        return Err(RestError::Forbidden);
+    }
+    Ok(())
+}
+
+// ─── Handlers ─────────────────────────────────────────────────────────────────
+
+/// `GET /v1/groups/{group_id}/files` — cursor-paginated file listing.
+///
+/// When `folder_id` is supplied, only files directly inside that folder are
+/// returned. When omitted, all non-deleted files in the group are returned.
+/// Ordering: `(created_at DESC, id DESC)`.
+///
+/// Authz: `Action::FilesRead`.
+///
+/// ## Error matrix
+///
+/// | Condition                          | Status |
+/// |------------------------------------|--------|
+/// | Missing/invalid JWT                | 401    |
+/// | Not a group member                 | 403    |
+/// | Path group_id ≠ principal group_id | 403    |
+/// | Happy path                         | 200    |
+#[utoipa::path(
+    get,
+    path = "/v1/groups/{group_id}/files",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ListFilesQuery,
+    ),
+    responses(
+        (status = 200, description = "File list.", body = FileListResponse),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn list_files(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(path_group_id): Path<Uuid>,
+    Query(params): Query<ListFilesQuery>,
+) -> Result<Json<FileListResponse>, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::FilesRead) {
+        return Err(RestError::Forbidden);
+    }
+
+    let effective_limit = params.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+    let fetch_limit = (effective_limit + 1) as i64;
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    let rows: Vec<FileRow> = match params.cursor {
+        Some(cursor_id) => {
+            sqlx::query_as(
+                "SELECT f.id, f.name, f.mime_type, f.size_bytes, \
+                         f.current_version, f.total_versions, f.folder_id, \
+                         f.created_by, f.created_by_label, f.created_at, f.updated_at \
+                  FROM files f \
+                  WHERE f.deleted_at IS NULL \
+                    AND ($1::uuid IS NULL OR f.folder_id = $1::uuid) \
+                    AND (f.created_at, f.id) < ( \
+                        SELECT created_at, id FROM files WHERE id = $2 \
+                    ) \
+                  ORDER BY f.created_at DESC, f.id DESC \
+                  LIMIT $3",
+            )
+            .bind(params.folder_id)
+            .bind(cursor_id)
+            .bind(fetch_limit)
+            .fetch_all(&mut *tx)
+            .await
+            .map_err(|e| RestError::Internal(e.into()))?
+        }
+        None => {
+            sqlx::query_as(
+                "SELECT f.id, f.name, f.mime_type, f.size_bytes, \
+                         f.current_version, f.total_versions, f.folder_id, \
+                         f.created_by, f.created_by_label, f.created_at, f.updated_at \
+                  FROM files f \
+                  WHERE f.deleted_at IS NULL \
+                    AND ($1::uuid IS NULL OR f.folder_id = $1::uuid) \
+                  ORDER BY f.created_at DESC, f.id DESC \
+                  LIMIT $2",
+            )
+            .bind(params.folder_id)
+            .bind(fetch_limit)
+            .fetch_all(&mut *tx)
+            .await
+            .map_err(|e| RestError::Internal(e.into()))?
+        }
+    };
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    let has_next = rows.len() > effective_limit as usize;
+    let mut items: Vec<FileSummary> = rows
+        .into_iter()
+        .take(effective_limit as usize)
+        .map(FileSummary::from)
+        .collect();
+    let next_cursor = if has_next { items.last().map(|f| f.id) } else { None };
+    if has_next {
+        items.pop();
+    }
+
+    Ok(Json(FileListResponse { items, next_cursor }))
+}
+
+/// `GET /v1/groups/{group_id}/folders` — cursor-paginated folder listing.
+///
+/// When `parent_id` is supplied, only direct children of that folder are
+/// returned. When omitted, only root-level folders (`parent_id IS NULL`)
+/// are returned. Ordering: `(created_at DESC, id DESC)`.
+///
+/// Authz: `Action::FilesRead`.
+///
+/// ## Error matrix
+///
+/// | Condition                          | Status |
+/// |------------------------------------|--------|
+/// | Missing/invalid JWT                | 401    |
+/// | Not a group member                 | 403    |
+/// | Path group_id ≠ principal group_id | 403    |
+/// | Happy path                         | 200    |
+#[utoipa::path(
+    get,
+    path = "/v1/groups/{group_id}/folders",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ListFoldersQuery,
+    ),
+    responses(
+        (status = 200, description = "Folder list.", body = FolderListResponse),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn list_folders(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(path_group_id): Path<Uuid>,
+    Query(params): Query<ListFoldersQuery>,
+) -> Result<Json<FolderListResponse>, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::FilesRead) {
+        return Err(RestError::Forbidden);
+    }
+
+    let effective_limit = params.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+    let fetch_limit = (effective_limit + 1) as i64;
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    let rows: Vec<FolderRow> = match params.cursor {
+        Some(cursor_id) => {
+            sqlx::query_as(
+                "SELECT f.id, f.name, f.parent_id, \
+                         f.created_by, f.created_by_label, f.created_at, f.updated_at \
+                  FROM folders f \
+                  WHERE f.deleted_at IS NULL \
+                    AND f.parent_id IS NOT DISTINCT FROM $1::uuid \
+                    AND (f.created_at, f.id) < ( \
+                        SELECT created_at, id FROM folders WHERE id = $2 \
+                    ) \
+                  ORDER BY f.created_at DESC, f.id DESC \
+                  LIMIT $3",
+            )
+            .bind(params.parent_id)
+            .bind(cursor_id)
+            .bind(fetch_limit)
+            .fetch_all(&mut *tx)
+            .await
+            .map_err(|e| RestError::Internal(e.into()))?
+        }
+        None => {
+            sqlx::query_as(
+                "SELECT f.id, f.name, f.parent_id, \
+                         f.created_by, f.created_by_label, f.created_at, f.updated_at \
+                  FROM folders f \
+                  WHERE f.deleted_at IS NULL \
+                    AND f.parent_id IS NOT DISTINCT FROM $1::uuid \
+                  ORDER BY f.created_at DESC, f.id DESC \
+                  LIMIT $2",
+            )
+            .bind(params.parent_id)
+            .bind(fetch_limit)
+            .fetch_all(&mut *tx)
+            .await
+            .map_err(|e| RestError::Internal(e.into()))?
+        }
+    };
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    let has_next = rows.len() > effective_limit as usize;
+    let mut items: Vec<FolderSummary> = rows
+        .into_iter()
+        .take(effective_limit as usize)
+        .map(FolderSummary::from)
+        .collect();
+    let next_cursor = if has_next { items.last().map(|f| f.id) } else { None };
+    if has_next {
+        items.pop();
+    }
+
+    Ok(Json(FolderListResponse { items, next_cursor }))
+}
+
+/// `DELETE /v1/files/{file_id}` — idempotent soft-delete.
+///
+/// Sets `deleted_at = now()` on the file. Idempotent: if the file is already
+/// soft-deleted, returns 204 without emitting an audit event. Cross-group
+/// access is rejected by RLS (the file is invisible) → 404.
+///
+/// Authz: `Action::FilesDelete`.
+///
+/// ## Error matrix
+///
+/// | Condition                           | Status |
+/// |-------------------------------------|--------|
+/// | Missing/invalid JWT                 | 401    |
+/// | Not a group member                  | 403    |
+/// | Insufficient role (< Member)        | 403    |
+/// | File not found / cross-tenant       | 404    |
+/// | File already soft-deleted           | 204    |
+/// | Happy path                          | 204    |
+#[utoipa::path(
+    delete,
+    path = "/v1/files/{file_id}",
+    params(
+        ("file_id" = Uuid, Path, description = "File UUID."),
+    ),
+    responses(
+        (status = 204, description = "File deleted (or already deleted)."),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or lacks FilesDelete.", body = super::problem::ProblemDetails),
+        (status = 404, description = "File not found or cross-tenant.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn delete_file(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(file_id): Path<Uuid>,
+) -> Result<StatusCode, RestError> {
+    let group_id = require_group_id(&principal)?;
+    if !can(&principal, Action::FilesDelete) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Fetch the file regardless of deleted_at to distinguish:
+    //   - not found / cross-group (0 rows) → 404
+    //   - already deleted (deleted_at IS NOT NULL) → 204 idempotent, no audit
+    //   - live file (deleted_at IS NULL) → UPDATE + audit + 204
+    let existing: Option<(Option<DateTime<Utc>>, String)> = sqlx::query_as(
+        "SELECT deleted_at, name FROM files WHERE id = $1 AND group_id = $2",
+    )
+    .bind(file_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let (deleted_at, name) = match existing {
+        Some(row) => row,
+        None => return Err(RestError::NotFound),
+    };
+
+    if deleted_at.is_some() {
+        // Already deleted — idempotent 204 without audit.
+        tx.commit()
+            .await
+            .map_err(|e| RestError::Internal(e.into()))?;
+        return Ok(StatusCode::NO_CONTENT);
+    }
+
+    let name_len = name.chars().count();
+
+    sqlx::query("UPDATE files SET deleted_at = now() WHERE id = $1 AND deleted_at IS NULL")
+        .bind(file_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::FileDeleted,
+        principal.user_id,
+        group_id,
+        "files",
+        file_id.to_string(),
+        json!({ "name_len": name_len, "group_id": group_id }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_summary_from_row_preserves_fields() {
+        let now = Utc::now();
+        let file_id = Uuid::new_v4();
+        let folder_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let row = FileRow {
+            id: file_id,
+            name: "report.pdf".to_string(),
+            mime_type: "application/pdf".to_string(),
+            size_bytes: 12345,
+            current_version: 2,
+            total_versions: 3,
+            folder_id: Some(folder_id),
+            created_by: Some(user_id),
+            created_by_label: "Alice".to_string(),
+            created_at: now,
+            updated_at: now,
+        };
+        let summary = FileSummary::from(row);
+        assert_eq!(summary.id, file_id);
+        assert_eq!(summary.name, "report.pdf");
+        assert_eq!(summary.mime_type, "application/pdf");
+        assert_eq!(summary.size_bytes, 12345);
+        assert_eq!(summary.current_version, 2);
+        assert_eq!(summary.total_versions, 3);
+        assert_eq!(summary.folder_id, Some(folder_id));
+        assert_eq!(summary.created_by_label, "Alice");
+    }
+
+    #[test]
+    fn folder_summary_from_row_preserves_fields() {
+        let now = Utc::now();
+        let folder_id = Uuid::new_v4();
+        let parent_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let row = FolderRow {
+            id: folder_id,
+            name: "Documents".to_string(),
+            parent_id: Some(parent_id),
+            created_by: Some(user_id),
+            created_by_label: "Bob".to_string(),
+            created_at: now,
+            updated_at: now,
+        };
+        let summary = FolderSummary::from(row);
+        assert_eq!(summary.id, folder_id);
+        assert_eq!(summary.name, "Documents");
+        assert_eq!(summary.parent_id, Some(parent_id));
+        assert_eq!(summary.created_by_label, "Bob");
+    }
+
+    #[test]
+    fn file_summary_null_folder_id() {
+        let now = Utc::now();
+        let row = FileRow {
+            id: Uuid::new_v4(),
+            name: "root_file.txt".to_string(),
+            mime_type: "text/plain".to_string(),
+            size_bytes: 0,
+            current_version: 1,
+            total_versions: 1,
+            folder_id: None,
+            created_by: None,
+            created_by_label: "System".to_string(),
+            created_at: now,
+            updated_at: now,
+        };
+        let summary = FileSummary::from(row);
+        assert!(summary.folder_id.is_none());
+        assert!(summary.created_by.is_none());
+    }
+
+    #[test]
+    fn folder_summary_root_has_null_parent() {
+        let now = Utc::now();
+        let row = FolderRow {
+            id: Uuid::new_v4(),
+            name: "Root".to_string(),
+            parent_id: None,
+            created_by: None,
+            created_by_label: "System".to_string(),
+            created_at: now,
+            updated_at: now,
+        };
+        let summary = FolderSummary::from(row);
+        assert!(summary.parent_id.is_none());
+    }
+
+    #[test]
+    fn file_list_response_empty() {
+        let resp = FileListResponse {
+            items: vec![],
+            next_cursor: None,
+        };
+        assert!(resp.items.is_empty());
+        assert!(resp.next_cursor.is_none());
+    }
+
+    #[test]
+    fn folder_list_response_empty() {
+        let resp = FolderListResponse {
+            items: vec![],
+            next_cursor: None,
+        };
+        assert!(resp.items.is_empty());
+        assert!(resp.next_cursor.is_none());
+    }
+
+    #[test]
+    fn list_files_query_defaults() {
+        let q = ListFilesQuery {
+            folder_id: None,
+            cursor: None,
+            limit: None,
+        };
+        assert!(q.folder_id.is_none());
+        assert!(q.cursor.is_none());
+        assert!(q.limit.is_none());
+    }
+
+    #[test]
+    fn list_folders_query_defaults() {
+        let q = ListFoldersQuery {
+            parent_id: None,
+            cursor: None,
+            limit: None,
+        };
+        assert!(q.parent_id.is_none());
+        assert!(q.cursor.is_none());
+        assert!(q.limit.is_none());
+    }
+
+    #[test]
+    fn pagination_has_next_detection() {
+        let limit: u32 = 2;
+        // Simulate 3 rows returned for fetch_limit = limit + 1 = 3.
+        let now = Utc::now();
+        let make_row = |n: u8| FileRow {
+            id: Uuid::new_v4(),
+            name: format!("file{n}.txt"),
+            mime_type: "text/plain".to_string(),
+            size_bytes: 0,
+            current_version: 1,
+            total_versions: 1,
+            folder_id: None,
+            created_by: None,
+            created_by_label: "x".to_string(),
+            created_at: now,
+            updated_at: now,
+        };
+        let rows: Vec<FileRow> = (0..3).map(make_row).collect();
+        let has_next = rows.len() > limit as usize;
+        assert!(has_next, "3 rows > limit 2 → has_next");
+        let truncated: Vec<FileSummary> = rows
+            .into_iter()
+            .take(limit as usize)
+            .map(FileSummary::from)
+            .collect();
+        assert_eq!(truncated.len(), 2);
+    }
+
+    #[test]
+    fn pagination_no_next_when_at_limit() {
+        let limit: u32 = 2;
+        // Exactly 2 rows → no next page.
+        let now = Utc::now();
+        let make_row = |n: u8| FileRow {
+            id: Uuid::new_v4(),
+            name: format!("file{n}.txt"),
+            mime_type: "text/plain".to_string(),
+            size_bytes: 0,
+            current_version: 1,
+            total_versions: 1,
+            folder_id: None,
+            created_by: None,
+            created_by_label: "x".to_string(),
+            created_at: now,
+            updated_at: now,
+        };
+        let rows: Vec<FileRow> = (0..2).map(make_row).collect();
+        let has_next = rows.len() > limit as usize;
+        assert!(!has_next, "2 rows == limit 2 → no next");
+    }
+
+    #[test]
+    fn require_group_id_returns_err_when_none() {
+        let principal = Principal {
+            user_id: Uuid::new_v4(),
+            group_id: None,
+            role: None,
+        };
+        let result = require_group_id(&principal);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn require_group_id_returns_ok_when_present() {
+        let gid = Uuid::new_v4();
+        let principal = Principal {
+            user_id: Uuid::new_v4(),
+            group_id: Some(gid),
+            role: None,
+        };
+        let result = require_group_id(&principal);
+        assert_eq!(result.unwrap(), gid);
+    }
+
+    #[test]
+    fn check_group_match_ok_when_equal() {
+        let id = Uuid::new_v4();
+        assert!(check_group_match(id, id).is_ok());
+    }
+
+    #[test]
+    fn check_group_match_err_when_different() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        assert!(check_group_match(a, b).is_err());
+    }
+
+    #[test]
+    fn file_summary_size_zero_is_valid() {
+        let now = Utc::now();
+        let row = FileRow {
+            id: Uuid::new_v4(),
+            name: "empty.txt".to_string(),
+            mime_type: "text/plain".to_string(),
+            size_bytes: 0,
+            current_version: 1,
+            total_versions: 1,
+            folder_id: None,
+            created_by: None,
+            created_by_label: "x".to_string(),
+            created_at: now,
+            updated_at: now,
+        };
+        let summary = FileSummary::from(row);
+        assert_eq!(summary.size_bytes, 0);
+    }
+
+    #[test]
+    fn file_list_response_with_cursor() {
+        let id1 = Uuid::new_v4();
+        let now = Utc::now();
+        let resp = FileListResponse {
+            items: vec![FileSummary {
+                id: id1,
+                name: "a.txt".to_string(),
+                mime_type: "text/plain".to_string(),
+                size_bytes: 1,
+                current_version: 1,
+                total_versions: 1,
+                folder_id: None,
+                created_by: None,
+                created_by_label: "x".to_string(),
+                created_at: now,
+                updated_at: now,
+            }],
+            next_cursor: Some(id1),
+        };
+        assert_eq!(resp.items.len(), 1);
+        assert_eq!(resp.next_cursor, Some(id1));
+    }
+}

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -31,6 +31,7 @@
 
 pub mod audit;
 pub mod chats;
+pub mod files;
 pub mod groups;
 pub mod invites;
 pub mod me;
@@ -392,6 +393,16 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 .route("/v1/groups/{group_id}/audit", get(audit::list_audit))
                 // Plan 0084 (GAR-549) — search API slice 1.
                 .route("/v1/search", get(search::search))
+                // Plan 0088 (GAR-555) — files API slice 1.
+                .route(
+                    "/v1/groups/{group_id}/files",
+                    get(files::list_files),
+                )
+                .route(
+                    "/v1/groups/{group_id}/folders",
+                    get(files::list_folders),
+                )
+                .route("/v1/files/{file_id}", delete(files::delete_file))
                 .merge(rate_limited_routes)
                 .merge(tus_routes)
                 .with_state(full)
@@ -487,6 +498,16 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 .route("/v1/groups/{group_id}/audit", get(unconfigured_handler))
                 // Plan 0084 (GAR-549) — search API slice 1, fail-soft 503.
                 .route("/v1/search", get(unconfigured_handler))
+                // Plan 0088 (GAR-555) — files API slice 1, fail-soft 503.
+                .route(
+                    "/v1/groups/{group_id}/files",
+                    get(unconfigured_handler),
+                )
+                .route(
+                    "/v1/groups/{group_id}/folders",
+                    get(unconfigured_handler),
+                )
+                .route("/v1/files/{file_id}", delete(unconfigured_handler))
                 .route(
                     "/v1/groups/{group_id}/tasks/{task_id}/comments",
                     post(unconfigured_handler).get(unconfigured_handler),
@@ -619,6 +640,16 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 .route("/v1/groups/{group_id}/audit", get(unconfigured_handler))
                 // Plan 0084 (GAR-549) — search API slice 1, no-auth stub.
                 .route("/v1/search", get(unconfigured_handler))
+                // Plan 0088 (GAR-555) — files API slice 1, no-auth stub.
+                .route(
+                    "/v1/groups/{group_id}/files",
+                    get(unconfigured_handler),
+                )
+                .route(
+                    "/v1/groups/{group_id}/folders",
+                    get(unconfigured_handler),
+                )
+                .route("/v1/files/{file_id}", delete(unconfigured_handler))
                 .route(
                     "/v1/groups/{group_id}/tasks/{task_id}/comments",
                     post(unconfigured_handler).get(unconfigured_handler),

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -394,14 +394,8 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 // Plan 0084 (GAR-549) — search API slice 1.
                 .route("/v1/search", get(search::search))
                 // Plan 0088 (GAR-555) — files API slice 1.
-                .route(
-                    "/v1/groups/{group_id}/files",
-                    get(files::list_files),
-                )
-                .route(
-                    "/v1/groups/{group_id}/folders",
-                    get(files::list_folders),
-                )
+                .route("/v1/groups/{group_id}/files", get(files::list_files))
+                .route("/v1/groups/{group_id}/folders", get(files::list_folders))
                 .route("/v1/files/{file_id}", delete(files::delete_file))
                 .merge(rate_limited_routes)
                 .merge(tus_routes)
@@ -499,14 +493,8 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 // Plan 0084 (GAR-549) — search API slice 1, fail-soft 503.
                 .route("/v1/search", get(unconfigured_handler))
                 // Plan 0088 (GAR-555) — files API slice 1, fail-soft 503.
-                .route(
-                    "/v1/groups/{group_id}/files",
-                    get(unconfigured_handler),
-                )
-                .route(
-                    "/v1/groups/{group_id}/folders",
-                    get(unconfigured_handler),
-                )
+                .route("/v1/groups/{group_id}/files", get(unconfigured_handler))
+                .route("/v1/groups/{group_id}/folders", get(unconfigured_handler))
                 .route("/v1/files/{file_id}", delete(unconfigured_handler))
                 .route(
                     "/v1/groups/{group_id}/tasks/{task_id}/comments",
@@ -641,14 +629,8 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 // Plan 0084 (GAR-549) — search API slice 1, no-auth stub.
                 .route("/v1/search", get(unconfigured_handler))
                 // Plan 0088 (GAR-555) — files API slice 1, no-auth stub.
-                .route(
-                    "/v1/groups/{group_id}/files",
-                    get(unconfigured_handler),
-                )
-                .route(
-                    "/v1/groups/{group_id}/folders",
-                    get(unconfigured_handler),
-                )
+                .route("/v1/groups/{group_id}/files", get(unconfigured_handler))
+                .route("/v1/groups/{group_id}/folders", get(unconfigured_handler))
                 .route("/v1/files/{file_id}", delete(unconfigured_handler))
                 .route(
                     "/v1/groups/{group_id}/tasks/{task_id}/comments",

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -13,6 +13,7 @@ use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
 use utoipa::{Modify, OpenApi};
 
 use super::audit::{AuditEventSummary, ListAuditResponse};
+use super::files::{FileListResponse, FileSummary, FolderListResponse, FolderSummary};
 use super::chats::{ChatListResponse, ChatResponse, ChatSummary, CreateChatRequest};
 use super::groups::{
     CreateGroupRequest, CreateInviteRequest, GroupReadResponse, GroupResponse, InviteResponse,
@@ -132,6 +133,9 @@ impl Modify for SecurityAddon {
         super::tasks::list_subtasks,
         super::audit::list_audit,
         super::search::search,
+        super::files::list_files,
+        super::files::list_folders,
+        super::files::delete_file,
     ),
     components(schemas(
         MeResponse,
@@ -190,6 +194,10 @@ impl Modify for SecurityAddon {
         SearchResult,
         SearchResponse,
         SearchResultType,
+        FileSummary,
+        FileListResponse,
+        FolderSummary,
+        FolderListResponse,
     )),
     modifiers(&SecurityAddon)
 )]

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -13,8 +13,8 @@ use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
 use utoipa::{Modify, OpenApi};
 
 use super::audit::{AuditEventSummary, ListAuditResponse};
-use super::files::{FileListResponse, FileSummary, FolderListResponse, FolderSummary};
 use super::chats::{ChatListResponse, ChatResponse, ChatSummary, CreateChatRequest};
+use super::files::{FileListResponse, FileSummary, FolderListResponse, FolderSummary};
 use super::groups::{
     CreateGroupRequest, CreateInviteRequest, GroupReadResponse, GroupResponse, InviteResponse,
     MemberResponse, SetRoleRequest, UpdateGroupRequest,

--- a/plans/0088-gar-555-files-api-slice1.md
+++ b/plans/0088-gar-555-files-api-slice1.md
@@ -1,0 +1,168 @@
+# Plan 0088 — Files REST API slice 1: GET files + GET folders + DELETE file
+
+**GAR-555** · epic:ws-api · Fase 3.4 "Arquivos"  
+**Branch:** `routine/202605090618-files-api-slice1`  
+**Date:** 2026-05-09 (America/New_York)
+
+---
+
+## Goal
+
+Land the first read-only + soft-delete slice of the Files REST surface (ROADMAP §3.4 "Arquivos"):
+
+- `GET /v1/groups/{group_id}/files?folder_id=&cursor=&limit=` — cursor-paginated file listing
+- `GET /v1/groups/{group_id}/folders?parent_id=&cursor=&limit=` — cursor-paginated folder listing
+- `DELETE /v1/files/{file_id}` — idempotent soft-delete
+
+Schema (`files`, `folders`, `file_versions`) and FORCE RLS are already live in migration 003 (GAR-387). This slice adds only the handler layer.
+
+---
+
+## Architecture
+
+```
+GET /v1/groups/{group_id}/files
+  → RestV1FullState → AppPool → garraia_app role
+  → SET LOCAL app.current_user_id / app.current_group_id via set_config (plan 0056 pattern)
+  → SELECT FROM files WHERE deleted_at IS NULL
+      AND (folder_id = $folder_id OR $folder_id IS NULL)
+      AND (created_at, id) < (cursor_ts, cursor_id)   -- cursor filter
+    ORDER BY created_at DESC, id DESC LIMIT $limit+1
+  ← FileRow list + next_cursor
+
+GET /v1/groups/{group_id}/folders
+  → same pool + RLS set
+  → SELECT FROM folders WHERE deleted_at IS NULL
+      AND (parent_id = $parent_id OR ($parent_id IS NULL AND parent_id IS NULL))
+      AND (created_at, id) < (cursor_ts, cursor_id)
+    ORDER BY created_at DESC, id DESC LIMIT $limit+1
+  ← FolderRow list + next_cursor
+
+DELETE /v1/files/{file_id}
+  → AppPool → RLS set (group_id = principal.group_id)
+  → UPDATE files SET deleted_at = now()
+      WHERE id = $file_id AND group_id = $group_id AND deleted_at IS NULL
+  → returns 204 (file found and soft-deleted) or 204 (already deleted — idempotent)
+  → audit_workspace_event WorkspaceAuditAction::FileDeleted
+```
+
+The `file_id`-only path for DELETE does **not** leak cross-group existence — RLS (`group_id = app.current_group_id`) filters the file out before the UPDATE runs, yielding `rows_affected = 0`. Both soft-delete paths (fresh and already-deleted) return 204 to remain idempotent per HTTP semantics (ROADMAP §3.4 "Arquivos" pattern mirrors `DELETE /v1/groups/{group_id}/task-lists/{list_id}`).
+
+---
+
+## Tech stack
+
+- **Rust / Axum 0.8** — handler functions, `FromRequestParts`, `Path`, `Query`, `State`
+- **sqlx 0.8** — parameterized queries via `sqlx::query!` / `sqlx::query_as!`  
+- **garraia-auth** — `Principal`, `can()`, `Action::{FilesRead, FilesDelete}`, `audit_workspace_event`
+- **utoipa** — `#[utoipa::path]` annotations for OpenAPI 3.1
+
+---
+
+## Design invariants
+
+1. **RLS dual-GUC**: SET LOCAL `app.current_user_id` AND `app.current_group_id` via `set_config($1, $2, true)` before every query (plan 0056 established pattern).
+2. **Group-ID cross-check**: path `{group_id}` must equal `principal.group_id`; mismatch → 403.
+3. **No PII in audit metadata**: carry `file_id` and `name_len` — never `name` nor `created_by_label`.
+4. **Idempotent soft-delete**: UPDATE WHERE `deleted_at IS NULL`; zero-row result also returns 204 (already deleted).
+5. **Cursor ordering**: `(created_at DESC, id DESC)` — consistent with all other cursor-paginated endpoints.
+
+---
+
+## Validações pré-plano
+
+- [x] `files`, `folders`, `file_versions` tables exist (migration 003, GAR-387) ✅
+- [x] FORCE RLS `files_group_isolation` + `folders_group_isolation` active (migration 003) ✅
+- [x] `Action::FilesRead`, `Action::FilesDelete` present in `garraia-auth/src/action.rs` ✅
+- [x] `can()` matrix covers FilesRead/FilesDelete for Owner/Admin/Member (CLAUDE.md §3.3) ✅
+- [x] `audit_workspace_event` + `WorkspaceAuditAction` are public API ✅
+- [x] `AppPool` + `Principal` + `set_config` pattern solid (plans 0054–0087) ✅
+
+---
+
+## Out of scope
+
+- Upload endpoints (`initUpload`, `completeUpload`, tus) — ObjectStore wiring
+- Download URLs / presigned URLs
+- Version management (`newVersion`)
+- Folder CRUD (create, rename, delete)
+- Hard delete / trash restoration
+- `has_attachment` search filter (deferred until after upload slice)
+
+---
+
+## Rollback
+
+This slice is handler-only — no migrations. Rolling back = reverting the `files.rs` handler + three route registrations in `mod.rs`. No DB changes to undo.
+
+---
+
+## §12 Open questions
+
+| # | Question | Decision |
+|---|----------|----------|
+| Q1 | Should `DELETE /v1/files/{file_id}` verify `group_id` in path (like tasks do) or rely purely on RLS? | App-layer verify: pass `group_id = principal.group_id` in WHERE clause. RLS would catch it anyway, but being explicit avoids 0-row ambiguity between "file not in group" and "file not found". |
+| Q2 | Should soft-deleted folders still appear as a valid `folder_id` in `GET /v1/groups/{group_id}/files`? | No. If the folder is soft-deleted, files in it become root-level (folder_id still points to the folder row, but the folder itself is hidden). For now, allow the filter — RLS on folders is separate from files. |
+| Q3 | Audit event for `GET` (list) endpoints? | No — read auditing deferred to a dedicated audit-trail slice per project pattern. |
+
+---
+
+## File structure
+
+```
+crates/garraia-gateway/src/rest_v1/
+  files.rs        ← NEW — 3 handlers + types + unit tests
+  mod.rs          ← ADD pub mod files; + 3 route registrations (all 3 modes)
+  openapi.rs      ← ADD 3 paths to ApiDoc
+```
+
+---
+
+## M1 task list
+
+- [ ] **T1** — Create `crates/garraia-gateway/src/rest_v1/files.rs` with types only (no handlers), compile green
+- [ ] **T2** — Add `list_files` handler + unit tests (red → green)
+- [ ] **T3** — Add `list_folders` handler + unit tests (red → green)
+- [ ] **T4** — Add `delete_file` handler + unit tests (red → green)
+- [ ] **T5** — Wire routes in `mod.rs` (all 3 modes) + OpenAPI annotations in `openapi.rs`
+- [ ] **T6** — `cargo check -p garraia-gateway` → green
+- [ ] **T7** — `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` → clean
+- [ ] **T8** — Update `plans/README.md` + `ROADMAP.md` (flip `[ ]` → `[x]` for 3 endpoints)
+
+---
+
+## Risk register
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|-----------|
+| sqlx compile fails without Postgres (unit tests) | Low | Medium | Use `#[cfg(test)]` mock helpers same as other handlers |
+| `WorkspaceAuditAction::FileDeleted` doesn't exist | Low | Low | Add it to `audit.rs` if missing; small change |
+| Cursor page boundary with NULL `folder_id` edge case | Medium | Low | Test explicitly in unit tests |
+
+---
+
+## Acceptance criteria
+
+- `GET /v1/groups/{group_id}/files` returns only the requesting user's group's files (RLS enforced).
+- `DELETE /v1/files/{file_id}` cross-group → 404; double-delete → 204 idempotent.
+- Cursor pagination stable across inserts.
+- ≥15 unit tests green.
+- Clippy clean.
+- All CI checks pass.
+
+---
+
+## Cross-references
+
+- Migration 003: `crates/garraia-workspace/migrations/003_files_and_folders.sql`
+- GAR-387: schema implementation
+- GAR-394/395: `garraia-storage` crate (ObjectStore — used in slice 2+)
+- ROADMAP §3.4 "Arquivos" checklist
+- Plan 0084 (search slice 1) — establishes same cursor pattern for files will plug into `has_attachment` filter
+
+---
+
+## Estimativa
+
+- T1–T8: ~3h
+- LOC: ~350 (files.rs ~300 + mod.rs ~30 + openapi.rs ~20)

--- a/plans/README.md
+++ b/plans/README.md
@@ -111,6 +111,7 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0085 | [GAR-551 — REST `/v1` search slice 2: chat + user scope](0085-gar-551-search-api-slice2-chat-user-scope.md) | [GAR-551](https://linear.app/chatgpt25/issue/GAR-551) | ✅ Merged 2026-05-08 via PR #228 (`fdef9bc`) |
 | 0086 | [GAR-552 — REST `/v1` search slice 3: from_date/to_date/author_id filters](0086-gar-552-search-api-slice3-date-author-filters.md) | [GAR-552](https://linear.app/chatgpt25/issue/GAR-552) | ✅ Merged 2026-05-09 via PR #231 (`49c4a6b`) |
 | 0087 | [GAR-553 — drop aws-sdk-s3 legacy rustls 0.21 chain (defense-in-depth)](0087-gar-553-aws-sdk-s3-drop-legacy-rustls-chain.md) | [GAR-553](https://linear.app/chatgpt25/issue/GAR-553) | ✅ Merged 2026-05-09 via PR #232 (`f69b794`) |
+| 0088 | [GAR-555 — Files REST API slice 1: GET files + GET folders + DELETE file](0088-gar-555-files-api-slice1.md) | [GAR-555](https://linear.app/chatgpt25/issue/GAR-555) | 🚧 In Progress |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

Lands the first slice of the Files REST API surface (ROADMAP §3.4 "Arquivos" + [GAR-555](https://linear.app/chatgpt25/issue/GAR-555)), building on the `files`/`folders`/`file_versions` schema from migration 003 (GAR-387) and the FORCE RLS + `set_config` pattern established in plans 0056+.

Three endpoints on the `garraia_app` RLS pool:

- **`GET /v1/groups/{group_id}/files?folder_id=&cursor=&limit=`** — cursor-paginated file listing; optional `folder_id` filter via `$1::uuid IS NULL OR folder_id = $1::uuid`; ordering `(created_at DESC, id DESC)`.
- **`GET /v1/groups/{group_id}/folders?parent_id=&cursor=&limit=`** — cursor-paginated folder listing; `parent_id IS NOT DISTINCT FROM $1::uuid` handles both root (`NULL`) and subfolder cases.
- **`DELETE /v1/files/{file_id}`** — idempotent soft-delete; `file.deleted` audit event emitted only on the first delete (not on repeat 204s). Cross-group files return 404 via RLS.

Also adds `WorkspaceAuditAction::FileDeleted` + `as_str()` mapping and one test assertion in `garraia-auth`.

## Changes

| File | Change |
|------|--------|
| `crates/garraia-auth/src/audit_workspace.rs` | Add `FileDeleted` variant + test assertion |
| `crates/garraia-gateway/src/rest_v1/files.rs` | New handler module — 3 handlers, types, 16 unit tests |
| `crates/garraia-gateway/src/rest_v1/mod.rs` | `pub mod files` + 3 route registrations in all 3 router modes |
| `crates/garraia-gateway/src/rest_v1/openapi.rs` | Add 3 paths + 4 schemas to `ApiDoc` |
| `plans/0088-gar-555-files-api-slice1.md` | Plan doc |
| `plans/README.md` | Plan row added |

## Security / authz invariants

- Both `files` and `folders` FORCE RLS via `app.current_group_id` (migration 003). GUCs set via parameterized `set_config` — no `format!()` interpolation.
- `GET` endpoints: path `{group_id}` checked against `principal.group_id` → 403 on mismatch.
- `DELETE`: no group_id in path; RLS + explicit `group_id = $2` WHERE clause prevents cross-group access (→ 404).
- `FilesDelete` requires Member+ per `can()` matrix.
- Audit metadata carries only `name_len` and `group_id` — never the raw file name (no PII in audit events).

## Test plan

- [x] 16 unit tests in `rest_v1::files::tests` — all green locally
- [x] `WorkspaceAuditAction::FileDeleted` test assertion in `garraia-auth` — green
- [x] `cargo check -p garraia-gateway` — clean
- [x] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` — clean
- [ ] CI: Format, Clippy, Test×3, Build, MSRV, cargo-deny, Security Audit, Coverage, CodeQL, Playwright, E2E, Secret Scan, Dependency Review

https://claude.ai/code/session_01Gqkq6352mMiJ2B79VCcKMf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gqkq6352mMiJ2B79VCcKMf)_