### PR TITLE
feat(files): GAR-569 — Files REST API slice 8: GET /v1/groups/{group_id}/files/{file_id}/versions (plan 0095)

### DIFF
--- a/crates/garraia-auth/src/audit_workspace.rs
+++ b/crates/garraia-auth/src/audit_workspace.rs
@@ -424,6 +424,12 @@ pub enum WorkspaceAuditAction {
     /// Metadata: `{ file_id, group_id, filename_len: usize }` — never the
     /// raw filename (PII).
     FileDownloadIssued,
+
+    /// Emitted when `GET /v1/groups/{group_id}/files/{file_id}/versions`
+    /// returns successfully (plan 0095, GAR-569).
+    /// `resource_type = "files"`, `resource_id = "{file_id}"`.
+    /// Metadata: `{ file_id, group_id, version_count: usize }` — PII-safe.
+    FileVersionsListed,
 }
 
 impl WorkspaceAuditAction {
@@ -470,6 +476,7 @@ impl WorkspaceAuditAction {
             WorkspaceAuditAction::FolderCreated => "folder.created",
             WorkspaceAuditAction::FolderDeleted => "folder.deleted",
             WorkspaceAuditAction::FileDownloadIssued => "file.download_issued",
+            WorkspaceAuditAction::FileVersionsListed => "file.versions.listed",
         }
     }
 }
@@ -705,6 +712,7 @@ mod tests {
             WorkspaceAuditAction::FolderCreated.as_str(),
             WorkspaceAuditAction::FolderDeleted.as_str(),
             WorkspaceAuditAction::FileDownloadIssued.as_str(),
+            WorkspaceAuditAction::FileVersionsListed.as_str(),
         ];
         let unique: std::collections::HashSet<_> = strings.iter().collect();
         assert_eq!(unique.len(), strings.len(), "duplicate action strings");

--- a/crates/garraia-gateway/src/rest_v1/files.rs
+++ b/crates/garraia-gateway/src/rest_v1/files.rs
@@ -171,6 +171,65 @@ pub struct ListFoldersQuery {
     pub limit: Option<u32>,
 }
 
+/// Query parameters for `GET /v1/groups/{group_id}/files/{file_id}/versions`.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ListFileVersionsQuery {
+    /// Cursor: last seen `version` integer (exclusive, descending). Omit for the first page.
+    pub cursor: Option<i32>,
+    /// Page size. Default 50, max 100.
+    pub limit: Option<u32>,
+}
+
+/// Private row from `file_versions` (excludes `object_key` and `integrity_hmac`).
+#[derive(sqlx::FromRow)]
+struct FileVersionRow {
+    version: i32,
+    size_bytes: i64,
+    mime_type: String,
+    checksum_sha256: String,
+    created_by: Option<Uuid>,
+    created_by_label: String,
+    created_at: DateTime<Utc>,
+}
+
+/// One version entry returned by `GET .../versions` (plan 0095, GAR-569).
+///
+/// `object_key` and `integrity_hmac` are intentionally absent — they are
+/// internal storage identifiers (ADR 0004 invariant).
+#[derive(Debug, Serialize, ToSchema)]
+pub struct FileVersionSummary {
+    pub version: i32,
+    pub size_bytes: i64,
+    pub mime_type: String,
+    /// Lowercase hex SHA-256 of the version content.
+    pub checksum_sha256: String,
+    pub created_by: Option<Uuid>,
+    pub created_by_label: String,
+    pub created_at: DateTime<Utc>,
+}
+
+impl From<FileVersionRow> for FileVersionSummary {
+    fn from(r: FileVersionRow) -> Self {
+        Self {
+            version: r.version,
+            size_bytes: r.size_bytes,
+            mime_type: r.mime_type,
+            checksum_sha256: r.checksum_sha256,
+            created_by: r.created_by,
+            created_by_label: r.created_by_label,
+            created_at: r.created_at,
+        }
+    }
+}
+
+/// Response body for `GET /v1/groups/{group_id}/files/{file_id}/versions`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct FileVersionListResponse {
+    pub items: Vec<FileVersionSummary>,
+    /// Opaque integer cursor for the next page. `null` when list is exhausted.
+    pub next_cursor: Option<i32>,
+}
+
 /// Body for `PATCH /v1/groups/{group_id}/files/{file_id}` (plan 0089, GAR-557).
 ///
 /// Only `name` is mutable in slice 2. Extra keys are silently ignored
@@ -1347,6 +1406,123 @@ pub async fn delete_folder(
         .map_err(|e| RestError::Internal(e.into()))?;
 
     Ok(StatusCode::NO_CONTENT)
+}
+
+/// `GET /v1/groups/{group_id}/files/{file_id}/versions` — paginated version list
+/// (plan 0095, GAR-569). Returns versions newest-first (version DESC). Cursor is
+/// the last seen `version` integer (exclusive).
+///
+/// Auth: `Principal` + `X-Group-Id` header + `FilesRead` action.
+/// Cross-group guard: `path_group_id` must equal `principal.group_id` → 403.
+/// Non-existent or soft-deleted file → 404.
+#[utoipa::path(
+    get,
+    path = "/v1/groups/{group_id}/files/{file_id}/versions",
+    tag = "files",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID"),
+        ("file_id"  = Uuid, Path, description = "File UUID"),
+        ListFileVersionsQuery,
+    ),
+    responses(
+        (status = 200, description = "Version list", body = FileVersionListResponse),
+        (status = 400, description = "Missing X-Group-Id header"),
+        (status = 403, description = "Forbidden — cross-group or insufficient role"),
+        (status = 404, description = "File not found or soft-deleted"),
+    ),
+    security(("bearer" = [])),
+)]
+pub async fn list_file_versions(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, file_id)): Path<(Uuid, Uuid)>,
+    Query(q): Query<ListFileVersionsQuery>,
+) -> Result<Json<FileVersionListResponse>, RestError> {
+    let group_id = require_group_id(&principal)?;
+
+    if path_group_id != group_id {
+        return Err(RestError::Forbidden);
+    }
+
+    if !can(&principal, Action::FilesRead) {
+        return Err(RestError::Forbidden);
+    }
+
+    let limit = q.limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as i64;
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Verify parent file exists and is not soft-deleted.
+    let exists: Option<i32> =
+        sqlx::query_scalar("SELECT 1 FROM files WHERE id = $1 AND deleted_at IS NULL")
+            .bind(file_id)
+            .fetch_optional(&mut *tx)
+            .await
+            .map_err(|e| RestError::Internal(e.into()))?;
+
+    if exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    // Paginated version list — cursor is exclusive upper bound on version (DESC).
+    let rows: Vec<FileVersionRow> = sqlx::query_as(
+        "SELECT version, size_bytes, mime_type, checksum_sha256, \
+                created_by, created_by_label, created_at \
+         FROM   file_versions \
+         WHERE  file_id  = $1 \
+           AND  group_id = $2 \
+           AND  ($3::int IS NULL OR version < $3) \
+         ORDER  BY version DESC \
+         LIMIT  $4",
+    )
+    .bind(file_id)
+    .bind(group_id)
+    .bind(q.cursor)
+    .bind(limit + 1)
+    .fetch_all(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let has_more = rows.len() > limit as usize;
+    let mut rows = rows;
+    if has_more {
+        rows.truncate(limit as usize);
+    }
+    let next_cursor = if has_more {
+        rows.last().map(|r| r.version)
+    } else {
+        None
+    };
+    let version_count = rows.len();
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::FileVersionsListed,
+        principal.user_id,
+        group_id,
+        "files",
+        file_id.to_string(),
+        json!({
+            "file_id": file_id,
+            "group_id": group_id,
+            "version_count": version_count,
+        }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    let items: Vec<FileVersionSummary> = rows.into_iter().map(FileVersionSummary::from).collect();
+    Ok(Json(FileVersionListResponse { items, next_cursor }))
 }
 
 // ─── Unit tests ───────────────────────────────────────────────────────────────

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -409,6 +409,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     "/v1/groups/{group_id}/files/{file_id}",
                     get(files::get_file).patch(files::patch_file),
                 )
+                // Plan 0095 (GAR-569) — files API slice 8: list versions.
+                .route(
+                    "/v1/groups/{group_id}/files/{file_id}/versions",
+                    get(files::list_file_versions),
+                )
                 // Plan 0090 (GAR-559) — files API slice 3: GET single folder.
                 // Plan 0091 (GAR-561) — files API slice 4: PATCH folder rename.
                 // Plan 0092 (GAR-562) — files API slice 5: DELETE folder.
@@ -530,6 +535,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 .route(
                     "/v1/groups/{group_id}/files/{file_id}",
                     get(unconfigured_handler).patch(unconfigured_handler),
+                )
+                // Plan 0095 (GAR-569) — files API slice 8: list versions, fail-soft 503.
+                .route(
+                    "/v1/groups/{group_id}/files/{file_id}/versions",
+                    get(unconfigured_handler),
                 )
                 .route(
                     "/v1/groups/{group_id}/folders/{folder_id}",
@@ -686,6 +696,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 .route(
                     "/v1/groups/{group_id}/files/{file_id}",
                     get(unconfigured_handler).patch(unconfigured_handler),
+                )
+                // Plan 0095 (GAR-569) — files API slice 8: list versions, no-auth stub.
+                .route(
+                    "/v1/groups/{group_id}/files/{file_id}/versions",
+                    get(unconfigured_handler),
                 )
                 .route(
                     "/v1/groups/{group_id}/folders/{folder_id}",

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -15,8 +15,8 @@ use utoipa::{Modify, OpenApi};
 use super::audit::{AuditEventSummary, ListAuditResponse};
 use super::chats::{ChatListResponse, ChatResponse, ChatSummary, CreateChatRequest};
 use super::files::{
-    CreateFolderRequest, FileListResponse, FileSummary, FolderListResponse, FolderSummary,
-    PatchFileRequest, PatchFolderRequest,
+    CreateFolderRequest, FileListResponse, FileSummary, FileVersionListResponse,
+    FileVersionSummary, FolderListResponse, FolderSummary, PatchFileRequest, PatchFolderRequest,
 };
 use super::groups::{
     CreateGroupRequest, CreateInviteRequest, GroupReadResponse, GroupResponse, InviteResponse,
@@ -146,6 +146,7 @@ impl Modify for SecurityAddon {
         super::files::create_folder,
         super::files::delete_folder,
         super::files::download_file,
+        super::files::list_file_versions,
     ),
     components(schemas(
         MeResponse,
@@ -211,6 +212,8 @@ impl Modify for SecurityAddon {
         PatchFileRequest,
         PatchFolderRequest,
         CreateFolderRequest,
+        FileVersionSummary,
+        FileVersionListResponse,
     )),
     modifiers(&SecurityAddon)
 )]

--- a/crates/garraia-gateway/tests/rest_v1_files_download.rs
+++ b/crates/garraia-gateway/tests/rest_v1_files_download.rs
@@ -26,7 +26,7 @@ use bytes::Bytes;
 use chrono::Utc;
 use garraia_gateway::rest_v1::uploads::UploadStaging;
 use garraia_gateway::server::build_router_for_test_with_storage;
-use garraia_storage::{LocalFs, PutOptions};
+use garraia_storage::{LocalFs, ObjectStore, PutOptions};
 use http_body_util::BodyExt;
 use tower::ServiceExt;
 use uuid::Uuid;
@@ -162,7 +162,7 @@ async fn build_storage_router(h: &Harness, tmp: &Path) -> (axum::Router, Arc<Loc
 }
 
 async fn build_no_storage_router(h: &Harness) -> axum::Router {
-    let staging_dir = tempfile::tempdir().expect("tempdir").into_path();
+    let staging_dir = tempfile::tempdir().expect("tempdir").keep();
     let staging = Arc::new(UploadStaging {
         staging_dir,
         max_patch_bytes: 10 * 1024 * 1024,

--- a/crates/garraia-gateway/tests/rest_v1_files_list_versions.rs
+++ b/crates/garraia-gateway/tests/rest_v1_files_list_versions.rs
@@ -1,0 +1,397 @@
+// Gated so `cargo clippy --all-targets` without `test-helpers` skips this
+// file and doesn't try to compile the `common` harness.
+#![cfg(feature = "test-helpers")]
+//! Integration tests for `GET /v1/groups/{group_id}/files/{file_id}/versions`
+//! (plan 0095, GAR-569, Fase 3.4 files slice 8).
+//!
+//! All scenarios bundled into ONE `#[tokio::test]` — same pattern as other
+//! files tests to avoid the sqlx runtime-teardown race.
+//!
+//! Scenarios:
+//! VL1. 200 happy path — 2 versions, newest-first, next_cursor=null.
+//! VL2. 200 pagination — 3 versions, limit=2 first page, then second page.
+//! VL3. 404 non-existent file_id.
+//! VL4. 404 soft-deleted file.
+//! VL5. 403 path_group_id ≠ principal.group_id.
+//! VL6. 403 role lacks FilesRead (child role).
+//! VL7. 400 missing X-Group-Id header.
+//! VL8. 200 empty list — file exists but zero versions.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
+use chrono::Utc;
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use common::Harness;
+use common::fixtures::{seed_member_via_admin, seed_user_with_group};
+
+fn list_versions_req(
+    token: Option<&str>,
+    path_group_id: &str,
+    file_id: &str,
+    x_group_id: Option<&str>,
+    query: &str,
+) -> Request<Body> {
+    let uri = format!("/v1/groups/{path_group_id}/files/{file_id}/versions{query}");
+    let mut req = Request::builder()
+        .method("GET")
+        .uri(&uri)
+        .body(Body::empty())
+        .expect("request builder");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    if let Some(t) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {t}")).unwrap(),
+        );
+    }
+    if let Some(g) = x_group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    req
+}
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("failed to collect response body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("response body is not JSON")
+}
+
+/// Seed a `files` row with explicit version counters. Pass the desired
+/// `current_version` / `total_versions` to satisfy schema CHECK (>= 1).
+async fn seed_file(
+    h: &Harness,
+    group_id: Uuid,
+    created_by: Uuid,
+    name: &str,
+    current_version: i32,
+    total_versions: i32,
+) -> anyhow::Result<Uuid> {
+    let file_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO files (id, group_id, folder_id, name, current_version, \
+                            total_versions, size_bytes, mime_type, settings, \
+                            created_by, created_by_label) \
+         VALUES ($1, $2, NULL, $3, $4, $5, 0, 'text/plain', '{}'::jsonb, $6, $7)",
+    )
+    .bind(file_id)
+    .bind(group_id)
+    .bind(name)
+    .bind(current_version)
+    .bind(total_versions)
+    .bind(created_by)
+    .bind("Test User")
+    .execute(&h.admin_pool)
+    .await?;
+    Ok(file_id)
+}
+
+/// Seed a `file_versions` row with the given `version` number.
+async fn seed_file_version(
+    h: &Harness,
+    file_id: Uuid,
+    group_id: Uuid,
+    created_by: Uuid,
+    version: i32,
+    size_bytes: i64,
+    mime_type: &str,
+) -> anyhow::Result<()> {
+    let hex64 = "a".repeat(64);
+    let object_key = format!("groups/{group_id}/files/{file_id}/v{version}/blob");
+    sqlx::query(
+        "INSERT INTO file_versions \
+         (file_id, group_id, version, object_key, etag, checksum_sha256, \
+          integrity_hmac, size_bytes, mime_type, created_by, created_by_label) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
+    )
+    .bind(file_id)
+    .bind(group_id)
+    .bind(version)
+    .bind(&object_key)
+    .bind("abc123")
+    .bind(&hex64)
+    .bind(&hex64)
+    .bind(size_bytes)
+    .bind(mime_type)
+    .bind(created_by)
+    .bind("Test User")
+    .execute(&h.admin_pool)
+    .await?;
+    Ok(())
+}
+
+/// Soft-delete a file.
+async fn soft_delete_file(h: &Harness, file_id: Uuid) -> anyhow::Result<()> {
+    sqlx::query("UPDATE files SET deleted_at = $1 WHERE id = $2")
+        .bind(Utc::now())
+        .bind(file_id)
+        .execute(&h.admin_pool)
+        .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn v1_files_list_versions_scenarios() {
+    let h = Harness::get().await;
+
+    let (owner_id, group_id, owner_token) =
+        seed_user_with_group(&h, "owner@0095-list-versions.test")
+            .await
+            .expect("seed owner+group");
+    let gid_str = group_id.to_string();
+
+    // ─── VL1. 200 happy path — 2 versions, newest-first ──────────────────
+    let vl1_id = seed_file(&h, group_id, owner_id, "doc-vl1.txt", 2, 2)
+        .await
+        .expect("VL1 seed file");
+    seed_file_version(&h, vl1_id, group_id, owner_id, 1, 100, "text/plain")
+        .await
+        .expect("VL1 seed v1");
+    seed_file_version(&h, vl1_id, group_id, owner_id, 2, 200, "text/plain")
+        .await
+        .expect("VL1 seed v2");
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(list_versions_req(
+            Some(&owner_token),
+            &gid_str,
+            &vl1_id.to_string(),
+            Some(&gid_str),
+            "",
+        ))
+        .await
+        .expect("VL1 oneshot");
+    assert_eq!(resp.status(), StatusCode::OK, "VL1 status");
+    let body = body_json(resp).await;
+    let items = body["items"].as_array().expect("VL1 items array");
+    assert_eq!(items.len(), 2, "VL1 item count");
+    // Newest first: version 2, then version 1
+    assert_eq!(items[0]["version"].as_i64(), Some(2), "VL1 first version");
+    assert_eq!(items[1]["version"].as_i64(), Some(1), "VL1 second version");
+    assert!(body["next_cursor"].is_null(), "VL1 next_cursor null");
+    // object_key must NOT appear in any response field
+    assert!(
+        items[0].get("object_key").is_none(),
+        "VL1 object_key absent"
+    );
+    assert!(
+        items[0].get("integrity_hmac").is_none(),
+        "VL1 integrity_hmac absent"
+    );
+
+    // ─── VL2. 200 pagination — 3 versions, limit=2 ───────────────────────
+    let vl2_id = seed_file(&h, group_id, owner_id, "doc-vl2.txt", 3, 3)
+        .await
+        .expect("VL2 seed file");
+    for v in 1..=3i32 {
+        seed_file_version(
+            &h,
+            vl2_id,
+            group_id,
+            owner_id,
+            v,
+            50 * v as i64,
+            "text/plain",
+        )
+        .await
+        .expect("VL2 seed version");
+    }
+
+    // First page: limit=2 → versions 3 and 2; next_cursor = 2
+    let resp = h
+        .router
+        .clone()
+        .oneshot(list_versions_req(
+            Some(&owner_token),
+            &gid_str,
+            &vl2_id.to_string(),
+            Some(&gid_str),
+            "?limit=2",
+        ))
+        .await
+        .expect("VL2 first-page oneshot");
+    assert_eq!(resp.status(), StatusCode::OK, "VL2 first-page status");
+    let page1 = body_json(resp).await;
+    let p1_items = page1["items"].as_array().expect("VL2 p1 items");
+    assert_eq!(p1_items.len(), 2, "VL2 p1 item count");
+    assert_eq!(p1_items[0]["version"].as_i64(), Some(3), "VL2 p1 first");
+    assert_eq!(p1_items[1]["version"].as_i64(), Some(2), "VL2 p1 second");
+    let next_cursor = page1["next_cursor"].as_i64().expect("VL2 next_cursor");
+    assert_eq!(next_cursor, 2, "VL2 next_cursor value");
+
+    // Second page: cursor=2 → versions < 2 → version 1; next_cursor = null
+    let resp = h
+        .router
+        .clone()
+        .oneshot(list_versions_req(
+            Some(&owner_token),
+            &gid_str,
+            &vl2_id.to_string(),
+            Some(&gid_str),
+            &format!("?limit=2&cursor={next_cursor}"),
+        ))
+        .await
+        .expect("VL2 second-page oneshot");
+    assert_eq!(resp.status(), StatusCode::OK, "VL2 second-page status");
+    let page2 = body_json(resp).await;
+    let p2_items = page2["items"].as_array().expect("VL2 p2 items");
+    assert_eq!(p2_items.len(), 1, "VL2 p2 item count");
+    assert_eq!(p2_items[0]["version"].as_i64(), Some(1), "VL2 p2 version");
+    assert!(page2["next_cursor"].is_null(), "VL2 p2 next_cursor null");
+
+    // ─── VL3. 404 non-existent file_id ───────────────────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(list_versions_req(
+            Some(&owner_token),
+            &gid_str,
+            &Uuid::new_v4().to_string(),
+            Some(&gid_str),
+            "",
+        ))
+        .await
+        .expect("VL3 oneshot");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND, "VL3 status");
+
+    // ─── VL4. 404 soft-deleted file ──────────────────────────────────────
+    let vl4_id = seed_file(&h, group_id, owner_id, "dead-vl4.txt", 1, 1)
+        .await
+        .expect("VL4 seed file");
+    seed_file_version(&h, vl4_id, group_id, owner_id, 1, 10, "text/plain")
+        .await
+        .expect("VL4 seed v1");
+    soft_delete_file(&h, vl4_id).await.expect("VL4 soft delete");
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(list_versions_req(
+            Some(&owner_token),
+            &gid_str,
+            &vl4_id.to_string(),
+            Some(&gid_str),
+            "",
+        ))
+        .await
+        .expect("VL4 oneshot");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND, "VL4 status");
+
+    // ─── VL5. 403 path_group_id ≠ principal.group_id ─────────────────────
+    let (_other_id, other_group_id, _other_token) =
+        seed_user_with_group(&h, "other@0095-list-versions.test")
+            .await
+            .expect("VL5 seed other group");
+
+    let vl5_id = seed_file(&h, group_id, owner_id, "cross-vl5.txt", 1, 1)
+        .await
+        .expect("VL5 seed file");
+    seed_file_version(&h, vl5_id, group_id, owner_id, 1, 5, "text/plain")
+        .await
+        .expect("VL5 seed v1");
+
+    // owner_token → principal.group_id = group_id, but path says other_group_id
+    let resp = h
+        .router
+        .clone()
+        .oneshot(list_versions_req(
+            Some(&owner_token),
+            &other_group_id.to_string(),
+            &vl5_id.to_string(),
+            Some(&other_group_id.to_string()),
+            "",
+        ))
+        .await
+        .expect("VL5 oneshot");
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN, "VL5 status");
+
+    // ─── VL6. 403 child role lacks FilesRead ─────────────────────────────
+    let (_child_id, child_token) =
+        seed_member_via_admin(&h, group_id, "child", "child@0095-list-versions.test")
+            .await
+            .expect("VL6 seed child");
+
+    let vl6_id = seed_file(&h, group_id, owner_id, "child-vl6.txt", 1, 1)
+        .await
+        .expect("VL6 seed file");
+    seed_file_version(&h, vl6_id, group_id, owner_id, 1, 7, "text/plain")
+        .await
+        .expect("VL6 seed v1");
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(list_versions_req(
+            Some(&child_token),
+            &gid_str,
+            &vl6_id.to_string(),
+            Some(&gid_str),
+            "",
+        ))
+        .await
+        .expect("VL6 oneshot");
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN, "VL6 status");
+
+    // ─── VL7. 400 missing X-Group-Id header ──────────────────────────────
+    let vl7_id = seed_file(&h, group_id, owner_id, "noxgid-vl7.txt", 1, 1)
+        .await
+        .expect("VL7 seed file");
+    seed_file_version(&h, vl7_id, group_id, owner_id, 1, 3, "text/plain")
+        .await
+        .expect("VL7 seed v1");
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(list_versions_req(
+            Some(&owner_token),
+            &gid_str,
+            &vl7_id.to_string(),
+            None, // no X-Group-Id
+            "",
+        ))
+        .await
+        .expect("VL7 oneshot");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "VL7 status");
+
+    // ─── VL8. 200 empty list — file exists, zero file_versions rows ──────
+    // Schema requires current_version >= 1, so seed with 1.
+    // No file_versions row is inserted, so the query returns an empty list.
+    let vl8_id = seed_file(&h, group_id, owner_id, "empty-vl8.txt", 1, 1)
+        .await
+        .expect("VL8 seed file");
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(list_versions_req(
+            Some(&owner_token),
+            &gid_str,
+            &vl8_id.to_string(),
+            Some(&gid_str),
+            "",
+        ))
+        .await
+        .expect("VL8 oneshot");
+    assert_eq!(resp.status(), StatusCode::OK, "VL8 status");
+    let body = body_json(resp).await;
+    let items = body["items"].as_array().expect("VL8 items array");
+    assert_eq!(items.len(), 0, "VL8 empty items");
+    assert!(body["next_cursor"].is_null(), "VL8 next_cursor null");
+}

--- a/plans/0095-gar-569-files-api-slice8-list-versions.md
+++ b/plans/0095-gar-569-files-api-slice8-list-versions.md
@@ -1,0 +1,244 @@
+# Plan 0095 — GAR-569 — Files REST API slice 8: GET /v1/groups/{group_id}/files/{file_id}/versions
+
+## Goal
+
+Add the file-version list endpoint to the `/v1` REST surface:
+
+* `GET /v1/groups/{group_id}/files/{file_id}/versions` — returns a paginated list of
+  `FileVersionSummary` objects (version number, size, MIME, checksum, uploader, timestamp)
+  for an existing non-deleted file in the group.
+
+This is the eighth slice of the files API (plans 0088–0094). It exposes the per-file
+version history that the schema (`file_versions` table, migration 003) and the upload
+handler (plan 0094, GAR-567) already produce.
+
+## Architecture
+
+### Handler (`list_file_versions`)
+
+1. `require_group_id` → 400 if `X-Group-Id` header missing
+2. `can(&principal, Action::FilesRead)` → 403 if denied
+3. `path_group_id ≠ principal.group_id` → 403 (cross-group guard)
+4. Begin tx → `set_rls_context` (both `app.current_user_id` + `app.current_group_id`)
+5. Verify the parent file exists and is not soft-deleted:
+   ```sql
+   SELECT id FROM files
+   WHERE  id = $file_id
+     AND  deleted_at IS NULL
+   ```
+   Returns `None` → 404 (not found or RLS-filtered)
+6. Paginated version list (cursor = last seen `version` integer, descending):
+   ```sql
+   SELECT version, size_bytes, mime_type, checksum_sha256,
+          created_by, created_by_label, created_at
+   FROM   file_versions
+   WHERE  file_id  = $file_id
+     AND  group_id = $group_id
+     AND  ($cursor IS NULL OR version < $cursor)
+   ORDER  BY version DESC
+   LIMIT  $limit + 1
+   ```
+   Fetch `limit + 1`; if `len > limit`, set `next_cursor = items[limit].version`
+   and truncate to `limit`.
+7. COMMIT tx (read-only — release connection)
+8. Emit audit event `FileVersionsListed`:
+   `{ file_id, group_id, version_count: usize }` — PII-safe.
+9. Return 200 `{ items: Vec<FileVersionSummary>, next_cursor: Option<i32> }`
+
+### Pagination
+
+Uses integer `version` (not UUID) as cursor because versions are dense monotonic integers
+(1, 2, 3, …). The cursor is the lowest version number on the last page, and the next page
+fetches `version < cursor`. Descending order shows newest first, which is the most common
+UI pattern for version history.
+
+`next_cursor` is `i32` (matching the `version` column type) to match the schema exactly.
+The query parameter is `cursor: Option<i32>`.
+
+Default limit: 50. Maximum: 100.
+
+### DTOs
+
+```rust
+pub struct FileVersionSummary {
+    pub version: i32,
+    pub size_bytes: i64,
+    pub mime_type: String,
+    pub checksum_sha256: String,
+    pub created_by: Option<Uuid>,
+    pub created_by_label: String,
+    pub created_at: DateTime<Utc>,
+}
+
+pub struct FileVersionListResponse {
+    pub items: Vec<FileVersionSummary>,
+    pub next_cursor: Option<i32>,
+}
+```
+
+Note: `object_key` and `integrity_hmac` are NEVER returned in HTTP responses
+(internal storage details — ADR 0004 invariant).
+
+## Tech stack
+
+* Axum 0.8, `garraia-auth::Principal`
+* `garraia-auth::Action::FilesRead`
+* `sqlx` (Postgres), `set_rls_context` for FORCE RLS compliance
+* `garraia-auth::WorkspaceAuditAction::FileVersionsListed` (new variant)
+* `utoipa` annotations, registered in `openapi.rs`
+
+## Design invariants
+
+* FORCE RLS protocol: `SET LOCAL app.current_user_id` AND `app.current_group_id`
+  before every SQL operation.
+* PII-free audit: metadata carries `version_count: usize`, not raw file names or user data.
+* `object_key` and `integrity_hmac` are NEVER returned in HTTP responses.
+* Cross-group attempts on path `group_id` → 403 (not 404) — path validation happens
+  before RLS context is set.
+* Non-existent or soft-deleted file → 404.
+* An empty version list (hypothetical inconsistency) returns 200 `{ items: [], next_cursor: null }`.
+
+## Validações pré-plano
+
+* PR #252 (GAR-567, slice 7 — POST versions) merged — `file_versions` rows are being
+  created by the new-version upload handler; the list endpoint has data to work with.
+* `file_versions` table exists with columns: `file_id`, `group_id`, `version`, `object_key`,
+  `etag`, `checksum_sha256`, `integrity_hmac`, `size_bytes`, `mime_type`, `created_by`,
+  `created_by_label`, `created_at`. PK: `(file_id, version)`. Index: `(file_id, version DESC)`.
+* `garraia-auth::Action::FilesRead` and `require_group_id` helpers established.
+* `set_rls_context` helper in `files.rs` sets both RLS params parameterized.
+* Route slot `/v1/groups/{group_id}/files/{file_id}/versions` is unregistered.
+
+## Out of scope
+
+* `GET /v1/groups/{group_id}/files/{file_id}/versions/{version}` — fetch a specific
+  version's metadata (deferred to slice 9 if needed).
+* Downloading a specific version (non-current) — deferred.
+* Deleting a specific version — deferred (GDPR erasure path uses hard-delete on the
+  parent file).
+* Searching / filtering versions by MIME or date — deferred.
+
+## Rollback
+
+Purely additive:
+1. Drop the new route from `mod.rs`.
+2. Remove the `list_file_versions` function from `files.rs`.
+3. Remove `FileVersionsListed` variant from `audit_workspace.rs`.
+4. No schema changes, no migrations — fully reversible.
+
+## §12 Open questions
+
+None blocking. All design decisions resolved:
+* Cursor type: `i32` (version integer), not UUID — matches schema, simpler for clients.
+* Object key exposure: never in response — matches ADR 0004 invariant.
+* Audit scope: read event is useful for LGPD compliance (art. 46-49); logged at INFO level.
+
+## File structure
+
+```
+Modified:
+  crates/garraia-auth/src/audit_workspace.rs   — +1 variant FileVersionsListed + as_str match arm
+  crates/garraia-gateway/src/rest_v1/files.rs  — +handler list_file_versions + DTOs + row type
+  crates/garraia-gateway/src/rest_v1/mod.rs    — +route /v1/groups/{group_id}/files/{file_id}/versions
+  crates/garraia-gateway/src/openapi.rs        — +list_file_versions to ApiDoc::paths()
+
+New:
+  crates/garraia-gateway/tests/rest_v1_files_list_versions.rs  — integration tests
+```
+
+## M1 task checklist
+
+### T1 — audit variant
+
+- [ ] Add `FileVersionsListed` to `WorkspaceAuditAction` enum in `audit_workspace.rs`
+- [ ] Add `WorkspaceAuditAction::FileVersionsListed => "file.versions.listed"` arm in `as_str()`
+- [ ] Add assertion in existing `#[cfg(test)] mod tests` that `as_str()` returns the correct string
+- [ ] `cargo test -p garraia-auth --lib` passes
+
+### T2 — DTOs + row type
+
+- [ ] Add `FileVersionRow` (private, `sqlx::FromRow`) with all non-secret columns
+- [ ] Add `FileVersionSummary` (public, `Serialize + ToSchema`) with safe columns only (no `object_key`, no `integrity_hmac`)
+- [ ] Add `FileVersionListResponse` (public, `Serialize + ToSchema`)
+- [ ] Add `ListFileVersionsQuery` (`Deserialize + IntoParams`, fields: `cursor: Option<i32>`, `limit: Option<u32>`)
+
+### T3 — handler + query (tests first)
+
+- [ ] Write `tests/rest_v1_files_list_versions.rs` with test stubs (compile-fail red)
+- [ ] Implement `pub async fn list_file_versions(...)` handler
+- [ ] Register route in `mod.rs`: `.route("/v1/groups/{group_id}/files/{file_id}/versions", get(files::list_file_versions))`
+- [ ] Register route in test router (both `build_router_for_test_with_storage` paths)
+- [ ] `cargo check -p garraia-gateway` passes
+
+### T4 — integration tests (green)
+
+Test matrix (run in order; each isolated transaction with FORCE RLS):
+
+- [ ] VL1: 200 happy path — 2 versions exist, returns them newest-first, `next_cursor = null`
+- [ ] VL2: 200 pagination — 3 versions, limit=2 → first page has 2 + `next_cursor = 2`, second page has 1 + null cursor
+- [ ] VL3: 404 non-existent `file_id`
+- [ ] VL4: 404 soft-deleted file
+- [ ] VL5: 403 `path_group_id ≠ principal.group_id` (cross-group guard)
+- [ ] VL6: 403 role lacks `FilesRead` (child role without permission)
+- [ ] VL7: 400 missing `X-Group-Id` header
+- [ ] VL8: 200 empty list — file exists but zero versions (edge case for consistency)
+
+- [ ] `cargo test -p garraia-gateway --test rest_v1_files_list_versions` passes
+
+### T5 — OpenAPI + clippy
+
+- [ ] Add `#[utoipa::path(...)]` annotation to `list_file_versions`
+- [ ] Register in `openapi.rs` `ApiDoc::paths()`
+- [ ] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` clean
+
+### T6 — per-task commit + push
+
+- [ ] Commit T1: `feat(auth): add FileVersionsListed audit action`
+- [ ] Commit T2+T3+T4: `feat(files): GAR-569 — GET /v1/groups/{group_id}/files/{file_id}/versions`
+- [ ] Commit T5: `feat(openapi): register list_file_versions in ApiDoc`
+- [ ] Push branch and open PR
+
+### T7 — ROADMAP + plans/README bookkeeping (merge commit)
+
+- [ ] ROADMAP.md §3.4 Arquivos: tick `[ ] GET /v1/groups/{group_id}/files/{file_id}/versions`
+- [ ] `plans/README.md`: add row `| 0095 | ... | GAR-569 | ✅ Merged ... via PR #NNN |`
+
+## Risk register
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| `object_key` accidentally exposed | Low | High | DTO only includes safe columns; `FileVersionRow` uses select-list not `SELECT *` |
+| Cross-group data leak via version list | Low | High | Path-level group check (403) + RLS `set_config` on both params |
+| Pagination off-by-one | Medium | Low | VL2 test covers multi-page exactly |
+| Soft-deleted file still returns versions | Medium | Medium | Parent-file existence check (step 5) before version query |
+
+## Acceptance criteria
+
+1. `GET /v1/groups/{group_id}/files/{file_id}/versions` → 200 + `{ items, next_cursor }`
+2. Items sorted newest-first (version DESC).
+3. Cursor pagination works for multi-page results.
+4. `object_key` and `integrity_hmac` are NOT present in any response field.
+5. Cross-group guard: `path_group_id ≠ principal.group_id` → 403.
+6. Soft-deleted parent file → 404.
+7. `cargo clippy --workspace ... -- -D warnings` clean.
+8. 8 integration tests pass (VL1–VL8).
+9. `FileVersionsListed` audit action asserted in `garraia-auth` tests.
+
+## Cross-references
+
+* Plan 0094 (GAR-567) — POST /v1/groups/{group_id}/files/{file_id}/versions (creates versions)
+* Plan 0093 (GAR-564) — GET /v1/files/{file_id}/download (streams current version)
+* Plan 0090 (GAR-559) — GET /v1/groups/{group_id}/files/{file_id} (shows current_version + total_versions)
+* Migration 003 (`003_files_and_folders.sql`) — `file_versions` table schema
+* ADR 0004 — object storage security policy (object_key never in HTTP responses)
+* ROADMAP §3.4 — Arquivos checklist
+
+## Estimativa
+
+* T1 (audit): 15 min
+* T2 (DTOs): 20 min
+* T3 (handler + route): 30 min
+* T4 (tests): 40 min
+* T5 (OpenAPI + clippy): 15 min
+* Total: **~2h** (low estimate 1.5h / high 3h)
+* LOC delta: ~250 LOC new (handler ~80, tests ~120, DTOs ~40, audit ~10)

--- a/plans/README.md
+++ b/plans/README.md
@@ -117,6 +117,8 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0091 | [GAR-561 — Files REST API slice 4: PATCH folder rename](0091-gar-561-files-api-slice4-folder-rename.md) | [GAR-561](https://linear.app/chatgpt25/issue/GAR-561) | ✅ Merged 2026-05-09 via PR #246 (`3679ccc`) |
 | 0092 | [GAR-562 — Files REST API slice 5: folder POST + DELETE](0092-gar-562-files-api-slice5-folder-post-delete.md) | [GAR-562](https://linear.app/chatgpt25/issue/GAR-562) | ✅ Merged 2026-05-09 via PR #247 (`28b3b0f`) |
 | 0093 | [GAR-564 — Files REST API slice 6: GET /v1/files/{file_id}/download](0093-gar-564-files-api-slice6-download.md) | [GAR-564](https://linear.app/chatgpt25/issue/GAR-564) | ✅ Merged 2026-05-10 via PR #250 (`b2de161`) |
+| 0094 | [GAR-567 — Files REST API slice 7: POST /v1/groups/{group_id}/files/{file_id}/versions (new version)](0094-gar-565-files-api-slice7-new-version.md) | [GAR-567](https://linear.app/chatgpt25/issue/GAR-567) | ✅ Merged 2026-05-10 via PR #252 |
+| 0095 | [GAR-569 — Files REST API slice 8: GET /v1/groups/{group_id}/files/{file_id}/versions (list versions)](0095-gar-569-files-api-slice8-list-versions.md) | [GAR-569](https://linear.app/chatgpt25/issue/GAR-569) | 🟡 Em execução 2026-05-10 |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

- Adds `GET /v1/groups/{group_id}/files/{file_id}/versions` — cursor-paginated list of all content versions for an existing file (plan 0095, Fase 3.4 files slice 8).
- Items sorted newest-first (version DESC). Cursor is an integer version number (exclusive upper bound).
- `object_key` and `integrity_hmac` intentionally absent from `FileVersionSummary` (ADR 0004 invariant — storage keys are internal).
- Single Postgres transaction: RLS context (`set_config`) + parent file existence check (soft-delete guard) + version list query + `FileVersionsListed` audit event.
- New audit action `FileVersionsListed` → `"file.versions.listed"` in `garraia-auth::WorkspaceAuditAction` (PII-safe: carries `version_count`, no filename).
- Also fixes two pre-existing clippy errors in `tests/rest_v1_files_download.rs`: missing `use garraia_storage::ObjectStore;` and deprecated `TempDir::into_path()` → `TempDir::keep()`.

## Test plan

- [x] VL1: 200 happy path — 2 versions exist, items newest-first, `next_cursor = null`.
- [x] VL2: 200 pagination — 3 versions, limit=2 → first page 2 items + `next_cursor`, second page 1 item + null cursor.
- [x] VL3: 404 non-existent `file_id`.
- [x] VL4: 404 soft-deleted file.
- [x] VL5: 403 `path_group_id` ≠ `principal.group_id` (cross-group guard).
- [x] VL6: 403 role lacks `FilesRead` (child role).
- [x] VL7: 400 missing `X-Group-Id` header.
- [x] VL8: 200 empty list — file exists but zero `file_versions` rows.
- [x] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` clean.
- [x] `cargo test -p garraia-auth --lib` — 57 tests pass (includes `FileVersionsListed` uniqueness assertion).

Closes GAR-569.

https://claude.ai/code/session_01SDBoo78HVKsuWWAN1JtDRD

---
_Generated by [Claude Code](https://claude.ai/code/session_01SDBoo78HVKsuWWAN1JtDRD)_