### PR TITLE
feat(files): GAR-562 — Files REST API slice 5: POST + DELETE folders (plan 0092)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -408,6 +408,8 @@ Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
 - [x] `GET /v1/groups/{group_id}/files?folder_id=...` + `GET /v1/groups/{group_id}/folders` ✅ PR #235 GAR-555
 - [x] `GET /v1/groups/{group_id}/files/{file_id}` + `GET /v1/groups/{group_id}/folders/{folder_id}` (single resource read) — plan 0090 / [GAR-559](https://linear.app/chatgpt25/issue/GAR-559), implementado 2026-05-09 (Florida) ✅ PR #242 (`4adcb02`)
 - [x] `PATCH /v1/groups/{group_id}/files/{file_id}` (rename) — plan 0089 / [GAR-557](https://linear.app/chatgpt25/issue/GAR-557), implementado 2026-05-09 (Florida) ✅ PR #238 (`9255515`)
+- [x] `PATCH /v1/groups/{group_id}/folders/{folder_id}` (rename) — plan 0091 / [GAR-561](https://linear.app/chatgpt25/issue/GAR-561), implementado 2026-05-09 (Florida) ✅ PR #246 (`3679ccc`)
+- [ ] `POST /v1/groups/{group_id}/folders` + `DELETE /v1/groups/{group_id}/folders/{folder_id}` — plan 0092 / [GAR-562](https://linear.app/chatgpt25/issue/GAR-562), em execução 2026-05-09 (Florida)
 - [ ] `GET /v1/files/{file_id}:download` (URL temporária curta duração)
 - [ ] `POST /v1/files/{file_id}:newVersion`
 - [x] `DELETE /v1/files/{file_id}` (soft delete + lixeira) ✅ PR #235 GAR-555

--- a/crates/garraia-auth/src/audit_workspace.rs
+++ b/crates/garraia-auth/src/audit_workspace.rs
@@ -384,6 +384,13 @@ pub enum WorkspaceAuditAction {
     /// in `files` plus prior audit entries already reconstruct history.
     FileRenamed,
 
+    /// A folder was created via `POST /v1/groups/{group_id}/folders`
+    /// (plan 0092 / GAR-562, Fase 3.4 files slice 5).
+    ///
+    /// `resource_type = "folders"`, `resource_id = "{folder_id}"`.
+    /// Metadata: `{ name_len, group_id, has_parent }` — never the raw name.
+    FolderCreated,
+
     /// A folder was renamed via
     /// `PATCH /v1/groups/{group_id}/folders/{folder_id}`
     /// (plan 0091 / GAR-561, Fase 3.4 files slice 4).
@@ -397,6 +404,14 @@ pub enum WorkspaceAuditAction {
     /// (consumers can filter on metadata.folder_id without parsing
     /// resource_id). Never carries the raw folder name.
     FolderRenamed,
+
+    /// A folder was soft-deleted via
+    /// `DELETE /v1/groups/{group_id}/folders/{folder_id}`
+    /// (plan 0092 / GAR-562, Fase 3.4 files slice 5).
+    ///
+    /// `resource_type = "folders"`, `resource_id = "{folder_id}"`.
+    /// Metadata: `{ group_id }` — folder name not carried (PII-safe).
+    FolderDeleted,
 }
 
 impl WorkspaceAuditAction {
@@ -439,7 +454,9 @@ impl WorkspaceAuditAction {
             WorkspaceAuditAction::TaskMoved => "task.moved",
             WorkspaceAuditAction::FileDeleted => "file.deleted",
             WorkspaceAuditAction::FileRenamed => "file.renamed",
+            WorkspaceAuditAction::FolderCreated => "folder.created",
             WorkspaceAuditAction::FolderRenamed => "folder.renamed",
+            WorkspaceAuditAction::FolderDeleted => "folder.deleted",
         }
     }
 }
@@ -617,8 +634,16 @@ mod tests {
         assert_eq!(WorkspaceAuditAction::FileDeleted.as_str(), "file.deleted");
         assert_eq!(WorkspaceAuditAction::FileRenamed.as_str(), "file.renamed");
         assert_eq!(
+            WorkspaceAuditAction::FolderCreated.as_str(),
+            "folder.created"
+        );
+        assert_eq!(
             WorkspaceAuditAction::FolderRenamed.as_str(),
             "folder.renamed"
+        );
+        assert_eq!(
+            WorkspaceAuditAction::FolderDeleted.as_str(),
+            "folder.deleted"
         );
     }
 
@@ -659,7 +684,9 @@ mod tests {
             WorkspaceAuditAction::TaskSubscribed.as_str(),
             WorkspaceAuditAction::TaskUnsubscribed.as_str(),
             WorkspaceAuditAction::TaskMoved.as_str(),
+            WorkspaceAuditAction::FolderCreated.as_str(),
             WorkspaceAuditAction::FolderRenamed.as_str(),
+            WorkspaceAuditAction::FolderDeleted.as_str(),
         ];
         let unique: std::collections::HashSet<_> = strings.iter().collect();
         assert_eq!(unique.len(), strings.len(), "duplicate action strings");

--- a/crates/garraia-gateway/src/rest_v1/files.rs
+++ b/crates/garraia-gateway/src/rest_v1/files.rs
@@ -194,6 +194,16 @@ pub struct PatchFolderRequest {
     pub name: String,
 }
 
+/// Body for `POST /v1/groups/{group_id}/folders`
+/// (plan 0092, GAR-562, Fase 3.4 files slice 5).
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct CreateFolderRequest {
+    /// Folder name. Trimmed; 1..=200 chars; no `/` or NUL byte.
+    pub name: String,
+    /// Parent folder UUID. `null` / absent = root-level folder.
+    pub parent_id: Option<Uuid>,
+}
+
 /// Validation error message family. Plain strings — never embed
 /// the offending value (it is user-controlled and may include PII).
 const ERR_NAME_EMPTY: &str = "name must not be empty after trim";
@@ -959,6 +969,201 @@ pub async fn patch_folder(
         .map_err(|e| RestError::Internal(e.into()))?;
 
     Ok(Json(FolderSummary::from(row)))
+}
+
+/// `POST /v1/groups/{group_id}/folders` — create a folder.
+///
+/// Creates a root-level folder (`parent_id` absent / null) or a nested folder
+/// (valid `parent_id` in the same group). `parent_id` must refer to a live
+/// (not soft-deleted) folder in the same group; otherwise 404.
+///
+/// Authz: `Action::FilesWrite`.
+///
+/// ## Error matrix
+///
+/// | Condition                                      | Status |
+/// |------------------------------------------------|--------|
+/// | Missing/invalid JWT                            | 401    |
+/// | Path group_id ≠ principal group_id             | 403    |
+/// | Caller lacks `FilesWrite`                      | 403    |
+/// | Validation error (name)                        | 400    |
+/// | `parent_id` not found, soft-deleted, or wrong group | 404 |
+/// | Happy path                                     | 201    |
+#[utoipa::path(
+    post,
+    path = "/v1/groups/{group_id}/folders",
+    tag = "files",
+    request_body = CreateFolderRequest,
+    responses(
+        (status = 201, description = "Folder created", body = FolderSummary),
+        (status = 400, description = "Validation error"),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden"),
+        (status = 404, description = "Parent folder not found"),
+    )
+)]
+pub async fn create_folder(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(path_group_id): Path<Uuid>,
+    Json(body): Json<CreateFolderRequest>,
+) -> Result<(StatusCode, Json<FolderSummary>), RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::FilesWrite) {
+        return Err(RestError::Forbidden);
+    }
+
+    let name = validate_folder_name(&body.name).map_err(|msg| RestError::BadRequest(msg.into()))?;
+    let name_len = name.chars().count();
+    let has_parent = body.parent_id.is_some();
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Validate parent_id exists in same group and is not soft-deleted.
+    if let Some(parent_id) = body.parent_id {
+        let exists: Option<(bool,)> = sqlx::query_as(
+            "SELECT true FROM folders \
+             WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+        )
+        .bind(parent_id)
+        .bind(group_id)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+        if exists.is_none() {
+            return Err(RestError::NotFound);
+        }
+    }
+
+    let (created_by_label,): (String,) =
+        sqlx::query_as("SELECT display_name FROM users WHERE id = $1")
+            .bind(principal.user_id)
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(|e| RestError::Internal(e.into()))?;
+
+    let folder_id = Uuid::new_v4();
+    let row: FolderRow = sqlx::query_as(
+        "INSERT INTO folders \
+             (id, group_id, parent_id, name, created_by, created_by_label) \
+         VALUES ($1, $2, $3, $4, $5, $6) \
+         RETURNING id, name, parent_id, created_by, created_by_label, \
+                   created_at, updated_at",
+    )
+    .bind(folder_id)
+    .bind(group_id)
+    .bind(body.parent_id)
+    .bind(&name)
+    .bind(principal.user_id)
+    .bind(&created_by_label)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::FolderCreated,
+        principal.user_id,
+        group_id,
+        "folders",
+        folder_id.to_string(),
+        json!({ "name_len": name_len, "group_id": group_id, "has_parent": has_parent }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok((StatusCode::CREATED, Json(FolderSummary::from(row))))
+}
+
+/// `DELETE /v1/groups/{group_id}/folders/{folder_id}` — soft-delete a folder.
+///
+/// Sets `deleted_at = now()` on the folder. Files inside the folder become
+/// orphans (visible at group root) — no cascade. Already-deleted or
+/// non-existent folders return 404 (not idempotent per tus pattern; mirrors
+/// `DELETE /v1/files/{file_id}` which is group-scoped via RLS → 404).
+///
+/// Authz: `Action::FilesDelete`.
+///
+/// ## Error matrix
+///
+/// | Condition                                        | Status |
+/// |--------------------------------------------------|--------|
+/// | Missing/invalid JWT                              | 401    |
+/// | Path group_id ≠ principal group_id               | 403    |
+/// | Caller lacks `FilesDelete`                       | 403    |
+/// | Folder not found, soft-deleted, or cross-group   | 404    |
+/// | Happy path                                       | 204    |
+#[utoipa::path(
+    delete,
+    path = "/v1/groups/{group_id}/folders/{folder_id}",
+    tag = "files",
+    responses(
+        (status = 204, description = "Folder soft-deleted"),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden"),
+        (status = 404, description = "Folder not found"),
+    )
+)]
+pub async fn delete_folder(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, folder_id)): Path<(Uuid, Uuid)>,
+) -> Result<StatusCode, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::FilesDelete) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    let result = sqlx::query(
+        "UPDATE folders SET deleted_at = now() \
+         WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+    )
+    .bind(folder_id)
+    .bind(group_id)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if result.rows_affected() == 0 {
+        return Err(RestError::NotFound);
+    }
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::FolderDeleted,
+        principal.user_id,
+        group_id,
+        "folders",
+        folder_id.to_string(),
+        json!({ "group_id": group_id }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(StatusCode::NO_CONTENT)
 }
 
 // ─── Unit tests ───────────────────────────────────────────────────────────────

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -394,8 +394,12 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 // Plan 0084 (GAR-549) — search API slice 1.
                 .route("/v1/search", get(search::search))
                 // Plan 0088 (GAR-555) — files API slice 1.
+                // Plan 0092 (GAR-562) — files API slice 5: POST folder.
                 .route("/v1/groups/{group_id}/files", get(files::list_files))
-                .route("/v1/groups/{group_id}/folders", get(files::list_folders))
+                .route(
+                    "/v1/groups/{group_id}/folders",
+                    get(files::list_folders).post(files::create_folder),
+                )
                 .route("/v1/files/{file_id}", delete(files::delete_file))
                 // Plan 0089 (GAR-557) — files API slice 2: rename.
                 // Plan 0090 (GAR-559) — files API slice 3: GET single file.
@@ -405,9 +409,12 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 )
                 // Plan 0090 (GAR-559) — files API slice 3: GET single folder.
                 // Plan 0091 (GAR-561) — files API slice 4: PATCH folder rename.
+                // Plan 0092 (GAR-562) — files API slice 5: DELETE folder.
                 .route(
                     "/v1/groups/{group_id}/folders/{folder_id}",
-                    get(files::get_folder).patch(files::patch_folder),
+                    get(files::get_folder)
+                        .patch(files::patch_folder)
+                        .delete(files::delete_folder),
                 )
                 .merge(rate_limited_routes)
                 .merge(tus_routes)
@@ -505,19 +512,26 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 // Plan 0084 (GAR-549) — search API slice 1, fail-soft 503.
                 .route("/v1/search", get(unconfigured_handler))
                 // Plan 0088 (GAR-555) — files API slice 1, fail-soft 503.
+                // Plan 0092 (GAR-562) — files API slice 5: POST folder, fail-soft 503.
                 .route("/v1/groups/{group_id}/files", get(unconfigured_handler))
-                .route("/v1/groups/{group_id}/folders", get(unconfigured_handler))
+                .route(
+                    "/v1/groups/{group_id}/folders",
+                    get(unconfigured_handler).post(unconfigured_handler),
+                )
                 .route("/v1/files/{file_id}", delete(unconfigured_handler))
                 // Plan 0089 (GAR-557) — files API slice 2 PATCH, fail-soft 503.
                 // Plan 0090 (GAR-559) — files API slice 3 GET single, fail-soft 503.
                 // Plan 0091 (GAR-561) — files API slice 4 PATCH folder, fail-soft 503.
+                // Plan 0092 (GAR-562) — files API slice 5 DELETE folder, fail-soft 503.
                 .route(
                     "/v1/groups/{group_id}/files/{file_id}",
                     get(unconfigured_handler).patch(unconfigured_handler),
                 )
                 .route(
                     "/v1/groups/{group_id}/folders/{folder_id}",
-                    get(unconfigured_handler).patch(unconfigured_handler),
+                    get(unconfigured_handler)
+                        .patch(unconfigured_handler)
+                        .delete(unconfigured_handler),
                 )
                 .route(
                     "/v1/groups/{group_id}/tasks/{task_id}/comments",
@@ -652,19 +666,26 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 // Plan 0084 (GAR-549) — search API slice 1, no-auth stub.
                 .route("/v1/search", get(unconfigured_handler))
                 // Plan 0088 (GAR-555) — files API slice 1, no-auth stub.
+                // Plan 0092 (GAR-562) — files API slice 5: POST folder, no-auth stub.
                 .route("/v1/groups/{group_id}/files", get(unconfigured_handler))
-                .route("/v1/groups/{group_id}/folders", get(unconfigured_handler))
+                .route(
+                    "/v1/groups/{group_id}/folders",
+                    get(unconfigured_handler).post(unconfigured_handler),
+                )
                 .route("/v1/files/{file_id}", delete(unconfigured_handler))
                 // Plan 0089 (GAR-557) — files API slice 2 PATCH, no-auth stub.
                 // Plan 0090 (GAR-559) — files API slice 3 GET single, no-auth stub.
                 // Plan 0091 (GAR-561) — files API slice 4 PATCH folder, no-auth stub.
+                // Plan 0092 (GAR-562) — files API slice 5 DELETE folder, no-auth stub.
                 .route(
                     "/v1/groups/{group_id}/files/{file_id}",
                     get(unconfigured_handler).patch(unconfigured_handler),
                 )
                 .route(
                     "/v1/groups/{group_id}/folders/{folder_id}",
-                    get(unconfigured_handler).patch(unconfigured_handler),
+                    get(unconfigured_handler)
+                        .patch(unconfigured_handler)
+                        .delete(unconfigured_handler),
                 )
                 .route(
                     "/v1/groups/{group_id}/tasks/{task_id}/comments",

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -15,8 +15,8 @@ use utoipa::{Modify, OpenApi};
 use super::audit::{AuditEventSummary, ListAuditResponse};
 use super::chats::{ChatListResponse, ChatResponse, ChatSummary, CreateChatRequest};
 use super::files::{
-    FileListResponse, FileSummary, FolderListResponse, FolderSummary, PatchFileRequest,
-    PatchFolderRequest,
+    CreateFolderRequest, FileListResponse, FileSummary, FolderListResponse, FolderSummary,
+    PatchFileRequest, PatchFolderRequest,
 };
 use super::groups::{
     CreateGroupRequest, CreateInviteRequest, GroupReadResponse, GroupResponse, InviteResponse,
@@ -143,6 +143,8 @@ impl Modify for SecurityAddon {
         super::files::get_file,
         super::files::get_folder,
         super::files::patch_folder,
+        super::files::create_folder,
+        super::files::delete_folder,
     ),
     components(schemas(
         MeResponse,
@@ -207,6 +209,7 @@ impl Modify for SecurityAddon {
         FolderListResponse,
         PatchFileRequest,
         PatchFolderRequest,
+        CreateFolderRequest,
     )),
     modifiers(&SecurityAddon)
 )]

--- a/crates/garraia-gateway/tests/rest_v1_folders_post_delete.rs
+++ b/crates/garraia-gateway/tests/rest_v1_folders_post_delete.rs
@@ -1,0 +1,369 @@
+#![cfg(feature = "test-helpers")]
+//! Integration tests for:
+//!   `POST   /v1/groups/{group_id}/folders`
+//!   `DELETE /v1/groups/{group_id}/folders/{folder_id}`
+//! (plan 0092, GAR-562, Fase 3.4 files slice 5).
+//!
+//! All scenarios in ONE `#[tokio::test]` — same pattern as the other files
+//! integration suites (`rest_v1_folders_patch.rs`, `rest_v1_files_patch.rs`).
+//!
+//! Scenarios covered (10 total):
+//!
+//! C1. POST 201 — create root folder (parent_id absent).
+//! C2. POST 201 — create nested folder under a live parent; parent_id echoed.
+//! C3. POST 403 — path group_id ≠ principal group_id.
+//! C4. POST 400 — name > 200 chars (folder name boundary).
+//! C5. POST 404 — parent_id points to a soft-deleted folder.
+//!
+//! D1. DELETE 204 — soft-delete a live folder; deleted_at set in DB.
+//! D2. DELETE 404 — folder already soft-deleted.
+//! D3. DELETE 404 — non-existent folder_id.
+//! D4. DELETE 403 — path group_id ≠ principal group_id.
+//! D5. DELETE 204 — verify audit row `folder.deleted` is present after success.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
+use chrono::Utc;
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use common::Harness;
+use common::fixtures::{fetch_audit_events_for_group, seed_user_with_group};
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("body is JSON")
+}
+
+fn build_req(
+    method: &str,
+    uri: &str,
+    token: Option<&str>,
+    x_group_id: Option<&str>,
+    body: Option<serde_json::Value>,
+) -> Request<Body> {
+    let raw_body = body.map(|v| v.to_string()).unwrap_or_default();
+    let mut req = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(raw_body))
+        .expect("request builder");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    if let Some(t) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {t}")).unwrap(),
+        );
+    }
+    if let Some(g) = x_group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    req
+}
+
+/// Seed a folder directly via the admin pool.
+async fn seed_folder(
+    h: &Harness,
+    group_id: Uuid,
+    parent_id: Option<Uuid>,
+    created_by: Uuid,
+    name: &str,
+) -> anyhow::Result<Uuid> {
+    let folder_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO folders (id, group_id, parent_id, name, created_by, created_by_label) \
+         VALUES ($1, $2, $3, $4, $5, $6)",
+    )
+    .bind(folder_id)
+    .bind(group_id)
+    .bind(parent_id)
+    .bind(name)
+    .bind(created_by)
+    .bind("Test User")
+    .execute(&h.admin_pool)
+    .await?;
+    Ok(folder_id)
+}
+
+/// Soft-delete a folder directly via the admin pool.
+async fn soft_delete_folder(h: &Harness, folder_id: Uuid) -> anyhow::Result<()> {
+    sqlx::query("UPDATE folders SET deleted_at = $1 WHERE id = $2")
+        .bind(Utc::now())
+        .bind(folder_id)
+        .execute(&h.admin_pool)
+        .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn v1_folders_post_delete_scenarios() {
+    let h = Harness::get().await;
+
+    // Seed owner + group A — reused across all scenarios.
+    let (owner_id, group_id, owner_token) = seed_user_with_group(&h, "owner@folders-slice5.test")
+        .await
+        .expect("seed owner+group A");
+
+    let g = group_id.to_string();
+    let other_group = Uuid::new_v4().to_string();
+
+    // ── C1. POST 201 — root folder ──────────────────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(build_req(
+            "POST",
+            &format!("/v1/groups/{g}/folders"),
+            Some(&owner_token),
+            Some(&g),
+            Some(json!({ "name": "my-root-folder" })),
+        ))
+        .await
+        .expect("C1 oneshot");
+    assert_eq!(resp.status(), StatusCode::CREATED, "C1 status");
+    let v = body_json(resp).await;
+    assert_eq!(v["name"], "my-root-folder", "C1 name");
+    assert!(v["parent_id"].is_null(), "C1 parent_id null");
+    let c1_folder_id = v["id"].as_str().expect("C1 id").to_string();
+
+    // C1 — verify DB row.
+    let (db_name,): (String,) = sqlx::query_as("SELECT name FROM folders WHERE id = $1")
+        .bind(Uuid::parse_str(&c1_folder_id).unwrap())
+        .fetch_one(&h.admin_pool)
+        .await
+        .expect("C1 fetch db");
+    assert_eq!(db_name, "my-root-folder", "C1 db name");
+
+    // C1 — audit row with PII-safe metadata.
+    let events = fetch_audit_events_for_group(&h, group_id)
+        .await
+        .expect("C1 fetch audit");
+    let create_event = events
+        .iter()
+        .find(|(action, _, _, rid, _)| action == "folder.created" && rid == &c1_folder_id)
+        .expect("C1 folder.created audit row");
+    let (_, actor, resource_type, _, metadata) = create_event;
+    assert_eq!(actor.as_ref(), Some(&owner_id), "C1 audit actor");
+    assert_eq!(resource_type, "folders", "C1 audit resource_type");
+    assert!(
+        metadata.get("name").is_none(),
+        "C1 audit MUST NOT carry raw folder name"
+    );
+    assert!(
+        metadata.get("name_len").is_some(),
+        "C1 audit must carry name_len"
+    );
+
+    // ── C2. POST 201 — nested folder ───────────────────────────────
+    let parent_id = seed_folder(&h, group_id, None, owner_id, "parent-folder-c2")
+        .await
+        .expect("C2 seed parent");
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(build_req(
+            "POST",
+            &format!("/v1/groups/{g}/folders"),
+            Some(&owner_token),
+            Some(&g),
+            Some(json!({ "name": "nested-folder", "parent_id": parent_id })),
+        ))
+        .await
+        .expect("C2 oneshot");
+    assert_eq!(resp.status(), StatusCode::CREATED, "C2 status");
+    let v = body_json(resp).await;
+    assert_eq!(v["name"], "nested-folder", "C2 name");
+    assert_eq!(
+        v["parent_id"].as_str().expect("C2 parent_id str"),
+        parent_id.to_string(),
+        "C2 parent_id echoed"
+    );
+
+    // ── C3. POST 403 — group mismatch ──────────────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(build_req(
+            "POST",
+            &format!("/v1/groups/{other_group}/folders"),
+            Some(&owner_token),
+            Some(&other_group),
+            Some(json!({ "name": "should-fail" })),
+        ))
+        .await
+        .expect("C3 oneshot");
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN, "C3 status");
+
+    // ── C4. POST 400 — name too long (> 200 chars) ─────────────────
+    let long_name = "a".repeat(201);
+    let resp = h
+        .router
+        .clone()
+        .oneshot(build_req(
+            "POST",
+            &format!("/v1/groups/{g}/folders"),
+            Some(&owner_token),
+            Some(&g),
+            Some(json!({ "name": long_name })),
+        ))
+        .await
+        .expect("C4 oneshot");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "C4 status");
+
+    // ── C5. POST 404 — parent_id is soft-deleted ───────────────────
+    let deleted_parent = seed_folder(&h, group_id, None, owner_id, "deleted-parent-c5")
+        .await
+        .expect("C5 seed parent");
+    soft_delete_folder(&h, deleted_parent)
+        .await
+        .expect("C5 soft-delete parent");
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(build_req(
+            "POST",
+            &format!("/v1/groups/{g}/folders"),
+            Some(&owner_token),
+            Some(&g),
+            Some(json!({ "name": "nested-under-deleted", "parent_id": deleted_parent })),
+        ))
+        .await
+        .expect("C5 oneshot");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND, "C5 status");
+
+    // ── D1. DELETE 204 — soft-delete a live folder ─────────────────
+    let d1_folder = seed_folder(&h, group_id, None, owner_id, "d1-live-folder")
+        .await
+        .expect("D1 seed folder");
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(build_req(
+            "DELETE",
+            &format!("/v1/groups/{g}/folders/{d1_folder}"),
+            Some(&owner_token),
+            Some(&g),
+            None,
+        ))
+        .await
+        .expect("D1 oneshot");
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT, "D1 status");
+
+    // D1 — verify deleted_at is set in DB.
+    let (deleted_at,): (Option<chrono::DateTime<Utc>>,) =
+        sqlx::query_as("SELECT deleted_at FROM folders WHERE id = $1")
+            .bind(d1_folder)
+            .fetch_one(&h.admin_pool)
+            .await
+            .expect("D1 fetch db");
+    assert!(deleted_at.is_some(), "D1 deleted_at set in DB");
+
+    // ── D2. DELETE 404 — already soft-deleted ──────────────────────
+    let d2_folder = seed_folder(&h, group_id, None, owner_id, "d2-already-deleted")
+        .await
+        .expect("D2 seed folder");
+    soft_delete_folder(&h, d2_folder)
+        .await
+        .expect("D2 soft-delete setup");
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(build_req(
+            "DELETE",
+            &format!("/v1/groups/{g}/folders/{d2_folder}"),
+            Some(&owner_token),
+            Some(&g),
+            None,
+        ))
+        .await
+        .expect("D2 oneshot");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND, "D2 status");
+
+    // ── D3. DELETE 404 — non-existent folder ───────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(build_req(
+            "DELETE",
+            &format!("/v1/groups/{g}/folders/{}", Uuid::new_v4()),
+            Some(&owner_token),
+            Some(&g),
+            None,
+        ))
+        .await
+        .expect("D3 oneshot");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND, "D3 status");
+
+    // ── D4. DELETE 403 — group mismatch ────────────────────────────
+    let d4_folder = seed_folder(&h, group_id, None, owner_id, "d4-group-mismatch")
+        .await
+        .expect("D4 seed folder");
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(build_req(
+            "DELETE",
+            &format!("/v1/groups/{other_group}/folders/{d4_folder}"),
+            Some(&owner_token),
+            Some(&other_group),
+            None,
+        ))
+        .await
+        .expect("D4 oneshot");
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN, "D4 status");
+
+    // ── D5. DELETE 204 + audit ─────────────────────────────────────
+    let d5_folder = seed_folder(&h, group_id, None, owner_id, "d5-audit-check")
+        .await
+        .expect("D5 seed folder");
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(build_req(
+            "DELETE",
+            &format!("/v1/groups/{g}/folders/{d5_folder}"),
+            Some(&owner_token),
+            Some(&g),
+            None,
+        ))
+        .await
+        .expect("D5 oneshot");
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT, "D5 status");
+
+    let events = fetch_audit_events_for_group(&h, group_id)
+        .await
+        .expect("D5 fetch audit");
+    let delete_event = events
+        .iter()
+        .find(|(action, _, _, rid, _)| action == "folder.deleted" && rid == &d5_folder.to_string())
+        .expect("D5 folder.deleted audit row");
+    let (_, actor, resource_type, _, metadata) = delete_event;
+    assert_eq!(actor.as_ref(), Some(&owner_id), "D5 audit actor");
+    assert_eq!(resource_type, "folders", "D5 audit resource_type");
+    assert!(
+        metadata.get("name").is_none(),
+        "D5 audit MUST NOT carry raw folder name"
+    );
+}

--- a/plans/0092-gar-562-files-api-slice5-folder-post-delete.md
+++ b/plans/0092-gar-562-files-api-slice5-folder-post-delete.md
@@ -1,0 +1,160 @@
+# Plan 0092 — GAR-562: Files REST API slice 5 — POST + DELETE folders
+
+**Issue:** [GAR-562](https://linear.app/chatgpt25/issue/GAR-562)
+**Parent epic:** `epic:ws-api` / Fase 3.4
+**Branch:** `routine/202605091815-gar562-folder-post-delete`
+**Date:** 2026-05-09 (America/New_York)
+
+---
+
+## §1 Goal
+
+Ship the two remaining folder-mutation endpoints deferred from GAR-561 (plan 0091):
+
+- `POST /v1/groups/{group_id}/folders` — create a folder (top-level or nested) → 201 `FolderSummary`
+- `DELETE /v1/groups/{group_id}/folders/{folder_id}` — soft-delete a folder → 204
+
+This completes the folder management surface established by plan 0088 (GET folders) and plan 0091 (PATCH rename). The schema (`folders` table, migration 003) and RLS policies are already in place.
+
+---
+
+## §2 Architecture
+
+No new crates, no new migrations. All changes are additive within:
+
+- `crates/garraia-auth/src/audit_workspace.rs` — two new `WorkspaceAuditAction` variants
+- `crates/garraia-gateway/src/rest_v1/files.rs` — `CreateFolderRequest` DTO + two handlers
+- `crates/garraia-gateway/src/rest_v1/mod.rs` — POST + DELETE routes wired in 3 router modes
+- `crates/garraia-gateway/src/rest_v1/openapi.rs` — `create_folder` + `delete_folder` paths
+- `crates/garraia-gateway/tests/rest_v1_folders_post_delete.rs` — integration suite
+
+---
+
+## §3 Tech stack
+
+Same as plan 0091: `axum 0.8`, `sqlx 0.8`, `utoipa`, `garraia-auth` pool newtype, Postgres 16 FORCE RLS, pgvector testcontainer.
+
+---
+
+## §4 Design invariants
+
+1. **No new migration** — `folders` table exists since migration 003 (`compound FK`, `parent_id`, `deleted_at` soft-delete, `FORCE RLS`).
+2. **FORCE RLS** — `set_rls_context` (SET LOCAL `app.current_user_id` + `app.current_group_id`) before every SQL statement.
+3. **`parent_id` validation** — if supplied, verify parent folder exists in same group and is not soft-deleted (404 if not).
+4. **PII-safe audit** — metadata carries `name_len` not the raw folder name; `FolderCreated` metadata = `{ name_len, group_id, has_parent }`.
+5. **Soft-delete only** — `DELETE` sets `deleted_at = now()`; children files become orphans (visible at root); no cascade.
+6. **Auth gates** — POST requires `Action::FilesWrite`; DELETE requires `Action::FilesDelete`.
+7. **Cross-group = 403** — path `group_id` ≠ principal group → 403 (same as all other files endpoints).
+8. **Soft-deleted folder not found** — DELETE on already-soft-deleted or non-existent → 404.
+9. **Zero `unwrap` / `expect` in production** — propagate via `?`.
+10. **`validate_file_name`** is reused for folder name validation (1..=500 chars, no `/`, no NUL) — same as file names, matches `validate_folder_name` but that fn already exists in `files.rs` for the PATCH.
+
+---
+
+## §5 Out of scope
+
+- Folder move (`parent_id` mutation)
+- Cascading soft-delete of children
+- Hard delete
+- Undelete / restore
+- `POST /v1/groups/{group_id}/files:initUpload` (separate slice)
+- `GET /v1/files/{file_id}:download` (separate slice)
+
+---
+
+## §6 Rollback
+
+Revert the squash commit. No DB migrations to roll back. The new `FolderCreated` and `FolderDeleted` enum variants are additive — removing them later only matters if any audit consumer dispatches on them (none today).
+
+---
+
+## §7 Validações pré-plano
+
+- [x] `folders` table present since migration 003 with `parent_id`, `deleted_at`, FORCE RLS ✅
+- [x] `validate_folder_name` function present in `files.rs` ✅
+- [x] `set_rls_context` helper present in `files.rs` ✅
+- [x] `Action::FilesWrite` + `Action::FilesDelete` defined in `garraia-auth` ✅
+- [x] `audit_workspace_event` helper available ✅
+- [x] `FolderRenamed` variant already merged (plan 0091) — adding `FolderCreated` / `FolderDeleted` is additive ✅
+
+---
+
+## §8 File structure
+
+```
+crates/garraia-auth/src/audit_workspace.rs   ← +FolderCreated, +FolderDeleted variants
+crates/garraia-gateway/src/rest_v1/files.rs  ← +CreateFolderRequest, +create_folder, +delete_folder
+crates/garraia-gateway/src/rest_v1/mod.rs    ← POST + DELETE routes wired
+crates/garraia-gateway/src/rest_v1/openapi.rs← +create_folder path, +delete_folder path, +CreateFolderRequest schema
+crates/garraia-gateway/tests/rest_v1_folders_post_delete.rs  ← NEW integration test
+plans/0092-gar-562-files-api-slice5-folder-post-delete.md    ← this file
+plans/README.md                              ← +row 0092 + mark 0091 merged
+```
+
+---
+
+## §9 M1 tasks (TDD)
+
+- [x] T1 — `FolderCreated` + `FolderDeleted` audit variants + `as_str` arms + tests
+- [x] T2 — `CreateFolderRequest` DTO + `create_folder` handler
+- [x] T3 — `delete_folder` handler
+- [x] T4 — Wire POST + DELETE routes in all 3 router modes (mod.rs)
+- [x] T5 — OpenAPI paths + schema (openapi.rs)
+- [x] T6 — Integration test `rest_v1_folders_post_delete.rs` (10 scenarios)
+- [x] T7 — `cargo clippy` clean + `cargo fmt`
+- [x] T8 — Update `plans/README.md` + `ROADMAP.md`
+
+---
+
+## §10 Integration scenarios (test_id → description → expected)
+
+| # | Endpoint | Scenario | Expected |
+|---|----------|----------|----------|
+| C1 | POST folders | Create root folder (no parent_id) | 201 + FolderSummary (parent_id null) |
+| C2 | POST folders | Create nested folder (valid parent_id) | 201 + FolderSummary (parent_id echoed) |
+| C3 | POST folders | path group_id ≠ principal | 403 |
+| C4 | POST folders | name > 500 chars | 400 |
+| C5 | POST folders | parent_id points to soft-deleted folder | 404 |
+| D1 | DELETE folders | Soft-delete live folder | 204, deleted_at set |
+| D2 | DELETE folders | Delete already-soft-deleted folder | 404 |
+| D3 | DELETE folders | Delete non-existent folder_id | 404 |
+| D4 | DELETE folders | path group_id ≠ principal | 403 |
+| D5 | DELETE folders | Audit row present after delete | 204 + audit entry `folder.deleted` |
+
+---
+
+## §11 Risk register
+
+| Risk | Severity | Mitigation |
+|------|----------|-----------|
+| `parent_id` validation misses RLS context | Med | `set_rls_context` called before parent lookup query |
+| Soft-deleted parent accepted as valid | Med | `AND deleted_at IS NULL` in parent existence check |
+| `FolderCreated` metadata leaks name | Low | Only `name_len`, `group_id`, `has_parent` in JSON |
+
+---
+
+## §12 Acceptance criteria
+
+- `POST /v1/groups/{group_id}/folders` returns 201 with `FolderSummary` and audit row `folder.created`
+- `DELETE /v1/groups/{group_id}/folders/{folder_id}` returns 204 and sets `deleted_at`
+- All 10 integration scenarios pass
+- `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` clean
+- CI 18/18 green
+
+---
+
+## §13 Cross-references
+
+- Plan 0088 (GAR-555): Files slice 1 — GET files + GET folders + DELETE file
+- Plan 0089 (GAR-557): Files slice 2 — PATCH file rename
+- Plan 0090 (GAR-559): Files slice 3 — GET single file + folder
+- Plan 0091 (GAR-561): Files slice 4 — PATCH folder rename
+- Migration 003 (GAR-387): `folders` / `files` / `file_versions` schema
+
+---
+
+## §14 Estimativa
+
+- Low: 1h
+- Probable: 2h
+- High: 3h

--- a/plans/README.md
+++ b/plans/README.md
@@ -114,7 +114,8 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0088 | [GAR-555 — Files REST API slice 1: GET files + GET folders + DELETE file](0088-gar-555-files-api-slice1.md) | [GAR-555](https://linear.app/chatgpt25/issue/GAR-555) | ✅ Merged 2026-05-09 via PR #235 (`75d7a44`) |
 | 0089 | [GAR-557 — Files REST API slice 2: PATCH /v1/groups/{group_id}/files/{file_id} (rename)](0089-gar-557-files-api-slice2-rename.md) | [GAR-557](https://linear.app/chatgpt25/issue/GAR-557) | ✅ Merged 2026-05-09 via PR #238 (`9255515`) |
 | 0090 | [GAR-559 — Files REST API slice 3: GET single file + folder](0090-gar-559-files-api-slice3-get-single.md) | [GAR-559](https://linear.app/chatgpt25/issue/GAR-559) | ✅ Merged 2026-05-09 via PR #242 (`4adcb02`) |
-| 0091 | [GAR-561 — Files REST API slice 4: PATCH folder rename](0091-gar-561-files-api-slice4-folder-rename.md) | [GAR-561](https://linear.app/chatgpt25/issue/GAR-561) | 🟡 Ready for Review (PR open, awaiting approval). Slice 4 rescoped to PATCH-only; folder POST + DELETE deferred to GAR-562. |
+| 0091 | [GAR-561 — Files REST API slice 4: PATCH folder rename](0091-gar-561-files-api-slice4-folder-rename.md) | [GAR-561](https://linear.app/chatgpt25/issue/GAR-561) | ✅ Merged 2026-05-09 via PR #246 (`3679ccc`) |
+| 0092 | [GAR-562 — Files REST API slice 5: POST + DELETE folders](0092-gar-562-files-api-slice5-folder-post-delete.md) | [GAR-562](https://linear.app/chatgpt25/issue/GAR-562) | 🟡 In progress |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

Fase 3.4 files slice 5 — two new folder endpoints:

- `POST /v1/groups/{group_id}/folders` → 201 `FolderSummary` (create root or nested folder)
- `DELETE /v1/groups/{group_id}/folders/{folder_id}` → 204 (soft-delete)

Implements plan 0092 / GAR-562.

### Key design decisions

- **parent_id validation**: checks `deleted_at IS NULL` + `group_id` match → 404 if parent is soft-deleted or cross-group
- **Soft-delete is non-cascading**: children remain in DB but become orphaned (consistent with ROADMAP §3.4 policy)
- **PII-safe audit**: `FolderCreated` emits `{ name_len, group_id, has_parent }` — never the raw folder name; `FolderDeleted` emits `{ group_id }` only
- **Cross-group authz** tested in C3 (POST) and D4 (DELETE)

### New audit actions

`WorkspaceAuditAction::{FolderCreated, FolderDeleted}` added to `garraia-auth/src/audit_workspace.rs` with `as_str()` and unit-test coverage.

### Files changed

| File | Change |
|------|--------|
| `crates/garraia-auth/src/audit_workspace.rs` | +2 audit variants + tests |
| `crates/garraia-gateway/src/rest_v1/files.rs` | `CreateFolderRequest` DTO + `create_folder` + `delete_folder` handlers |
| `crates/garraia-gateway/src/rest_v1/mod.rs` | Wire POST + DELETE to all 3 router modes |
| `crates/garraia-gateway/src/rest_v1/openapi.rs` | Register paths + schema |
| `crates/garraia-gateway/tests/rest_v1_folders_post_delete.rs` | 10 integration scenarios (NEW) |
| `plans/0092-gar-562-files-api-slice5-folder-post-delete.md` | Plan document (NEW) |
| `plans/README.md` | Row 0092 added |
| `ROADMAP.md` | §3.4 Arquivos checklist updated |

## Test plan

- [x] `cargo check -p garraia-auth -p garraia-gateway` (SWAGGER_UI_DOWNLOAD_URL=file:///...) — clean
- [x] `cargo clippy -p garraia-auth -p garraia-gateway --all-features -D warnings` — zero warnings
- [x] `cargo fmt --check` — clean
- [x] 10 integration scenarios in `tests/rest_v1_folders_post_delete.rs`:
  - C1: POST 201 root folder + DB verify + audit PII-safe
  - C2: POST 201 nested folder, parent_id echoed
  - C3: POST 403 cross-group path mismatch
  - C4: POST 400 name > 200 chars
  - C5: POST 404 parent_id → soft-deleted folder
  - D1: DELETE 204 live folder + `deleted_at` DB verify
  - D2: DELETE 404 already-soft-deleted
  - D3: DELETE 404 non-existent folder_id
  - D4: DELETE 403 cross-group path mismatch
  - D5: DELETE 204 + `folder.deleted` audit row (PII-safe)

https://claude.ai/code/session_0147XekYpw6fGUhNiDDpc58R

---
_Generated by [Claude Code](https://claude.ai/code/session_0147XekYpw6fGUhNiDDpc58R)_