### PR TITLE
feat(files): GAR-561 — Files REST API slice 4: PATCH folder rename (plan 0091)

### DIFF
--- a/crates/garraia-auth/src/audit_workspace.rs
+++ b/crates/garraia-auth/src/audit_workspace.rs
@@ -383,6 +383,20 @@ pub enum WorkspaceAuditAction {
     /// receipt-of-action ledger, not a full diff log, and the renamed row
     /// in `files` plus prior audit entries already reconstruct history.
     FileRenamed,
+
+    /// A folder was renamed via
+    /// `PATCH /v1/groups/{group_id}/folders/{folder_id}`
+    /// (plan 0091 / GAR-561, Fase 3.4 files slice 4).
+    ///
+    /// Emitted exactly once per successful 200 response. Not emitted on 4xx
+    /// (validation failure, soft-deleted target, cross-group, missing,
+    /// or 409 unique-name collision under the same parent).
+    /// `resource_type = "folders"`, `resource_id = "{folder_id}"`.
+    /// Metadata: `{ folder_id, group_id, name_len }` — `folder_id` is
+    /// duplicated alongside `resource_id` for log-search ergonomics
+    /// (consumers can filter on metadata.folder_id without parsing
+    /// resource_id). Never carries the raw folder name.
+    FolderRenamed,
 }
 
 impl WorkspaceAuditAction {
@@ -425,6 +439,7 @@ impl WorkspaceAuditAction {
             WorkspaceAuditAction::TaskMoved => "task.moved",
             WorkspaceAuditAction::FileDeleted => "file.deleted",
             WorkspaceAuditAction::FileRenamed => "file.renamed",
+            WorkspaceAuditAction::FolderRenamed => "folder.renamed",
         }
     }
 }
@@ -601,6 +616,10 @@ mod tests {
         assert_eq!(WorkspaceAuditAction::TaskMoved.as_str(), "task.moved");
         assert_eq!(WorkspaceAuditAction::FileDeleted.as_str(), "file.deleted");
         assert_eq!(WorkspaceAuditAction::FileRenamed.as_str(), "file.renamed");
+        assert_eq!(
+            WorkspaceAuditAction::FolderRenamed.as_str(),
+            "folder.renamed"
+        );
     }
 
     #[test]
@@ -640,6 +659,7 @@ mod tests {
             WorkspaceAuditAction::TaskSubscribed.as_str(),
             WorkspaceAuditAction::TaskUnsubscribed.as_str(),
             WorkspaceAuditAction::TaskMoved.as_str(),
+            WorkspaceAuditAction::FolderRenamed.as_str(),
         ];
         let unique: std::collections::HashSet<_> = strings.iter().collect();
         assert_eq!(unique.len(), strings.len(), "duplicate action strings");

--- a/crates/garraia-gateway/src/rest_v1/files.rs
+++ b/crates/garraia-gateway/src/rest_v1/files.rs
@@ -180,6 +180,20 @@ pub struct PatchFileRequest {
     pub name: String,
 }
 
+/// Body for `PATCH /v1/groups/{group_id}/folders/{folder_id}`
+/// (plan 0091, GAR-561).
+///
+/// Only `name` is mutable in slice 4. Extra keys are silently ignored
+/// per `serde::Deserialize` defaults — we only act on the fields we
+/// declare here. Folder moves (changing `parent_id`) are out of scope.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct PatchFolderRequest {
+    /// New folder name. Trimmed before validation. Length must be
+    /// 1..=200 chars after trim (matches DB CHECK on `folders.name`),
+    /// must not contain `/` or NUL byte.
+    pub name: String,
+}
+
 /// Validation error message family. Plain strings — never embed
 /// the offending value (it is user-controlled and may include PII).
 const ERR_NAME_EMPTY: &str = "name must not be empty after trim";
@@ -202,6 +216,36 @@ fn validate_file_name(raw: &str) -> Result<String, &'static str> {
     }
     if trimmed.contains('\0') {
         return Err(ERR_NAME_HAS_NUL);
+    }
+    Ok(trimmed.to_string())
+}
+
+// Folder validation has identical shape to file validation but a tighter
+// length cap (200 chars vs 500) — matches the DB CHECK on `folders.name`
+// at `migrations/003_files_and_folders.sql:59`. The only divergence
+// rationale: file names may legitimately encode long descriptive paths
+// inside the user's mental model (e.g. "2026-Q3 retrospective notes —
+// final v3.pdf"), while folder names tend to be short tags.
+const ERR_FOLDER_NAME_EMPTY: &str = "name must not be empty after trim";
+const ERR_FOLDER_NAME_TOO_LONG: &str = "name exceeds 200 characters";
+const ERR_FOLDER_NAME_HAS_SLASH: &str = "name must not contain '/'";
+const ERR_FOLDER_NAME_HAS_NUL: &str = "name must not contain NUL byte";
+
+/// Validate a candidate folder name. Returns the trimmed name on success
+/// or a user-safe error string on failure (no PII echoed).
+fn validate_folder_name(raw: &str) -> Result<String, &'static str> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(ERR_FOLDER_NAME_EMPTY);
+    }
+    if trimmed.chars().count() > 200 {
+        return Err(ERR_FOLDER_NAME_TOO_LONG);
+    }
+    if trimmed.contains('/') {
+        return Err(ERR_FOLDER_NAME_HAS_SLASH);
+    }
+    if trimmed.contains('\0') {
+        return Err(ERR_FOLDER_NAME_HAS_NUL);
     }
     Ok(trimmed.to_string())
 }
@@ -797,6 +841,126 @@ pub async fn get_folder(
     Ok(Json(FolderSummary::from(row)))
 }
 
+/// `PATCH /v1/groups/{group_id}/folders/{folder_id}` — rename a folder
+/// (plan 0091, GAR-561, Fase 3.4 files slice 4).
+///
+/// Only the `name` field may change. Returns the updated `FolderSummary`
+/// (200) on success.
+///
+/// Authz: `Action::FilesWrite`. The `can()` matrix already grants this to
+/// Owner/Admin/Member; no separate `FoldersWrite` action exists in the
+/// 22-action enum and folder mutations are intentionally gated by the
+/// same capability as file mutations (mirrors plan 0089).
+///
+/// Concurrency note: `folders_unique_name_per_parent_idx` enforces unique
+/// `(group_id, COALESCE(parent_id, nil_uuid), name)` for non-deleted rows.
+/// A rename to a name already taken by a sibling under the same parent
+/// raises Postgres `23505`, which this handler maps to `409 Conflict`
+/// with a PII-safe detail (no echo of the conflicting name). Without this
+/// branch the same condition would surface as 5xx — wrong UX for a
+/// user-recoverable error.
+///
+/// ## Error matrix
+///
+/// | Condition                                      | Status |
+/// |------------------------------------------------|--------|
+/// | Missing/invalid JWT                            | 401    |
+/// | Path group_id ≠ principal group_id             | 403    |
+/// | Caller lacks `FilesWrite`                      | 403    |
+/// | Body name empty/too long/has '/' or NUL        | 400    |
+/// | Folder not found, soft-deleted, or cross-group | 404    |
+/// | Name collides with sibling under same parent   | 409    |
+/// | Happy path                                     | 200    |
+#[utoipa::path(
+    patch,
+    path = "/v1/groups/{group_id}/folders/{folder_id}",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("folder_id" = Uuid, Path, description = "Folder UUID."),
+    ),
+    request_body = PatchFolderRequest,
+    responses(
+        (status = 200, description = "Folder renamed.", body = FolderSummary),
+        (status = 400, description = "Invalid name.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller lacks FilesWrite or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Folder not found, soft-deleted, or cross-group.", body = super::problem::ProblemDetails),
+        (status = 409, description = "A sibling folder under the same parent already uses this name.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn patch_folder(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, folder_id)): Path<(Uuid, Uuid)>,
+    Json(body): Json<PatchFolderRequest>,
+) -> Result<Json<FolderSummary>, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::FilesWrite) {
+        return Err(RestError::Forbidden);
+    }
+
+    let new_name =
+        validate_folder_name(&body.name).map_err(|msg| RestError::BadRequest(msg.into()))?;
+    let name_len = new_name.chars().count();
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    let update_result: Result<Option<FolderRow>, sqlx::Error> = sqlx::query_as(
+        "UPDATE folders \
+         SET name = $1, updated_at = now() \
+         WHERE id = $2 AND group_id = $3 AND deleted_at IS NULL \
+         RETURNING id, name, parent_id, created_by, created_by_label, \
+                   created_at, updated_at",
+    )
+    .bind(&new_name)
+    .bind(folder_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await;
+
+    let row = match update_result {
+        Ok(Some(r)) => r,
+        Ok(None) => return Err(RestError::NotFound),
+        Err(sqlx::Error::Database(ref db_err)) if db_err.code().as_deref() == Some("23505") => {
+            // UNIQUE collision on `folders_unique_name_per_parent_idx`.
+            // PII-safe detail: never echo the conflicting name back.
+            return Err(RestError::Conflict(
+                "a folder with this name already exists under the same parent".into(),
+            ));
+        }
+        Err(e) => return Err(RestError::Internal(e.into())),
+    };
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::FolderRenamed,
+        principal.user_id,
+        group_id,
+        "folders",
+        folder_id.to_string(),
+        json!({
+            "folder_id": folder_id,
+            "group_id": group_id,
+            "name_len": name_len,
+        }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(Json(FolderSummary::from(row)))
+}
+
 // ─── Unit tests ───────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -1076,6 +1240,60 @@ mod tests {
         // Multi-byte UTF-8 chars should count as chars, not bytes.
         let name = "café-relatório.pdf";
         let out = validate_file_name(name).expect("utf8");
+        assert_eq!(out, name);
+    }
+
+    // ─── PATCH folder validation helpers (plan 0091, GAR-561) ──────────
+
+    #[test]
+    fn validate_folder_name_happy_path_trims() {
+        let out = validate_folder_name("  Documents  ").expect("trim+accept");
+        assert_eq!(out, "Documents");
+    }
+
+    #[test]
+    fn validate_folder_name_rejects_empty_after_trim() {
+        let err = validate_folder_name("   ").expect_err("empty");
+        assert_eq!(err, ERR_FOLDER_NAME_EMPTY);
+    }
+
+    #[test]
+    fn validate_folder_name_rejects_zero_length() {
+        let err = validate_folder_name("").expect_err("empty literal");
+        assert_eq!(err, ERR_FOLDER_NAME_EMPTY);
+    }
+
+    #[test]
+    fn validate_folder_name_accepts_200_chars() {
+        // Boundary: exactly 200 chars passes (matches DB CHECK).
+        let name: String = "a".repeat(200);
+        let out = validate_folder_name(&name).expect("200 ok");
+        assert_eq!(out.chars().count(), 200);
+    }
+
+    #[test]
+    fn validate_folder_name_rejects_201_chars() {
+        let name: String = "a".repeat(201);
+        let err = validate_folder_name(&name).expect_err("too long");
+        assert_eq!(err, ERR_FOLDER_NAME_TOO_LONG);
+    }
+
+    #[test]
+    fn validate_folder_name_rejects_slash() {
+        let err = validate_folder_name("a/b").expect_err("slash");
+        assert_eq!(err, ERR_FOLDER_NAME_HAS_SLASH);
+    }
+
+    #[test]
+    fn validate_folder_name_rejects_nul_byte() {
+        let err = validate_folder_name("foo\0bar").expect_err("nul");
+        assert_eq!(err, ERR_FOLDER_NAME_HAS_NUL);
+    }
+
+    #[test]
+    fn validate_folder_name_accepts_unicode() {
+        let name = "Relatórios-2026";
+        let out = validate_folder_name(name).expect("utf8");
         assert_eq!(out, name);
     }
 

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -404,9 +404,10 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     get(files::get_file).patch(files::patch_file),
                 )
                 // Plan 0090 (GAR-559) — files API slice 3: GET single folder.
+                // Plan 0091 (GAR-561) — files API slice 4: PATCH folder rename.
                 .route(
                     "/v1/groups/{group_id}/folders/{folder_id}",
-                    get(files::get_folder),
+                    get(files::get_folder).patch(files::patch_folder),
                 )
                 .merge(rate_limited_routes)
                 .merge(tus_routes)
@@ -509,13 +510,14 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 .route("/v1/files/{file_id}", delete(unconfigured_handler))
                 // Plan 0089 (GAR-557) — files API slice 2 PATCH, fail-soft 503.
                 // Plan 0090 (GAR-559) — files API slice 3 GET single, fail-soft 503.
+                // Plan 0091 (GAR-561) — files API slice 4 PATCH folder, fail-soft 503.
                 .route(
                     "/v1/groups/{group_id}/files/{file_id}",
                     get(unconfigured_handler).patch(unconfigured_handler),
                 )
                 .route(
                     "/v1/groups/{group_id}/folders/{folder_id}",
-                    get(unconfigured_handler),
+                    get(unconfigured_handler).patch(unconfigured_handler),
                 )
                 .route(
                     "/v1/groups/{group_id}/tasks/{task_id}/comments",
@@ -655,13 +657,14 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 .route("/v1/files/{file_id}", delete(unconfigured_handler))
                 // Plan 0089 (GAR-557) — files API slice 2 PATCH, no-auth stub.
                 // Plan 0090 (GAR-559) — files API slice 3 GET single, no-auth stub.
+                // Plan 0091 (GAR-561) — files API slice 4 PATCH folder, no-auth stub.
                 .route(
                     "/v1/groups/{group_id}/files/{file_id}",
                     get(unconfigured_handler).patch(unconfigured_handler),
                 )
                 .route(
                     "/v1/groups/{group_id}/folders/{folder_id}",
-                    get(unconfigured_handler),
+                    get(unconfigured_handler).patch(unconfigured_handler),
                 )
                 .route(
                     "/v1/groups/{group_id}/tasks/{task_id}/comments",

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -16,6 +16,7 @@ use super::audit::{AuditEventSummary, ListAuditResponse};
 use super::chats::{ChatListResponse, ChatResponse, ChatSummary, CreateChatRequest};
 use super::files::{
     FileListResponse, FileSummary, FolderListResponse, FolderSummary, PatchFileRequest,
+    PatchFolderRequest,
 };
 use super::groups::{
     CreateGroupRequest, CreateInviteRequest, GroupReadResponse, GroupResponse, InviteResponse,
@@ -141,6 +142,7 @@ impl Modify for SecurityAddon {
         super::files::patch_file,
         super::files::get_file,
         super::files::get_folder,
+        super::files::patch_folder,
     ),
     components(schemas(
         MeResponse,
@@ -204,6 +206,7 @@ impl Modify for SecurityAddon {
         FolderSummary,
         FolderListResponse,
         PatchFileRequest,
+        PatchFolderRequest,
     )),
     modifiers(&SecurityAddon)
 )]

--- a/crates/garraia-gateway/tests/rest_v1_folders_patch.rs
+++ b/crates/garraia-gateway/tests/rest_v1_folders_patch.rs
@@ -1,0 +1,353 @@
+//! Integration tests for `PATCH /v1/groups/{group_id}/folders/{folder_id}`
+//! (plan 0091, GAR-561, Fase 3.4 files slice 4).
+//!
+//! All scenarios bundled into ONE `#[tokio::test]` function — same pattern
+//! as `rest_v1_files_patch.rs`/`rest_v1_chats.rs`/`rest_v1_groups.rs`.
+//! Splitting into multiple `#[tokio::test]`s historically triggered the
+//! sqlx runtime-teardown race documented in plan 0016 M3 commit `4f8be37`.
+//!
+//! Scenarios covered (8 total):
+//!
+//! F1. PATCH 200 — owner happy-path rename: asserts response shape, DB
+//!     `folders.name` updated, `audit_events` row with action=`folder.renamed`
+//!     and PII-safe metadata (`folder_id`, `group_id`, `name_len` only —
+//!     never `name`).
+//! F2. PATCH 404 — soft-deleted folder (`deleted_at IS NOT NULL`).
+//! F3. PATCH 404 — non-existent folder_id.
+//! F4. PATCH 400 — empty name (after trim).
+//! F5. PATCH 400 — name exceeding 200 chars (folders boundary, not 500).
+//! F6. PATCH 400 — name containing `/`.
+//! F7. PATCH 403 — path group_id ≠ principal group_id.
+//! F8. PATCH 409 — name collides with sibling under same parent
+//!     (`folders_unique_name_per_parent_idx` UNIQUE; new for slice 4 —
+//!     plan 0089 file rename did not need this branch).
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
+use chrono::Utc;
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use common::Harness;
+use common::fixtures::{fetch_audit_events_for_group, seed_user_with_group};
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("failed to collect response body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("response body is not JSON")
+}
+
+fn patch_folder_req(
+    token: Option<&str>,
+    path_group_id: &str,
+    folder_id: &str,
+    x_group_id: Option<&str>,
+    body: serde_json::Value,
+) -> Request<Body> {
+    let mut req = Request::builder()
+        .method("PATCH")
+        .uri(format!("/v1/groups/{path_group_id}/folders/{folder_id}"))
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .expect("request builder");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    if let Some(t) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {t}")).unwrap(),
+        );
+    }
+    if let Some(g) = x_group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    req
+}
+
+/// Insert one live `folders` row directly via the admin pool. Mirrors the
+/// schema in migration 003 — every NOT NULL column is supplied. `parent_id`
+/// is optional (`None` → root-level folder).
+async fn seed_folder(
+    h: &Harness,
+    group_id: Uuid,
+    parent_id: Option<Uuid>,
+    created_by: Uuid,
+    name: &str,
+) -> anyhow::Result<Uuid> {
+    let folder_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO folders (id, group_id, parent_id, name, \
+                              created_by, created_by_label) \
+         VALUES ($1, $2, $3, $4, $5, $6)",
+    )
+    .bind(folder_id)
+    .bind(group_id)
+    .bind(parent_id)
+    .bind(name)
+    .bind(created_by)
+    .bind("Test User")
+    .execute(&h.admin_pool)
+    .await?;
+    Ok(folder_id)
+}
+
+/// Soft-delete a folder directly via the admin pool. Used by F2.
+async fn soft_delete_folder(h: &Harness, folder_id: Uuid) -> anyhow::Result<()> {
+    sqlx::query("UPDATE folders SET deleted_at = $1 WHERE id = $2")
+        .bind(Utc::now())
+        .bind(folder_id)
+        .execute(&h.admin_pool)
+        .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn v1_folders_patch_scenarios() {
+    let h = Harness::get().await;
+
+    // Seed owner + group A — used by all F1..F8.
+    let (owner_id, group_id, owner_token) = seed_user_with_group(&h, "owner@folders-slice4.test")
+        .await
+        .expect("seed owner+group A");
+
+    let group_id_str = group_id.to_string();
+
+    // ── F1. PATCH 200 happy path ────────────────────────────────────
+    let live_id = seed_folder(&h, group_id, None, owner_id, "old-name")
+        .await
+        .expect("F1 seed folder");
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(patch_folder_req(
+            Some(&owner_token),
+            &group_id_str,
+            &live_id.to_string(),
+            Some(&group_id_str),
+            json!({ "name": "renamed-folder" }),
+        ))
+        .await
+        .expect("F1 oneshot");
+    assert_eq!(resp.status(), StatusCode::OK, "F1 status");
+    let v = body_json(resp).await;
+    assert_eq!(v["id"], live_id.to_string(), "F1 id");
+    assert_eq!(v["name"], "renamed-folder", "F1 name");
+    assert!(v["parent_id"].is_null(), "F1 parent_id null for root");
+
+    // F1 — verify DB row was actually updated.
+    let (db_name,): (String,) = sqlx::query_as("SELECT name FROM folders WHERE id = $1")
+        .bind(live_id)
+        .fetch_one(&h.admin_pool)
+        .await
+        .expect("F1 fetch db name");
+    assert_eq!(db_name, "renamed-folder", "F1 db name");
+
+    // F1 — audit row asserted (PII-safe metadata only).
+    let events = fetch_audit_events_for_group(&h, group_id)
+        .await
+        .expect("F1 fetch audit");
+    let rename_event = events
+        .iter()
+        .find(|(action, _, _, rid, _)| action == "folder.renamed" && rid == &live_id.to_string())
+        .expect("F1 folder.renamed audit row");
+    let (_, actor, resource_type, resource_id, metadata) = rename_event;
+    assert_eq!(actor.as_ref(), Some(&owner_id), "F1 audit actor");
+    assert_eq!(resource_type, "folders", "F1 audit resource_type");
+    assert_eq!(resource_id, &live_id.to_string(), "F1 audit resource_id");
+    // PII safety: only structural fields. `name` MUST NOT appear.
+    assert!(
+        metadata.get("name").is_none(),
+        "F1 audit MUST NOT carry raw folder name"
+    );
+    assert_eq!(
+        metadata["name_len"].as_u64(),
+        Some("renamed-folder".chars().count() as u64),
+        "F1 audit name_len"
+    );
+    assert_eq!(metadata["group_id"], group_id_str, "F1 audit group_id");
+    assert_eq!(
+        metadata["folder_id"],
+        live_id.to_string(),
+        "F1 audit folder_id"
+    );
+
+    // ── F2. PATCH 404 — soft-deleted folder ─────────────────────────
+    let dead_id = seed_folder(&h, group_id, None, owner_id, "to-be-deleted")
+        .await
+        .expect("F2 seed folder");
+    soft_delete_folder(&h, dead_id)
+        .await
+        .expect("F2 soft-delete");
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(patch_folder_req(
+            Some(&owner_token),
+            &group_id_str,
+            &dead_id.to_string(),
+            Some(&group_id_str),
+            json!({ "name": "ghost-folder" }),
+        ))
+        .await
+        .expect("F2 oneshot");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND, "F2 status");
+
+    // F2 — DB confirms name was NOT changed.
+    let (after_name,): (String,) = sqlx::query_as("SELECT name FROM folders WHERE id = $1")
+        .bind(dead_id)
+        .fetch_one(&h.admin_pool)
+        .await
+        .expect("F2 fetch db name");
+    assert_eq!(after_name, "to-be-deleted", "F2 name preserved");
+
+    // ── F3. PATCH 404 — non-existent folder_id ──────────────────────
+    let phantom = Uuid::new_v4();
+    let resp = h
+        .router
+        .clone()
+        .oneshot(patch_folder_req(
+            Some(&owner_token),
+            &group_id_str,
+            &phantom.to_string(),
+            Some(&group_id_str),
+            json!({ "name": "ghost" }),
+        ))
+        .await
+        .expect("F3 oneshot");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND, "F3 status");
+
+    // ── F4. PATCH 400 — empty name after trim ───────────────────────
+    let f4_id = seed_folder(&h, group_id, None, owner_id, "f4")
+        .await
+        .expect("F4 seed");
+    let resp = h
+        .router
+        .clone()
+        .oneshot(patch_folder_req(
+            Some(&owner_token),
+            &group_id_str,
+            &f4_id.to_string(),
+            Some(&group_id_str),
+            json!({ "name": "   " }),
+        ))
+        .await
+        .expect("F4 oneshot");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "F4 status");
+
+    // ── F5. PATCH 400 — name >200 chars ─────────────────────────────
+    let f5_id = seed_folder(&h, group_id, None, owner_id, "f5")
+        .await
+        .expect("F5 seed");
+    let too_long: String = "a".repeat(201);
+    let resp = h
+        .router
+        .clone()
+        .oneshot(patch_folder_req(
+            Some(&owner_token),
+            &group_id_str,
+            &f5_id.to_string(),
+            Some(&group_id_str),
+            json!({ "name": too_long }),
+        ))
+        .await
+        .expect("F5 oneshot");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "F5 status");
+
+    // ── F6. PATCH 400 — name with '/' ───────────────────────────────
+    let f6_id = seed_folder(&h, group_id, None, owner_id, "f6")
+        .await
+        .expect("F6 seed");
+    let resp = h
+        .router
+        .clone()
+        .oneshot(patch_folder_req(
+            Some(&owner_token),
+            &group_id_str,
+            &f6_id.to_string(),
+            Some(&group_id_str),
+            json!({ "name": "etc/passwd" }),
+        ))
+        .await
+        .expect("F6 oneshot");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "F6 status");
+
+    // ── F7. PATCH 403 — path group_id ≠ principal group_id ─────────
+    // X-Group-Id matches principal (A) so we get past require_group_id
+    // and check_group_match catches the path mismatch.
+    let other_group = Uuid::new_v4();
+    let f7_id = seed_folder(&h, group_id, None, owner_id, "f7")
+        .await
+        .expect("F7 seed");
+    let resp = h
+        .router
+        .clone()
+        .oneshot(patch_folder_req(
+            Some(&owner_token),
+            &other_group.to_string(),
+            &f7_id.to_string(),
+            Some(&group_id_str),
+            json!({ "name": "trying-cross-group" }),
+        ))
+        .await
+        .expect("F7 oneshot");
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN, "F7 status");
+
+    // ── F8. PATCH 409 — sibling unique-name collision ───────────────
+    // Seed two folders under the SAME parent (root). Try to rename
+    // f8_target to "f8-sibling" — the index
+    // `folders_unique_name_per_parent_idx UNIQUE (group_id,
+    // COALESCE(parent_id, nil_uuid), name) WHERE deleted_at IS NULL`
+    // raises 23505, which the handler maps to 409 Conflict.
+    let _f8_sibling = seed_folder(&h, group_id, None, owner_id, "f8-sibling")
+        .await
+        .expect("F8 seed sibling");
+    let f8_target = seed_folder(&h, group_id, None, owner_id, "f8-target")
+        .await
+        .expect("F8 seed target");
+    let resp = h
+        .router
+        .clone()
+        .oneshot(patch_folder_req(
+            Some(&owner_token),
+            &group_id_str,
+            &f8_target.to_string(),
+            Some(&group_id_str),
+            json!({ "name": "f8-sibling" }),
+        ))
+        .await
+        .expect("F8 oneshot");
+    assert_eq!(resp.status(), StatusCode::CONFLICT, "F8 status");
+
+    // F8 — DB confirms target name was NOT changed (rolled back).
+    let (after_name,): (String,) = sqlx::query_as("SELECT name FROM folders WHERE id = $1")
+        .bind(f8_target)
+        .fetch_one(&h.admin_pool)
+        .await
+        .expect("F8 fetch db name");
+    assert_eq!(after_name, "f8-target", "F8 name preserved");
+
+    // F8 — body MUST NOT echo the conflicting name (PII safety).
+    // (Handler returns a static string; this is a guardrail in case
+    // someone later edits the message to include the user-controlled name.)
+    let v = body_json(resp).await;
+    let detail = v["detail"].as_str().unwrap_or_default();
+    assert!(
+        !detail.contains("f8-sibling"),
+        "F8 conflict detail MUST NOT echo the conflicting name: {detail}"
+    );
+}

--- a/crates/garraia-gateway/tests/rest_v1_folders_patch.rs
+++ b/crates/garraia-gateway/tests/rest_v1_folders_patch.rs
@@ -1,3 +1,8 @@
+// Gated so `cargo clippy --all-targets` without `test-helpers` skips this
+// file and doesn't try to compile the `common` harness (which references
+// `JwtIssuer::new_for_test` and `issue_access_for_test`, both gated by
+// `garraia-auth/test-support`). Same pattern as `rest_v1_files_get_single.rs`.
+#![cfg(feature = "test-helpers")]
 //! Integration tests for `PATCH /v1/groups/{group_id}/folders/{folder_id}`
 //! (plan 0091, GAR-561, Fase 3.4 files slice 4).
 //!

--- a/plans/0091-gar-561-files-api-slice4-folder-rename.md
+++ b/plans/0091-gar-561-files-api-slice4-folder-rename.md
@@ -1,0 +1,183 @@
+# Plan 0091 — Files REST API slice 4: PATCH folder rename
+
+**GAR-561** · epic:ws-api · Fase 3.4 "Arquivos"
+**Branch:** `feat/gar-561-files-api-slice4-folder-rename`
+**Date:** 2026-05-09 (America/New_York)
+
+---
+
+## Goal
+
+Land slice 4 of the Files REST surface: a single endpoint that lets a member rename a folder inside their group.
+
+- `PATCH /v1/groups/{group_id}/folders/{folder_id}` — body `{ "name": "..." }` → 200 + updated `FolderSummary`
+
+Schema (`folders`) and FORCE RLS are already live (migration 003, GAR-387). Authz primitive `Action::FilesWrite` exists and is granted to Owner/Admin/Member (GAR-391c can() matrix, lines 38/63/106 of `garraia-auth/src/can.rs`). This slice adds:
+
+1. One new `WorkspaceAuditAction::FolderRenamed` variant (= `"folder.renamed"`).
+2. One handler `patch_folder` in `crates/garraia-gateway/src/rest_v1/files.rs` (extends, does not duplicate, the slice 1–3 module).
+3. One `.patch(...)` chained on the existing `/v1/groups/{group_id}/folders/{folder_id}` route in 3 router-build modes.
+4. One utoipa entry in `openapi.rs`.
+5. One integration test file `tests/rest_v1_folders_patch.rs`, single `#[tokio::test]` bundling 8 scenarios.
+
+**Rescope note.** GAR-561 was originally created with a wider declared scope (POST + PATCH + DELETE folder CRUD). This session ships PATCH only; folder POST + DELETE move to a follow-up issue (GAR-562 or sibling).
+
+---
+
+## Architecture
+
+```
+PATCH /v1/groups/{group_id}/folders/{folder_id}
+  → RestV1FullState → AppPool → garraia_app role
+  → require_group_id(principal) → 400 if X-Group-Id missing
+  → check_group_match(path_group_id, principal.group_id) → 403 mismatch
+  → can(principal, Action::FilesWrite) → 403 if denied
+  → validate_folder_name: trim → 1..=200 chars, reject '/', NUL → 400
+  → BEGIN
+    → SET LOCAL app.current_user_id / app.current_group_id (set_config)
+    → UPDATE folders SET name = $1, updated_at = now()
+        WHERE id = $2 AND group_id = $3 AND deleted_at IS NULL
+        RETURNING id, name, parent_id, created_by, created_by_label,
+                  created_at, updated_at
+    → 0 rows → return 404 (rolls back tx)
+    → on UniqueViolation (SQLSTATE 23505 from
+        folders_unique_name_per_parent_idx) → return 409 Conflict
+        with PII-safe detail (no echo of the conflicting name)
+    → audit_workspace_event(FolderRenamed,
+        metadata = { folder_id, group_id, name_len })
+  → COMMIT
+  ← 200 + FolderSummary (updated)
+```
+
+`name_len` is computed in characters (`name.chars().count()`) so multi-byte UTF-8 names report a stable count regardless of byte width. Pattern matches the `name_len` already emitted by `FileRenamed` (plan 0089). `folder_id` is duplicated alongside `resource_id` in the metadata for log-search ergonomics — consumers can filter on `metadata.folder_id` without parsing `resource_id`.
+
+---
+
+## Tech stack
+
+- **Rust / Axum 0.8** — `patch` route, `Path`, `Json`, `State`, `FromRequestParts`
+- **sqlx 0.8** — parameterized `query_as` over `Postgres`
+- **garraia-auth** — `Principal`, `can()`, `Action::FilesWrite`, `WorkspaceAuditAction::FolderRenamed` (NEW), `audit_workspace_event`
+- **utoipa** — `#[utoipa::path]` annotation for OpenAPI 3.1
+- **integration test** — same `Harness::get().await` + `seed_user_with_group` pattern as `tests/rest_v1_files_patch.rs`
+
+---
+
+## Design invariants
+
+1. **RLS dual-GUC**: SET LOCAL `app.current_user_id` AND `app.current_group_id` via `set_config($_, $1, true)` before the UPDATE (plan 0056 / 0088 / 0089 pattern reused via the `set_rls_context` already present in `files.rs`).
+2. **Group-ID cross-check**: path `{group_id}` must equal `principal.group_id`; mismatch → 403 (uses `check_group_match` already in `files.rs`).
+3. **No PII in audit metadata**: carry `folder_id`, `group_id`, and `name_len` — never the raw `name` (mirrors `FileRenamed` and the family-wide pattern from `ChatCreated`/`MemberCreated`).
+4. **Soft-deleted folders not renameable**: WHERE `deleted_at IS NULL` → 0 rows → 404. We do NOT distinguish "not in group" vs "deleted" vs "never existed" — RLS already filters cross-group, the explicit `group_id = $3` clause is belt-and-suspenders, and 404 is the same for all three cases (plan 0088 §"Out of scope" Q1 precedent).
+5. **Validation in app layer**: `name` 1..=200 chars (matches DB CHECK on `folders.name` at `migrations/003_files_and_folders.sql:59` — note: 200, not 500 like `files.name`), trimmed, rejecting `/` and NUL byte. The DB CHECK is the safety net; the app-layer 400 gives callers a precise error message instead of a generic `23514 check_violation`.
+6. **23505 → 409 Conflict.** `folders_unique_name_per_parent_idx UNIQUE (group_id, COALESCE(parent_id, nil_uuid), name) WHERE deleted_at IS NULL` (migration 003:88-90) means a rename to a sibling-already-using name raises Postgres `23505`. Plan 0089 file rename did NOT need this branch (files have no name UNIQUE). **Folder rename MUST catch and translate to 409 Conflict** with PII-safe body (no echo of conflicting name) — leaking 5xx for a user-recoverable conflict is wrong UX. This is the only handler-shape delta vs plan 0089.
+7. **No partial fields in this slice**: body MUST contain `name`. Other fields (`parent_id` for moves, `settings`) are out of scope and not deserialized — extra JSON keys are silently ignored by `serde::Deserialize` default behavior, but only `name` is read.
+
+---
+
+## Validações pré-plano
+
+- [x] `Action::FilesWrite` exists and is in the `can()` matrix for Owner/Admin/Member (`crates/garraia-auth/src/can.rs:38,67,106`)
+- [x] `set_rls_context` and `check_group_match` helpers already present in `files.rs` (slice 1)
+- [x] `audit_workspace_event` is the public API for inserting `audit_events` rows
+- [x] `folders.name` DB CHECK is `length(name) BETWEEN 1 AND 200` (`crates/garraia-workspace/migrations/003_files_and_folders.sql:59`)
+- [x] `folders` has `updated_at` column and FORCE RLS via `app.current_group_id`
+- [x] `folders_unique_name_per_parent_idx` covers (group_id, COALESCE(parent_id, nil_uuid), name) where deleted_at IS NULL (`migrations/003_files_and_folders.sql:88-90`)
+- [x] `RestError::Conflict(String)` already maps to 409 (`rest_v1/problem.rs:50,95,112`)
+- [x] 23505 mapping pattern verified against existing handlers (`groups.rs:755`, `invites.rs:269`, `messages.rs:614`)
+- [x] No existing `rest_v1_folders*` integration test — bootstrap a fresh `tests/rest_v1_folders_patch.rs`
+
+---
+
+## Out of scope
+
+- Create folder (`POST /v1/groups/{group_id}/folders`) — needs same-group `parent_id` validation + cycle protection + initial-name UNIQUE handling. Move to GAR-562 / slice 5.
+- Soft-delete folder (`DELETE /v1/groups/{group_id}/folders/{folder_id}`) — needs cascade semantics (subfolders? files inside?). Move to GAR-562 / slice 5.
+- Move folder (`parent_id` mutation) — needs cross-group destination validation + cycle protection. Slice 6+.
+- Cascading soft-delete of children files / subfolders.
+- Hard delete / restore from trash (deferred indefinitely).
+
+---
+
+## Rollback
+
+This slice is handler + audit-enum + 1 test file + 1 doc file. Rolling back =
+revert the squash commit; no DB migration changes. The `FolderRenamed`
+enum variant is additive — removing it later only matters if any
+audit consumer dispatched on it (none today).
+
+---
+
+## File structure
+
+```
+crates/garraia-auth/src/
+  audit_workspace.rs                 ← ADD FolderRenamed variant + as_str arm + 2 unit-test entries
+crates/garraia-gateway/src/rest_v1/
+  files.rs                           ← ADD PatchFolderRequest DTO + ERR_FOLDER_* consts + validate_folder_name + patch_folder handler + 8 unit tests
+  mod.rs                             ← chain .patch(files::patch_folder) on /v1/groups/{group_id}/folders/{folder_id} in 3 build modes
+  openapi.rs                         ← ADD PatchFolderRequest import + super::files::patch_folder path + PatchFolderRequest schema entry
+crates/garraia-gateway/tests/
+  rest_v1_folders_patch.rs           ← NEW — single #[tokio::test] with 8 scenarios
+plans/
+  0091-gar-561-files-api-slice4-folder-rename.md   ← NEW (this file)
+  README.md                          ← + row 0091
+```
+
+No migrations.
+
+---
+
+## Integration scenarios
+
+Bundled into one `#[tokio::test] async fn v1_folders_patch_scenarios()` to avoid the sqlx runtime-teardown race (plan 0016 M3 commit `4f8be37`).
+
+| # | Description | Expected |
+|---|-------------|----------|
+| F1 | Owner renames live folder (happy path) | 200 + name updated + audit row `folder.renamed` with `{folder_id, group_id, name_len}` and NO `name` key |
+| F2 | Owner renames soft-deleted folder | 404; DB name preserved |
+| F3 | Owner renames folder_id that does not exist | 404 |
+| F4 | Empty name (after trim) | 400 |
+| F5 | Name exceeding 200 chars | 400 (boundary: 200 chars OK, 201 fails) |
+| F6 | Name containing `/` | 400 |
+| F7 | Path `group_id` ≠ principal group_id | 403 |
+| F8 | Rename collides with sibling under same parent (UNIQUE) | 409 Conflict; DB name preserved; body MUST NOT echo the conflicting name |
+
+`401 missing bearer` is covered by router-level middleware (already validated in `rest_v1_chats.rs` C4); not duplicated here. NUL-byte rejection is exercised by `validate_folder_name_rejects_nul_byte` unit test in `files::tests`.
+
+---
+
+## Verification
+
+End-to-end:
+
+1. `cargo fmt --check`
+2. `cargo check -p garraia-auth -p garraia-gateway`
+3. `cargo check -p garraia-gateway --tests --features garraia-gateway/test-helpers`
+4. `cargo clippy -p garraia-auth -p garraia-gateway --tests --features garraia-gateway/test-helpers --no-deps -- -D warnings`
+5. `cargo test -p garraia-auth audit_workspace` (3 unit tests including new `FolderRenamed.as_str` assertion + `distinct_strings` entry)
+6. `cargo test -p garraia-gateway --lib rest_v1::files::tests` (existing 18 + new 8 = 26 unit tests)
+7. `cargo test -p garraia-gateway --test rest_v1_folders_patch --features garraia-gateway/test-helpers` (8 scenarios, requires Postgres harness)
+8. `cargo audit --no-fetch` — 22 warnings, 0 errors (unchanged baseline)
+9. `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok
+
+---
+
+## Regras absolutas
+
+| Regra | Aplicação |
+|-------|-----------|
+| Zero unwrap em prod | handler usa `?` propagation; tests podem usar `.expect("…")` |
+| Só queries parametrizadas | `sqlx::query_as` com `.bind` |
+| PII out of audit | metadata só carrega `folder_id`, `group_id`, `name_len` (usize) — nunca o raw name |
+| RLS forçada em todas leituras de tenant | `set_rls_context` antes do UPDATE |
+| Documentar por que não é apenas RLS | §Design invariants 4 explica o belt-and-suspenders WHERE |
+| 23505 nunca vira 5xx | §Design invariants 6 + handler match arm explícito |
+
+---
+
+## Próximos slices possíveis (não-bloqueantes)
+
+- **slice 5** — `POST /v1/groups/{group_id}/folders` (create folder) + `DELETE /v1/groups/{group_id}/folders/{folder_id}` (soft-delete folder). GAR-562.
+- **slice 6** — `POST /v1/groups/{group_id}/folders/{folder_id}/move` (move between parents).
+- **slice 7** — version mgmt (`POST /v1/files/{file_id}/versions`, `GET versions`, `download`).

--- a/plans/README.md
+++ b/plans/README.md
@@ -114,6 +114,7 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0088 | [GAR-555 — Files REST API slice 1: GET files + GET folders + DELETE file](0088-gar-555-files-api-slice1.md) | [GAR-555](https://linear.app/chatgpt25/issue/GAR-555) | ✅ Merged 2026-05-09 via PR #235 (`75d7a44`) |
 | 0089 | [GAR-557 — Files REST API slice 2: PATCH /v1/groups/{group_id}/files/{file_id} (rename)](0089-gar-557-files-api-slice2-rename.md) | [GAR-557](https://linear.app/chatgpt25/issue/GAR-557) | ✅ Merged 2026-05-09 via PR #238 (`9255515`) |
 | 0090 | [GAR-559 — Files REST API slice 3: GET single file + folder](0090-gar-559-files-api-slice3-get-single.md) | [GAR-559](https://linear.app/chatgpt25/issue/GAR-559) | ✅ Merged 2026-05-09 via PR #242 (`4adcb02`) |
+| 0091 | [GAR-561 — Files REST API slice 4: PATCH folder rename](0091-gar-561-files-api-slice4-folder-rename.md) | [GAR-561](https://linear.app/chatgpt25/issue/GAR-561) | 🟡 Ready for Review (PR open, awaiting approval). Slice 4 rescoped to PATCH-only; folder POST + DELETE deferred to GAR-562. |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

- New endpoint: `PATCH /v1/groups/{group_id}/folders/{folder_id}` (folder rename) → 200 + `FolderSummary`.
- Mirrors plan 0089 (file rename) with three deltas: max length **200** chars (vs 500), `WorkspaceAuditAction::FolderRenamed` audit variant, and **23505 → 409 Conflict** mapping for the `folders_unique_name_per_parent_idx` UNIQUE index (file rename did not need this branch).
- 8 integration scenarios + 8 new unit tests for the validator.
- 0 new dependencies, 0 migrations, no `Cargo.lock` churn.

**Rescope note:** GAR-561 was originally created with a wider declared scope (POST + PATCH + DELETE folder CRUD). This session ships **PATCH only**; folder POST + DELETE move to a follow-up issue (GAR-562 / sibling) — keeps this PR small, revisable, and free of folder-tree-mutation semantics not yet pinned down.

## What changed

- `garraia-auth/src/audit_workspace.rs` — `+` `WorkspaceAuditAction::FolderRenamed` variant + `as_str` arm + entries in `as_str_stable` and `distinct_strings` tests.
- `garraia-gateway/src/rest_v1/files.rs` — `+` `PatchFolderRequest` DTO, `ERR_FOLDER_NAME_*` consts, `validate_folder_name` (max 200), `patch_folder` handler with 23505 catch, +8 unit tests for the validator.
- `garraia-gateway/src/rest_v1/mod.rs` — chain `.patch(files::patch_folder)` on `/v1/groups/{group_id}/folders/{folder_id}` in the **3 router-build modes** (handlers / unconfigured / no-auth stub).
- `garraia-gateway/src/rest_v1/openapi.rs` — `+` `PatchFolderRequest` import + `super::files::patch_folder` path entry + `PatchFolderRequest` schema.
- `crates/garraia-gateway/tests/rest_v1_folders_patch.rs` — **NEW**, single `#[tokio::test]` bundling 8 scenarios.
- `plans/0091-gar-561-files-api-slice4-folder-rename.md` — **NEW**.
- `plans/README.md` — `+` row 0091 (status `🟡 Ready for Review`, not merged).

## Security impact

- `Action::FilesWrite` gate via central `can()` matrix — Owner/Admin/Member only (matrix unchanged).
- RLS via `set_config` dual GUC (`app.current_user_id` + `app.current_group_id`) before the `UPDATE`.
- `WHERE id=$1 AND group_id=$2 AND deleted_at IS NULL` — soft-deleted folders are invisible (404).
- All queries parameterized via `sqlx::query_as` + `.bind`. Zero string concat.
- Audit metadata is **structurally PII-safe**: `{ folder_id, group_id, name_len }` only. F1 asserts `metadata` has NO `name` key.
- 23505 (UNIQUE collision) translated to 409 with a static body — F8 asserts the conflicting name does not appear in the response detail.
- Zero `unwrap`/`expect` in production code (handler uses `?` propagation).

## Test plan

- [x] `cargo fmt --check --all` — clean
- [x] `cargo check -p garraia-auth -p garraia-gateway` — clean
- [x] `cargo check -p garraia-gateway --tests --features garraia-gateway/test-helpers` — clean
- [x] `cargo clippy -p garraia-auth -p garraia-gateway --tests --features garraia-gateway/test-helpers --no-deps -- -D warnings` — 0 warnings
- [x] `cargo test -p garraia-auth audit_workspace` — 3/3 pass (incl. new `FolderRenamed.as_str` + `distinct_strings` entry)
- [x] `cargo test -p garraia-gateway --lib rest_v1::files::tests::validate` — 16/16 pass (8 file + 8 folder validators)
- [x] `cargo audit --no-fetch` — 22 allowed warnings (unchanged baseline), 0 errors
- [x] `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok
- [ ] CI 18/18 green (in flight)
- [ ] CodeQL green (in flight)
- [ ] Quality Ratchet (report-only) green (in flight)

## Integration scenarios (`tests/rest_v1_folders_patch.rs`)

| # | Description | Expected |
|---|-------------|----------|
| F1 | Owner renames live folder (happy path) | 200 + name updated in DB + `audit_events` row `folder.renamed` with `{folder_id, group_id, name_len}` and **NO** raw `name` |
| F2 | Owner renames soft-deleted folder | 404; DB name preserved |
| F3 | Owner renames non-existent folder_id | 404 |
| F4 | Empty name after trim | 400 |
| F5 | Name 201 chars (boundary: 200 OK, 201 fails) | 400 |
| F6 | Name with `/` | 400 |
| F7 | Path `group_id` ≠ principal group_id | 403 |
| F8 | Rename collides with sibling under same parent | **409 Conflict**; DB name preserved; body MUST NOT echo conflicting name |

`401 missing bearer` is covered by router-level middleware (already validated in `rest_v1_chats.rs` C4); not duplicated. NUL-byte rejection is covered by `validate_folder_name_rejects_nul_byte` unit test.

## Linear

- [GAR-561](https://linear.app/chatgpt25/issue/GAR-561) — rescoped to PATCH-only this session.
- GAR-562 (folder POST + DELETE) — to be opened as follow-up after dedup search in Linear.

## Plan

- `plans/0091-gar-561-files-api-slice4-folder-rename.md` (new, lands with this PR).

## Out of scope

- `POST /v1/groups/{group_id}/folders` (create folder).
- `DELETE /v1/groups/{group_id}/folders/{folder_id}` (soft-delete folder).
- Move folder (mutate `parent_id`).
- Cascading soft-delete of children files/subfolders.
- ROADMAP §"Arquivos" line will be added in a follow-up doc-only PR after merge (per session convention).

## Rollback

Revert the squash commit. No DB migrations to roll back. The `FolderRenamed` enum variant is additive — removing it later only matters if any audit consumer dispatched on it (none today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)