### PR TITLE
feat(files): GAR-567 — Files REST API slice 7: POST /v1/groups/{group_id}/files/{file_id}/versions (plan 0094)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -409,7 +409,7 @@ Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
 - [x] `GET /v1/groups/{group_id}/files/{file_id}` + `GET /v1/groups/{group_id}/folders/{folder_id}` (single resource read) — plan 0090 / [GAR-559](https://linear.app/chatgpt25/issue/GAR-559), implementado 2026-05-09 (Florida) ✅ PR #242 (`4adcb02`)
 - [x] `PATCH /v1/groups/{group_id}/files/{file_id}` (rename) — plan 0089 / [GAR-557](https://linear.app/chatgpt25/issue/GAR-557), implementado 2026-05-09 (Florida) ✅ PR #238 (`9255515`)
 - [x] `GET /v1/files/{file_id}/download` (streaming bytes via ObjectStore) — plan 0093 / [GAR-564](https://linear.app/chatgpt25/issue/GAR-564), implementado 2026-05-10 (Florida) ✅ PR #250 (`b2de161`)
-- [ ] `POST /v1/files/{file_id}:newVersion`
+- [x] `POST /v1/groups/{group_id}/files/{file_id}/versions` (new content version, direct upload) — plan 0094 / [GAR-567](https://linear.app/chatgpt25/issue/GAR-567), implementado 2026-05-10 (Florida)
 - [x] `DELETE /v1/files/{file_id}` (soft delete + lixeira) ✅ PR #235 GAR-555
 - [ ] Suporte a **tus** (resumable upload) como alternativa
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -410,6 +410,7 @@ Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
 - [x] `PATCH /v1/groups/{group_id}/files/{file_id}` (rename) — plan 0089 / [GAR-557](https://linear.app/chatgpt25/issue/GAR-557), implementado 2026-05-09 (Florida) ✅ PR #238 (`9255515`)
 - [x] `GET /v1/files/{file_id}/download` (streaming bytes via ObjectStore) — plan 0093 / [GAR-564](https://linear.app/chatgpt25/issue/GAR-564), implementado 2026-05-10 (Florida) ✅ PR #250 (`b2de161`)
 - [x] `POST /v1/groups/{group_id}/files/{file_id}/versions` (new content version, direct upload) — plan 0094 / [GAR-567](https://linear.app/chatgpt25/issue/GAR-567), implementado 2026-05-10 (Florida)
+- [x] `GET /v1/groups/{group_id}/files/{file_id}/versions` (list content versions, cursor-paginated) — plan 0095 / [GAR-569](https://linear.app/chatgpt25/issue/GAR-569), implementado 2026-05-10 (Florida) ✅ PR #253 (`0cc9a85`)
 - [x] `DELETE /v1/files/{file_id}` (soft delete + lixeira) ✅ PR #235 GAR-555
 - [ ] Suporte a **tus** (resumable upload) como alternativa
 

--- a/crates/garraia-auth/src/audit_workspace.rs
+++ b/crates/garraia-auth/src/audit_workspace.rs
@@ -425,6 +425,17 @@ pub enum WorkspaceAuditAction {
     /// raw filename (PII).
     FileDownloadIssued,
 
+    /// A new content version was uploaded via
+    /// `POST /v1/groups/{group_id}/files/{file_id}/versions`
+    /// (plan 0094 / GAR-567, Fase 3.4 files slice 7).
+    ///
+    /// Emitted exactly once per successful 201 response, inside the
+    /// same transaction that inserts `file_versions` and bumps `files`.
+    /// `resource_type = "files"`, `resource_id = "{file_id}"`.
+    /// Metadata: `{ file_id, group_id, new_version: u32, size_bytes: u64 }`
+    /// — never raw filename or MIME type (PII-safe per CLAUDE.md rule 6).
+    FileVersionCreated,
+
     /// Emitted when `GET /v1/groups/{group_id}/files/{file_id}/versions`
     /// returns successfully (plan 0095, GAR-569).
     /// `resource_type = "files"`, `resource_id = "{file_id}"`.
@@ -476,6 +487,7 @@ impl WorkspaceAuditAction {
             WorkspaceAuditAction::FolderCreated => "folder.created",
             WorkspaceAuditAction::FolderDeleted => "folder.deleted",
             WorkspaceAuditAction::FileDownloadIssued => "file.download_issued",
+            WorkspaceAuditAction::FileVersionCreated => "file.version.created",
             WorkspaceAuditAction::FileVersionsListed => "file.versions.listed",
         }
     }
@@ -669,6 +681,10 @@ mod tests {
             WorkspaceAuditAction::FileDownloadIssued.as_str(),
             "file.download_issued"
         );
+        assert_eq!(
+            WorkspaceAuditAction::FileVersionCreated.as_str(),
+            "file.version.created"
+        );
     }
 
     #[test]
@@ -712,6 +728,7 @@ mod tests {
             WorkspaceAuditAction::FolderCreated.as_str(),
             WorkspaceAuditAction::FolderDeleted.as_str(),
             WorkspaceAuditAction::FileDownloadIssued.as_str(),
+            WorkspaceAuditAction::FileVersionCreated.as_str(),
             WorkspaceAuditAction::FileVersionsListed.as_str(),
         ];
         let unique: std::collections::HashSet<_> = strings.iter().collect();

--- a/crates/garraia-gateway/src/rest_v1/files.rs
+++ b/crates/garraia-gateway/src/rest_v1/files.rs
@@ -1,6 +1,7 @@
 //! `/v1/groups/{group_id}/files`, `/v1/groups/{group_id}/folders`,
-//! `DELETE /v1/files/{file_id}`, and `GET /v1/files/{file_id}/download` handlers
-//! (plans 0088-0093, GAR-555/557/559/561/562/564, Fase 3.4 files slices 1-6).
+//! `DELETE /v1/files/{file_id}`, `GET /v1/files/{file_id}/download`, and
+//! `POST /v1/groups/{group_id}/files/{file_id}/versions` handlers
+//! (plans 0088-0094, GAR-555/557/559/561/562/564/567, Fase 3.4 files slices 1-7).
 //!
 //! Endpoints on the `garraia_app` RLS-enforced pool:
 //! - `GET /v1/groups/{group_id}/files?folder_id=&cursor=&limit=` — cursor-paginated list
@@ -20,12 +21,14 @@
 //! no group_id in path; RLS filters silently → 404.
 
 use axum::Json;
-use axum::body::Body;
+use axum::body::{Body, to_bytes};
 use axum::extract::{Path, Query, State};
+use axum::http::HeaderMap;
 use axum::http::StatusCode;
 use axum::response::Response;
 use chrono::{DateTime, Utc};
 use garraia_auth::{Action, Principal, WorkspaceAuditAction, audit_workspace_event, can};
+use garraia_storage::PutOptions;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use utoipa::{IntoParams, ToSchema};
@@ -816,6 +819,254 @@ pub async fn download_file(
         .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
 
     Ok(response)
+}
+
+// ─── Slice 7: new file version ───────────────────────────────────────────────
+
+/// Response body for a successful new-version upload.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct FileVersionResponse {
+    /// UUID of the logical file (unchanged across versions).
+    pub file_id: Uuid,
+    /// The version number of the newly created version.
+    pub version: i32,
+    /// Byte count of the new version's content.
+    pub size_bytes: u64,
+    /// MIME type of the new version.
+    pub mime_type: String,
+    /// UTC timestamp of the version creation (approximate — set after commit).
+    pub created_at: DateTime<Utc>,
+}
+
+/// `POST /v1/groups/{group_id}/files/{file_id}/versions` — upload a new content
+/// version for an existing file (plan 0094, GAR-567, Fase 3.4 files slice 7).
+///
+/// Accepts raw bytes in the request body (capped to `storage.max_patch_bytes`,
+/// default 100 MiB). Stores the bytes in the configured `ObjectStore`, inserts
+/// a new `file_versions` row, and bumps `files.current_version` + related
+/// counters atomically in one Postgres transaction.
+///
+/// Auth: `Action::FilesWrite`. `X-Group-Id` header required for RLS context.
+/// `path_group_id` must match `principal.group_id`.
+///
+/// ## Two-phase commit ordering
+///
+/// `ObjectStore::put` runs before the Postgres COMMIT. If the commit fails
+/// after the object write, the blob is orphaned — acceptable per plan 0044
+/// §5.3.1 (future maintenance job reclaims orphaned blobs).
+///
+/// ## Error matrix
+///
+/// | Condition                              | Status |
+/// |----------------------------------------|--------|
+/// | Missing/invalid JWT                    | 401    |
+/// | Insufficient role (no `FilesWrite`)    | 403    |
+/// | `path_group_id` ≠ `principal.group_id` | 403    |
+/// | Missing `X-Group-Id` header            | 400    |
+/// | File not found / deleted               | 404    |
+/// | MIME type not in allow-list            | 415    |
+/// | Body exceeds cap                       | 413    |
+/// | ObjectStore not configured             | 503    |
+/// | Happy path                             | 201    |
+#[utoipa::path(
+    post,
+    path = "/v1/groups/{group_id}/files/{file_id}/versions",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID (must match caller's group)."),
+        ("file_id"  = Uuid, Path, description = "File UUID to create a new version for."),
+    ),
+    request_body(
+        content = (),
+        description = "Raw file bytes. Set Content-Type to the MIME type of the new version.",
+    ),
+    responses(
+        (status = 201, description = "New version created.", body = FileVersionResponse),
+        (status = 400, description = "Missing X-Group-Id header.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller lacks FilesWrite or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "File not found or soft-deleted.", body = super::problem::ProblemDetails),
+        (status = 413, description = "Body exceeds operator cap.", body = super::problem::ProblemDetails),
+        (status = 415, description = "MIME type not in allow-list.", body = super::problem::ProblemDetails),
+        (status = 503, description = "Object store not configured.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn post_new_version(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, file_id)): Path<(Uuid, Uuid)>,
+    headers: HeaderMap,
+    body: Body,
+) -> Result<(StatusCode, Json<FileVersionResponse>), RestError> {
+    let group_id = require_group_id(&principal)?;
+    if !can(&principal, Action::FilesWrite) {
+        return Err(RestError::Forbidden);
+    }
+    check_group_match(path_group_id, group_id)?;
+
+    let object_store = state
+        .storage
+        .object_store
+        .as_ref()
+        .ok_or(RestError::AuthUnconfigured)?
+        .clone();
+    let staging = state
+        .storage
+        .upload_staging
+        .as_ref()
+        .ok_or(RestError::AuthUnconfigured)?
+        .clone();
+
+    // Validate MIME type before reading body (fail fast — 415 before 413).
+    let content_type = headers
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.split(';').next().unwrap_or(s).trim().to_owned())
+        .ok_or(RestError::UnsupportedMediaType(
+            "Content-Type header missing".into(),
+        ))?;
+    if !garraia_storage::mime_allowlist::is_mime_allowed(&content_type) {
+        return Err(RestError::UnsupportedMediaType(format!(
+            "MIME type '{content_type}' is not in the allow-list"
+        )));
+    }
+
+    // Read body with operator cap.
+    let cap: usize = staging.max_patch_bytes.try_into().unwrap_or(usize::MAX);
+    let bytes = to_bytes(body, cap).await.map_err(|e| {
+        tracing::debug!(error = %e, "new-version body too large or read failed");
+        RestError::PayloadTooLarge(format!(
+            "body exceeds operator cap of {} bytes",
+            staging.max_patch_bytes
+        ))
+    })?;
+    let body_len = bytes.len() as i64;
+    let checksum_sha256 = sha256_hex_of_bytes(&bytes);
+
+    // DB transaction: lock the row + verify the file exists.
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    let row: Option<(i32, Option<Uuid>, String)> = sqlx::query_as(
+        "SELECT current_version, created_by, created_by_label \
+         FROM   files \
+         WHERE  id         = $1 \
+           AND  deleted_at IS NULL \
+         FOR UPDATE",
+    )
+    .bind(file_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let (current_version, _file_created_by, creator_label) = match row {
+        Some(r) => r,
+        None => return Err(RestError::NotFound),
+    };
+
+    let new_version = current_version + 1;
+    let version_uuid = Uuid::new_v4();
+    let object_key = format!("groups/{group_id}/files/{file_id}/v{new_version}/{version_uuid}");
+
+    // ObjectStore PUT — runs before Postgres COMMIT (two-phase ordering).
+    let put_opts = PutOptions {
+        content_type: Some(content_type.clone()),
+        hmac_secret: Some(staging.hmac_secret.clone()),
+        ..Default::default()
+    };
+    let put_meta = object_store
+        .put(&object_key, bytes, put_opts)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "ObjectStore::put failed for new file version");
+            RestError::BadGateway("object store write failed; please retry".into())
+        })?;
+
+    let integrity_hmac = put_meta.integrity_hmac.ok_or_else(|| {
+        RestError::Internal(anyhow::anyhow!(
+            "ObjectStore did not return integrity_hmac; GARRAIA_UPLOAD_HMAC_SECRET misconfigured"
+        ))
+    })?;
+
+    sqlx::query(
+        "INSERT INTO file_versions \
+            (file_id, group_id, version, object_key, etag, checksum_sha256, \
+             integrity_hmac, size_bytes, mime_type, created_by, created_by_label) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
+    )
+    .bind(file_id)
+    .bind(group_id)
+    .bind(new_version)
+    .bind(&object_key)
+    .bind(&put_meta.etag_sha256[..put_meta.etag_sha256.len().min(200)])
+    .bind(&checksum_sha256)
+    .bind(&integrity_hmac)
+    .bind(body_len)
+    .bind(&content_type)
+    .bind(principal.user_id)
+    .bind(&creator_label)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e).context("insert file_versions")))?;
+
+    sqlx::query(
+        "UPDATE files \
+         SET current_version = $1, \
+             total_versions  = total_versions + 1, \
+             size_bytes      = $2, \
+             mime_type       = $3, \
+             updated_at      = now() \
+         WHERE id = $4",
+    )
+    .bind(new_version)
+    .bind(body_len)
+    .bind(&content_type)
+    .bind(file_id)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e).context("update files")))?;
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::FileVersionCreated,
+        principal.user_id,
+        group_id,
+        "files",
+        file_id.to_string(),
+        json!({
+            "file_id": file_id,
+            "group_id": group_id,
+            "new_version": new_version,
+            "size_bytes": body_len,
+        }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(FileVersionResponse {
+            file_id,
+            version: new_version,
+            size_bytes: body_len as u64,
+            mime_type: content_type,
+            created_at: Utc::now(),
+        }),
+    ))
+}
+
+fn sha256_hex_of_bytes(input: &[u8]) -> String {
+    use sha2::Digest;
+    let digest = sha2::Sha256::digest(input);
+    hex::encode(digest)
 }
 
 /// `PATCH /v1/groups/{group_id}/files/{file_id}` — rename a file

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -403,6 +403,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 .route("/v1/files/{file_id}", delete(files::delete_file))
                 // Plan 0093 (GAR-564) — files API slice 6: download.
                 .route("/v1/files/{file_id}/download", get(files::download_file))
+                // Plan 0094 (GAR-567) — files API slice 7: new file version.
+                .route(
+                    "/v1/groups/{group_id}/files/{file_id}/versions",
+                    post(files::post_new_version),
+                )
                 // Plan 0089 (GAR-557) — files API slice 2: rename.
                 // Plan 0090 (GAR-559) — files API slice 3: GET single file.
                 .route(

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -16,7 +16,8 @@ use super::audit::{AuditEventSummary, ListAuditResponse};
 use super::chats::{ChatListResponse, ChatResponse, ChatSummary, CreateChatRequest};
 use super::files::{
     CreateFolderRequest, FileListResponse, FileSummary, FileVersionListResponse,
-    FileVersionSummary, FolderListResponse, FolderSummary, PatchFileRequest, PatchFolderRequest,
+    FileVersionResponse, FileVersionSummary, FolderListResponse, FolderSummary, PatchFileRequest,
+    PatchFolderRequest,
 };
 use super::groups::{
     CreateGroupRequest, CreateInviteRequest, GroupReadResponse, GroupResponse, InviteResponse,
@@ -147,6 +148,7 @@ impl Modify for SecurityAddon {
         super::files::delete_folder,
         super::files::download_file,
         super::files::list_file_versions,
+        super::files::post_new_version,
     ),
     components(schemas(
         MeResponse,
@@ -207,6 +209,7 @@ impl Modify for SecurityAddon {
         SearchResultType,
         FileSummary,
         FileListResponse,
+        FileVersionResponse,
         FolderSummary,
         FolderListResponse,
         PatchFileRequest,

--- a/crates/garraia-gateway/tests/rest_v1_files_new_version.rs
+++ b/crates/garraia-gateway/tests/rest_v1_files_new_version.rs
@@ -59,11 +59,9 @@ fn new_version_req(
     content_type: Option<&str>,
     body_bytes: Vec<u8>,
 ) -> Request<Body> {
-    let mut builder = Request::builder()
-        .method("POST")
-        .uri(format!(
-            "/v1/groups/{path_group_id}/files/{file_id}/versions"
-        ));
+    let mut builder = Request::builder().method("POST").uri(format!(
+        "/v1/groups/{path_group_id}/files/{file_id}/versions"
+    ));
     if let Some(ct) = content_type {
         builder = builder.header("content-type", ct);
     }
@@ -172,9 +170,7 @@ async fn build_storage_router(h: &Harness, tmp: &Path) -> axum::Router {
     std::fs::create_dir_all(&fs_root).unwrap();
     std::fs::create_dir_all(&staging_dir).unwrap();
 
-    let local_fs = Arc::new(
-        garraia_storage::LocalFs::new(&fs_root).expect("LocalFs::new"),
-    );
+    let local_fs = Arc::new(garraia_storage::LocalFs::new(&fs_root).expect("LocalFs::new"));
     let staging = Arc::new(UploadStaging {
         staging_dir: std::fs::canonicalize(&staging_dir).unwrap(),
         max_patch_bytes: 10 * 1024 * 1024,
@@ -231,16 +227,9 @@ async fn v1_files_new_version_scenarios() {
 
     // ─── NV1. 201 happy path ───────────────────────────────────────────────
     let nv1_payload: &[u8] = b"version 2 content";
-    let nv1_id = seed_file(
-        &h,
-        group_id,
-        owner_id,
-        "doc.txt",
-        5,
-        "text/plain",
-    )
-    .await
-    .expect("NV1 seed file");
+    let nv1_id = seed_file(&h, group_id, owner_id, "doc.txt", 5, "text/plain")
+        .await
+        .expect("NV1 seed file");
     seed_file_version(
         &h,
         nv1_id,
@@ -291,13 +280,12 @@ async fn v1_files_new_version_scenarios() {
     assert_eq!(mime, "text/plain", "NV1 db mime_type");
 
     // NV1 — DB: file_versions row created.
-    let (fv_ver,): (i32,) = sqlx::query_as(
-        "SELECT version FROM file_versions WHERE file_id = $1 AND version = 2",
-    )
-    .bind(nv1_id)
-    .fetch_one(&h.admin_pool)
-    .await
-    .expect("NV1 fetch file_versions v2");
+    let (fv_ver,): (i32,) =
+        sqlx::query_as("SELECT version FROM file_versions WHERE file_id = $1 AND version = 2")
+            .bind(nv1_id)
+            .fetch_one(&h.admin_pool)
+            .await
+            .expect("NV1 fetch file_versions v2");
     assert_eq!(fv_ver, 2, "NV1 db file_versions version");
 
     // ─── NV2. 404 non-existent file_id ────────────────────────────────────
@@ -387,10 +375,9 @@ async fn v1_files_new_version_scenarios() {
 
     // ─── NV5. 403 Child role lacks FilesWrite ────────────────────────────
     let child_email = "child@0094-new-version.test";
-    let (child_id, child_token) =
-        seed_member_via_admin(&h, group_id, "child", child_email)
-            .await
-            .expect("NV5 seed child");
+    let (child_id, child_token) = seed_member_via_admin(&h, group_id, "child", child_email)
+        .await
+        .expect("NV5 seed child");
     let _ = child_id;
 
     let nv5_id = seed_file(&h, group_id, owner_id, "child-target.txt", 2, "text/plain")
@@ -516,9 +503,5 @@ async fn v1_files_new_version_scenarios() {
         ))
         .await
         .expect("NV8 oneshot");
-    assert_eq!(
-        resp.status(),
-        StatusCode::SERVICE_UNAVAILABLE,
-        "NV8 status"
-    );
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE, "NV8 status");
 }

--- a/crates/garraia-gateway/tests/rest_v1_files_new_version.rs
+++ b/crates/garraia-gateway/tests/rest_v1_files_new_version.rs
@@ -1,0 +1,524 @@
+// Gated so `cargo clippy --all-targets` without `test-helpers` skips this
+// file and doesn't try to compile the `common` harness.
+#![cfg(feature = "test-helpers")]
+//! Integration tests for `POST /v1/groups/{group_id}/files/{file_id}/versions`
+//! (plan 0094, GAR-567, Fase 3.4 files slice 7).
+//!
+//! All scenarios bundled into ONE `#[tokio::test]` — same pattern as other
+//! files tests to avoid the sqlx runtime-teardown race.
+//!
+//! Scenarios:
+//! NV1. 201 happy path — valid bytes + Content-Type, files row updated.
+//! NV2. 404 non-existent file_id.
+//! NV3. 404 soft-deleted file.
+//! NV4. 404 cross-group attempt (RLS filters).
+//! NV5. 403 Child role lacks FilesWrite.
+//! NV6. 400 missing X-Group-Id header.
+//! NV7. 415 Content-Type MIME not in allow-list (or absent).
+//! NV8. 503 object store not configured.
+
+mod common;
+
+use std::path::Path;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
+use chrono::Utc;
+use garraia_gateway::rest_v1::uploads::UploadStaging;
+use garraia_gateway::server::build_router_for_test_with_storage;
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use common::Harness;
+use common::fixtures::{seed_member_via_admin, seed_user_with_group};
+
+fn docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn req_with_peer(builder: axum::http::request::Builder, body: Body) -> Request<Body> {
+    let mut req = builder.body(body).expect("request builder");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    req
+}
+
+fn new_version_req(
+    token: Option<&str>,
+    path_group_id: &str,
+    file_id: &str,
+    x_group_id: Option<&str>,
+    content_type: Option<&str>,
+    body_bytes: Vec<u8>,
+) -> Request<Body> {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri(format!(
+            "/v1/groups/{path_group_id}/files/{file_id}/versions"
+        ));
+    if let Some(ct) = content_type {
+        builder = builder.header("content-type", ct);
+    }
+    if let Some(cl) = Some(body_bytes.len().to_string()) {
+        builder = builder.header("content-length", cl);
+    }
+    let mut req = req_with_peer(builder, Body::from(body_bytes));
+    if let Some(t) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {t}")).unwrap(),
+        );
+    }
+    if let Some(g) = x_group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    req
+}
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("failed to collect response body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("response body is not JSON")
+}
+
+/// Seed a `files` row and return its id.
+async fn seed_file(
+    h: &Harness,
+    group_id: Uuid,
+    created_by: Uuid,
+    name: &str,
+    size_bytes: i64,
+    mime_type: &str,
+) -> anyhow::Result<Uuid> {
+    let file_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO files (id, group_id, folder_id, name, current_version, \
+                            total_versions, size_bytes, mime_type, settings, \
+                            created_by, created_by_label) \
+         VALUES ($1, $2, NULL, $3, 1, 1, $4, $5, '{}'::jsonb, $6, $7)",
+    )
+    .bind(file_id)
+    .bind(group_id)
+    .bind(name)
+    .bind(size_bytes)
+    .bind(mime_type)
+    .bind(created_by)
+    .bind("Test User")
+    .execute(&h.admin_pool)
+    .await?;
+    Ok(file_id)
+}
+
+/// Seed a `file_versions` row (version 1) for the given file.
+async fn seed_file_version(
+    h: &Harness,
+    file_id: Uuid,
+    group_id: Uuid,
+    created_by: Uuid,
+    object_key: &str,
+    size_bytes: i64,
+    mime_type: &str,
+) -> anyhow::Result<()> {
+    let hex64 = "a".repeat(64);
+    sqlx::query(
+        "INSERT INTO file_versions \
+         (file_id, group_id, version, object_key, etag, checksum_sha256, \
+          integrity_hmac, size_bytes, mime_type, created_by, created_by_label) \
+         VALUES ($1, $2, 1, $3, $4, $5, $6, $7, $8, $9, $10)",
+    )
+    .bind(file_id)
+    .bind(group_id)
+    .bind(object_key)
+    .bind(&hex64[..64])
+    .bind(&hex64)
+    .bind(&hex64)
+    .bind(size_bytes)
+    .bind(mime_type)
+    .bind(created_by)
+    .bind("Test User")
+    .execute(&h.admin_pool)
+    .await?;
+    Ok(())
+}
+
+/// Soft-delete a file directly via the admin pool.
+async fn soft_delete_file(h: &Harness, file_id: Uuid) -> anyhow::Result<()> {
+    sqlx::query("UPDATE files SET deleted_at = $1 WHERE id = $2")
+        .bind(Utc::now())
+        .bind(file_id)
+        .execute(&h.admin_pool)
+        .await?;
+    Ok(())
+}
+
+async fn build_storage_router(h: &Harness, tmp: &Path) -> axum::Router {
+    let fs_root = tmp.join("storage");
+    let staging_dir = tmp.join("staging");
+    std::fs::create_dir_all(&fs_root).unwrap();
+    std::fs::create_dir_all(&staging_dir).unwrap();
+
+    let local_fs = Arc::new(
+        garraia_storage::LocalFs::new(&fs_root).expect("LocalFs::new"),
+    );
+    let staging = Arc::new(UploadStaging {
+        staging_dir: std::fs::canonicalize(&staging_dir).unwrap(),
+        max_patch_bytes: 10 * 1024 * 1024,
+        hmac_secret: b"test-secret-32-bytes-minimum-xxx".to_vec(),
+    });
+
+    build_router_for_test_with_storage(
+        garraia_config::AppConfig::default(),
+        h.login_pool.clone(),
+        h.signup_pool.clone(),
+        h.jwt.clone(),
+        Some(h.app_pool.clone()),
+        Some(local_fs as Arc<dyn garraia_storage::ObjectStore>),
+        Some(staging),
+    )
+    .await
+}
+
+async fn build_no_storage_router(h: &Harness) -> axum::Router {
+    let staging_dir = tempfile::tempdir().expect("tempdir").keep().0;
+    let staging = Arc::new(UploadStaging {
+        staging_dir,
+        max_patch_bytes: 10 * 1024 * 1024,
+        hmac_secret: b"test-secret-32-bytes-minimum-xxx".to_vec(),
+    });
+    build_router_for_test_with_storage(
+        garraia_config::AppConfig::default(),
+        h.login_pool.clone(),
+        h.signup_pool.clone(),
+        h.jwt.clone(),
+        Some(h.app_pool.clone()),
+        None,
+        Some(staging),
+    )
+    .await
+}
+
+#[tokio::test]
+async fn v1_files_new_version_scenarios() {
+    if !docker_available() {
+        eprintln!("docker not available; skipping v1_files_new_version_scenarios");
+        return;
+    }
+
+    let h = Harness::get().await;
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let router = build_storage_router(&h, tmp.path()).await;
+
+    let (owner_id, group_id, owner_token) =
+        seed_user_with_group(&h, "owner@0094-new-version.test")
+            .await
+            .expect("seed owner+group");
+    let gid_str = group_id.to_string();
+
+    // ─── NV1. 201 happy path ───────────────────────────────────────────────
+    let nv1_payload: &[u8] = b"version 2 content";
+    let nv1_id = seed_file(
+        &h,
+        group_id,
+        owner_id,
+        "doc.txt",
+        5,
+        "text/plain",
+    )
+    .await
+    .expect("NV1 seed file");
+    seed_file_version(
+        &h,
+        nv1_id,
+        group_id,
+        owner_id,
+        &format!("{group_id}/files/{nv1_id}/v1/init.txt"),
+        5,
+        "text/plain",
+    )
+    .await
+    .expect("NV1 seed file_version");
+
+    let resp = router
+        .clone()
+        .oneshot(new_version_req(
+            Some(&owner_token),
+            &gid_str,
+            &nv1_id.to_string(),
+            Some(&gid_str),
+            Some("text/plain"),
+            nv1_payload.to_vec(),
+        ))
+        .await
+        .expect("NV1 oneshot");
+    assert_eq!(resp.status(), StatusCode::CREATED, "NV1 status");
+    let body = body_json(resp).await;
+    assert_eq!(body["file_id"], nv1_id.to_string(), "NV1 file_id");
+    assert_eq!(body["version"].as_u64(), Some(2), "NV1 version");
+    assert_eq!(
+        body["size_bytes"].as_u64(),
+        Some(nv1_payload.len() as u64),
+        "NV1 size_bytes"
+    );
+    assert_eq!(body["mime_type"], "text/plain", "NV1 mime_type");
+
+    // NV1 — DB: files row updated.
+    let (cur_ver, tot_ver, sz, mime): (i32, i32, i64, String) = sqlx::query_as(
+        "SELECT current_version, total_versions, size_bytes, mime_type \
+         FROM files WHERE id = $1",
+    )
+    .bind(nv1_id)
+    .fetch_one(&h.admin_pool)
+    .await
+    .expect("NV1 fetch files row");
+    assert_eq!(cur_ver, 2, "NV1 db current_version");
+    assert_eq!(tot_ver, 2, "NV1 db total_versions");
+    assert_eq!(sz, nv1_payload.len() as i64, "NV1 db size_bytes");
+    assert_eq!(mime, "text/plain", "NV1 db mime_type");
+
+    // NV1 — DB: file_versions row created.
+    let (fv_ver,): (i32,) = sqlx::query_as(
+        "SELECT version FROM file_versions WHERE file_id = $1 AND version = 2",
+    )
+    .bind(nv1_id)
+    .fetch_one(&h.admin_pool)
+    .await
+    .expect("NV1 fetch file_versions v2");
+    assert_eq!(fv_ver, 2, "NV1 db file_versions version");
+
+    // ─── NV2. 404 non-existent file_id ────────────────────────────────────
+    let resp = router
+        .clone()
+        .oneshot(new_version_req(
+            Some(&owner_token),
+            &gid_str,
+            &Uuid::new_v4().to_string(),
+            Some(&gid_str),
+            Some("text/plain"),
+            b"data".to_vec(),
+        ))
+        .await
+        .expect("NV2 oneshot");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND, "NV2 status");
+
+    // ─── NV3. 404 soft-deleted file ───────────────────────────────────────
+    let nv3_id = seed_file(&h, group_id, owner_id, "dead.txt", 0, "text/plain")
+        .await
+        .expect("NV3 seed file");
+    seed_file_version(
+        &h,
+        nv3_id,
+        group_id,
+        owner_id,
+        &format!("{group_id}/files/{nv3_id}/v1/init.txt"),
+        0,
+        "text/plain",
+    )
+    .await
+    .expect("NV3 seed file_version");
+    soft_delete_file(&h, nv3_id).await.expect("NV3 soft-delete");
+
+    let resp = router
+        .clone()
+        .oneshot(new_version_req(
+            Some(&owner_token),
+            &gid_str,
+            &nv3_id.to_string(),
+            Some(&gid_str),
+            Some("text/plain"),
+            b"data".to_vec(),
+        ))
+        .await
+        .expect("NV3 oneshot");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND, "NV3 status");
+
+    // ─── NV4. 404 cross-group (RLS) ───────────────────────────────────────
+    let (_other_id, other_group_id, _other_token) =
+        seed_user_with_group(&h, "other@0094-new-version.test")
+            .await
+            .expect("NV4 seed other group");
+    let other_gid_str = other_group_id.to_string();
+
+    // File in group_id; principal group = other_group_id → RLS filters → 404
+    let nv4_id = seed_file(&h, group_id, owner_id, "cross.txt", 4, "text/plain")
+        .await
+        .expect("NV4 seed file");
+    seed_file_version(
+        &h,
+        nv4_id,
+        group_id,
+        owner_id,
+        &format!("{group_id}/files/{nv4_id}/v1/cross.txt"),
+        4,
+        "text/plain",
+    )
+    .await
+    .expect("NV4 seed file_version");
+
+    // Attempt with owner_token but path/header group = other_group_id → 403 path mismatch
+    let resp = router
+        .clone()
+        .oneshot(new_version_req(
+            Some(&owner_token),
+            &other_gid_str,
+            &nv4_id.to_string(),
+            Some(&other_gid_str),
+            Some("text/plain"),
+            b"data".to_vec(),
+        ))
+        .await
+        .expect("NV4 oneshot");
+    // Group mismatch (principal.group_id ≠ path_group_id) returns 403
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN, "NV4 status");
+
+    // ─── NV5. 403 Child role lacks FilesWrite ────────────────────────────
+    let child_email = "child@0094-new-version.test";
+    let (child_id, child_token) =
+        seed_member_via_admin(&h, group_id, "child", child_email)
+            .await
+            .expect("NV5 seed child");
+    let _ = child_id;
+
+    let nv5_id = seed_file(&h, group_id, owner_id, "child-target.txt", 2, "text/plain")
+        .await
+        .expect("NV5 seed file");
+    seed_file_version(
+        &h,
+        nv5_id,
+        group_id,
+        owner_id,
+        &format!("{group_id}/files/{nv5_id}/v1/init.txt"),
+        2,
+        "text/plain",
+    )
+    .await
+    .expect("NV5 seed file_version");
+
+    let resp = router
+        .clone()
+        .oneshot(new_version_req(
+            Some(&child_token),
+            &gid_str,
+            &nv5_id.to_string(),
+            Some(&gid_str),
+            Some("text/plain"),
+            b"data".to_vec(),
+        ))
+        .await
+        .expect("NV5 oneshot");
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN, "NV5 status");
+
+    // ─── NV6. 400 missing X-Group-Id header ──────────────────────────────
+    let nv6_id = seed_file(&h, group_id, owner_id, "nv6.txt", 1, "text/plain")
+        .await
+        .expect("NV6 seed file");
+    seed_file_version(
+        &h,
+        nv6_id,
+        group_id,
+        owner_id,
+        &format!("{group_id}/files/{nv6_id}/v1/init.txt"),
+        1,
+        "text/plain",
+    )
+    .await
+    .expect("NV6 seed file_version");
+
+    let resp = router
+        .clone()
+        .oneshot(new_version_req(
+            Some(&owner_token),
+            &gid_str,
+            &nv6_id.to_string(),
+            None, // no X-Group-Id
+            Some("text/plain"),
+            b"data".to_vec(),
+        ))
+        .await
+        .expect("NV6 oneshot");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "NV6 status");
+
+    // ─── NV7. 415 MIME type not in allow-list ────────────────────────────
+    let nv7_id = seed_file(&h, group_id, owner_id, "nv7.bin", 1, "text/plain")
+        .await
+        .expect("NV7 seed file");
+    seed_file_version(
+        &h,
+        nv7_id,
+        group_id,
+        owner_id,
+        &format!("{group_id}/files/{nv7_id}/v1/init.txt"),
+        1,
+        "text/plain",
+    )
+    .await
+    .expect("NV7 seed file_version");
+
+    // "application/x-evil" is not in the MIME allow-list.
+    let resp = router
+        .clone()
+        .oneshot(new_version_req(
+            Some(&owner_token),
+            &gid_str,
+            &nv7_id.to_string(),
+            Some(&gid_str),
+            Some("application/x-evil"),
+            b"data".to_vec(),
+        ))
+        .await
+        .expect("NV7 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNSUPPORTED_MEDIA_TYPE,
+        "NV7 status"
+    );
+
+    // ─── NV8. 503 object store not configured ────────────────────────────
+    let no_store_router = build_no_storage_router(&h).await;
+
+    let nv8_id = seed_file(&h, group_id, owner_id, "nv8.txt", 1, "text/plain")
+        .await
+        .expect("NV8 seed file");
+    seed_file_version(
+        &h,
+        nv8_id,
+        group_id,
+        owner_id,
+        &format!("{group_id}/files/{nv8_id}/v1/init.txt"),
+        1,
+        "text/plain",
+    )
+    .await
+    .expect("NV8 seed file_version");
+
+    let resp = no_store_router
+        .oneshot(new_version_req(
+            Some(&owner_token),
+            &gid_str,
+            &nv8_id.to_string(),
+            Some(&gid_str),
+            Some("text/plain"),
+            b"data".to_vec(),
+        ))
+        .await
+        .expect("NV8 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "NV8 status"
+    );
+}

--- a/crates/garraia-gateway/tests/rest_v1_files_new_version.rs
+++ b/crates/garraia-gateway/tests/rest_v1_files_new_version.rs
@@ -190,7 +190,7 @@ async fn build_storage_router(h: &Harness, tmp: &Path) -> axum::Router {
 }
 
 async fn build_no_storage_router(h: &Harness) -> axum::Router {
-    let staging_dir = tempfile::tempdir().expect("tempdir").keep().0;
+    let staging_dir = tempfile::tempdir().expect("tempdir").keep();
     let staging = Arc::new(UploadStaging {
         staging_dir,
         max_patch_bytes: 10 * 1024 * 1024,

--- a/crates/garraia-gateway/tests/rest_v1_files_new_version.rs
+++ b/crates/garraia-gateway/tests/rest_v1_files_new_version.rs
@@ -219,10 +219,9 @@ async fn v1_files_new_version_scenarios() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let router = build_storage_router(&h, tmp.path()).await;
 
-    let (owner_id, group_id, owner_token) =
-        seed_user_with_group(&h, "owner@0094-new-version.test")
-            .await
-            .expect("seed owner+group");
+    let (owner_id, group_id, owner_token) = seed_user_with_group(&h, "owner@0094-new-version.test")
+        .await
+        .expect("seed owner+group");
     let gid_str = group_id.to_string();
 
     // ─── NV1. 201 happy path ───────────────────────────────────────────────

--- a/plans/0094-gar-565-files-api-slice7-new-version.md
+++ b/plans/0094-gar-565-files-api-slice7-new-version.md
@@ -1,0 +1,177 @@
+# Plan 0094 — Files REST API slice 7: POST /v1/files/{id}/versions (new file version)
+
+**Issue:** GAR-567
+**Epic:** GAR-WS-API (Fase 3.4)
+**Branch:** `routine/202605100800-files-new-version`
+**Created:** 2026-05-10 (America/New_York)
+
+---
+
+## 1. Goal
+
+Add `POST /v1/groups/{group_id}/files/{file_id}/versions` — a synchronous endpoint that accepts raw bytes in the request body and creates a new content version for an existing file. Closes the `[ ] POST /v1/files/{file_id}:newVersion` ROADMAP item (§3.4 Arquivos).
+
+This completes the core CRUD surface for individual files in Fase 3.4. Future slices can add version listing, rollback, and tus-linked versioning.
+
+---
+
+## 2. Architecture
+
+```
+Client ──POST /v1/groups/{gid}/files/{fid}/versions──► garraia-gateway
+         headers: Content-Type, Content-Length
+         body: raw bytes (≤ max_patch_bytes)
+
+Handler (files.rs):
+  1. Auth (Principal JWT + FilesWrite + group_id match)
+  2. Read Content-Type → mime_type; validate MIME allow-list
+  3. Read body bytes (capped)
+  4. Compute SHA-256 hex of body
+  5. Build object_key = "groups/{gid}/files/{fid}/v{N+1}/{uuid}"
+  6. ObjectStore::put(key, bytes, PutOptions { hmac_secret, content_type })
+     → ObjectMetadata { etag_sha256, integrity_hmac, size_bytes }
+  7. DB transaction (AppPool, FORCE RLS):
+     a. SELECT files FOR UPDATE → current_version, check deleted_at IS NULL
+     b. INSERT file_versions (version = current_version + 1)
+     c. UPDATE files SET current_version=N+1, total_versions=total_versions+1,
+                         size_bytes=?, mime_type=?, updated_at=now()
+     d. INSERT audit_events (file.version.created, PII-safe)
+  8. Return 201 + FileVersionResponse
+```
+
+**Two-phase ordering:** object store write happens BEFORE the DB transaction commits. If the DB commit fails after the object write, the orphaned blob is cleaned up by a future maintenance job (same rationale as plan 0044 §5.3.1). If the object store write fails, the DB transaction never starts → no orphan.
+
+---
+
+## 3. Tech stack
+
+- **Language:** Rust (stable 1.92+)
+- **Web:** Axum 0.8 (`State`, `Path`, `TypedHeader`, axum `Bytes` extractor)
+- **DB:** `sqlx` 0.8 with Postgres 16 (AppPool, FORCE RLS via `set_config`)
+- **Storage:** `garraia_storage::ObjectStore::put` (LocalFs in dev/CI, S3 in prod)
+- **Hashing:** `sha2` crate (already in workspace) for SHA-256
+- **MIME:** `garraia_storage::mime_allowlist::is_mime_allowed`
+- **OpenAPI:** `utoipa::path` annotation + `openapi.rs` registration
+
+---
+
+## 4. Design invariants
+
+1. **PII-safe audit:** metadata carries `size_bytes`, `new_version`, `group_id`, `file_id` — no raw filename or MIME type.
+2. **NO `object_key` in HTTP responses** — internal storage detail.
+3. **Cross-group Rule 10:** `path_group_id == principal.group_id`; RLS provides defense-in-depth.
+4. **MIME allow-list enforced before bytes are read** to fail fast on 415.
+5. **Fail-closed on missing staging:** 503 when `upload_staging` is `None`.
+6. **Atomic DB update:** `INSERT file_versions` + `UPDATE files` in one transaction.
+7. **`files_current_le_total` CHECK** preserved: `total_versions = total_versions + 1` before `current_version = new_version` satisfies `current_version <= total_versions` at all times.
+
+---
+
+## 5. Validações pré-plano
+
+- [x] `file_versions` schema reviewed (migration 003) — compound PK `(file_id, version)`, FK `(file_id, group_id) → files(id, group_id)`.
+- [x] `files` schema reviewed — `current_version`, `total_versions`, `size_bytes`, `mime_type`, `updated_at` are mutable columns.
+- [x] `ObjectStore::put` interface confirmed — returns `ObjectMetadata { etag_sha256, integrity_hmac, size_bytes }`.
+- [x] MIME allow-list function confirmed: `garraia_storage::mime_allowlist::is_mime_allowed(&str) -> bool`.
+- [x] HMAC secret available via `upload_staging.hmac_secret` — same as tus upload commit.
+- [x] `sha256_hex_of` helper already in `uploads.rs` (module-private) — will duplicate as `files`-local fn.
+- [x] `Action::FilesWrite` exists in `can.rs` and is granted to Owner/Admin/Member.
+- [x] Route `/v1/groups/{group_id}/files/{file_id}/versions` does not conflict with existing routes.
+
+---
+
+## 6. Out of scope
+
+- Listing all versions of a file (`GET /v1/groups/{group_id}/files/{file_id}/versions`)
+- Rolling back to a previous version
+- Tus-linked versioning (large files via `/v1/uploads` → new version)
+- `Content-Encoding` / compression handling
+- Range requests / partial uploads
+
+---
+
+## 7. Rollback
+
+- The new handler is additive (no schema changes, no migration). If reverted, callers get 404 on the route — no data corruption.
+- Objects already written to the ObjectStore are orphaned but recoverable (maintenance job).
+
+---
+
+## 8. File structure
+
+```
+crates/garraia-auth/src/audit_workspace.rs   ← add FileVersionCreated variant + as_str + test
+crates/garraia-gateway/src/rest_v1/files.rs  ← add post_new_version handler + FileVersionResponse DTO
+crates/garraia-gateway/src/rest_v1/mod.rs    ← register route + openapi schemas
+crates/garraia-gateway/src/rest_v1/openapi.rs← register path
+crates/garraia-gateway/tests/rest_v1_files_new_version.rs ← integration tests NV1–NV8
+plans/0094-gar-565-files-api-slice7-new-version.md ← this file
+plans/README.md ← new row
+ROADMAP.md ← tick [ ] POST /v1/files/{file_id}:newVersion
+```
+
+---
+
+## 9. Tasks (M1)
+
+- [ ] **T1** — `audit_workspace.rs`: add `FileVersionCreated` variant, `as_str` → `"file.version.created"`, unit test.
+- [ ] **T2** — `tests/rest_v1_files_new_version.rs`: write integration tests NV1–NV8 (red).
+- [ ] **T3** — `files.rs`: implement `post_new_version` handler + `FileVersionResponse` DTO + local `sha256_hex_of` + `validate_mime_type` helper.
+- [ ] **T4** — `mod.rs` + `openapi.rs`: register route + OpenAPI schemas; `cargo check -p garraia-gateway --features test-helpers` green.
+- [ ] **T5** — `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` clean; ROADMAP + plans/README updated; commit.
+
+---
+
+## 10. Test plan (NV1–NV8)
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| NV1 | Happy path — valid bytes + Content-Type | 201, `version = 2`, files row updated |
+| NV2 | File not found (random UUID) | 404 |
+| NV3 | Soft-deleted file | 404 |
+| NV4 | Cross-group attempt (RLS) | 404 |
+| NV5 | Principal lacks `FilesWrite` (Child role) | 403 |
+| NV6 | Missing `X-Group-Id` header | 400 |
+| NV7 | Missing `Content-Type` header (treated as octet-stream, MIME not in list) | 415 |
+| NV8 | Object store not configured | 503 |
+
+---
+
+## 11. Risk register
+
+| Risk | Mitigation |
+|------|------------|
+| Orphaned blob if DB commit fails after object write | Same risk as tus; future cleanup job; acceptable per plan 0044 §5.3.1 |
+| Body buffering into RAM for large files | Cap enforced (max_patch_bytes = 100 MiB); large files should use tus |
+| MIME allow-list bypass via content-sniffing | Validation is on declared Content-Type; content-sniffing out of scope |
+
+---
+
+## 12. Acceptance criteria
+
+1. `POST /v1/groups/{group_id}/files/{file_id}/versions` returns 201 + `FileVersionResponse`.
+2. `files.current_version` increments; `files.total_versions` increments; `files.size_bytes` + `files.mime_type` updated.
+3. New `file_versions` row exists with `version = old_current + 1`.
+4. All NV1–NV8 scenarios pass.
+5. `cargo clippy --workspace ... -D warnings` clean.
+6. CI green (all 18 checks).
+
+---
+
+## 13. Cross-references
+
+- Plans 0088–0093: Files API slices 1–6
+- Plan 0044: uploads two-phase commit pattern (object write before DB)
+- ADR 0004: object storage key schema
+- ROADMAP §3.4 Arquivos: `[ ] POST /v1/files/{file_id}:newVersion`
+
+---
+
+## 14. Estimativa
+
+- T1: 15 min
+- T2: 45 min
+- T3: 60 min
+- T4: 20 min
+- T5: 20 min
+- **Total:** ~2.5 h (provável)

--- a/plans/README.md
+++ b/plans/README.md
@@ -118,7 +118,7 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0092 | [GAR-562 — Files REST API slice 5: folder POST + DELETE](0092-gar-562-files-api-slice5-folder-post-delete.md) | [GAR-562](https://linear.app/chatgpt25/issue/GAR-562) | ✅ Merged 2026-05-09 via PR #247 (`28b3b0f`) |
 | 0093 | [GAR-564 — Files REST API slice 6: GET /v1/files/{file_id}/download](0093-gar-564-files-api-slice6-download.md) | [GAR-564](https://linear.app/chatgpt25/issue/GAR-564) | ✅ Merged 2026-05-10 via PR #250 (`b2de161`) |
 | 0094 | [GAR-567 — Files REST API slice 7: POST /v1/groups/{group_id}/files/{file_id}/versions (new version)](0094-gar-565-files-api-slice7-new-version.md) | [GAR-567](https://linear.app/chatgpt25/issue/GAR-567) | 🟡 Em execução 2026-05-10 |
-| 0095 | [GAR-569 — Files REST API slice 8: GET /v1/groups/{group_id}/files/{file_id}/versions (list versions)](0095-gar-569-files-api-slice8-list-versions.md) | [GAR-569](https://linear.app/chatgpt25/issue/GAR-569) | 🟡 Em execução 2026-05-10 |
+| 0095 | [GAR-569 — Files REST API slice 8: GET /v1/groups/{group_id}/files/{file_id}/versions (list versions)](0095-gar-569-files-api-slice8-list-versions.md) | [GAR-569](https://linear.app/chatgpt25/issue/GAR-569) | ✅ Merged 2026-05-10 via PR #253 (`0cc9a85`) |
 
 ## Arquivos não-versionados
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -117,7 +117,7 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0091 | [GAR-561 — Files REST API slice 4: PATCH folder rename](0091-gar-561-files-api-slice4-folder-rename.md) | [GAR-561](https://linear.app/chatgpt25/issue/GAR-561) | ✅ Merged 2026-05-09 via PR #246 (`3679ccc`) |
 | 0092 | [GAR-562 — Files REST API slice 5: folder POST + DELETE](0092-gar-562-files-api-slice5-folder-post-delete.md) | [GAR-562](https://linear.app/chatgpt25/issue/GAR-562) | ✅ Merged 2026-05-09 via PR #247 (`28b3b0f`) |
 | 0093 | [GAR-564 — Files REST API slice 6: GET /v1/files/{file_id}/download](0093-gar-564-files-api-slice6-download.md) | [GAR-564](https://linear.app/chatgpt25/issue/GAR-564) | ✅ Merged 2026-05-10 via PR #250 (`b2de161`) |
-| 0094 | [GAR-567 — Files REST API slice 7: POST /v1/groups/{group_id}/files/{file_id}/versions (new version)](0094-gar-565-files-api-slice7-new-version.md) | [GAR-567](https://linear.app/chatgpt25/issue/GAR-567) | ✅ Merged 2026-05-10 via PR #252 |
+| 0094 | [GAR-567 — Files REST API slice 7: POST /v1/groups/{group_id}/files/{file_id}/versions (new version)](0094-gar-565-files-api-slice7-new-version.md) | [GAR-567](https://linear.app/chatgpt25/issue/GAR-567) | 🟡 Em execução 2026-05-10 |
 | 0095 | [GAR-569 — Files REST API slice 8: GET /v1/groups/{group_id}/files/{file_id}/versions (list versions)](0095-gar-569-files-api-slice8-list-versions.md) | [GAR-569](https://linear.app/chatgpt25/issue/GAR-569) | 🟡 Em execução 2026-05-10 |
 
 ## Arquivos não-versionados


### PR DESCRIPTION
## Summary

- Adds `POST /v1/groups/{group_id}/files/{file_id}/versions` — synchronous new-version upload endpoint (plan 0094, Fase 3.4 files slice 7).
- Accepts raw bytes in request body (capped to `upload_staging.max_patch_bytes`, default 100 MiB). `Content-Type` header sets the MIME type; MIME allow-list enforced before body read (fast 415).
- Atomically bumps `files.current_version`, `files.total_versions`, `files.size_bytes`, `files.mime_type`, `files.updated_at` and inserts a `file_versions` row (`version = current + 1`) in one Postgres transaction.
- Two-phase commit: `ObjectStore::put` before Postgres COMMIT (ADR 0004 §5.3.1). SHA-256 + HMAC integrity computed and stored in `file_versions`.
- New audit action `FileVersionCreated` → `"file.version.created"` in `garraia-auth::WorkspaceAuditAction` (PII-safe: carries `size_bytes` + `new_version`, no filename).
- Also fixes pre-existing clippy error in `tests/rest_v1_files_new_version.rs`: deprecated `TempDir::keep().0` → `keep()` (same fix as PR #253 for the download tests).
- Also includes bookkeeping: ROADMAP.md and plans/README.md updated for both GAR-567 (plan 0094) and GAR-569 (plan 0095/PR #253).

> **Note:** Originally PR #252 — closed due to irreducible git hunk-overlap merge conflict. Re-opened as PR #254 with a clean cherry-pick onto post-PR-#253 main.

## Test plan

- [x] NV1: 201 happy path — bytes stored in LocalFs, `file_versions` v2 row created, `files.current_version = 2`, `files.total_versions = 2`, `files.size_bytes` + `files.mime_type` updated.
- [x] NV2: 404 non-existent `file_id`.
- [x] NV3: 404 soft-deleted file.
- [x] NV4: 403 `path_group_id` ≠ `principal.group_id` (group mismatch).
- [x] NV5: 403 Child role lacks `FilesWrite`.
- [x] NV6: 400 missing `X-Group-Id` header.
- [x] NV7: 415 MIME type not in allow-list (`application/x-evil`).
- [x] NV8: 503 object store not configured.
- [x] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` clean.
- [x] `cargo test -p garraia-auth --lib` — 58 tests pass (FileVersionCreated + FileVersionsListed both present and unique).

Closes GAR-567.

https://claude.ai/code/session_01SDBoo78HVKsuWWAN1JtDRD