### PR TITLE
feat(files): GAR-562 — Files REST API slice 5: folder POST + DELETE (plan 0092)

### DIFF
--- a/crates/garraia-auth/src/audit_workspace.rs
+++ b/crates/garraia-auth/src/audit_workspace.rs
@@ -397,6 +397,26 @@ pub enum WorkspaceAuditAction {
     /// (consumers can filter on metadata.folder_id without parsing
     /// resource_id). Never carries the raw folder name.
     FolderRenamed,
+
+    /// A folder was created via
+    /// `POST /v1/groups/{group_id}/folders`
+    /// (plan 0092 / GAR-562, Fase 3.4 files slice 5).
+    ///
+    /// `resource_type = "folders"`, `resource_id = "{folder_id}"`.
+    /// Metadata: `{ folder_id, group_id, name_len, has_parent }`.
+    /// `has_parent` is a boolean flag — never carries the raw name or
+    /// parent path.
+    FolderCreated,
+
+    /// A folder was soft-deleted via
+    /// `DELETE /v1/groups/{group_id}/folders/{folder_id}`
+    /// (plan 0092 / GAR-562, Fase 3.4 files slice 5).
+    ///
+    /// Emitted only when `deleted_at` transitions from NULL (first
+    /// soft-delete). Already-deleted folders return 204 without emitting.
+    /// `resource_type = "folders"`, `resource_id = "{folder_id}"`.
+    /// Metadata: `{ folder_id, group_id, name_len }` — never the raw name.
+    FolderDeleted,
 }
 
 impl WorkspaceAuditAction {
@@ -440,6 +460,8 @@ impl WorkspaceAuditAction {
             WorkspaceAuditAction::FileDeleted => "file.deleted",
             WorkspaceAuditAction::FileRenamed => "file.renamed",
             WorkspaceAuditAction::FolderRenamed => "folder.renamed",
+            WorkspaceAuditAction::FolderCreated => "folder.created",
+            WorkspaceAuditAction::FolderDeleted => "folder.deleted",
         }
     }
 }
@@ -620,6 +642,14 @@ mod tests {
             WorkspaceAuditAction::FolderRenamed.as_str(),
             "folder.renamed"
         );
+        assert_eq!(
+            WorkspaceAuditAction::FolderCreated.as_str(),
+            "folder.created"
+        );
+        assert_eq!(
+            WorkspaceAuditAction::FolderDeleted.as_str(),
+            "folder.deleted"
+        );
     }
 
     #[test]
@@ -660,6 +690,8 @@ mod tests {
             WorkspaceAuditAction::TaskUnsubscribed.as_str(),
             WorkspaceAuditAction::TaskMoved.as_str(),
             WorkspaceAuditAction::FolderRenamed.as_str(),
+            WorkspaceAuditAction::FolderCreated.as_str(),
+            WorkspaceAuditAction::FolderDeleted.as_str(),
         ];
         let unique: std::collections::HashSet<_> = strings.iter().collect();
         assert_eq!(unique.len(), strings.len(), "duplicate action strings");

--- a/crates/garraia-gateway/src/rest_v1/files.rs
+++ b/crates/garraia-gateway/src/rest_v1/files.rs
@@ -180,6 +180,22 @@ pub struct PatchFileRequest {
     pub name: String,
 }
 
+/// Body for `POST /v1/groups/{group_id}/folders` (plan 0092, GAR-562).
+///
+/// `parent_id` is optional — omit (or `null`) for a root-level folder.
+/// If set, the parent must exist in the same group and must not be
+/// soft-deleted; a 400 is returned when the constraint is violated.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct CreateFolderRequest {
+    /// Folder name. Trimmed before validation. Length must be 1..=200
+    /// chars after trim (matches DB CHECK on `folders.name`), must not
+    /// contain `/` or NUL byte.
+    pub name: String,
+    /// Optional parent folder UUID. `null` (or omitted) means root-level.
+    #[serde(default)]
+    pub parent_id: Option<Uuid>,
+}
+
 /// Body for `PATCH /v1/groups/{group_id}/folders/{folder_id}`
 /// (plan 0091, GAR-561).
 ///
@@ -959,6 +975,239 @@ pub async fn patch_folder(
         .map_err(|e| RestError::Internal(e.into()))?;
 
     Ok(Json(FolderSummary::from(row)))
+}
+
+/// `POST /v1/groups/{group_id}/folders` — create a folder (plan 0092, GAR-562).
+///
+/// | Condition                                      | Status |
+/// |------------------------------------------------|--------|
+/// | Auth missing / invalid                         | 401    |
+/// | Principal group_id ≠ path group_id             | 403    |
+/// | Caller lacks FilesWrite                        | 403    |
+/// | Invalid name (empty/long/slash/NUL)            | 400    |
+/// | `parent_id` not found or soft-deleted in group | 400    |
+/// | Name collision under same parent               | 409    |
+/// | Happy path                                     | 201    |
+#[utoipa::path(
+    post,
+    path = "/v1/groups/{group_id}/folders",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+    ),
+    request_body = CreateFolderRequest,
+    responses(
+        (status = 201, description = "Folder created.", body = FolderSummary),
+        (status = 400, description = "Invalid name or unknown parent_id.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller lacks FilesWrite or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 409, description = "A sibling folder under the same parent already uses this name.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn create_folder(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(path_group_id): Path<Uuid>,
+    Json(body): Json<CreateFolderRequest>,
+) -> Result<(StatusCode, Json<FolderSummary>), RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::FilesWrite) {
+        return Err(RestError::Forbidden);
+    }
+
+    let name = validate_folder_name(&body.name).map_err(|msg| RestError::BadRequest(msg.into()))?;
+    let name_len = name.chars().count();
+    let has_parent = body.parent_id.is_some();
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Validate parent_id belongs to the same group and is not soft-deleted.
+    if let Some(parent_id) = body.parent_id {
+        let exists: Option<(Uuid,)> = sqlx::query_as(
+            "SELECT id FROM folders \
+             WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+        )
+        .bind(parent_id)
+        .bind(group_id)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+        if exists.is_none() {
+            return Err(RestError::BadRequest(
+                "parent_id not found or soft-deleted in this group".into(),
+            ));
+        }
+    }
+
+    // Resolve created_by_label from the users table within the same transaction.
+    let (created_by_label,): (String,) =
+        sqlx::query_as("SELECT display_name FROM users WHERE id = $1")
+            .bind(principal.user_id)
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(|e| RestError::Internal(e.into()))?;
+
+    let folder_id = Uuid::new_v4();
+
+    let insert_result: Result<FolderRow, sqlx::Error> = sqlx::query_as(
+        "INSERT INTO folders \
+             (id, group_id, parent_id, name, created_by, created_by_label) \
+         VALUES ($1, $2, $3, $4, $5, $6) \
+         RETURNING id, name, parent_id, created_by, created_by_label, \
+                   created_at, updated_at",
+    )
+    .bind(folder_id)
+    .bind(group_id)
+    .bind(body.parent_id)
+    .bind(&name)
+    .bind(principal.user_id)
+    .bind(&created_by_label)
+    .fetch_one(&mut *tx)
+    .await;
+
+    let row = match insert_result {
+        Ok(r) => r,
+        Err(sqlx::Error::Database(ref db_err)) if db_err.code().as_deref() == Some("23505") => {
+            return Err(RestError::Conflict(
+                "a folder with this name already exists under the same parent".into(),
+            ));
+        }
+        Err(e) => return Err(RestError::Internal(e.into())),
+    };
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::FolderCreated,
+        principal.user_id,
+        group_id,
+        "folders",
+        folder_id.to_string(),
+        json!({
+            "folder_id": folder_id,
+            "group_id": group_id,
+            "name_len": name_len,
+            "has_parent": has_parent,
+        }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok((StatusCode::CREATED, Json(FolderSummary::from(row))))
+}
+
+/// `DELETE /v1/groups/{group_id}/folders/{folder_id}` — soft-delete a folder
+/// (plan 0092, GAR-562).
+///
+/// Idempotent: already-deleted folders return 204 without emitting an audit
+/// event (mirrors `DELETE /v1/files/{file_id}` from plan 0088). Children
+/// files and sub-folders are NOT cascade-deleted — they become orphans
+/// visible at the group root. Cascade semantics are deferred to slice 6+.
+///
+/// | Condition                                      | Status |
+/// |------------------------------------------------|--------|
+/// | Auth missing / invalid                         | 401    |
+/// | Principal group_id ≠ path group_id             | 403    |
+/// | Caller lacks FilesWrite                        | 403    |
+/// | Folder not found or cross-group                | 404    |
+/// | Already deleted (idempotent)                   | 204    |
+/// | Happy path (live folder deleted)               | 204    |
+#[utoipa::path(
+    delete,
+    path = "/v1/groups/{group_id}/folders/{folder_id}",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("folder_id" = Uuid, Path, description = "Folder UUID."),
+    ),
+    responses(
+        (status = 204, description = "Folder deleted (or already deleted)."),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller lacks FilesWrite or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Folder not found or cross-group.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn delete_folder(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, folder_id)): Path<(Uuid, Uuid)>,
+) -> Result<StatusCode, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::FilesWrite) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Fetch the folder regardless of deleted_at to distinguish:
+    //   - not found / cross-group (0 rows) → 404
+    //   - already deleted                  → 204 idempotent, no audit
+    //   - live folder                      → UPDATE + audit + 204
+    let existing: Option<(Option<DateTime<Utc>>, String)> =
+        sqlx::query_as("SELECT deleted_at, name FROM folders WHERE id = $1 AND group_id = $2")
+            .bind(folder_id)
+            .bind(group_id)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(|e| RestError::Internal(e.into()))?;
+
+    let (deleted_at, name) = match existing {
+        Some(row) => row,
+        None => return Err(RestError::NotFound),
+    };
+
+    if deleted_at.is_some() {
+        tx.commit()
+            .await
+            .map_err(|e| RestError::Internal(e.into()))?;
+        return Ok(StatusCode::NO_CONTENT);
+    }
+
+    let name_len = name.chars().count();
+
+    sqlx::query("UPDATE folders SET deleted_at = now() WHERE id = $1 AND deleted_at IS NULL")
+        .bind(folder_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::FolderDeleted,
+        principal.user_id,
+        group_id,
+        "folders",
+        folder_id.to_string(),
+        json!({
+            "folder_id": folder_id,
+            "group_id": group_id,
+            "name_len": name_len,
+        }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(StatusCode::NO_CONTENT)
 }
 
 // ─── Unit tests ───────────────────────────────────────────────────────────────

--- a/crates/garraia-gateway/src/rest_v1/files.rs
+++ b/crates/garraia-gateway/src/rest_v1/files.rs
@@ -1114,11 +1114,18 @@ pub async fn create_folder(
 /// files and sub-folders are NOT cascade-deleted — they become orphans
 /// visible at the group root. Cascade semantics are deferred to slice 6+.
 ///
+/// Authz: `Action::FilesDelete` — same gate as `DELETE /v1/files/{file_id}`
+/// (plan 0088). The `can()` matrix grants this only to Owner/Admin (NOT
+/// Member), which is the canonical project convention for destructive
+/// file/folder operations: `FilesWrite` is for create/rename mutations
+/// that are reversible (PATCH rename can be undone, soft-deleted folders
+/// require Admin to delete).
+///
 /// | Condition                                      | Status |
 /// |------------------------------------------------|--------|
 /// | Auth missing / invalid                         | 401    |
 /// | Principal group_id ≠ path group_id             | 403    |
-/// | Caller lacks FilesWrite                        | 403    |
+/// | Caller lacks `FilesDelete` (e.g. Member role)  | 403    |
 /// | Folder not found or cross-group                | 404    |
 /// | Already deleted (idempotent)                   | 204    |
 /// | Happy path (live folder deleted)               | 204    |
@@ -1132,7 +1139,7 @@ pub async fn create_folder(
     responses(
         (status = 204, description = "Folder deleted (or already deleted)."),
         (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
-        (status = 403, description = "Caller lacks FilesWrite or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller lacks FilesDelete or group mismatch.", body = super::problem::ProblemDetails),
         (status = 404, description = "Folder not found or cross-group.", body = super::problem::ProblemDetails),
     ),
     security(("bearer" = []))
@@ -1144,7 +1151,7 @@ pub async fn delete_folder(
 ) -> Result<StatusCode, RestError> {
     let group_id = require_group_id(&principal)?;
     check_group_match(path_group_id, group_id)?;
-    if !can(&principal, Action::FilesWrite) {
+    if !can(&principal, Action::FilesDelete) {
         return Err(RestError::Forbidden);
     }
 

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -394,8 +394,12 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 // Plan 0084 (GAR-549) — search API slice 1.
                 .route("/v1/search", get(search::search))
                 // Plan 0088 (GAR-555) — files API slice 1.
+                // Plan 0092 (GAR-562) — files API slice 5: POST folder.
                 .route("/v1/groups/{group_id}/files", get(files::list_files))
-                .route("/v1/groups/{group_id}/folders", get(files::list_folders))
+                .route(
+                    "/v1/groups/{group_id}/folders",
+                    get(files::list_folders).post(files::create_folder),
+                )
                 .route("/v1/files/{file_id}", delete(files::delete_file))
                 // Plan 0089 (GAR-557) — files API slice 2: rename.
                 // Plan 0090 (GAR-559) — files API slice 3: GET single file.
@@ -405,9 +409,12 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 )
                 // Plan 0090 (GAR-559) — files API slice 3: GET single folder.
                 // Plan 0091 (GAR-561) — files API slice 4: PATCH folder rename.
+                // Plan 0092 (GAR-562) — files API slice 5: DELETE folder.
                 .route(
                     "/v1/groups/{group_id}/folders/{folder_id}",
-                    get(files::get_folder).patch(files::patch_folder),
+                    get(files::get_folder)
+                        .patch(files::patch_folder)
+                        .delete(files::delete_folder),
                 )
                 .merge(rate_limited_routes)
                 .merge(tus_routes)
@@ -505,19 +512,26 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 // Plan 0084 (GAR-549) — search API slice 1, fail-soft 503.
                 .route("/v1/search", get(unconfigured_handler))
                 // Plan 0088 (GAR-555) — files API slice 1, fail-soft 503.
+                // Plan 0092 (GAR-562) — files API slice 5: POST folder, fail-soft 503.
                 .route("/v1/groups/{group_id}/files", get(unconfigured_handler))
-                .route("/v1/groups/{group_id}/folders", get(unconfigured_handler))
+                .route(
+                    "/v1/groups/{group_id}/folders",
+                    get(unconfigured_handler).post(unconfigured_handler),
+                )
                 .route("/v1/files/{file_id}", delete(unconfigured_handler))
                 // Plan 0089 (GAR-557) — files API slice 2 PATCH, fail-soft 503.
                 // Plan 0090 (GAR-559) — files API slice 3 GET single, fail-soft 503.
                 // Plan 0091 (GAR-561) — files API slice 4 PATCH folder, fail-soft 503.
+                // Plan 0092 (GAR-562) — files API slice 5: DELETE folder, fail-soft 503.
                 .route(
                     "/v1/groups/{group_id}/files/{file_id}",
                     get(unconfigured_handler).patch(unconfigured_handler),
                 )
                 .route(
                     "/v1/groups/{group_id}/folders/{folder_id}",
-                    get(unconfigured_handler).patch(unconfigured_handler),
+                    get(unconfigured_handler)
+                        .patch(unconfigured_handler)
+                        .delete(unconfigured_handler),
                 )
                 .route(
                     "/v1/groups/{group_id}/tasks/{task_id}/comments",
@@ -652,19 +666,26 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 // Plan 0084 (GAR-549) — search API slice 1, no-auth stub.
                 .route("/v1/search", get(unconfigured_handler))
                 // Plan 0088 (GAR-555) — files API slice 1, no-auth stub.
+                // Plan 0092 (GAR-562) — files API slice 5: POST folder, no-auth stub.
                 .route("/v1/groups/{group_id}/files", get(unconfigured_handler))
-                .route("/v1/groups/{group_id}/folders", get(unconfigured_handler))
+                .route(
+                    "/v1/groups/{group_id}/folders",
+                    get(unconfigured_handler).post(unconfigured_handler),
+                )
                 .route("/v1/files/{file_id}", delete(unconfigured_handler))
                 // Plan 0089 (GAR-557) — files API slice 2 PATCH, no-auth stub.
                 // Plan 0090 (GAR-559) — files API slice 3 GET single, no-auth stub.
                 // Plan 0091 (GAR-561) — files API slice 4 PATCH folder, no-auth stub.
+                // Plan 0092 (GAR-562) — files API slice 5: DELETE folder, no-auth stub.
                 .route(
                     "/v1/groups/{group_id}/files/{file_id}",
                     get(unconfigured_handler).patch(unconfigured_handler),
                 )
                 .route(
                     "/v1/groups/{group_id}/folders/{folder_id}",
-                    get(unconfigured_handler).patch(unconfigured_handler),
+                    get(unconfigured_handler)
+                        .patch(unconfigured_handler)
+                        .delete(unconfigured_handler),
                 )
                 .route(
                     "/v1/groups/{group_id}/tasks/{task_id}/comments",

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -15,8 +15,8 @@ use utoipa::{Modify, OpenApi};
 use super::audit::{AuditEventSummary, ListAuditResponse};
 use super::chats::{ChatListResponse, ChatResponse, ChatSummary, CreateChatRequest};
 use super::files::{
-    FileListResponse, FileSummary, FolderListResponse, FolderSummary, PatchFileRequest,
-    PatchFolderRequest,
+    CreateFolderRequest, FileListResponse, FileSummary, FolderListResponse, FolderSummary,
+    PatchFileRequest, PatchFolderRequest,
 };
 use super::groups::{
     CreateGroupRequest, CreateInviteRequest, GroupReadResponse, GroupResponse, InviteResponse,
@@ -143,6 +143,8 @@ impl Modify for SecurityAddon {
         super::files::get_file,
         super::files::get_folder,
         super::files::patch_folder,
+        super::files::create_folder,
+        super::files::delete_folder,
     ),
     components(schemas(
         MeResponse,
@@ -207,6 +209,7 @@ impl Modify for SecurityAddon {
         FolderListResponse,
         PatchFileRequest,
         PatchFolderRequest,
+        CreateFolderRequest,
     )),
     modifiers(&SecurityAddon)
 )]

--- a/crates/garraia-gateway/tests/rest_v1_folders_post_delete.rs
+++ b/crates/garraia-gateway/tests/rest_v1_folders_post_delete.rs
@@ -1,0 +1,521 @@
+// Gated so `cargo clippy --all-targets` without `test-helpers` skips this
+// file and doesn't try to compile the `common` harness (which references
+// `JwtIssuer::new_for_test` and `issue_access_for_test`, both gated by
+// `garraia-auth/test-support`). Same pattern as `rest_v1_folders_patch.rs`.
+#![cfg(feature = "test-helpers")]
+//! Integration tests for:
+//!   `POST   /v1/groups/{group_id}/folders`              (plan 0092, GAR-562)
+//!   `DELETE /v1/groups/{group_id}/folders/{folder_id}`  (plan 0092, GAR-562)
+//!
+//! All scenarios bundled into ONE `#[tokio::test]` function — same pattern
+//! as `rest_v1_folders_patch.rs`/`rest_v1_files_patch.rs`. Splitting into
+//! multiple `#[tokio::test]`s historically triggered the sqlx
+//! runtime-teardown race documented in plan 0016 M3 commit `4f8be37`.
+//!
+//! POST scenarios (C1–C7):
+//! C1. POST 201 — root folder (no parent_id): asserts response shape, DB row,
+//!     `audit_events` row with `folder.created` + PII-safe metadata.
+//! C2. POST 201 — child folder (valid parent_id): asserts `parent_id` in body.
+//! C3. POST 400 — empty name.
+//! C4. POST 400 — name >200 chars.
+//! C5. POST 400 — name with `/`.
+//! C6. POST 400 — unknown parent_id (not in group).
+//! C7. POST 403 — path group_id ≠ principal group_id.
+//! C8. POST 409 — sibling name collision under same parent.
+//!
+//! DELETE scenarios (D1–D5):
+//! D1. DELETE 204 — live folder: DB shows deleted_at set, audit row emitted.
+//! D2. DELETE 204 — already soft-deleted (idempotent, NO audit re-emitted).
+//! D3. DELETE 404 — non-existent folder_id.
+//! D4. DELETE 404 — cross-group folder_id.
+//! D5. DELETE 403 — path group_id ≠ principal group_id.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
+use chrono::Utc;
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use common::Harness;
+use common::fixtures::{fetch_audit_events_for_group, seed_user_with_group};
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("failed to collect response body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("response body is not JSON")
+}
+
+fn post_folder_req(
+    token: Option<&str>,
+    path_group_id: &str,
+    x_group_id: Option<&str>,
+    body: serde_json::Value,
+) -> Request<Body> {
+    let mut req = Request::builder()
+        .method("POST")
+        .uri(format!("/v1/groups/{path_group_id}/folders"))
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .expect("request builder");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    if let Some(t) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {t}")).unwrap(),
+        );
+    }
+    if let Some(g) = x_group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    req
+}
+
+fn delete_folder_req(
+    token: Option<&str>,
+    path_group_id: &str,
+    folder_id: &str,
+    x_group_id: Option<&str>,
+) -> Request<Body> {
+    let mut req = Request::builder()
+        .method("DELETE")
+        .uri(format!("/v1/groups/{path_group_id}/folders/{folder_id}"))
+        .body(Body::empty())
+        .expect("request builder");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    if let Some(t) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {t}")).unwrap(),
+        );
+    }
+    if let Some(g) = x_group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    req
+}
+
+/// Insert a live `folders` row directly via the admin pool (bypassing RLS).
+/// Every NOT NULL column is supplied; `parent_id` is optional.
+async fn seed_folder(
+    h: &Harness,
+    group_id: Uuid,
+    parent_id: Option<Uuid>,
+    created_by: Uuid,
+    name: &str,
+) -> anyhow::Result<Uuid> {
+    let folder_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO folders (id, group_id, parent_id, name, \
+                              created_by, created_by_label) \
+         VALUES ($1, $2, $3, $4, $5, $6)",
+    )
+    .bind(folder_id)
+    .bind(group_id)
+    .bind(parent_id)
+    .bind(name)
+    .bind(created_by)
+    .bind("Test User")
+    .execute(&h.admin_pool)
+    .await?;
+    Ok(folder_id)
+}
+
+/// Soft-delete a folder directly via the admin pool.
+async fn soft_delete_folder(h: &Harness, folder_id: Uuid) -> anyhow::Result<()> {
+    sqlx::query("UPDATE folders SET deleted_at = $1 WHERE id = $2")
+        .bind(Utc::now())
+        .bind(folder_id)
+        .execute(&h.admin_pool)
+        .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn v1_folders_post_delete_scenarios() {
+    let h = Harness::get().await;
+
+    // Seed owner + group A — used by C1..C8 + D1..D5.
+    let (owner_id, group_id, owner_token) = seed_user_with_group(&h, "owner@folders-slice5.test")
+        .await
+        .expect("seed owner+group A");
+
+    let group_id_str = group_id.to_string();
+
+    // ── C1. POST 201 — root folder (no parent_id) ───────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(post_folder_req(
+            Some(&owner_token),
+            &group_id_str,
+            Some(&group_id_str),
+            json!({ "name": "my-root-folder" }),
+        ))
+        .await
+        .expect("C1 oneshot");
+    assert_eq!(resp.status(), StatusCode::CREATED, "C1 status");
+    let v = body_json(resp).await;
+    assert!(v["id"].is_string(), "C1 id is string: {v}");
+    assert_eq!(v["name"], "my-root-folder", "C1 name");
+    assert!(v["parent_id"].is_null(), "C1 parent_id null");
+    let c1_folder_id: Uuid = v["id"].as_str().unwrap().parse().expect("C1 uuid");
+
+    // C1 — verify DB row was actually inserted.
+    let (db_name,): (String,) = sqlx::query_as("SELECT name FROM folders WHERE id = $1")
+        .bind(c1_folder_id)
+        .fetch_one(&h.admin_pool)
+        .await
+        .expect("C1 fetch db name");
+    assert_eq!(db_name, "my-root-folder", "C1 db name");
+
+    // C1 — audit row (PII-safe metadata only).
+    let events = fetch_audit_events_for_group(&h, group_id)
+        .await
+        .expect("C1 fetch audit");
+    let create_event = events
+        .iter()
+        .find(|(action, _, _, rid, _)| {
+            action == "folder.created" && rid == &c1_folder_id.to_string()
+        })
+        .expect("C1 folder.created audit row");
+    let (_, actor, resource_type, resource_id, metadata) = create_event;
+    assert_eq!(actor.as_ref(), Some(&owner_id), "C1 audit actor");
+    assert_eq!(resource_type, "folders", "C1 audit resource_type");
+    assert_eq!(
+        resource_id,
+        &c1_folder_id.to_string(),
+        "C1 audit resource_id"
+    );
+    assert!(
+        metadata.get("name").is_none(),
+        "C1 audit MUST NOT carry raw folder name"
+    );
+    assert_eq!(
+        metadata["name_len"].as_u64(),
+        Some("my-root-folder".chars().count() as u64),
+        "C1 audit name_len"
+    );
+    assert_eq!(metadata["group_id"], group_id_str, "C1 audit group_id");
+    assert_eq!(
+        metadata["has_parent"].as_bool(),
+        Some(false),
+        "C1 audit has_parent false"
+    );
+
+    // ── C2. POST 201 — child folder (valid parent_id) ──────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(post_folder_req(
+            Some(&owner_token),
+            &group_id_str,
+            Some(&group_id_str),
+            json!({ "name": "child-folder", "parent_id": c1_folder_id }),
+        ))
+        .await
+        .expect("C2 oneshot");
+    assert_eq!(resp.status(), StatusCode::CREATED, "C2 status");
+    let v = body_json(resp).await;
+    assert_eq!(v["name"], "child-folder", "C2 name");
+    assert_eq!(
+        v["parent_id"].as_str(),
+        Some(c1_folder_id.to_string().as_str()),
+        "C2 parent_id"
+    );
+    let c2_folder_id: Uuid = v["id"].as_str().unwrap().parse().expect("C2 uuid");
+
+    // C2 — audit has_parent = true.
+    let events2 = fetch_audit_events_for_group(&h, group_id)
+        .await
+        .expect("C2 fetch audit");
+    let c2_event = events2
+        .iter()
+        .find(|(action, _, _, rid, _)| {
+            action == "folder.created" && rid == &c2_folder_id.to_string()
+        })
+        .expect("C2 folder.created audit row");
+    assert_eq!(
+        c2_event.4["has_parent"].as_bool(),
+        Some(true),
+        "C2 audit has_parent true"
+    );
+
+    // ── C3. POST 400 — empty name ───────────────────────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(post_folder_req(
+            Some(&owner_token),
+            &group_id_str,
+            Some(&group_id_str),
+            json!({ "name": "   " }),
+        ))
+        .await
+        .expect("C3 oneshot");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "C3 status");
+
+    // ── C4. POST 400 — name >200 chars ─────────────────────────────────
+    let too_long: String = "b".repeat(201);
+    let resp = h
+        .router
+        .clone()
+        .oneshot(post_folder_req(
+            Some(&owner_token),
+            &group_id_str,
+            Some(&group_id_str),
+            json!({ "name": too_long }),
+        ))
+        .await
+        .expect("C4 oneshot");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "C4 status");
+
+    // ── C5. POST 400 — name with '/' ────────────────────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(post_folder_req(
+            Some(&owner_token),
+            &group_id_str,
+            Some(&group_id_str),
+            json!({ "name": "etc/passwd" }),
+        ))
+        .await
+        .expect("C5 oneshot");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "C5 status");
+
+    // ── C6. POST 400 — unknown parent_id ───────────────────────────────
+    let ghost_parent = Uuid::new_v4();
+    let resp = h
+        .router
+        .clone()
+        .oneshot(post_folder_req(
+            Some(&owner_token),
+            &group_id_str,
+            Some(&group_id_str),
+            json!({ "name": "orphan", "parent_id": ghost_parent }),
+        ))
+        .await
+        .expect("C6 oneshot");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "C6 status");
+
+    // ── C7. POST 403 — path group_id ≠ principal group_id ──────────────
+    let other_group = Uuid::new_v4();
+    let resp = h
+        .router
+        .clone()
+        .oneshot(post_folder_req(
+            Some(&owner_token),
+            &other_group.to_string(),
+            Some(&group_id_str), // X-Group-Id matches principal → no 400
+            json!({ "name": "cross-group-attempt" }),
+        ))
+        .await
+        .expect("C7 oneshot");
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN, "C7 status");
+
+    // ── C8. POST 409 — sibling name collision ───────────────────────────
+    // Create a root-level folder called "c8-sibling", then try to POST another
+    // folder with the same name under the same parent (root).
+    let resp = h
+        .router
+        .clone()
+        .oneshot(post_folder_req(
+            Some(&owner_token),
+            &group_id_str,
+            Some(&group_id_str),
+            json!({ "name": "c8-collision" }),
+        ))
+        .await
+        .expect("C8 first POST");
+    assert_eq!(resp.status(), StatusCode::CREATED, "C8 first create");
+
+    // Second POST with identical name → 409.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(post_folder_req(
+            Some(&owner_token),
+            &group_id_str,
+            Some(&group_id_str),
+            json!({ "name": "c8-collision" }),
+        ))
+        .await
+        .expect("C8 duplicate POST");
+    assert_eq!(resp.status(), StatusCode::CONFLICT, "C8 status");
+    // Body MUST NOT echo the user-controlled name (PII safety).
+    let v = body_json(resp).await;
+    let detail = v["detail"].as_str().unwrap_or_default();
+    assert!(
+        !detail.contains("c8-collision"),
+        "C8 conflict detail MUST NOT echo the name: {detail}"
+    );
+
+    // ── D1. DELETE 204 — live folder, audit row emitted ─────────────────
+    let d1_id = seed_folder(&h, group_id, None, owner_id, "d1-live")
+        .await
+        .expect("D1 seed");
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(delete_folder_req(
+            Some(&owner_token),
+            &group_id_str,
+            &d1_id.to_string(),
+            Some(&group_id_str),
+        ))
+        .await
+        .expect("D1 oneshot");
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT, "D1 status");
+
+    // D1 — verify DB row has deleted_at set.
+    let (deleted_at,): (Option<chrono::DateTime<Utc>>,) =
+        sqlx::query_as("SELECT deleted_at FROM folders WHERE id = $1")
+            .bind(d1_id)
+            .fetch_one(&h.admin_pool)
+            .await
+            .expect("D1 fetch deleted_at");
+    assert!(deleted_at.is_some(), "D1 deleted_at is set");
+
+    // D1 — audit row emitted.
+    let events_d1 = fetch_audit_events_for_group(&h, group_id)
+        .await
+        .expect("D1 fetch audit");
+    let delete_event = events_d1
+        .iter()
+        .find(|(action, _, _, rid, _)| action == "folder.deleted" && rid == &d1_id.to_string())
+        .expect("D1 folder.deleted audit row");
+    let (_, actor_d1, resource_type_d1, _, metadata_d1) = delete_event;
+    assert_eq!(actor_d1.as_ref(), Some(&owner_id), "D1 audit actor");
+    assert_eq!(resource_type_d1, "folders", "D1 audit resource_type");
+    assert!(
+        metadata_d1.get("name").is_none(),
+        "D1 audit MUST NOT carry raw folder name"
+    );
+    assert_eq!(
+        metadata_d1["name_len"].as_u64(),
+        Some("d1-live".chars().count() as u64),
+        "D1 audit name_len"
+    );
+
+    // ── D2. DELETE 204 — already soft-deleted (idempotent, no new audit) ─
+    let d2_id = seed_folder(&h, group_id, None, owner_id, "d2-predead")
+        .await
+        .expect("D2 seed");
+    soft_delete_folder(&h, d2_id).await.expect("D2 pre-delete");
+
+    let events_before = fetch_audit_events_for_group(&h, group_id)
+        .await
+        .expect("D2 events before");
+    let audit_count_before = events_before
+        .iter()
+        .filter(|(a, _, _, rid, _)| a == "folder.deleted" && rid == &d2_id.to_string())
+        .count();
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(delete_folder_req(
+            Some(&owner_token),
+            &group_id_str,
+            &d2_id.to_string(),
+            Some(&group_id_str),
+        ))
+        .await
+        .expect("D2 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NO_CONTENT,
+        "D2 status (idempotent)"
+    );
+
+    // D2 — no NEW audit row was emitted.
+    let events_after = fetch_audit_events_for_group(&h, group_id)
+        .await
+        .expect("D2 events after");
+    let audit_count_after = events_after
+        .iter()
+        .filter(|(a, _, _, rid, _)| a == "folder.deleted" && rid == &d2_id.to_string())
+        .count();
+    assert_eq!(
+        audit_count_before, audit_count_after,
+        "D2 no new audit row on idempotent delete"
+    );
+
+    // ── D3. DELETE 404 — non-existent folder_id ─────────────────────────
+    let phantom = Uuid::new_v4();
+    let resp = h
+        .router
+        .clone()
+        .oneshot(delete_folder_req(
+            Some(&owner_token),
+            &group_id_str,
+            &phantom.to_string(),
+            Some(&group_id_str),
+        ))
+        .await
+        .expect("D3 oneshot");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND, "D3 status");
+
+    // ── D4. DELETE 404 — cross-group folder (belongs to group B) ────────
+    // Seed a second user+group B. Insert a folder in group B. Principal A
+    // cannot see it because the SELECT filters on group_id = A's group_id.
+    let (owner_b_id, group_b_id, _owner_b_token) =
+        seed_user_with_group(&h, "owner-b@folders-slice5.test")
+            .await
+            .expect("D4 seed group B");
+    let d4_folder = seed_folder(&h, group_b_id, None, owner_b_id, "group-b-folder")
+        .await
+        .expect("D4 seed folder in group B");
+
+    // Principal A's path uses group A's ID, folder ID belongs to group B.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(delete_folder_req(
+            Some(&owner_token),
+            &group_id_str,          // path = group A
+            &d4_folder.to_string(), // folder is in group B
+            Some(&group_id_str),
+        ))
+        .await
+        .expect("D4 oneshot");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND, "D4 status");
+
+    // ── D5. DELETE 403 — path group_id ≠ principal group_id ────────────
+    let d5_id = seed_folder(&h, group_id, None, owner_id, "d5")
+        .await
+        .expect("D5 seed");
+    let resp = h
+        .router
+        .clone()
+        .oneshot(delete_folder_req(
+            Some(&owner_token),
+            &other_group.to_string(), // path = some other group
+            &d5_id.to_string(),
+            Some(&group_id_str), // X-Group-Id matches principal (A)
+        ))
+        .await
+        .expect("D5 oneshot");
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN, "D5 status");
+}

--- a/crates/garraia-gateway/tests/rest_v1_folders_post_delete.rs
+++ b/crates/garraia-gateway/tests/rest_v1_folders_post_delete.rs
@@ -23,12 +23,15 @@
 //! C7. POST 403 — path group_id ≠ principal group_id.
 //! C8. POST 409 — sibling name collision under same parent.
 //!
-//! DELETE scenarios (D1–D5):
+//! DELETE scenarios (D1–D6):
 //! D1. DELETE 204 — live folder: DB shows deleted_at set, audit row emitted.
 //! D2. DELETE 204 — already soft-deleted (idempotent, NO audit re-emitted).
 //! D3. DELETE 404 — non-existent folder_id.
 //! D4. DELETE 404 — cross-group folder_id.
 //! D5. DELETE 403 — path group_id ≠ principal group_id.
+//! D6. DELETE 403 — Member role (has FilesWrite, lacks FilesDelete): proves
+//!     the canonical authz delta vs PR #248 — Members can rename/create
+//!     folders but cannot delete them. Uses `seed_member_via_admin`.
 
 mod common;
 
@@ -41,7 +44,7 @@ use tower::ServiceExt;
 use uuid::Uuid;
 
 use common::Harness;
-use common::fixtures::{fetch_audit_events_for_group, seed_user_with_group};
+use common::fixtures::{fetch_audit_events_for_group, seed_member_via_admin, seed_user_with_group};
 
 async fn body_json(resp: axum::response::Response) -> serde_json::Value {
     let bytes = resp
@@ -518,4 +521,46 @@ async fn v1_folders_post_delete_scenarios() {
         .await
         .expect("D5 oneshot");
     assert_eq!(resp.status(), StatusCode::FORBIDDEN, "D5 status");
+
+    // ── D6. DELETE 403 — Member lacks FilesDelete (canonical authz) ─────
+    // Member role has FilesWrite (can create/rename folders via POST/PATCH)
+    // but NOT FilesDelete (which is Owner/Admin only, per `can()` matrix
+    // mirroring migration 002 lines 78-111). This test guards against a
+    // regression where folder DELETE would inherit FilesWrite instead of
+    // matching the canonical `delete_file` precedent from plan 0088.
+    let (_member_id, member_token) =
+        seed_member_via_admin(&h, group_id, "member", "member@folders-slice5.test")
+            .await
+            .expect("D6 seed member");
+    let d6_id = seed_folder(&h, group_id, None, owner_id, "d6")
+        .await
+        .expect("D6 seed folder");
+    let resp = h
+        .router
+        .clone()
+        .oneshot(delete_folder_req(
+            Some(&member_token),
+            &group_id_str, // path matches principal's group
+            &d6_id.to_string(),
+            Some(&group_id_str),
+        ))
+        .await
+        .expect("D6 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "D6 status — Member must NOT be able to delete folders (FilesDelete is Owner/Admin)"
+    );
+
+    // D6 — DB confirms folder was NOT soft-deleted by the rejected request.
+    let (deleted_at,): (Option<chrono::DateTime<chrono::Utc>>,) =
+        sqlx::query_as("SELECT deleted_at FROM folders WHERE id = $1")
+            .bind(d6_id)
+            .fetch_one(&h.admin_pool)
+            .await
+            .expect("D6 fetch deleted_at");
+    assert!(
+        deleted_at.is_none(),
+        "D6 folder MUST remain live after Member's rejected DELETE"
+    );
 }

--- a/plans/0092-gar-562-files-api-slice5-folder-post-delete.md
+++ b/plans/0092-gar-562-files-api-slice5-folder-post-delete.md
@@ -28,7 +28,12 @@ and DELETE as a self-contained slice.
 ### DELETE handler (`delete_folder`)
 
 1. `require_group_id` + `check_group_match` → 403
-2. `can(&principal, Action::FilesWrite)` → 403
+2. `can(&principal, Action::FilesDelete)` → 403  ← **canonical project pattern**:
+   matches `delete_file` from plan 0088 (the only existing soft-delete precedent
+   in the `/v1` files surface). `FilesDelete` is granted to **Owner + Admin only**
+   (NOT Member); `FilesWrite` would inherit Member, which is wrong for a destructive
+   operation that can orphan children files. See review-side-by-side analysis 2026-05-09
+   (PR #247 vs PR #248) for the rationale.
 3. Begin tx → `set_rls_context`
 4. SELECT `deleted_at, name` WHERE `id=$1 AND group_id=$2`
    - None → 404 (not found or cross-group)
@@ -42,7 +47,9 @@ Cascade semantics are deferred to a later slice.
 
 ## Tech stack
 
-* Axum 0.8, `garraia-auth::Principal`, `garraia-auth::Action::FilesWrite`
+* Axum 0.8, `garraia-auth::Principal`
+* `garraia-auth::Action::FilesWrite` (POST `create_folder`)
+* `garraia-auth::Action::FilesDelete` (DELETE `delete_folder` — Owner/Admin only)
 * `sqlx` (Postgres), `set_rls_context` for FORCE RLS compliance
 * `utoipa` annotations (`#[utoipa::path(...)]`), registered in `openapi.rs`
 * `garraia-auth::audit_workspace` — two new variants: `FolderCreated`, `FolderDeleted`
@@ -69,7 +76,8 @@ Cascade semantics are deferred to a later slice.
 
 * Cascade-delete of child folders/files.
 * Moving a folder (`parent_id` change via PATCH is slice 6).
-* Permissions beyond `FilesWrite` (no `FilesAdmin`-only route yet).
+* Folder DELETE auth differentiation beyond Owner/Admin (`FilesDelete`) is
+  intentional — Members can rename and create folders but NOT delete them.
 
 ## Rollback
 

--- a/plans/0092-gar-562-files-api-slice5-folder-post-delete.md
+++ b/plans/0092-gar-562-files-api-slice5-folder-post-delete.md
@@ -1,0 +1,135 @@
+# Plan 0092 — GAR-562 — Files REST API slice 5: folder POST + DELETE
+
+## Goal
+
+Add the two missing folder-mutation endpoints to the `/v1` REST surface:
+
+* `POST   /v1/groups/{group_id}/folders`              — create a folder
+* `DELETE /v1/groups/{group_id}/folders/{folder_id}`  — soft-delete a folder
+
+Both were originally scoped for plan 0091 / PR #245 (full CRUD), but that PR was
+superseded by PR #246 (PATCH-only, GAR-561). This plan delivers the deferred POST
+and DELETE as a self-contained slice.
+
+## Architecture
+
+### POST handler (`create_folder`)
+
+1. `require_group_id` + `check_group_match` (path ≠ principal.group_id → 403)
+2. `can(&principal, Action::FilesWrite)` — 403 if denied
+3. `validate_folder_name` — 400 on empty/>200 chars/contains `/`
+4. Begin tx → `set_rls_context` (both `app.current_user_id` + `app.current_group_id`)
+5. If `parent_id` supplied: SELECT to confirm it exists and is not soft-deleted (400 otherwise)
+6. SELECT `display_name` from `users` for `created_by_label`
+7. INSERT INTO `folders` RETURNING — map 23505 → 409 Conflict
+8. Audit `folder.created` with `{ folder_id, group_id, name_len, has_parent }` (no raw names)
+9. COMMIT → 201 + `FolderSummary`
+
+### DELETE handler (`delete_folder`)
+
+1. `require_group_id` + `check_group_match` → 403
+2. `can(&principal, Action::FilesWrite)` → 403
+3. Begin tx → `set_rls_context`
+4. SELECT `deleted_at, name` WHERE `id=$1 AND group_id=$2`
+   - None → 404 (not found or cross-group)
+   - Some, `deleted_at IS NOT NULL` → 204 idempotent (no audit, commit + return)
+5. UPDATE `folders SET deleted_at=now()` WHERE `id=$1 AND deleted_at IS NULL`
+6. Audit `folder.deleted` with `{ folder_id, group_id, name_len }` (no raw names)
+7. COMMIT → 204
+
+Children files/sub-folders are NOT cascade-deleted; they become root-level orphans.
+Cascade semantics are deferred to a later slice.
+
+## Tech stack
+
+* Axum 0.8, `garraia-auth::Principal`, `garraia-auth::Action::FilesWrite`
+* `sqlx` (Postgres), `set_rls_context` for FORCE RLS compliance
+* `utoipa` annotations (`#[utoipa::path(...)]`), registered in `openapi.rs`
+* `garraia-auth::audit_workspace` — two new variants: `FolderCreated`, `FolderDeleted`
+
+## Design invariants
+
+* FORCE RLS protocol: `SET LOCAL app.current_user_id` AND `app.current_group_id`
+  before every SQL operation — both must be set for FORCE RLS tables.
+* PII-free audit: metadata carries `name_len` + `has_parent` booleans, never raw
+  folder names.
+* Idempotent DELETE: already-deleted folders return 204 without re-emitting an audit
+  event (mirrors `delete_file` from plan 0088).
+* No cascade: orphan children are acceptable for slice 5; cascade is slice 6+.
+
+## Validações pré-plano
+
+* PR #246 (GAR-561, PATCH-only) merged as `3679ccc` — PATCH `patch_folder` present.
+* `validate_folder_name` (max 200 chars, no `/`, no NUL) already tested in PR #246.
+* `FolderSummary` struct already present; fields: `id`, `name`, `parent_id`,
+  `created_by`, `created_by_label`, `created_at`, `updated_at`.
+* `folders_unique_name_per_parent_idx UNIQUE (group_id, COALESCE(parent_id, nil_uuid), name) WHERE deleted_at IS NULL` — 23505 maps to 409.
+
+## Out of scope
+
+* Cascade-delete of child folders/files.
+* Moving a folder (`parent_id` change via PATCH is slice 6).
+* Permissions beyond `FilesWrite` (no `FilesAdmin`-only route yet).
+
+## Rollback
+
+* `mod.rs` router entries for `POST` and `DELETE` removed.
+* `files.rs` handlers `create_folder` + `delete_folder` deleted.
+* `openapi.rs` paths + schema registration reverted.
+* `audit_workspace.rs` variants `FolderCreated` + `FolderDeleted` removed.
+* Integration test file `rest_v1_folders_post_delete.rs` deleted.
+* DB schema unchanged (soft-delete is reversible by clearing `deleted_at`).
+
+## File structure
+
+```text
+crates/garraia-auth/src/audit_workspace.rs        — FolderCreated + FolderDeleted variants
+crates/garraia-gateway/src/rest_v1/files.rs       — create_folder + delete_folder handlers
+crates/garraia-gateway/src/rest_v1/mod.rs         — router wiring (3 modes)
+crates/garraia-gateway/src/rest_v1/openapi.rs     — paths + schemas registration
+crates/garraia-gateway/tests/rest_v1_folders_post_delete.rs  — 13 integration scenarios
+```
+
+## Tasks
+
+- [x] M1-T1: `audit_workspace.rs` — add `FolderCreated` + `FolderDeleted` variants + `as_str` arms + tests
+- [x] M1-T2: `files.rs` — add `CreateFolderRequest` DTO + `create_folder` handler
+- [x] M1-T3: `files.rs` — add `delete_folder` handler
+- [x] M1-T4: `mod.rs` — wire POST + DELETE in all 3 router build modes
+- [x] M1-T5: `openapi.rs` — register `create_folder`, `delete_folder` in paths; `CreateFolderRequest` in schemas
+- [x] M1-T6: `rest_v1_folders_post_delete.rs` — 13 scenarios (C1–C8 POST + D1–D5 DELETE)
+- [x] M1-T7: `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` clean
+- [x] M1-T8: `cargo fmt --check` clean
+- [ ] M1-T9: commit + push → PR + CI green → merge
+
+## Risk register
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| 23505 on UNIQUE index not mapped in test environment | Low | Test C8 exercises this path |
+| RLS blocks cross-group SELECT due to set_rls_context filtering | Medium | D4 tests cross-group 404 |
+| parent_id from different group sneaks through | Low | C6 validates app-layer SELECT within same tx |
+
+## Acceptance criteria
+
+1. `POST /v1/groups/{group_id}/folders` returns 201 with `FolderSummary` body; DB row inserted; audit `folder.created` emitted.
+2. `DELETE /v1/groups/{group_id}/folders/{folder_id}` returns 204; DB row has `deleted_at` set; audit `folder.deleted` emitted.
+3. Idempotent DELETE: already-deleted folder returns 204, no second audit row.
+4. All 13 integration scenarios pass in CI (Postgres 16).
+5. Zero `cargo clippy` warnings (workspace + tests).
+6. `cargo fmt --check` clean.
+
+## Cross-references
+
+* Plan 0091 (GAR-561) — PATCH folder rename (shipped as PR #246, `3679ccc`)
+* Plan 0088 (GAR-555) — `delete_file` (idempotent pattern used as model)
+* ADR 0003 — Postgres for Group Workspace
+* ADR 0004 — Object Storage (files schema in migration 003)
+
+## Estimativa
+
+~200 LOC production + ~300 LOC tests. Estimated 1 session.
+
+## Linear issue
+
+[GAR-562](https://linear.app/chatgpt25/issue/GAR-562)

--- a/plans/README.md
+++ b/plans/README.md
@@ -114,7 +114,8 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0088 | [GAR-555 — Files REST API slice 1: GET files + GET folders + DELETE file](0088-gar-555-files-api-slice1.md) | [GAR-555](https://linear.app/chatgpt25/issue/GAR-555) | ✅ Merged 2026-05-09 via PR #235 (`75d7a44`) |
 | 0089 | [GAR-557 — Files REST API slice 2: PATCH /v1/groups/{group_id}/files/{file_id} (rename)](0089-gar-557-files-api-slice2-rename.md) | [GAR-557](https://linear.app/chatgpt25/issue/GAR-557) | ✅ Merged 2026-05-09 via PR #238 (`9255515`) |
 | 0090 | [GAR-559 — Files REST API slice 3: GET single file + folder](0090-gar-559-files-api-slice3-get-single.md) | [GAR-559](https://linear.app/chatgpt25/issue/GAR-559) | ✅ Merged 2026-05-09 via PR #242 (`4adcb02`) |
-| 0091 | [GAR-561 — Files REST API slice 4: PATCH folder rename](0091-gar-561-files-api-slice4-folder-rename.md) | [GAR-561](https://linear.app/chatgpt25/issue/GAR-561) | 🟡 Ready for Review (PR open, awaiting approval). Slice 4 rescoped to PATCH-only; folder POST + DELETE deferred to GAR-562. |
+| 0091 | [GAR-561 — Files REST API slice 4: PATCH folder rename](0091-gar-561-files-api-slice4-folder-rename.md) | [GAR-561](https://linear.app/chatgpt25/issue/GAR-561) | ✅ Merged 2026-05-09 via PR #246 (`3679ccc`) |
+| 0092 | [GAR-562 — Files REST API slice 5: folder POST + DELETE](0092-gar-562-files-api-slice5-folder-post-delete.md) | [GAR-562](https://linear.app/chatgpt25/issue/GAR-562) | 🔵 In Progress |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

- Adds `POST /v1/groups/{group_id}/folders` — create a folder (201 + `FolderSummary`)
- Adds `DELETE /v1/groups/{group_id}/folders/{folder_id}` — soft-delete a folder (204 idempotent)
- Two new `WorkspaceAuditAction` variants: `FolderCreated` (`folder.created`) and `FolderDeleted` (`folder.deleted`)
- 13 integration scenarios in `rest_v1_folders_post_delete.rs` (C1–C8 POST, D1–D5 DELETE)

## Design highlights

- **FORCE RLS**: both handlers call `set_rls_context` (sets `app.current_user_id` + `app.current_group_id`) before every SQL operation
- **PII-safe audit**: metadata carries `name_len` + `has_parent` booleans — never raw folder names
- **Idempotent DELETE**: already-deleted folder returns 204 without re-emitting an audit event (mirrors `delete_file` from plan 0088)
- **23505 → 409**: `folders_unique_name_per_parent_idx` UNIQUE collision mapped to `RestError::Conflict`
- **Parent validation**: app-layer SELECT before INSERT gives precise 400 for unknown/soft-deleted `parent_id`
- **`created_by_label`**: resolved via `SELECT display_name FROM users WHERE id = $1` within the same transaction

## Test plan

- [x] C1. POST 201 root folder — response shape, DB row, audit `folder.created` + PII-safe metadata
- [x] C2. POST 201 child folder — `parent_id` in response, `has_parent: true` in audit
- [x] C3. POST 400 empty name
- [x] C4. POST 400 name >200 chars
- [x] C5. POST 400 name with `/`
- [x] C6. POST 400 unknown parent_id
- [x] C7. POST 403 path group_id ≠ principal group_id
- [x] C8. POST 409 sibling name collision (23505 → Conflict, body does not echo name)
- [x] D1. DELETE 204 live folder — `deleted_at` set in DB, audit `folder.deleted` emitted
- [x] D2. DELETE 204 already-deleted (idempotent, no new audit row)
- [x] D3. DELETE 404 non-existent folder_id
- [x] D4. DELETE 404 cross-group folder (group B folder, principal A)
- [x] D5. DELETE 403 path group_id ≠ principal group_id
- [x] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` clean
- [x] `cargo fmt --check` clean

## References

- Plan 0092: `plans/0092-gar-562-files-api-slice5-folder-post-delete.md`
- Linear: [GAR-562](https://linear.app/chatgpt25/issue/GAR-562)
- Precursor: PR #246 — plan 0091 PATCH folder rename (GAR-561)

https://claude.ai/code/session_01XdJUihWipv4z5B6QjjsvWd

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdJUihWipv4z5B6QjjsvWd)_