### PR TITLE
chore(sec): daily audit 2026-05-09 — fix stale paste entry + transposed advisory comments

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -34,7 +34,7 @@
 #     from BOTH files atomically. When GAR-455 closes (serenity 0.13 +
 #     aws-smithy upgrade), ALL 4 rustls-webpki IDs below MUST be
 #     dropped from BOTH files atomically.
-#   * The 23 unmaintained-only IDs in `deny.toml` (8 directly named +
+#   * The 22 unmaintained-only IDs in `deny.toml` (7 directly named +
 #     10 gtk-rs + 5 unic-*) are intentionally NOT mirrored here. Do not
 #     "fix" the asymmetry by mass-mirroring; that would change runtime
 #     behavior of `cargo audit`.

--- a/deny.toml
+++ b/deny.toml
@@ -15,8 +15,8 @@
 #     When the upstream blockers close, the IDs MUST be dropped from
 #     BOTH files atomically. (quinn-proto previously here was closed
 #     by GAR-457 on 2026-04-27.)
-#   * The 23 unmaintained-only IDs (8 directly named: daemonize,
-#     derivative, fxhash, instant, paste, proc-macro-error, async-std,
+#   * The 22 unmaintained-only IDs (7 directly named: daemonize,
+#     derivative, fxhash, instant, proc-macro-error, async-std,
 #     rustls-pemfile + 10× gtk-rs + 5× unic-*) are intentionally NOT
 #     mirrored in `audit.toml`. `cargo audit` auto-classifies them as
 #     "allowed warnings" and does NOT require explicit ignore.
@@ -67,7 +67,6 @@ ignore = [
     "RUSTSEC-2024-0388", # derivative (transitive via poise/serenity)
     "RUSTSEC-2025-0057", # fxhash (transitive via wasmtime)
     "RUSTSEC-2024-0384", # instant (transitive via notify)
-    "RUSTSEC-2024-0436", # paste (transitive via wasmtime)
     "RUSTSEC-2024-0370", # proc-macro-error (transitive, no maintained alt)
     "RUSTSEC-2025-0052", # async-std (via opentelemetry_sdk 0.26 → garraia-telemetry)
     # Added 2026-04-27 (PR #75 CI surfaced this — local cache was stale):
@@ -112,27 +111,27 @@ ignore = [
     # so runtime risk on Linux server deploys is zero, but `cargo deny` walks
     # the full lockfile. Upstream gtk-rs GTK3 bindings discontinued; GTK4
     # migration is a Tauri-side decision. Owner: epic GAR-430.
-    "RUSTSEC-2024-0411", # gdk
-    "RUSTSEC-2024-0412", # gdk-sys
+    "RUSTSEC-2024-0411", # gdkwayland-sys
+    "RUSTSEC-2024-0412", # gdk
     "RUSTSEC-2024-0413", # atk
-    "RUSTSEC-2024-0414", # atk-sys
-    "RUSTSEC-2024-0415", # gdkwayland-sys
-    "RUSTSEC-2024-0416", # gdkx11
-    "RUSTSEC-2024-0417", # gdkx11-sys
-    "RUSTSEC-2024-0418", # gtk
-    "RUSTSEC-2024-0419", # gtk-sys
-    "RUSTSEC-2024-0420", # gtk3-macros
+    "RUSTSEC-2024-0414", # gdkx11-sys
+    "RUSTSEC-2024-0415", # gtk
+    "RUSTSEC-2024-0416", # atk-sys
+    "RUSTSEC-2024-0417", # gdkx11
+    "RUSTSEC-2024-0418", # gdk-sys
+    "RUSTSEC-2024-0419", # gtk3-macros
+    "RUSTSEC-2024-0420", # gtk-sys
 
     # --- unic-* unmaintained — open-i18n/rust-unic discontinued (5 IDs) ---
     # Pulled via tauri-utils 2.8 → urlpattern 0.3 → unic-ucd-ident → unic-*.
     # Tauri 2.x uses urlpattern for permission scope matching; replacement
     # depends on a Tauri or urlpattern crate update. Owner: GAR-430.
     # Expires 2026-07-31.
-    "RUSTSEC-2025-0075", # unic-char-property
-    "RUSTSEC-2025-0080", # unic-char-range
-    "RUSTSEC-2025-0081", # unic-common
-    "RUSTSEC-2025-0098", # unic-ucd-ident
-    "RUSTSEC-2025-0100", # unic-ucd-version
+    "RUSTSEC-2025-0075", # unic-char-range
+    "RUSTSEC-2025-0080", # unic-common
+    "RUSTSEC-2025-0081", # unic-char-property
+    "RUSTSEC-2025-0098", # unic-ucd-version
+    "RUSTSEC-2025-0100", # unic-ucd-ident
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

Daily security/dependency audit — 2026-05-09 (America/New_York).

`cargo audit` found **22 warnings, 0 errors**. No new exploitable vulnerabilities. All suppressions in `audit.toml` remain valid and within their expiration windows. Three cosmetic hygiene issues were found in `deny.toml` and `audit.toml` and are fixed here:

- **Remove stale RUSTSEC-2024-0436 (`paste`)** from `deny.toml`: `paste` is no longer present in `Cargo.lock` (removed when wasmtime was bumped to 44.x in GAR-454). Confirmed by `grep -c "^name = \"paste\""` returning 0.
- **Correct 9 transposed gtk-rs comments** (RUSTSEC-2024-0411..0420): advisory IDs were all correct and will continue to suppress as before; only the inline `# crate-name` labels were shuffled. Verified against `cargo audit` output + advisory DB files.
- **Correct 5 transposed unic-* comments** (RUSTSEC-2025-0075, 0080, 0081, 0098, 0100): same situation — IDs correct, labels wrong.
- **Update SYNC NOTE count** 23→22 / 8→7 in both `deny.toml` and `.cargo/audit.toml` to reflect the removed `paste` entry.

## Verification

```
cargo audit --no-fetch
# warning: 22 allowed warnings found  ← unchanged
# 0 errors
```

## GitHub Dependabot Status (from push output)

GitHub reports **7 vulnerabilities (1 high, 2 moderate, 4 low)** on the default branch. These map exactly to the suppressed advisories already tracked in `audit.toml`:

| Advisory | Crate | Severity | Owner | Expires |
|---|---|---|---|---|
| RUSTSEC-2023-0071 | rsa 0.9.10 (Marvin Attack) | High | GAR-456 | 2026-07-31 |
| RUSTSEC-2026-0049 | rustls-webpki (CRL match) | Moderate | GAR-455 | 2026-07-31 |
| RUSTSEC-2026-0098 | rustls-webpki (URI constraints) | Moderate | GAR-455 | 2026-07-31 |
| RUSTSEC-2026-0099 | rustls-webpki (wildcard) | Low | GAR-455 | 2026-07-31 |
| RUSTSEC-2026-0104 | rustls-webpki (CRL panic) | Low | GAR-455 | 2026-07-31 |
| RUSTSEC-2024-0429 | glib (unsound iterator) | Low | GAR-513 | 2026-07-31 |
| RUSTSEC-2026-0002 | lru (stacked-borrows) | Low | GAR-513 | 2026-07-31 |

(rand RUSTSEC-2026-0097 may appear as the 7th depending on GitHub's classifier.)

No new advisories. No lockfile changes. No dependency version bumps. This is a documentation-only PR.

## Test plan

- [x] `cargo audit --no-fetch` — 22 warnings, 0 errors (unchanged)
- [x] No changes to `Cargo.lock` or `Cargo.toml` files
- [ ] CI: `cargo deny check advisories` should pass (RUSTSEC-2024-0436 was already absent from lockfile, so removing it from ignore list is safe)

https://claude.ai/code/session_01Rb42b4aNimtphhBiYDSSRr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rb42b4aNimtphhBiYDSSRr)_