### PR TITLE
feat(files): GAR-564 — Files REST API slice 6: GET /v1/files/{id}/download (plan 0093)

### DIFF
--- a/crates/garraia-auth/src/audit_workspace.rs
+++ b/crates/garraia-auth/src/audit_workspace.rs
@@ -417,6 +417,13 @@ pub enum WorkspaceAuditAction {
     /// `resource_type = "folders"`, `resource_id = "{folder_id}"`.
     /// Metadata: `{ folder_id, group_id, name_len }` — never the raw name.
     FolderDeleted,
+
+    /// Emitted when `GET /v1/files/{file_id}/download` succeeds and file
+    /// bytes are about to be streamed to the caller (plan 0093, GAR-564).
+    /// `resource_type = "files"`, `resource_id = "{file_id}"`.
+    /// Metadata: `{ file_id, group_id, filename_len: usize }` — never the
+    /// raw filename (PII).
+    FileDownloadIssued,
 }
 
 impl WorkspaceAuditAction {
@@ -462,6 +469,7 @@ impl WorkspaceAuditAction {
             WorkspaceAuditAction::FolderRenamed => "folder.renamed",
             WorkspaceAuditAction::FolderCreated => "folder.created",
             WorkspaceAuditAction::FolderDeleted => "folder.deleted",
+            WorkspaceAuditAction::FileDownloadIssued => "file.download_issued",
         }
     }
 }
@@ -650,6 +658,10 @@ mod tests {
             WorkspaceAuditAction::FolderDeleted.as_str(),
             "folder.deleted"
         );
+        assert_eq!(
+            WorkspaceAuditAction::FileDownloadIssued.as_str(),
+            "file.download_issued"
+        );
     }
 
     #[test]
@@ -692,6 +704,7 @@ mod tests {
             WorkspaceAuditAction::FolderRenamed.as_str(),
             WorkspaceAuditAction::FolderCreated.as_str(),
             WorkspaceAuditAction::FolderDeleted.as_str(),
+            WorkspaceAuditAction::FileDownloadIssued.as_str(),
         ];
         let unique: std::collections::HashSet<_> = strings.iter().collect();
         assert_eq!(unique.len(), strings.len(), "duplicate action strings");

--- a/crates/garraia-gateway/src/rest_v1/files.rs
+++ b/crates/garraia-gateway/src/rest_v1/files.rs
@@ -1,11 +1,12 @@
 //! `/v1/groups/{group_id}/files`, `/v1/groups/{group_id}/folders`,
-//! and `DELETE /v1/files/{file_id}` handlers
-//! (plan 0088, GAR-555, Fase 3.4 files slice 1).
+//! `DELETE /v1/files/{file_id}`, and `GET /v1/files/{file_id}/download` handlers
+//! (plans 0088-0093, GAR-555/557/559/561/562/564, Fase 3.4 files slices 1-6).
 //!
-//! Three endpoints on the `garraia_app` RLS-enforced pool:
+//! Endpoints on the `garraia_app` RLS-enforced pool:
 //! - `GET /v1/groups/{group_id}/files?folder_id=&cursor=&limit=` — cursor-paginated list
 //! - `GET /v1/groups/{group_id}/folders?parent_id=&cursor=&limit=` — cursor-paginated list
 //! - `DELETE /v1/files/{file_id}` — idempotent soft-delete
+//! - `GET /v1/files/{file_id}/download` — stream current version bytes (plan 0093)
 //!
 //! ## Tenant-context protocol
 //!
@@ -15,11 +16,14 @@
 //! ## Cross-group protection
 //!
 //! For group-path endpoints: `path_group_id` must equal `principal.group_id` → 403.
-//! For `DELETE /v1/files/{file_id}`: no group_id in path; RLS filters silently → 404.
+//! For `DELETE /v1/files/{file_id}` and `GET /v1/files/{file_id}/download`:
+//! no group_id in path; RLS filters silently → 404.
 
 use axum::Json;
+use axum::body::Body;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
+use axum::response::Response;
 use chrono::{DateTime, Utc};
 use garraia_auth::{Action, Principal, WorkspaceAuditAction, audit_workspace_event, can};
 use serde::{Deserialize, Serialize};
@@ -625,6 +629,134 @@ pub async fn delete_file(
         .map_err(|e| RestError::Internal(e.into()))?;
 
     Ok(StatusCode::NO_CONTENT)
+}
+
+/// Private row returned by the download lookup query.
+#[derive(sqlx::FromRow)]
+struct DownloadRow {
+    name: String,
+    object_key: String,
+    mime_type: String,
+}
+
+/// `GET /v1/files/{file_id}/download` — stream the current file version
+/// (plan 0093, GAR-564, Fase 3.4 files slice 6).
+///
+/// Looks up the current `file_versions.object_key` via RLS-enforced JOIN,
+/// then reads the bytes from the configured `ObjectStore`. Returns a 200
+/// response with `Content-Type` and `Content-Disposition: attachment` so
+/// browsers offer a Save dialog. The raw filename is NOT reflected in any
+/// response header (PII-safe); clients use `GET .../files/{id}` for that.
+///
+/// Auth: `Action::FilesRead`. `X-Group-Id` header required for RLS context.
+/// Cross-group attempts are silently 404 via RLS filtering.
+///
+/// ## Error matrix
+///
+/// | Condition                              | Status |
+/// |----------------------------------------|--------|
+/// | Missing/invalid JWT                    | 401    |
+/// | Insufficient role (no `FilesRead`)     | 403    |
+/// | Missing `X-Group-Id` header            | 400    |
+/// | File not found / deleted / cross-group | 404    |
+/// | `ObjectStore` not configured           | 503    |
+/// | Object missing from storage backend    | 404    |
+/// | Happy path                             | 200    |
+#[utoipa::path(
+    get,
+    path = "/v1/files/{file_id}/download",
+    params(
+        ("file_id" = Uuid, Path, description = "File UUID."),
+    ),
+    responses(
+        (status = 200, description = "File bytes streamed with Content-Type and Content-Disposition."),
+        (status = 400, description = "Missing X-Group-Id header.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller lacks FilesRead.", body = super::problem::ProblemDetails),
+        (status = 404, description = "File not found, deleted, or cross-group.", body = super::problem::ProblemDetails),
+        (status = 503, description = "Object store not configured.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn download_file(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(file_id): Path<Uuid>,
+) -> Result<Response, RestError> {
+    let group_id = require_group_id(&principal)?;
+    if !can(&principal, Action::FilesRead) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    let row: Option<DownloadRow> = sqlx::query_as(
+        "SELECT f.name, fv.object_key, fv.mime_type \
+         FROM   files f \
+         JOIN   file_versions fv \
+                ON  fv.file_id  = f.id \
+                AND fv.version  = f.current_version \
+                AND fv.group_id = f.group_id \
+         WHERE  f.id         = $1 \
+           AND  f.deleted_at IS NULL",
+    )
+    .bind(file_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let row = match row {
+        Some(r) => r,
+        None => return Err(RestError::NotFound),
+    };
+
+    let filename_len = row.name.chars().count();
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::FileDownloadIssued,
+        principal.user_id,
+        group_id,
+        "files",
+        file_id.to_string(),
+        json!({ "file_id": file_id, "group_id": group_id, "filename_len": filename_len }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    let object_store = state
+        .storage
+        .object_store
+        .as_ref()
+        .ok_or(RestError::AuthUnconfigured)?
+        .clone();
+
+    let result = object_store
+        .get(&row.object_key)
+        .await
+        .map_err(|e| match e {
+            garraia_storage::StorageError::NotFound { .. } => RestError::NotFound,
+            other => RestError::Internal(anyhow::anyhow!(other)),
+        })?;
+
+    let response = Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", row.mime_type)
+        .header("content-disposition", "attachment; filename=\"download\"")
+        .header("content-length", result.metadata.size_bytes.to_string())
+        .body(Body::from(result.bytes))
+        .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    Ok(response)
 }
 
 /// `PATCH /v1/groups/{group_id}/files/{file_id}` — rename a file

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -401,6 +401,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     get(files::list_folders).post(files::create_folder),
                 )
                 .route("/v1/files/{file_id}", delete(files::delete_file))
+                // Plan 0093 (GAR-564) — files API slice 6: download.
+                .route(
+                    "/v1/files/{file_id}/download",
+                    get(files::download_file),
+                )
                 // Plan 0089 (GAR-557) — files API slice 2: rename.
                 // Plan 0090 (GAR-559) — files API slice 3: GET single file.
                 .route(
@@ -519,6 +524,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     get(unconfigured_handler).post(unconfigured_handler),
                 )
                 .route("/v1/files/{file_id}", delete(unconfigured_handler))
+                // Plan 0093 (GAR-564) — files API slice 6: download, fail-soft 503.
+                .route(
+                    "/v1/files/{file_id}/download",
+                    get(unconfigured_handler),
+                )
                 // Plan 0089 (GAR-557) — files API slice 2 PATCH, fail-soft 503.
                 // Plan 0090 (GAR-559) — files API slice 3 GET single, fail-soft 503.
                 // Plan 0091 (GAR-561) — files API slice 4 PATCH folder, fail-soft 503.
@@ -673,6 +683,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     get(unconfigured_handler).post(unconfigured_handler),
                 )
                 .route("/v1/files/{file_id}", delete(unconfigured_handler))
+                // Plan 0093 (GAR-564) — files API slice 6: download, no-auth stub.
+                .route(
+                    "/v1/files/{file_id}/download",
+                    get(unconfigured_handler),
+                )
                 // Plan 0089 (GAR-557) — files API slice 2 PATCH, no-auth stub.
                 // Plan 0090 (GAR-559) — files API slice 3 GET single, no-auth stub.
                 // Plan 0091 (GAR-561) — files API slice 4 PATCH folder, no-auth stub.

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -402,10 +402,7 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 )
                 .route("/v1/files/{file_id}", delete(files::delete_file))
                 // Plan 0093 (GAR-564) — files API slice 6: download.
-                .route(
-                    "/v1/files/{file_id}/download",
-                    get(files::download_file),
-                )
+                .route("/v1/files/{file_id}/download", get(files::download_file))
                 // Plan 0089 (GAR-557) — files API slice 2: rename.
                 // Plan 0090 (GAR-559) — files API slice 3: GET single file.
                 .route(
@@ -525,10 +522,7 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 )
                 .route("/v1/files/{file_id}", delete(unconfigured_handler))
                 // Plan 0093 (GAR-564) — files API slice 6: download, fail-soft 503.
-                .route(
-                    "/v1/files/{file_id}/download",
-                    get(unconfigured_handler),
-                )
+                .route("/v1/files/{file_id}/download", get(unconfigured_handler))
                 // Plan 0089 (GAR-557) — files API slice 2 PATCH, fail-soft 503.
                 // Plan 0090 (GAR-559) — files API slice 3 GET single, fail-soft 503.
                 // Plan 0091 (GAR-561) — files API slice 4 PATCH folder, fail-soft 503.
@@ -684,10 +678,7 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 )
                 .route("/v1/files/{file_id}", delete(unconfigured_handler))
                 // Plan 0093 (GAR-564) — files API slice 6: download, no-auth stub.
-                .route(
-                    "/v1/files/{file_id}/download",
-                    get(unconfigured_handler),
-                )
+                .route("/v1/files/{file_id}/download", get(unconfigured_handler))
                 // Plan 0089 (GAR-557) — files API slice 2 PATCH, no-auth stub.
                 // Plan 0090 (GAR-559) — files API slice 3 GET single, no-auth stub.
                 // Plan 0091 (GAR-561) — files API slice 4 PATCH folder, no-auth stub.

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -145,6 +145,7 @@ impl Modify for SecurityAddon {
         super::files::patch_folder,
         super::files::create_folder,
         super::files::delete_folder,
+        super::files::download_file,
     ),
     components(schemas(
         MeResponse,

--- a/crates/garraia-gateway/tests/rest_v1_files_download.rs
+++ b/crates/garraia-gateway/tests/rest_v1_files_download.rs
@@ -123,8 +123,8 @@ async fn seed_file_version(
     .bind(group_id)
     .bind(object_key)
     .bind("abc123") // short etag — allowed per migration comment
-    .bind(&hex64)   // checksum_sha256
-    .bind(&hex64)   // integrity_hmac
+    .bind(&hex64) // checksum_sha256
+    .bind(&hex64) // integrity_hmac
     .bind(size_bytes)
     .bind(mime_type)
     .bind(created_by)
@@ -191,10 +191,9 @@ async fn v1_files_download_scenarios() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let (router, local_fs) = build_storage_router(&h, tmp.path()).await;
 
-    let (owner_id, group_id, owner_token) =
-        seed_user_with_group(&h, "owner@0093-download.test")
-            .await
-            .expect("seed owner+group");
+    let (owner_id, group_id, owner_token) = seed_user_with_group(&h, "owner@0093-download.test")
+        .await
+        .expect("seed owner+group");
     let gid_str = group_id.to_string();
 
     // ─── D1. 200 happy path ────────────────────────────────────────────
@@ -229,7 +228,11 @@ async fn v1_files_download_scenarios() {
 
     let resp = router
         .clone()
-        .oneshot(download_req(&owner_token, &d1_id.to_string(), Some(&gid_str)))
+        .oneshot(download_req(
+            &owner_token,
+            &d1_id.to_string(),
+            Some(&gid_str),
+        ))
         .await
         .expect("D1 oneshot");
     assert_eq!(resp.status(), StatusCode::OK, "D1 status");
@@ -244,9 +247,16 @@ async fn v1_files_download_scenarios() {
     assert_eq!(body.as_ref(), d1_bytes, "D1 body bytes");
 
     // ─── D2. 404 soft-deleted file ─────────────────────────────────────
-    let d2_id = seed_file(&h, group_id, owner_id, "d2.bin", 10, "application/octet-stream")
-        .await
-        .expect("D2 seed file");
+    let d2_id = seed_file(
+        &h,
+        group_id,
+        owner_id,
+        "d2.bin",
+        10,
+        "application/octet-stream",
+    )
+    .await
+    .expect("D2 seed file");
     sqlx::query("UPDATE files SET deleted_at = $1 WHERE id = $2")
         .bind(Utc::now())
         .bind(d2_id)

--- a/crates/garraia-gateway/tests/rest_v1_files_download.rs
+++ b/crates/garraia-gateway/tests/rest_v1_files_download.rs
@@ -1,0 +1,342 @@
+// Gated so `cargo clippy --all-targets` without `test-helpers` skips this
+// file and doesn't try to compile the `common` harness.
+#![cfg(feature = "test-helpers")]
+//! Integration tests for `GET /v1/files/{file_id}/download` (plan 0093, GAR-564).
+//!
+//! All scenarios bundled into ONE `#[tokio::test]` — same pattern as other
+//! files tests to avoid the sqlx runtime-teardown race.
+//!
+//! Scenarios:
+//! D1. 200 happy path — bytes stored in LocalFs, file_versions row present.
+//! D2. 404 soft-deleted file.
+//! D3. 404 non-existent file_id.
+//! D4. 403 Child role lacks FilesRead.
+//! D5. 400 missing X-Group-Id header.
+//! D6. 503 object store not configured.
+//! D7. 404 cross-group (RLS filters out the file).
+
+mod common;
+
+use std::path::Path;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
+use bytes::Bytes;
+use chrono::Utc;
+use garraia_gateway::rest_v1::uploads::UploadStaging;
+use garraia_gateway::server::build_router_for_test_with_storage;
+use garraia_storage::{LocalFs, PutOptions};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use common::Harness;
+use common::fixtures::{seed_member_via_admin, seed_user_with_group};
+
+fn docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn req_with_peer(builder: axum::http::request::Builder, body: Body) -> Request<Body> {
+    let mut req = builder.body(body).expect("request builder");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    req
+}
+
+fn download_req(token: &str, file_id: &str, group_id: Option<&str>) -> Request<Body> {
+    let mut req = req_with_peer(
+        Request::builder()
+            .method("GET")
+            .uri(format!("/v1/files/{file_id}/download")),
+        Body::empty(),
+    );
+    req.headers_mut().insert(
+        HeaderName::from_static("authorization"),
+        HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+    );
+    if let Some(g) = group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    req
+}
+
+/// Seed a `files` row and return its id.
+async fn seed_file(
+    h: &Harness,
+    group_id: Uuid,
+    created_by: Uuid,
+    name: &str,
+    size_bytes: i64,
+    mime_type: &str,
+) -> anyhow::Result<Uuid> {
+    let file_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO files (id, group_id, folder_id, name, current_version, \
+                            total_versions, size_bytes, mime_type, settings, \
+                            created_by, created_by_label) \
+         VALUES ($1, $2, NULL, $3, 1, 1, $4, $5, '{}'::jsonb, $6, $7)",
+    )
+    .bind(file_id)
+    .bind(group_id)
+    .bind(name)
+    .bind(size_bytes)
+    .bind(mime_type)
+    .bind(created_by)
+    .bind("Test User")
+    .execute(&h.admin_pool)
+    .await?;
+    Ok(file_id)
+}
+
+/// Seed a `file_versions` row (version 1) for the given file.
+///
+/// Uses placeholder etag / sha256 / hmac values — valid per schema
+/// constraints but not representing real content integrity.
+async fn seed_file_version(
+    h: &Harness,
+    file_id: Uuid,
+    group_id: Uuid,
+    created_by: Uuid,
+    object_key: &str,
+    size_bytes: i64,
+    mime_type: &str,
+) -> anyhow::Result<()> {
+    let hex64 = "a".repeat(64); // 64 lowercase hex chars — passes CHECK regex
+    sqlx::query(
+        "INSERT INTO file_versions \
+         (file_id, group_id, version, object_key, etag, checksum_sha256, \
+          integrity_hmac, size_bytes, mime_type, created_by, created_by_label) \
+         VALUES ($1, $2, 1, $3, $4, $5, $6, $7, $8, $9, $10)",
+    )
+    .bind(file_id)
+    .bind(group_id)
+    .bind(object_key)
+    .bind("abc123") // short etag — allowed per migration comment
+    .bind(&hex64)   // checksum_sha256
+    .bind(&hex64)   // integrity_hmac
+    .bind(size_bytes)
+    .bind(mime_type)
+    .bind(created_by)
+    .bind("Test User")
+    .execute(&h.admin_pool)
+    .await?;
+    Ok(())
+}
+
+async fn build_storage_router(h: &Harness, tmp: &Path) -> (axum::Router, Arc<LocalFs>) {
+    let fs_root = tmp.join("storage");
+    let staging_dir = tmp.join("staging");
+    std::fs::create_dir_all(&fs_root).unwrap();
+    std::fs::create_dir_all(&staging_dir).unwrap();
+
+    let local_fs = Arc::new(LocalFs::new(&fs_root).expect("LocalFs::new"));
+    let staging = Arc::new(UploadStaging {
+        staging_dir: std::fs::canonicalize(&staging_dir).unwrap(),
+        max_patch_bytes: 10 * 1024 * 1024,
+        hmac_secret: b"test-secret-32-bytes-minimum-xxx".to_vec(),
+    });
+
+    let router = build_router_for_test_with_storage(
+        garraia_config::AppConfig::default(),
+        h.login_pool.clone(),
+        h.signup_pool.clone(),
+        h.jwt.clone(),
+        Some(h.app_pool.clone()),
+        Some(local_fs.clone() as Arc<dyn garraia_storage::ObjectStore>),
+        Some(staging.clone()),
+    )
+    .await;
+
+    (router, local_fs)
+}
+
+async fn build_no_storage_router(h: &Harness) -> axum::Router {
+    let staging_dir = tempfile::tempdir().expect("tempdir").into_path();
+    let staging = Arc::new(UploadStaging {
+        staging_dir,
+        max_patch_bytes: 10 * 1024 * 1024,
+        hmac_secret: b"test-secret-32-bytes-minimum-xxx".to_vec(),
+    });
+    build_router_for_test_with_storage(
+        garraia_config::AppConfig::default(),
+        h.login_pool.clone(),
+        h.signup_pool.clone(),
+        h.jwt.clone(),
+        Some(h.app_pool.clone()),
+        None,
+        Some(staging),
+    )
+    .await
+}
+
+#[tokio::test]
+async fn v1_files_download_scenarios() {
+    if !docker_available() {
+        eprintln!("docker not available; skipping v1_files_download_scenarios");
+        return;
+    }
+
+    let h = Harness::get().await;
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (router, local_fs) = build_storage_router(&h, tmp.path()).await;
+
+    let (owner_id, group_id, owner_token) =
+        seed_user_with_group(&h, "owner@0093-download.test")
+            .await
+            .expect("seed owner+group");
+    let gid_str = group_id.to_string();
+
+    // ─── D1. 200 happy path ────────────────────────────────────────────
+    let d1_bytes: &[u8] = b"hello download world";
+    let d1_key = format!("{group_id}/files/v1/d1.bin");
+    local_fs
+        .put(&d1_key, Bytes::from_static(d1_bytes), PutOptions::default())
+        .await
+        .expect("D1 put to LocalFs");
+
+    let d1_id = seed_file(
+        &h,
+        group_id,
+        owner_id,
+        "d1.bin",
+        d1_bytes.len() as i64,
+        "application/octet-stream",
+    )
+    .await
+    .expect("D1 seed file");
+    seed_file_version(
+        &h,
+        d1_id,
+        group_id,
+        owner_id,
+        &d1_key,
+        d1_bytes.len() as i64,
+        "application/octet-stream",
+    )
+    .await
+    .expect("D1 seed file_version");
+
+    let resp = router
+        .clone()
+        .oneshot(download_req(&owner_token, &d1_id.to_string(), Some(&gid_str)))
+        .await
+        .expect("D1 oneshot");
+    assert_eq!(resp.status(), StatusCode::OK, "D1 status");
+    assert_eq!(
+        resp.headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok()),
+        Some("application/octet-stream"),
+        "D1 content-type"
+    );
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(body.as_ref(), d1_bytes, "D1 body bytes");
+
+    // ─── D2. 404 soft-deleted file ─────────────────────────────────────
+    let d2_id = seed_file(&h, group_id, owner_id, "d2.bin", 10, "application/octet-stream")
+        .await
+        .expect("D2 seed file");
+    sqlx::query("UPDATE files SET deleted_at = $1 WHERE id = $2")
+        .bind(Utc::now())
+        .bind(d2_id)
+        .execute(&h.admin_pool)
+        .await
+        .expect("D2 soft delete");
+
+    let resp = router
+        .clone()
+        .oneshot(download_req(
+            &owner_token,
+            &d2_id.to_string(),
+            Some(&gid_str),
+        ))
+        .await
+        .expect("D2 oneshot");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND, "D2 status");
+
+    // ─── D3. 404 non-existent file_id ─────────────────────────────────
+    let phantom = Uuid::new_v4();
+    let resp = router
+        .clone()
+        .oneshot(download_req(
+            &owner_token,
+            &phantom.to_string(),
+            Some(&gid_str),
+        ))
+        .await
+        .expect("D3 oneshot");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND, "D3 status");
+
+    // ─── D4. 403 Child role lacks FilesRead ────────────────────────────
+    let (_child_uid, child_token) =
+        seed_member_via_admin(&h, group_id, "child", "child@0093-download.test")
+            .await
+            .expect("D4 seed child");
+
+    let resp = router
+        .clone()
+        .oneshot(download_req(
+            &child_token,
+            &d1_id.to_string(),
+            Some(&gid_str),
+        ))
+        .await
+        .expect("D4 oneshot");
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN, "D4 status");
+
+    // ─── D5. 400 missing X-Group-Id ───────────────────────────────────
+    let resp = router
+        .clone()
+        .oneshot(download_req(&owner_token, &d1_id.to_string(), None))
+        .await
+        .expect("D5 oneshot");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "D5 status");
+
+    // ─── D6. 503 object store not configured ──────────────────────────
+    let d6_key = format!("{group_id}/files/v1/d6.bin");
+    let d6_id = seed_file(&h, group_id, owner_id, "d6.bin", 4, "text/plain")
+        .await
+        .expect("D6 seed file");
+    seed_file_version(&h, d6_id, group_id, owner_id, &d6_key, 4, "text/plain")
+        .await
+        .expect("D6 seed version");
+
+    let no_store_router = build_no_storage_router(&h).await;
+    let resp = no_store_router
+        .oneshot(download_req(
+            &owner_token,
+            &d6_id.to_string(),
+            Some(&gid_str),
+        ))
+        .await
+        .expect("D6 oneshot");
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE, "D6 status");
+
+    // ─── D7. 404 cross-group (RLS filters out the file) ───────────────
+    let (_other_uid, other_group_id, other_token) =
+        seed_user_with_group(&h, "other@0093-download.test")
+            .await
+            .expect("D7 seed other group");
+
+    let resp = router
+        .clone()
+        .oneshot(download_req(
+            &other_token,
+            &d1_id.to_string(),
+            Some(&other_group_id.to_string()),
+        ))
+        .await
+        .expect("D7 oneshot");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND, "D7 status");
+}

--- a/plans/0093-gar-564-files-api-slice6-download.md
+++ b/plans/0093-gar-564-files-api-slice6-download.md
@@ -1,0 +1,165 @@
+# Plan 0093 — GAR-564 — Files REST API slice 6: GET /v1/files/{file_id}/download
+
+## Goal
+
+Add streaming file download to the `/v1` REST surface:
+
+* `GET /v1/files/{file_id}/download` — streams the current version of a file as binary
+  content (200 + Content-Type + Content-Disposition: attachment).
+
+This is the sixth slice of the files API (plans 0088–0092). It closes the core
+download use-case for both LocalFs (dev) and S3-backed (production) deployments.
+
+## Architecture
+
+### Handler (`download_file`)
+
+1. `require_group_id` → 400 if `X-Group-Id` header missing
+2. `can(&principal, Action::FilesRead)` → 403 if denied
+3. Begin tx → `set_rls_context` (both `app.current_user_id` + `app.current_group_id`)
+4. ```sql
+   SELECT f.name, fv.object_key, fv.mime_type, fv.size_bytes
+   FROM   files f
+   JOIN   file_versions fv ON fv.file_id = f.id
+                          AND fv.version  = f.current_version
+                          AND fv.group_id = f.group_id
+   WHERE  f.id         = $file_id
+     AND  f.deleted_at IS NULL
+   ```
+   Returns `None` → 404 (not found or RLS-filtered cross-group)
+5. COMMIT tx (read-only — release connection)
+6. Require `AppState::object_store` (or fail 503)
+7. Call `object_store.get(object_key)` → map errors:
+   - `StorageError::NotFound` → 404
+   - Other → 500
+8. Emit audit event `file.download_issued`:
+   `{ file_id, group_id, filename_len: usize }` — no raw filename (PII)
+9. Return `axum::response::Response` with:
+   - Status: 200
+   - `Content-Type: <mime_type from file_versions>`
+   - `Content-Disposition: attachment; filename="download"` (no raw name in header —
+     clients that need the filename already have it from the GET /files/{id} response)
+   - `Content-Length: <size_bytes>`
+   - Body: `bytes::Bytes` from `GetResult`
+
+### Content-Disposition rationale
+
+Raw filenames in `Content-Disposition` require RFC 5987 percent-encoding for
+non-ASCII characters, which adds complexity. The file name is always available
+via `GET /v1/groups/{group_id}/files/{file_id}` (plan 0090). For this slice,
+use the literal `filename="download"` sentinel — a pragmatic choice that avoids
+PII leak in logs and the encoding edge-cases. A follow-up slice can add RFC 5987
+encoding if clients request it.
+
+## Tech stack
+
+* Axum 0.8, `garraia-auth::Principal`
+* `garraia-auth::Action::FilesRead`
+* `sqlx` (Postgres), `set_rls_context` for FORCE RLS compliance
+* `garraia-storage::ObjectStore::get` (streaming bytes)
+* `garraia-auth::audit_workspace` — new variant `FileDownloadIssued`
+* `utoipa` annotations, registered in `openapi.rs`
+
+## Design invariants
+
+* FORCE RLS protocol: `SET LOCAL app.current_user_id` AND `app.current_group_id`
+  before every SQL operation.
+* PII-free audit: metadata carries `filename_len: usize`, never the raw file name.
+* `object_key` is NEVER returned in HTTP responses (internal detail).
+* Cross-group attempts return 404 via RLS filtering (not 403 — avoids oracle).
+* No presigned-URL path in this slice — a future S3 slice adds `presign_get` redirect.
+
+## Validações pré-plano
+
+* PR #247 (GAR-562, slice 5 folder POST + DELETE) merged as `28b3b0f` — all
+  file/folder CRUD patterns established.
+* `ObjectStore::get(key) -> Result<GetResult>` is fully implemented in both
+  `LocalFs` and `S3Compatible`.
+* `AppState::object_store: Option<Arc<dyn ObjectStore>>` available in all handlers.
+* `build_router_for_test_with_storage` exists for integration tests (used by
+  `rest_v1_uploads_patch.rs`).
+* `WorkspaceAuditAction` enum is extensible (variants added per slice).
+
+## Out of scope
+
+* Presigned URL (S3 redirect) — `LocalFs::presign_get` returns `Unsupported`;
+  this will be a dedicated S3-only slice.
+* Range requests (HTTP 206 Partial Content) — future enhancement.
+* `Content-Disposition: inline` option — future.
+* Version-specific download (`?version=N`) — future.
+* `file_shares` table — deferred (ADR 0004 v1 drops sharing).
+
+## Rollback plan
+
+Reversible: the endpoint is additive (new route). Removing it is a one-line route
+deletion. No schema changes, no migrations.
+
+## §8 Rollback plan (formal)
+
+Add-only change — revert is `git revert <commit>` on the handler + route registration
+lines. No DB state is modified. Object store content is read-only.
+
+## §12 Open questions
+
+None — all building blocks confirmed present.
+
+## File structure
+
+```
+crates/garraia-gateway/src/rest_v1/files.rs       (handler + unit tests)
+crates/garraia-gateway/src/rest_v1/mod.rs          (route registration × 3 branches)
+crates/garraia-gateway/src/rest_v1/openapi.rs      (utoipa registration)
+crates/garraia-auth/src/audit_workspace.rs          (FileDownloadIssued variant)
+crates/garraia-gateway/tests/rest_v1_files_download.rs  (integration tests)
+```
+
+## M1 — Tests first (red)
+
+- [ ] Add `FileDownloadIssued` variant to `WorkspaceAuditAction`
+- [ ] Add `download_file` handler skeleton (returns 501) in `files.rs`
+- [ ] Register route in `mod.rs` (all 3 branches)
+- [ ] Write integration test `rest_v1_files_download.rs` (D1–D6 scenarios)
+- [ ] `cargo test -p garraia-gateway --test rest_v1_files_download --features test-helpers` → red
+
+## M2 — Implementation (green)
+
+- [ ] Implement `download_file` handler (SQL lookup + ObjectStore::get + response)
+- [ ] Add utoipa annotation in `openapi.rs`
+- [ ] `cargo test -p garraia-gateway --test rest_v1_files_download --features test-helpers` → green
+
+## M3 — Unit tests
+
+- [ ] Add unit tests inside `files.rs` covering helper functions
+- [ ] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` → clean
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| `file_versions` row missing (schema invariant violated) | JOIN returns None → 404 (safe fallback) |
+| `object_key` stored but object physically deleted | `StorageError::NotFound` → 404 |
+| Large file OOM | `ObjectStore::get` buffers into `Bytes` — acceptable for v1 (files ≤ 5 GiB cap per DB CHECK); streaming via `AsyncRead` is a future enhancement |
+| Content-Disposition filename encoding | Avoided by using literal `"download"` sentinel |
+
+## Acceptance criteria
+
+* `GET /v1/files/{file_id}/download` → 200 + correct bytes + correct Content-Type
+* Returns 404 when file is soft-deleted
+* Returns 404 when file does not exist
+* Returns 403 when `Action::FilesRead` is denied (Guest role or below)
+* Returns 503 when `object_store` is not configured
+* Returns 404 when RLS blocks cross-group attempt (Rule 10 satisfied)
+* `cargo clippy -- -D warnings` clean
+* CI green
+
+## Cross-references
+
+* Plan 0088 (GAR-555) — files list + DELETE slice 1 (pattern reference)
+* Plan 0090 (GAR-559) — GET single file (DB lookup pattern)
+* Plan 0047 (GAR-395 slice 3) — ObjectStore usage in gateway
+* ROADMAP.md §3.4 "Arquivos" — `GET /v1/files/{file_id}:download`
+* ADR 0004 — object storage (presigned URL deferred to follow-up)
+
+## Estimativa
+
+0.5 / 1 / 1.5 horas (baixo / provável / alto).

--- a/plans/README.md
+++ b/plans/README.md
@@ -116,6 +116,7 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0090 | [GAR-559 — Files REST API slice 3: GET single file + folder](0090-gar-559-files-api-slice3-get-single.md) | [GAR-559](https://linear.app/chatgpt25/issue/GAR-559) | ✅ Merged 2026-05-09 via PR #242 (`4adcb02`) |
 | 0091 | [GAR-561 — Files REST API slice 4: PATCH folder rename](0091-gar-561-files-api-slice4-folder-rename.md) | [GAR-561](https://linear.app/chatgpt25/issue/GAR-561) | ✅ Merged 2026-05-09 via PR #246 (`3679ccc`) |
 | 0092 | [GAR-562 — Files REST API slice 5: folder POST + DELETE](0092-gar-562-files-api-slice5-folder-post-delete.md) | [GAR-562](https://linear.app/chatgpt25/issue/GAR-562) | ✅ Merged 2026-05-09 via PR #247 (`28b3b0f`) |
+| 0093 | [GAR-564 — Files REST API slice 6: GET /v1/files/{file_id}/download](0093-gar-564-files-api-slice6-download.md) | [GAR-564](https://linear.app/chatgpt25/issue/GAR-564) | 🟡 Em execução 2026-05-10 |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

- Adds `GET /v1/files/{file_id}/download` — streams the current file version from the configured `ObjectStore` with `Content-Disposition: attachment`.
- `DownloadRow` private struct selects only `name`, `object_key`, `mime_type`; `content-length` comes from `result.metadata.size_bytes` (storage backend).
- RLS-enforced JOIN `files → file_versions` ensures cross-group attempts return 404 silently.
- `WorkspaceAuditAction::FileDownloadIssued` emitted before byte streaming (PII-safe: records `filename_len`, not raw name).
- Object store `None` guard returns 503 (consistent with uploads handlers).
- OpenAPI registered via `utoipa::path` + `components(schemas(...))` in `openapi.rs`.

## Test plan

- [x] D1: 200 happy path — bytes stored in LocalFs, `file_versions` row present; asserts body bytes + `content-type` header.
- [x] D2: 404 soft-deleted file.
- [x] D3: 404 non-existent `file_id`.
- [x] D4: 403 Child role lacks `FilesRead`.
- [x] D5: 400 missing `X-Group-Id` header.
- [x] D6: 503 object store not configured (router built with `None` store).
- [x] D7: 404 cross-group RLS filtering.
- [x] `cargo clippy -p garraia-gateway --features test-helpers --no-deps -- -D warnings` clean.

## Files changed

| File | Change |
|------|--------|
| `crates/garraia-auth/src/audit_workspace.rs` | `FileDownloadIssued` variant + test |
| `crates/garraia-gateway/src/rest_v1/files.rs` | `download_file` handler + `DownloadRow` |
| `crates/garraia-gateway/src/rest_v1/mod.rs` | Route registration in all 3 branches |
| `crates/garraia-gateway/src/rest_v1/openapi.rs` | OpenAPI path registration |
| `crates/garraia-gateway/tests/rest_v1_files_download.rs` | Integration tests D1–D7 |

Closes GAR-564. Completes Fase 3.4 Files REST API (slices 1–6, plans 0088–0093).

https://claude.ai/code/session_01796HDB4xhymbNrcm6sqWJW

---
_Generated by [Claude Code](https://claude.ai/code/session_01796HDB4xhymbNrcm6sqWJW)_