### PR TITLE
feat(tasks): GAR-572 — task_attachments API slice 9 (migration 017 + POST/GET/DELETE)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -502,7 +502,7 @@ Módulo dentro de `garraia-workspace`. Schema entregue via migration 006 com **R
 - [x] `task_labels` (`id`, `group_id`, `name`, `color` hex CHECK, `created_by ON DELETE SET NULL` + `created_by_label` cache, `UNIQUE (group_id, name)`) — migration 006 ✅
 - [x] `task_label_assignments` (PK composta `(task_id, label_id)`, `assigned_at`) — migration 006 ✅
 - [x] `task_comments` (`id`, `task_id` CASCADE, `author_user_id ON DELETE SET NULL` + `author_label` cache, `body_md` CHECK 50k, `edited_at`, `deleted_at`) — migration 006 ✅
-- [ ] `task_attachments` (`task_id`, `file_id`) — deferido até GAR-387 (files) materializar
+- [x] `task_attachments` (PK composta `(task_id, file_id)`, `group_id` denorm, `attached_by ON DELETE SET NULL`, `attached_by_label` cache, `attached_at`) — migration 017, FORCE RLS via JOIN tasks, plan 0096 / GAR-572 ✅
 - [x] `task_subscriptions` (PK composta `(task_id, user_id)` CASCADE, `subscribed_at`, `muted`) — migration 006 ✅
 - [x] `task_activity` (`id`, `task_id` CASCADE, **`group_id` denormalizado**, `actor_user_id` plain uuid sem FK, `actor_label` cache, `kind` CHECK 12 valores, `payload jsonb`) — migration 006 ✅
 - [x] Status enum: `backlog|todo|in_progress|review|done|canceled` — migration 006 ✅

--- a/crates/garraia-auth/src/audit_workspace.rs
+++ b/crates/garraia-auth/src/audit_workspace.rs
@@ -441,6 +441,23 @@ pub enum WorkspaceAuditAction {
     /// `resource_type = "files"`, `resource_id = "{file_id}"`.
     /// Metadata: `{ file_id, group_id, version_count: usize }` — PII-safe.
     FileVersionsListed,
+
+    /// An existing file was attached to a task via
+    /// `POST /v1/groups/{group_id}/tasks/{task_id}/attachments`
+    /// (plan 0096 / GAR-572, Fase 3.4 tasks slice 9).
+    ///
+    /// `resource_type = "task_attachments"`, `resource_id = "{task_id}"`.
+    /// Metadata: `{ task_id, file_id }` — both UUIDs, no display names (PII-safe).
+    TaskFileAttached,
+
+    /// A file was detached from a task via
+    /// `DELETE /v1/groups/{group_id}/tasks/{task_id}/attachments/{file_id}`
+    /// (plan 0096 / GAR-572, Fase 3.4 tasks slice 9).
+    ///
+    /// Emitted only when a row was actually deleted (idempotent: no event if
+    /// already absent). `resource_type = "task_attachments"`, `resource_id = "{task_id}"`.
+    /// Metadata: `{ task_id, file_id }` — PII-safe.
+    TaskFileDetached,
 }
 
 impl WorkspaceAuditAction {
@@ -489,6 +506,8 @@ impl WorkspaceAuditAction {
             WorkspaceAuditAction::FileDownloadIssued => "file.download_issued",
             WorkspaceAuditAction::FileVersionCreated => "file.version.created",
             WorkspaceAuditAction::FileVersionsListed => "file.versions.listed",
+            WorkspaceAuditAction::TaskFileAttached => "task.file.attached",
+            WorkspaceAuditAction::TaskFileDetached => "task.file.detached",
         }
     }
 }
@@ -685,6 +704,14 @@ mod tests {
             WorkspaceAuditAction::FileVersionCreated.as_str(),
             "file.version.created"
         );
+        assert_eq!(
+            WorkspaceAuditAction::TaskFileAttached.as_str(),
+            "task.file.attached"
+        );
+        assert_eq!(
+            WorkspaceAuditAction::TaskFileDetached.as_str(),
+            "task.file.detached"
+        );
     }
 
     #[test]
@@ -730,6 +757,8 @@ mod tests {
             WorkspaceAuditAction::FileDownloadIssued.as_str(),
             WorkspaceAuditAction::FileVersionCreated.as_str(),
             WorkspaceAuditAction::FileVersionsListed.as_str(),
+            WorkspaceAuditAction::TaskFileAttached.as_str(),
+            WorkspaceAuditAction::TaskFileDetached.as_str(),
         ];
         let unique: std::collections::HashSet<_> = strings.iter().collect();
         assert_eq!(unique.len(), strings.len(), "duplicate action strings");

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -331,6 +331,19 @@ name = "rest_v1_files_patch"
 path = "tests/rest_v1_files_patch.rs"
 required-features = ["test-helpers"]
 
+# Plan 0096 (GAR-572) — tasks slice 9: task attachments API
+# (POST/GET /v1/groups/{gid}/tasks/{tid}/attachments,
+#  DELETE .../attachments/{file_id}).
+# 8 bundled scenarios (AT1-AT8) covering happy paths, 409 duplicate,
+# 404 cross-group file guard, 404 soft-deleted file, 204 idempotent
+# DELETE, and cross-group task isolation. Feature-gated so
+# `cargo clippy --all-targets` without `--features test-helpers` skips
+# compilation cleanly.
+[[test]]
+name = "rest_v1_task_attachments"
+path = "tests/rest_v1_task_attachments.rs"
+required-features = ["test-helpers"]
+
 [dev-dependencies]
 # Plan 0024 T4 (GAR-412): metrics_exporter tests and the
 # metrics_auth_integration binary build a `PrometheusRecorder` directly

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -389,6 +389,15 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     "/v1/groups/{group_id}/tasks/{task_id}/subtasks",
                     get(tasks::list_subtasks),
                 )
+                // Plan 0096 (GAR-572) — task attachments API slice 9.
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/attachments",
+                    post(tasks::post_task_attachment).get(tasks::list_task_attachments),
+                )
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/attachments/{file_id}",
+                    delete(tasks::delete_task_attachment),
+                )
                 // Plan 0070 (GAR-522) — audit API slice 1.
                 .route("/v1/groups/{group_id}/audit", get(audit::list_audit))
                 // Plan 0084 (GAR-549) — search API slice 1.
@@ -583,6 +592,15 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     "/v1/groups/{group_id}/tasks/{task_id}/subtasks",
                     get(unconfigured_handler),
                 )
+                // Plan 0096 (GAR-572) — task attachments, fail-soft 503.
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/attachments",
+                    post(unconfigured_handler).get(unconfigured_handler),
+                )
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/attachments/{file_id}",
+                    delete(unconfigured_handler),
+                )
                 .route(
                     "/v1/uploads",
                     post(unconfigured_handler).options(uploads::options_uploads),
@@ -743,6 +761,15 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 .route(
                     "/v1/groups/{group_id}/tasks/{task_id}/subtasks",
                     get(unconfigured_handler),
+                )
+                // Plan 0096 (GAR-572) — task attachments, no-auth stub.
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/attachments",
+                    post(unconfigured_handler).get(unconfigured_handler),
+                )
+                .route(
+                    "/v1/groups/{group_id}/tasks/{task_id}/attachments/{file_id}",
+                    delete(unconfigured_handler),
                 )
                 .route(
                     "/v1/uploads",

--- a/crates/garraia-gateway/src/rest_v1/tasks.rs
+++ b/crates/garraia-gateway/src/rest_v1/tasks.rs
@@ -4043,7 +4043,11 @@ pub async fn list_task_attachments(
         .take(limit as usize)
         .map(TaskAttachmentResponse::from)
         .collect();
-    let next_cursor = if has_more { items.last().map(|r| r.file_id) } else { None };
+    let next_cursor = if has_more {
+        items.last().map(|r| r.file_id)
+    } else {
+        None
+    };
 
     Ok(Json(ListAttachmentsResponse { items, next_cursor }))
 }
@@ -4105,14 +4109,12 @@ pub async fn delete_task_attachment(
         return Err(RestError::NotFound);
     }
 
-    let deleted = sqlx::query(
-        "DELETE FROM task_attachments WHERE task_id = $1 AND file_id = $2",
-    )
-    .bind(task_id)
-    .bind(file_id)
-    .execute(&mut *tx)
-    .await
-    .map_err(|e| RestError::Internal(e.into()))?;
+    let deleted = sqlx::query("DELETE FROM task_attachments WHERE task_id = $1 AND file_id = $2")
+        .bind(task_id)
+        .bind(file_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
 
     // Emit audit only when a row was actually removed (idempotent: no event on no-op).
     if deleted.rows_affected() > 0 {

--- a/crates/garraia-gateway/src/rest_v1/tasks.rs
+++ b/crates/garraia-gateway/src/rest_v1/tasks.rs
@@ -1,7 +1,7 @@
-//! `/v1/groups/{group_id}/task-lists` and task/comment/assignee/label/subscription handlers
-//! (plan 0066/0067/0069/0077/0078/0079/0083, GAR-516/GAR-518/GAR-520/GAR-533/GAR-536/GAR-539/GAR-546).
+//! `/v1/groups/{group_id}/task-lists` and task/comment/assignee/label/subscription/attachment handlers
+//! (plan 0066/0067/0069/0077/0078/0079/0083/0096, GAR-516/GAR-518/GAR-520/GAR-533/GAR-536/GAR-539/GAR-546/GAR-572).
 //!
-//! Twenty-four endpoints on the `garraia_app` RLS-enforced pool:
+//! Twenty-seven endpoints on the `garraia_app` RLS-enforced pool:
 //!
 //! **Slice 1 (plan 0066 / GAR-516):**
 //! - `POST /v1/groups/{group_id}/task-lists` — create task list
@@ -3748,4 +3748,390 @@ pub async fn move_task(
         .map_err(|e| RestError::Internal(e.into()))?;
 
     Ok(Json(TaskResponse::from(row)))
+}
+
+// ─── Task attachments (plan 0096 / GAR-572, slice 9) ─────────────────────────
+
+/// Request body for `POST /v1/groups/{group_id}/tasks/{task_id}/attachments`.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct AttachFileRequest {
+    pub file_id: Uuid,
+}
+
+/// DB row for a single `task_attachments` record.
+#[derive(sqlx::FromRow)]
+struct TaskAttachmentRow {
+    task_id: Uuid,
+    file_id: Uuid,
+    attached_by: Option<Uuid>,
+    attached_at: DateTime<Utc>,
+    file_name: String,
+    mime_type: String,
+    size_bytes: i64,
+}
+
+/// Public response shape for a single task attachment.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct TaskAttachmentResponse {
+    pub task_id: Uuid,
+    pub file_id: Uuid,
+    pub attached_by: Option<Uuid>,
+    pub attached_at: DateTime<Utc>,
+    pub file_name: String,
+    pub mime_type: String,
+    pub size_bytes: i64,
+}
+
+impl From<TaskAttachmentRow> for TaskAttachmentResponse {
+    fn from(r: TaskAttachmentRow) -> Self {
+        Self {
+            task_id: r.task_id,
+            file_id: r.file_id,
+            attached_by: r.attached_by,
+            attached_at: r.attached_at,
+            file_name: r.file_name,
+            mime_type: r.mime_type,
+            size_bytes: r.size_bytes,
+        }
+    }
+}
+
+/// Response envelope for `GET .../attachments`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ListAttachmentsResponse {
+    pub items: Vec<TaskAttachmentResponse>,
+    pub next_cursor: Option<Uuid>,
+}
+
+/// Query params for `GET .../attachments`.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ListAttachmentsQuery {
+    pub cursor: Option<Uuid>,
+    pub limit: Option<u32>,
+}
+
+/// `POST /v1/groups/{group_id}/tasks/{task_id}/attachments` — attach a file to a task.
+///
+/// The file must belong to the same group and must not be soft-deleted.
+/// Returns 409 if the file is already attached.
+#[utoipa::path(
+    post,
+    path = "/v1/groups/{group_id}/tasks/{task_id}/attachments",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("task_id" = Uuid, Path, description = "Task UUID."),
+    ),
+    request_body = AttachFileRequest,
+    responses(
+        (status = 201, description = "File attached to task.", body = TaskAttachmentResponse),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Task or file not found in this group.", body = super::problem::ProblemDetails),
+        (status = 409, description = "File already attached to this task.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+#[tracing::instrument(
+    name = "rest_v1.post_task_attachment",
+    skip_all,
+    fields(task_id = %task_id, file_id = %body.file_id)
+)]
+pub async fn post_task_attachment(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, task_id)): Path<(Uuid, Uuid)>,
+    Json(body): Json<AttachFileRequest>,
+) -> Result<(StatusCode, Json<TaskAttachmentResponse>), RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksWrite) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Verify task exists and is not soft-deleted.
+    let task_exists: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM tasks WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+    )
+    .bind(task_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if task_exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    // Verify file belongs to this group and is not soft-deleted.
+    // Cross-group injection: file from another group is invisible via RLS → 0 rows → 404.
+    let file_exists: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM files \
+         WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+    )
+    .bind(body.file_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if file_exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    let (actor_label,): (String,) = sqlx::query_as("SELECT display_name FROM users WHERE id = $1")
+        .bind(principal.user_id)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    // INSERT and join back to files for the response payload.
+    let row: TaskAttachmentRow = sqlx::query_as(
+        "INSERT INTO task_attachments \
+             (task_id, file_id, group_id, attached_by, attached_by_label, attached_at) \
+         VALUES ($1, $2, $3, $4, $5, now()) \
+         RETURNING \
+             task_id, file_id, attached_by, attached_at, \
+             (SELECT name FROM files WHERE id = $2)      AS file_name, \
+             (SELECT mime_type FROM files WHERE id = $2)  AS mime_type, \
+             (SELECT size_bytes FROM files WHERE id = $2) AS size_bytes",
+    )
+    .bind(task_id)
+    .bind(body.file_id)
+    .bind(group_id)
+    .bind(principal.user_id)
+    .bind(&actor_label)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| {
+        if let sqlx::Error::Database(ref db_err) = e
+            && db_err.code().as_deref() == Some("23505")
+        {
+            return RestError::Conflict("file already attached to this task".into());
+        }
+        RestError::Internal(e.into())
+    })?;
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::TaskFileAttached,
+        principal.user_id,
+        group_id,
+        "task_attachments",
+        task_id.to_string(),
+        json!({ "task_id": task_id.to_string(), "file_id": body.file_id.to_string() }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok((StatusCode::CREATED, Json(TaskAttachmentResponse::from(row))))
+}
+
+/// `GET /v1/groups/{group_id}/tasks/{task_id}/attachments` — list files attached to a task.
+///
+/// Cursor-paginated (by `attached_at ASC, file_id ASC`). Default limit 50, max 100.
+#[utoipa::path(
+    get,
+    path = "/v1/groups/{group_id}/tasks/{task_id}/attachments",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("task_id" = Uuid, Path, description = "Task UUID."),
+        ListAttachmentsQuery,
+    ),
+    responses(
+        (status = 200, description = "Paginated list of attachments.", body = ListAttachmentsResponse),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Task not found in this group.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+#[tracing::instrument(
+    name = "rest_v1.list_task_attachments",
+    skip_all,
+    fields(task_id = %task_id)
+)]
+pub async fn list_task_attachments(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, task_id)): Path<(Uuid, Uuid)>,
+    Query(params): Query<ListAttachmentsQuery>,
+) -> Result<Json<ListAttachmentsResponse>, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksRead) {
+        return Err(RestError::Forbidden);
+    }
+
+    let limit = params.limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as i64;
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Explicit 404 for deleted/missing tasks.
+    let task_exists: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM tasks WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+    )
+    .bind(task_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if task_exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    let rows: Vec<TaskAttachmentRow> = if let Some(cursor) = params.cursor {
+        sqlx::query_as(
+            "SELECT ta.task_id, ta.file_id, ta.attached_by, ta.attached_at, \
+                    f.name AS file_name, f.mime_type, f.size_bytes \
+             FROM task_attachments ta \
+             JOIN files f ON f.id = ta.file_id AND f.deleted_at IS NULL \
+             WHERE ta.task_id = $1 \
+               AND (ta.attached_at, ta.file_id) > ( \
+                   SELECT attached_at, file_id FROM task_attachments \
+                   WHERE task_id = $1 AND file_id = $2 \
+               ) \
+             ORDER BY ta.attached_at ASC, ta.file_id ASC \
+             LIMIT $3",
+        )
+        .bind(task_id)
+        .bind(cursor)
+        .bind(limit + 1)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?
+    } else {
+        sqlx::query_as(
+            "SELECT ta.task_id, ta.file_id, ta.attached_by, ta.attached_at, \
+                    f.name AS file_name, f.mime_type, f.size_bytes \
+             FROM task_attachments ta \
+             JOIN files f ON f.id = ta.file_id AND f.deleted_at IS NULL \
+             WHERE ta.task_id = $1 \
+             ORDER BY ta.attached_at ASC, ta.file_id ASC \
+             LIMIT $2",
+        )
+        .bind(task_id)
+        .bind(limit + 1)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?
+    };
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    let has_more = rows.len() as i64 > limit;
+    let items: Vec<_> = rows
+        .into_iter()
+        .take(limit as usize)
+        .map(TaskAttachmentResponse::from)
+        .collect();
+    let next_cursor = if has_more { items.last().map(|r| r.file_id) } else { None };
+
+    Ok(Json(ListAttachmentsResponse { items, next_cursor }))
+}
+
+/// `DELETE /v1/groups/{group_id}/tasks/{task_id}/attachments/{file_id}` — detach a file.
+///
+/// Idempotent: returns 204 whether or not the attachment row existed.
+/// Emits audit only when a row was actually deleted.
+#[utoipa::path(
+    delete,
+    path = "/v1/groups/{group_id}/tasks/{task_id}/attachments/{file_id}",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("task_id" = Uuid, Path, description = "Task UUID."),
+        ("file_id" = Uuid, Path, description = "File UUID to detach."),
+    ),
+    responses(
+        (status = 204, description = "File detached (or was never attached)."),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Task not found in this group.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+#[tracing::instrument(
+    name = "rest_v1.delete_task_attachment",
+    skip_all,
+    fields(task_id = %task_id, file_id = %file_id)
+)]
+pub async fn delete_task_attachment(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, task_id, file_id)): Path<(Uuid, Uuid, Uuid)>,
+) -> Result<StatusCode, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksWrite) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Verify task exists before emitting audit.
+    let task_exists: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM tasks WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+    )
+    .bind(task_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if task_exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    let deleted = sqlx::query(
+        "DELETE FROM task_attachments WHERE task_id = $1 AND file_id = $2",
+    )
+    .bind(task_id)
+    .bind(file_id)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    // Emit audit only when a row was actually removed (idempotent: no event on no-op).
+    if deleted.rows_affected() > 0 {
+        audit_workspace_event(
+            &mut tx,
+            WorkspaceAuditAction::TaskFileDetached,
+            principal.user_id,
+            group_id,
+            "task_attachments",
+            task_id.to_string(),
+            json!({ "task_id": task_id.to_string(), "file_id": file_id.to_string() }),
+        )
+        .await
+        .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+    }
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(StatusCode::NO_CONTENT)
 }

--- a/crates/garraia-gateway/tests/rest_v1_task_attachments.rs
+++ b/crates/garraia-gateway/tests/rest_v1_task_attachments.rs
@@ -1,0 +1,489 @@
+//! Integration tests for task_attachments REST API (plan 0096, GAR-572).
+//!
+//! All scenarios bundled into ONE `#[tokio::test]` — same pattern as
+//! `rest_v1_task_assignees.rs`. Splitting triggers the sqlx runtime-teardown
+//! race documented in plan 0016 M3.
+//!
+//! Scenarios (8 total):
+//!
+//!   AT1. POST 201 — attach a file; response shape + audit row.
+//!   AT2. GET 200 — list attachments; returns AT1 entry (cursor pagination).
+//!   AT3. POST 409 — duplicate attach returns 409 Conflict.
+//!   AT4. DELETE 204 — detach the file; audit row emitted.
+//!   AT5. DELETE 204 idempotent — same file_id just detached; 204, no new audit.
+//!   AT6. POST 404 — file_id belongs to Bob's group (cross-group file guard).
+//!   AT7. POST 404 — file is soft-deleted in Alice's group.
+//!   AT8. POST/GET/DELETE 404 — task_id is from Bob's group (cross-group task guard).
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use common::Harness;
+use common::fixtures::{fetch_audit_events_for_group, seed_user_with_group};
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect response body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("response body is not JSON")
+}
+
+fn auth_req(
+    method: &str,
+    uri: &str,
+    token: Option<&str>,
+    x_group_id: Option<&str>,
+    body: Option<serde_json::Value>,
+) -> Request<Body> {
+    let body_bytes = match body {
+        Some(v) => Body::from(v.to_string()),
+        None => Body::empty(),
+    };
+    let mut req = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(body_bytes)
+        .expect("request builder");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    if let Some(t) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {t}")).unwrap(),
+        );
+    }
+    if let Some(g) = x_group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    req
+}
+
+/// Creates a task list + task under `group_id`. Returns (list_id, task_id).
+async fn create_task_list_and_task(h: &Harness, token: &str, group_id: &str) -> (String, String) {
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{group_id}/task-lists"),
+            Some(token),
+            Some(group_id),
+            Some(json!({ "name": "Attachment Test List", "type": "list" })),
+        ))
+        .await
+        .expect("create task-list");
+    assert_eq!(resp.status(), StatusCode::CREATED, "setup: task-list 201");
+    let tl = body_json(resp).await;
+    let list_id = tl["id"].as_str().expect("list id").to_string();
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{group_id}/task-lists/{list_id}/tasks"),
+            Some(token),
+            Some(group_id),
+            Some(json!({ "title": "Task with attachments" })),
+        ))
+        .await
+        .expect("create task");
+    assert_eq!(resp.status(), StatusCode::CREATED, "setup: task 201");
+    let task = body_json(resp).await;
+    let task_id = task["id"].as_str().expect("task id").to_string();
+
+    (list_id, task_id)
+}
+
+/// Seeds a minimal `files` + `file_versions` row directly via `admin_pool`,
+/// bypassing RLS. Returns the new `file_id`.
+///
+/// When `deleted` is true, sets `deleted_at` so the file counts as soft-deleted
+/// (AT7 scenario).
+async fn seed_file(h: &Harness, group_id: Uuid, uploader_id: Uuid, deleted: bool) -> Uuid {
+    let file_id = Uuid::new_v4();
+    // object_key includes file_id to satisfy the UNIQUE constraint across parallel tests.
+    let object_key = format!("test/{file_id}/v1/payload.bin");
+    // 64 lowercase hex chars satisfy both checksum_sha256 and integrity_hmac CHECK constraints.
+    let hex64 = "a".repeat(64);
+
+    let deleted_at_expr = if deleted {
+        "'2000-01-01T00:00:00Z'::timestamptz"
+    } else {
+        "NULL"
+    };
+
+    // files row — no folder (NULL folder_id is fine per migration 003 MATCH SIMPLE FK).
+    sqlx::query(&format!(
+        "INSERT INTO files \
+            (id, group_id, name, size_bytes, mime_type, \
+             created_by, created_by_label, deleted_at) \
+         VALUES ($1, $2, 'test-file.bin', 1024, 'application/octet-stream', \
+                 $3, 'Test User', {deleted_at_expr})",
+    ))
+    .bind(file_id)
+    .bind(group_id)
+    .bind(uploader_id)
+    .execute(&h.admin_pool)
+    .await
+    .expect("seed files row");
+
+    // file_versions row for version 1 (referenced by files.current_version default 1).
+    sqlx::query(
+        "INSERT INTO file_versions \
+            (file_id, group_id, version, object_key, etag, \
+             checksum_sha256, integrity_hmac, size_bytes, mime_type, \
+             created_by, created_by_label) \
+         VALUES ($1, $2, 1, $3, 'etag-test', $4, $4, 1024, \
+                 'application/octet-stream', $5, 'Test User')",
+    )
+    .bind(file_id)
+    .bind(group_id)
+    .bind(object_key)
+    .bind(&hex64)
+    .bind(uploader_id)
+    .execute(&h.admin_pool)
+    .await
+    .expect("seed file_versions row");
+
+    file_id
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(feature = "test-helpers")]
+#[tokio::test]
+async fn rest_v1_task_attachments_scenarios() {
+    let h = Harness::get().await;
+
+    // Seed Alice as group owner (primary actor).
+    // Bob owns a separate group for cross-group isolation tests.
+    let (alice_id, alice_group_id, alice_token) =
+        seed_user_with_group(&h, "alice@attachments.test")
+            .await
+            .expect("seed alice+group");
+    let (bob_id, bob_group_id, bob_token) = seed_user_with_group(&h, "bob@attachments.test")
+        .await
+        .expect("seed bob+group");
+
+    let gid = alice_group_id.to_string();
+    let g2id = bob_group_id.to_string();
+
+    // Create a task under Alice's group.
+    let (_list_id, task_id) = create_task_list_and_task(&h, &alice_token, &gid).await;
+
+    // Create a task under Bob's group (cross-group task guard, AT8).
+    let (_bob_list_id, bob_task_id) = create_task_list_and_task(&h, &bob_token, &g2id).await;
+
+    // Seed a live file in Alice's group (the one we'll attach in AT1).
+    let file_id = seed_file(&h, alice_group_id, alice_id, false).await;
+    let file_str = file_id.to_string();
+
+    // Seed a soft-deleted file in Alice's group (AT7).
+    let deleted_file_id = seed_file(&h, alice_group_id, alice_id, true).await;
+    let deleted_file_str = deleted_file_id.to_string();
+
+    // Seed a live file in Bob's group (cross-group file guard, AT6).
+    let bob_file_id = seed_file(&h, bob_group_id, bob_id, false).await;
+    let bob_file_str = bob_file_id.to_string();
+
+    // ── AT1. POST 201 — attach file; response shape + audit row ──────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/attachments"),
+            Some(&alice_token),
+            Some(&gid),
+            Some(json!({ "file_id": file_str })),
+        ))
+        .await
+        .expect("AT1 oneshot");
+    assert_eq!(resp.status(), StatusCode::CREATED, "AT1 must return 201");
+    let at1_body = body_json(resp).await;
+    assert_eq!(at1_body["task_id"], task_id, "AT1 task_id matches");
+    assert_eq!(at1_body["file_id"], file_str, "AT1 file_id matches");
+    assert!(
+        at1_body.get("attached_at").is_some(),
+        "AT1 attached_at present"
+    );
+    assert_eq!(
+        at1_body["file_name"], "test-file.bin",
+        "AT1 file_name from files table"
+    );
+    assert_eq!(
+        at1_body["mime_type"], "application/octet-stream",
+        "AT1 mime_type from files table"
+    );
+    assert_eq!(
+        at1_body["size_bytes"], 1024,
+        "AT1 size_bytes from files table"
+    );
+
+    // Audit row: action = "task.file.attached", resource_type = "task_attachments".
+    let audit = fetch_audit_events_for_group(&h, alice_group_id)
+        .await
+        .expect("AT1 fetch audit");
+    let at1_audit = audit
+        .iter()
+        .find(|e| e.0 == "task.file.attached")
+        .expect("AT1 audit row task.file.attached must exist");
+    let (_, _, at1_res_type, at1_res_id, at1_meta) = at1_audit;
+    assert_eq!(at1_res_type, "task_attachments", "AT1 audit resource_type");
+    assert_eq!(at1_res_id, &task_id, "AT1 audit resource_id is task_id");
+    // Metadata must carry task_id + file_id but no PII (no file_name, no email).
+    assert!(
+        at1_meta.get("task_id").is_some(),
+        "AT1 audit metadata has task_id"
+    );
+    assert!(
+        at1_meta.get("file_id").is_some(),
+        "AT1 audit metadata has file_id"
+    );
+    assert!(
+        at1_meta.get("file_name").is_none(),
+        "AT1 audit must NOT contain file_name (PII guard)"
+    );
+
+    // ── AT2. GET 200 — list attachments; AT1 entry present ───────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "GET",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/attachments"),
+            Some(&alice_token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("AT2 oneshot");
+    assert_eq!(resp.status(), StatusCode::OK, "AT2 must return 200");
+    let at2_body = body_json(resp).await;
+    let items = at2_body["items"].as_array().expect("AT2 items array");
+    assert!(
+        items.iter().any(|it| it["file_id"] == file_str),
+        "AT2 should contain the AT1 attachment"
+    );
+    // next_cursor should be null (only one item, well below limit).
+    assert!(
+        at2_body["next_cursor"].is_null(),
+        "AT2 next_cursor is null (single page)"
+    );
+
+    // ── AT3. POST 409 — duplicate attach ─────────────────────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/attachments"),
+            Some(&alice_token),
+            Some(&gid),
+            Some(json!({ "file_id": file_str })),
+        ))
+        .await
+        .expect("AT3 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::CONFLICT,
+        "AT3 duplicate attach must return 409"
+    );
+
+    // ── AT4. DELETE 204 — detach file; audit row emitted ─────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "DELETE",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/attachments/{file_str}"),
+            Some(&alice_token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("AT4 oneshot");
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT, "AT4 must return 204");
+
+    // Verify the file no longer appears in GET list.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "GET",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/attachments"),
+            Some(&alice_token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("AT4 list after detach");
+    let at4_list = body_json(resp).await;
+    let after_del = at4_list["items"].as_array().expect("AT4 items array");
+    assert!(
+        !after_del.iter().any(|it| it["file_id"] == file_str),
+        "AT4 detached file must not appear in GET list"
+    );
+
+    // Audit row: action = "task.file.detached".
+    let audit2 = fetch_audit_events_for_group(&h, alice_group_id)
+        .await
+        .expect("AT4 fetch audit");
+    assert!(
+        audit2
+            .iter()
+            .any(|e| e.0 == "task.file.detached" && e.3 == task_id),
+        "AT4 audit row task.file.detached must be present"
+    );
+
+    // ── AT5. DELETE 204 idempotent — same file_id, not attached ──────────────
+    let audit_count_before = audit2
+        .iter()
+        .filter(|e| e.0 == "task.file.detached")
+        .count();
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "DELETE",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/attachments/{file_str}"),
+            Some(&alice_token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("AT5 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NO_CONTENT,
+        "AT5 idempotent DELETE must return 204"
+    );
+
+    // No new audit row should have been emitted (rows_affected = 0).
+    let audit3 = fetch_audit_events_for_group(&h, alice_group_id)
+        .await
+        .expect("AT5 fetch audit");
+    let audit_count_after = audit3
+        .iter()
+        .filter(|e| e.0 == "task.file.detached")
+        .count();
+    assert_eq!(
+        audit_count_before, audit_count_after,
+        "AT5 no-op DELETE must not emit duplicate audit"
+    );
+
+    // ── AT6. POST 404 — file belongs to Bob's group (cross-group guard) ───────
+    // Alice references bob_file_id while acting in alice's group → 404 (never 403).
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/attachments"),
+            Some(&alice_token),
+            Some(&gid),
+            Some(json!({ "file_id": bob_file_str })),
+        ))
+        .await
+        .expect("AT6 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "AT6 cross-group file must return 404 (never 403)"
+    );
+
+    // ── AT7. POST 404 — soft-deleted file ────────────────────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{gid}/tasks/{task_id}/attachments"),
+            Some(&alice_token),
+            Some(&gid),
+            Some(json!({ "file_id": deleted_file_str })),
+        ))
+        .await
+        .expect("AT7 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "AT7 deleted file must return 404"
+    );
+
+    // ── AT8. POST/GET/DELETE 404 — task_id from Bob's group ──────────────────
+    // Alice uses her own group context but references bob_task_id → task not
+    // found in alice's group → 404 on all three verbs.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "POST",
+            &format!("/v1/groups/{gid}/tasks/{bob_task_id}/attachments"),
+            Some(&alice_token),
+            Some(&gid),
+            Some(json!({ "file_id": file_str })),
+        ))
+        .await
+        .expect("AT8 POST oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "AT8 POST cross-group task must return 404"
+    );
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "GET",
+            &format!("/v1/groups/{gid}/tasks/{bob_task_id}/attachments"),
+            Some(&alice_token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("AT8 GET oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "AT8 GET cross-group task must return 404"
+    );
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(auth_req(
+            "DELETE",
+            &format!("/v1/groups/{gid}/tasks/{bob_task_id}/attachments/{file_str}"),
+            Some(&alice_token),
+            Some(&gid),
+            None,
+        ))
+        .await
+        .expect("AT8 DELETE oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "AT8 DELETE cross-group task must return 404"
+    );
+}

--- a/crates/garraia-workspace/migrations/017_task_attachments.sql
+++ b/crates/garraia-workspace/migrations/017_task_attachments.sql
@@ -1,0 +1,60 @@
+-- 017_task_attachments.sql
+-- GAR-572 — Migration 017: task_attachments join table (plan 0096).
+-- Depends:  migration 003 (files table) + migration 006 (tasks table).
+-- Unblocks: ROADMAP §3.8 Tier 1 `[ ] task_attachments (task_id, file_id)`.
+-- Forward-only. No DROP, no destructive ALTER.
+
+CREATE TABLE task_attachments (
+    task_id         uuid        NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    file_id         uuid        NOT NULL REFERENCES files(id) ON DELETE CASCADE,
+    -- Denormalized group_id mirrors the tasks.group_id pattern used by
+    -- task_activity. Kept in sync by the caller (no trigger). Enables
+    -- cheap cross-group leak audits: SELECT ta.id FROM task_attachments ta
+    -- JOIN tasks t ON ta.task_id = t.id WHERE ta.group_id <> t.group_id.
+    group_id        uuid        NOT NULL,
+    attached_by     uuid        REFERENCES users(id) ON DELETE SET NULL,
+    attached_by_label text      NOT NULL DEFAULT '',
+    attached_at     timestamptz NOT NULL DEFAULT now(),
+
+    PRIMARY KEY (task_id, file_id)
+);
+
+COMMENT ON TABLE task_attachments IS
+    'M:N between tasks and files. A file can be attached to multiple tasks; a '
+    'task can have multiple file attachments. group_id is denormalized for audit '
+    'queries. RLS class: JOIN via tasks (same as task_assignees, task_label_assignments). '
+    'Unblocked by GAR-387 (files schema), implemented in plan 0096 / GAR-572.';
+
+COMMENT ON COLUMN task_attachments.group_id IS
+    'Denormalized from tasks.group_id. Kept in sync by the caller. Used for '
+    'audit drift detection — if ta.group_id != t.group_id, the handler has a bug.';
+
+COMMENT ON COLUMN task_attachments.attached_by IS
+    'User who performed the attach. SET NULL on hard-delete so history survives '
+    'without attribution. Display fallback: attached_by_label (cached at insert).';
+
+CREATE INDEX task_attachments_file_idx
+    ON task_attachments(file_id, attached_at DESC);
+
+COMMENT ON INDEX task_attachments_file_idx IS
+    'Supports "find all tasks this file is attached to" queries. Not used by '
+    'initial slice but avoids seqscan on files.id lookups.';
+
+-- FORCE RLS — JOIN class via tasks (same pattern as task_assignees, 006 §7).
+-- tasks is itself RLS-protected by tasks_group_isolation, so this composition
+-- filters to the current group without duplicating the group_id predicate.
+ALTER TABLE task_attachments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE task_attachments FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY task_attachments_through_tasks ON task_attachments
+    USING (task_id IN (SELECT id FROM tasks));
+
+COMMENT ON POLICY task_attachments_through_tasks ON task_attachments IS
+    'Class: JOIN (implicit recursive). The subquery against tasks is itself '
+    'RLS-protected by tasks_group_isolation (migration 006), so the composition '
+    'filters to app.current_group_id transparently. Matches the pattern used by '
+    'task_assignees, task_label_assignments, task_comments, task_subscriptions.';
+
+-- Grant to garraia_app (ALTER DEFAULT PRIVILEGES from migration 007 does NOT
+-- cover tables created in later migrations — explicit GRANT required here).
+GRANT SELECT, INSERT, DELETE ON task_attachments TO garraia_app;

--- a/plans/0096-gar-572-task-attachments-api.md
+++ b/plans/0096-gar-572-task-attachments-api.md
@@ -1,0 +1,191 @@
+# Plan 0096 — GAR-572: REST /v1 tasks — task_attachments (migration 017 + POST/GET/DELETE)
+
+**Status:** Em execução
+**Autor:** Claude Sonnet 4.6 (garra-routine 2026-05-10, America/New_York)
+**Data:** 2026-05-10 (America/New_York)
+**Issue:** [GAR-572](https://linear.app/chatgpt25/issue/GAR-572)
+**Branch:** `routine/202505101823-task-attachments-api`
+**Epic:** `epic:ws-api`, `epic:ws-tasks`
+**Parent:** GAR-396
+
+---
+
+## §1 Goal
+
+Land the `task_attachments` join table (migration 017) and three REST endpoints
+on the `garraia_app` RLS-enforced pool, closing the ROADMAP §3.8 Tier 1 item
+deferred since migration 006 pending GAR-387 (files schema, now Done).
+
+**Endpoints:**
+- `POST /v1/groups/{group_id}/tasks/{task_id}/attachments` — attach an existing file (201 / 409 dup / 404 cross-group)
+- `GET /v1/groups/{group_id}/tasks/{task_id}/attachments` — cursor-paginated list (200)
+- `DELETE /v1/groups/{group_id}/tasks/{task_id}/attachments/{file_id}` — detach (204, idempotent)
+
+---
+
+## §2 Architecture
+
+### RLS pattern
+
+`task_attachments` uses the **JOIN via tasks** pattern (same as `task_assignees`,
+`task_label_assignments` from migration 006):
+
+```sql
+CREATE POLICY task_attachments_group_isolation ON task_attachments
+    USING (
+        task_id IN (
+            SELECT id FROM tasks
+            WHERE group_id = NULLIF(current_setting('app.current_group_id', TRUE), '')::uuid
+        )
+    );
+```
+
+`tasks` already has FORCE RLS filtering by `app.current_group_id`, so the JOIN
+transitively scopes attachments to the current group without duplicating the predicate.
+
+### Cross-group file injection guard
+
+Before INSERT: verify `files.group_id = path_group_id AND files.deleted_at IS NULL`
+using the RLS-scoped tx. File belonging to another group is invisible via RLS → `SELECT`
+returns 0 rows → 404 (never 403, anti-enumeration per ADR 0004 §7).
+
+### Unique violation
+
+`task_attachments` PK is `(task_id, file_id)` — SQLSTATE `23505` → 409 Conflict.
+
+---
+
+## §3 Tech stack
+
+- Axum 0.8 + `RestV1FullState` (same as `tasks.rs`)
+- `sqlx::query` / `sqlx::query_as` (no SQL string concat)
+- `garraia_auth::{Action, Principal, WorkspaceAuditAction, audit_workspace_event}`
+- New `WorkspaceAuditAction` variants: `TaskFileAttached`, `TaskFileDetached`
+- `utoipa` OpenAPI annotations
+
+---
+
+## §4 Design invariants
+
+1. SET LOCAL both `app.current_user_id` AND `app.current_group_id` in every tx.
+2. Cross-group file injection → 404 (RLS + explicit `files.group_id = $path_group_id` check).
+3. Soft-deleted file (`files.deleted_at IS NOT NULL`) → 404 on attach.
+4. Audit metadata PII-safe: `{ file_id, task_id }` (both UUIDs, no display name).
+5. DELETE always 204 idempotent — no 404 if row already absent.
+6. No `unwrap()` in production; no SQL string concat.
+7. `object_key` and `integrity_hmac` never appear in any response field (ADR 0004 §Security 3).
+
+---
+
+## §5 Validações pré-plano
+
+- [x] Migration 003 (`files`, `file_versions`) — Done via GAR-387
+- [x] Migration 006 (`tasks`, `task_assignees` RLS pattern) — Done via GAR-390
+- [x] `AppPool` + `Principal` + `set_config` RLS wiring — Done via plan 0016
+- [x] `WorkspaceAuditAction` enum + `audit_workspace_event` fn — Done via plans 0054+
+- [x] `cargo check -p garraia-gateway` builds green on main
+- [x] Next free migration slot = 017 (015 = pinned_at, 016 = task_activity.kind)
+
+---
+
+## §6 Out of scope
+
+- `message_attachments` (different table, different slice)
+- `task_attachments` reordering / position column
+- Inline file preview in task view (frontend concern)
+- `has_attachment` search filter (deferred: requires messages/files schema change, separate slice)
+- Any changes to `files` or `file_versions` tables
+
+---
+
+## §7 Rollback
+
+Migration 017 is forward-only. To undo: `DROP TABLE task_attachments;` (no dependent tables).
+No breaking API changes: three new routes added, no existing routes modified.
+
+---
+
+## §8 Open questions
+
+None — pattern is established by `task_assignees` (plan 0077) and `task_label_assignments` (plan 0078).
+
+---
+
+## §9 File structure
+
+```
+crates/garraia-workspace/migrations/
+  017_task_attachments.sql                     NEW — migration
+crates/garraia-auth/src/
+  audit_workspace.rs                           EDIT — add TaskFileAttached, TaskFileDetached
+crates/garraia-gateway/src/
+  rest_v1/tasks.rs                             EDIT — 3 handlers + route wiring
+  rest_v1/mod.rs                              EDIT — route registration
+tests/
+  rest_v1_task_attachments.rs                 NEW — 8 integration test scenarios
+plans/
+  0096-gar-572-task-attachments-api.md        THIS FILE
+  README.md                                   EDIT — add row 0096
+ROADMAP.md                                    EDIT — tick [ ] task_attachments
+```
+
+---
+
+## §10 M1 tasks (TDD order)
+
+- [ ] **T1** — `audit_workspace.rs`: add `TaskFileAttached` + `TaskFileDetached` variants, update `as_str()` match arm, add unit tests asserting the string values.
+- [ ] **T2** — `migrations/017_task_attachments.sql`: `CREATE TABLE task_attachments`, composite PK, FK to `tasks` (CASCADE) + `files`, FORCE RLS + policy via JOIN on tasks.
+- [ ] **T3** — `rest_v1/tasks.rs`: implement `post_task_attachment`, `list_task_attachments`, `delete_task_attachment` handlers + DTOs; wire routes in `mod.rs`.
+- [ ] **T4** — `tests/rest_v1_task_attachments.rs`: 8 integration test scenarios AT1–AT8.
+- [ ] **T5** — OpenAPI `#[utoipa::path]` annotations, `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings`, `cargo fmt`.
+- [ ] **T6** — Update `ROADMAP.md` (`[ ] task_attachments` → `[x]`) + `plans/README.md` row 0096.
+
+---
+
+## §11 Risk register
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Migration slot conflict | Low | Low | Verified: 017 is free |
+| RLS JOIN vs direct policy confusion | Low | Medium | Follow plan 0077 pattern exactly |
+| `file.deleted_at` check missed | Low | High | Test AT6 specifically covers this |
+| Cross-group file injection | Low | High | Test AT5 + explicit `files.group_id` check |
+
+---
+
+## §12 Acceptance criteria
+
+1. `POST /v1/groups/{group_id}/tasks/{task_id}/attachments` → 201 + `{ task_id, file_id, attached_by, attached_at }`.
+2. `GET /v1/groups/{group_id}/tasks/{task_id}/attachments` → 200 + `{ items, next_cursor }`.
+3. `DELETE /v1/groups/{group_id}/tasks/{task_id}/attachments/{file_id}` → 204 (idempotent).
+4. 409 on duplicate `(task_id, file_id)`.
+5. 404 when file belongs to a different group.
+6. 404 when attaching a soft-deleted file.
+7. `cargo clippy --workspace ... -- -D warnings` clean.
+8. 8 integration tests (AT1–AT8) pass.
+9. `TaskFileAttached` + `TaskFileDetached` audit actions asserted in unit tests.
+
+---
+
+## §13 Cross-references
+
+- Plan 0077 (GAR-533) — task assignees (same RLS pattern, reference implementation)
+- Plan 0078 (GAR-536) — task labels (same RLS pattern)
+- Plan 0088 (GAR-555) — files API slice 1 (files table established)
+- Migration 003 (`003_files_and_folders.sql`) — files schema prerequisite
+- Migration 006 (`006_tasks_with_rls.sql`) — tasks schema prerequisite
+- ROADMAP §3.8 Tier 1 — `[ ] task_attachments (task_id, file_id)`
+- ADR 0004 — object storage security policy (object_key never in HTTP responses)
+
+---
+
+## §14 Estimativa
+
+- T1 (audit): 15 min
+- T2 (migration): 20 min
+- T3 (handlers + route): 45 min
+- T4 (tests): 40 min
+- T5 (OpenAPI + clippy): 15 min
+- T6 (ROADMAP + plans README): 10 min
+- Total: **~2h 25min** (low 2h / high 3.5h)
+- LOC delta: ~380 LOC new (migration ~35, audit ~20, handlers ~150, tests ~150, DTOs ~25)

--- a/plans/README.md
+++ b/plans/README.md
@@ -119,7 +119,7 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0093 | [GAR-564 — Files REST API slice 6: GET /v1/files/{file_id}/download](0093-gar-564-files-api-slice6-download.md) | [GAR-564](https://linear.app/chatgpt25/issue/GAR-564) | ✅ Merged 2026-05-10 via PR #250 (`b2de161`) |
 | 0094 | [GAR-567 — Files REST API slice 7: POST /v1/groups/{group_id}/files/{file_id}/versions (new version)](0094-gar-565-files-api-slice7-new-version.md) | [GAR-567](https://linear.app/chatgpt25/issue/GAR-567) | ✅ Merged 2026-05-10 via PR #254 (`5b0c5fd`) |
 | 0095 | [GAR-569 — Files REST API slice 8: GET /v1/groups/{group_id}/files/{file_id}/versions (list versions)](0095-gar-569-files-api-slice8-list-versions.md) | [GAR-569](https://linear.app/chatgpt25/issue/GAR-569) | ✅ Merged 2026-05-10 via PR #253 (`0cc9a85`) |
-| 0096 | [GAR-572 — Tasks REST API slice 9: task_attachments (migration 017 + POST/GET/DELETE)](0096-gar-572-task-attachments-api.md) | [GAR-572](https://linear.app/chatgpt25/issue/GAR-572) | 🟡 Em execução 2026-05-10 |
+| 0096 | [GAR-572 — Tasks REST API slice 9: task_attachments (migration 017 + POST/GET/DELETE)](0096-gar-572-task-attachments-api.md) | [GAR-572](https://linear.app/chatgpt25/issue/GAR-572) | 🔵 Implementado 2026-05-10, aguarda merge |
 
 ## Arquivos não-versionados
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -119,6 +119,7 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0093 | [GAR-564 — Files REST API slice 6: GET /v1/files/{file_id}/download](0093-gar-564-files-api-slice6-download.md) | [GAR-564](https://linear.app/chatgpt25/issue/GAR-564) | ✅ Merged 2026-05-10 via PR #250 (`b2de161`) |
 | 0094 | [GAR-567 — Files REST API slice 7: POST /v1/groups/{group_id}/files/{file_id}/versions (new version)](0094-gar-565-files-api-slice7-new-version.md) | [GAR-567](https://linear.app/chatgpt25/issue/GAR-567) | ✅ Merged 2026-05-10 via PR #254 (`5b0c5fd`) |
 | 0095 | [GAR-569 — Files REST API slice 8: GET /v1/groups/{group_id}/files/{file_id}/versions (list versions)](0095-gar-569-files-api-slice8-list-versions.md) | [GAR-569](https://linear.app/chatgpt25/issue/GAR-569) | ✅ Merged 2026-05-10 via PR #253 (`0cc9a85`) |
+| 0096 | [GAR-572 — Tasks REST API slice 9: task_attachments (migration 017 + POST/GET/DELETE)](0096-gar-572-task-attachments-api.md) | [GAR-572](https://linear.app/chatgpt25/issue/GAR-572) | 🟡 Em execução 2026-05-10 |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

- **Migration 017** (`task_attachments` table): PK `(task_id, file_id)`, `group_id` denormalized, `attached_by ON DELETE SET NULL`, `attached_by_label` cache, `attached_at`. FORCE RLS via JOIN policy (`task_id IN (SELECT id FROM tasks)`) — same pattern as `task_assignees`, `task_subscriptions`. Index on `(file_id, attached_at DESC)` for "find all tasks a file is attached to" queries.
- **Audit variants** (`TaskFileAttached` / `TaskFileDetached`) added to `WorkspaceAuditAction` in `garraia-auth/src/audit_workspace.rs`.
- **Three REST handlers** in `rest_v1/tasks.rs`:
  - `POST /v1/groups/{group_id}/tasks/{task_id}/attachments` — cross-group file guard (`files.group_id = path_group_id AND files.deleted_at IS NULL` → 404, never 403 per ADR 0004 §7), INSERT with scalar subqueries for `file_name`/`mime_type`/`size_bytes`, 409 on SQLSTATE 23505.
  - `GET /v1/groups/{group_id}/tasks/{task_id}/attachments` — cursor pagination `(attached_at ASC, file_id ASC)`, JOIN files filtering deleted, limit+1 next_cursor trick.
  - `DELETE /v1/groups/{group_id}/tasks/{task_id}/attachments/{file_id}` — idempotent 204; audit emitted only when `rows_affected() > 0`.
- Routes registered in `mod.rs` across all three router modes (full / unconfigured 503 / no-auth 503).
- **8 integration tests** (AT1–AT8): 201 attach, 200 list, 409 duplicate, 204 detach, 204 idempotent no-op, 404 cross-group file, 404 soft-deleted file, 404 cross-group task (all three verbs).
- ROADMAP.md §3.8 Tier 1 checkbox flipped `[ ]` → `[x]`.

Closes GAR-572. Plan: 0096.

## Test plan

- [x] `cargo check -p garraia-gateway` — clean
- [x] `cargo check -p garraia-gateway --tests --features garraia-gateway/test-helpers` — clean
- [x] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` — zero warnings
- [x] `cargo fmt --all` — no diff after formatting
- [ ] CI: Format Check
- [ ] CI: Clippy
- [ ] CI: Test (ubuntu / macos / windows)
- [ ] CI: Build + MSRV + cargo-deny + Security Audit + Coverage
- [ ] CI: Analyze (rust) + Analyze (javascript-typescript)
- [ ] CI: Playwright + E2E + Secret Scan + Dependency Review

https://claude.ai/code/session_01Sfx3gZWkbUQxHdcHJK2KnH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sfx3gZWkbUQxHdcHJK2KnH)_