### PR TITLE
feat(groups): GAR-574 — GET /v1/groups/{id}/members + GET /v1/groups/{id}/invites (plan 0097)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -390,6 +390,8 @@ Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
 - [x] `POST /v1/groups/{group_id}/invites` — plan 0018, entregue 2026-04-16
 - [x] `POST /v1/groups/{group_id}/members/{user_id}:setRole` — plan 0020, entregue 2026-04-20
 - [x] `DELETE /v1/groups/{group_id}/members/{user_id}` — plan 0020, entregue 2026-04-20
+- [ ] `GET /v1/groups/{group_id}/members` — plan 0097 / [GAR-574](https://linear.app/chatgpt25/issue/GAR-574)
+- [ ] `GET /v1/groups/{group_id}/invites` — plan 0097 / [GAR-574](https://linear.app/chatgpt25/issue/GAR-574)
 - [x] `GET /v1/me` — plan 0015 (skeleton Fase 3.4), entregue 2026-04-14
 
 **Chats**
@@ -536,7 +538,9 @@ Módulo dentro de `garraia-workspace`. Schema entregue via migration 006 com **R
 - [x] `GET /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — plan 0079 / GAR-539 ✅
 - [x] `DELETE /v1/groups/{group_id}/tasks/{task_id}/subscriptions` — plan 0079 / GAR-539 ✅
 - [x] `GET /v1/groups/{group_id}/tasks/{task_id}/activity?cursor=...` — plan 0080 / GAR-541 ✅
-- [ ] `POST /v1/groups/{group_id}/tasks/{task_id}/attachments`
+- [x] `POST /v1/groups/{group_id}/tasks/{task_id}/attachments` — plan 0096 / GAR-572 ✅
+- [x] `GET /v1/groups/{group_id}/tasks/{task_id}/attachments` — plan 0096 / GAR-572 ✅
+- [x] `DELETE /v1/groups/{group_id}/tasks/{task_id}/attachments/{file_id}` — plan 0096 / GAR-572 ✅
 - [x] `POST /v1/groups/{group_id}/tasks/{task_id}/move` — plan 0082 / GAR-544 ✅ (path scheme amendado de `:move` para `/move` por limitação Axum 0.8 / matchit; reordenar dentro da lista deferido — coluna `position` ainda não existe)
 - [x] `parent_task_id` em `CreateTaskRequest` — plan 0083 / [GAR-546](https://linear.app/chatgpt25/issue/GAR-546), implementado 2026-05-08 (Florida). Depth limit = 1 (grandchild → 400).
 - [x] `GET /v1/groups/{group_id}/tasks/{task_id}/subtasks?cursor=&limit=&status=` — plan 0083 / GAR-546, implementado 2026-05-08 (Florida)

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -344,6 +344,15 @@ name = "rest_v1_task_attachments"
 path = "tests/rest_v1_task_attachments.rs"
 required-features = ["test-helpers"]
 
+# Plan 0097 (GAR-574) — groups slice 2: GET /v1/groups/{id}/members
+# and GET /v1/groups/{id}/invites. 6+ bundled scenarios (GM1/GM1b/GM2/
+# GM3 + GI1/GI2/GI3). Feature-gated so `cargo clippy --all-targets`
+# without `--features test-helpers` skips compilation cleanly.
+[[test]]
+name = "rest_v1_groups_members_invites"
+path = "tests/rest_v1_groups_members_invites.rs"
+required-features = ["test-helpers"]
+
 [dev-dependencies]
 # Plan 0024 T4 (GAR-412): metrics_exporter tests and the
 # metrics_auth_integration binary build a `PrometheusRecorder` directly

--- a/crates/garraia-gateway/src/rest_v1/groups.rs
+++ b/crates/garraia-gateway/src/rest_v1/groups.rs
@@ -35,7 +35,7 @@
 
 use argon2::PasswordHasher;
 use axum::Json;
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -44,7 +44,7 @@ use garraia_auth::{Action, Principal, WorkspaceAuditAction, audit_workspace_even
 use password_hash::rand_core::RngCore;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use utoipa::ToSchema;
+use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
 
 use super::RestV1FullState;
@@ -1277,6 +1277,442 @@ pub async fn delete_member(
     Ok(StatusCode::NO_CONTENT)
 }
 
+// ─── Constants for list handlers ──────────────────────────────────────────────
+
+const DEFAULT_LIST_LIMIT: u32 = 50;
+const MAX_LIST_LIMIT: u32 = 100;
+
+// ─── DTOs: list_members ───────────────────────────────────────────────────────
+
+/// Query parameters for `GET /v1/groups/{id}/members`.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ListMembersQuery {
+    /// Keyset cursor — `user_id` UUID of the last member received. Omit for the first page.
+    pub cursor: Option<Uuid>,
+    /// Page size. Default 50, max 100.
+    pub limit: Option<u32>,
+    /// Filter by role (`owner`, `admin`, `member`, `guest`, `child`).
+    pub role: Option<String>,
+    /// Filter by status. Default excludes `removed` and `banned`.
+    pub status: Option<String>,
+}
+
+/// One member entry in the list response.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct MemberSummary {
+    pub user_id: Uuid,
+    pub role: String,
+    pub status: String,
+    pub joined_at: DateTime<Utc>,
+    pub invited_by: Option<Uuid>,
+}
+
+/// Response body for `GET /v1/groups/{id}/members`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ListMembersResponse {
+    pub items: Vec<MemberSummary>,
+    pub next_cursor: Option<Uuid>,
+}
+
+// ─── DTOs: list_invites ───────────────────────────────────────────────────────
+
+/// Query parameters for `GET /v1/groups/{id}/invites`.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ListInvitesQuery {
+    /// Keyset cursor — `id` UUID of the last invite received. Omit for the first page.
+    pub cursor: Option<Uuid>,
+    /// Page size. Default 50, max 100.
+    pub limit: Option<u32>,
+}
+
+/// One pending invite entry in the list response.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct InviteSummary {
+    pub id: Uuid,
+    pub invited_email: String,
+    pub proposed_role: String,
+    pub expires_at: DateTime<Utc>,
+    pub created_by: Uuid,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Response body for `GET /v1/groups/{id}/invites`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ListInvitesResponse {
+    pub items: Vec<InviteSummary>,
+    pub next_cursor: Option<Uuid>,
+}
+
+// ─── Handlers ─────────────────────────────────────────────────────────────────
+
+/// `GET /v1/groups/{id}/members` — cursor-paginated list of group members (plan 0097, GAR-574).
+///
+/// Any active group member may call this endpoint; no extra capability required.
+/// `group_members` is a tenant-root table (no FORCE RLS). Cross-group isolation
+/// is enforced via `WHERE group_id = $path_id` + the path/header coherence guard.
+///
+/// ## Cursor scheme
+///
+/// Ordered by `user_id ASC` (stable PK component). Cursor = `user_id` of the
+/// last item received. Pass `?cursor=<uuid>` for subsequent pages.
+#[utoipa::path(
+    get,
+    path = "/v1/groups/{id}/members",
+    params(
+        ("id" = Uuid, Path, description = "Group UUID."),
+        ListMembersQuery
+    ),
+    responses(
+        (status = 200, description = "Paginated member list.", body = ListMembersResponse),
+        (status = 400, description = "Missing or mismatched X-Group-Id header.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not an active group member.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn list_members(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(id): Path<Uuid>,
+    Query(params): Query<ListMembersQuery>,
+) -> Result<Json<ListMembersResponse>, RestError> {
+    // 1. Path/header coherence.
+    match principal.group_id {
+        Some(hdr) if hdr == id => {}
+        Some(_) => {
+            return Err(RestError::BadRequest(
+                "X-Group-Id header and path id must match".into(),
+            ));
+        }
+        None => {
+            return Err(RestError::BadRequest(
+                "X-Group-Id header is required".into(),
+            ));
+        }
+    }
+
+    // 2. Clamp limit.
+    let limit = params
+        .limit
+        .unwrap_or(DEFAULT_LIST_LIMIT)
+        .min(MAX_LIST_LIMIT) as i64;
+
+    // 3. Open tx + SET LOCAL (defensive; group_members has no FORCE RLS).
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(principal.user_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    // 4. Build query. Default excludes removed/banned unless caller filters explicitly.
+    //    Cursor: WHERE user_id > $cursor (keyset on user_id ASC).
+    //    Role/status filters are optional.
+    #[derive(sqlx::FromRow)]
+    struct MemberRow {
+        user_id: Uuid,
+        role: String,
+        status: String,
+        joined_at: DateTime<Utc>,
+        invited_by: Option<Uuid>,
+    }
+
+    let default_excluded: &[&str] = &["removed", "banned"];
+    let rows: Vec<MemberRow> = if let Some(cursor_user_id) = params.cursor {
+        // Keyset page 2+.
+        match (&params.role, &params.status) {
+            (Some(role), Some(status)) => {
+                sqlx::query_as(
+                    "SELECT user_id, role, status, joined_at, invited_by \
+                     FROM group_members \
+                     WHERE group_id = $1 AND user_id > $2 AND role = $3 AND status = $4 \
+                     ORDER BY user_id ASC LIMIT $5",
+                )
+                .bind(id)
+                .bind(cursor_user_id)
+                .bind(role)
+                .bind(status)
+                .bind(limit + 1)
+                .fetch_all(&mut *tx)
+                .await
+            }
+            (Some(role), None) => {
+                sqlx::query_as(
+                    "SELECT user_id, role, status, joined_at, invited_by \
+                     FROM group_members \
+                     WHERE group_id = $1 AND user_id > $2 AND role = $3 \
+                       AND status != ALL($4) \
+                     ORDER BY user_id ASC LIMIT $5",
+                )
+                .bind(id)
+                .bind(cursor_user_id)
+                .bind(role)
+                .bind(default_excluded)
+                .bind(limit + 1)
+                .fetch_all(&mut *tx)
+                .await
+            }
+            (None, Some(status)) => {
+                sqlx::query_as(
+                    "SELECT user_id, role, status, joined_at, invited_by \
+                     FROM group_members \
+                     WHERE group_id = $1 AND user_id > $2 AND status = $3 \
+                     ORDER BY user_id ASC LIMIT $4",
+                )
+                .bind(id)
+                .bind(cursor_user_id)
+                .bind(status)
+                .bind(limit + 1)
+                .fetch_all(&mut *tx)
+                .await
+            }
+            (None, None) => {
+                sqlx::query_as(
+                    "SELECT user_id, role, status, joined_at, invited_by \
+                     FROM group_members \
+                     WHERE group_id = $1 AND user_id > $2 AND status != ALL($3) \
+                     ORDER BY user_id ASC LIMIT $4",
+                )
+                .bind(id)
+                .bind(cursor_user_id)
+                .bind(default_excluded)
+                .bind(limit + 1)
+                .fetch_all(&mut *tx)
+                .await
+            }
+        }
+    } else {
+        // First page.
+        match (&params.role, &params.status) {
+            (Some(role), Some(status)) => {
+                sqlx::query_as(
+                    "SELECT user_id, role, status, joined_at, invited_by \
+                     FROM group_members \
+                     WHERE group_id = $1 AND role = $2 AND status = $3 \
+                     ORDER BY user_id ASC LIMIT $4",
+                )
+                .bind(id)
+                .bind(role)
+                .bind(status)
+                .bind(limit + 1)
+                .fetch_all(&mut *tx)
+                .await
+            }
+            (Some(role), None) => {
+                sqlx::query_as(
+                    "SELECT user_id, role, status, joined_at, invited_by \
+                     FROM group_members \
+                     WHERE group_id = $1 AND role = $2 AND status != ALL($3) \
+                     ORDER BY user_id ASC LIMIT $4",
+                )
+                .bind(id)
+                .bind(role)
+                .bind(default_excluded)
+                .bind(limit + 1)
+                .fetch_all(&mut *tx)
+                .await
+            }
+            (None, Some(status)) => {
+                sqlx::query_as(
+                    "SELECT user_id, role, status, joined_at, invited_by \
+                     FROM group_members \
+                     WHERE group_id = $1 AND status = $2 \
+                     ORDER BY user_id ASC LIMIT $3",
+                )
+                .bind(id)
+                .bind(status)
+                .bind(limit + 1)
+                .fetch_all(&mut *tx)
+                .await
+            }
+            (None, None) => {
+                sqlx::query_as(
+                    "SELECT user_id, role, status, joined_at, invited_by \
+                     FROM group_members \
+                     WHERE group_id = $1 AND status != ALL($2) \
+                     ORDER BY user_id ASC LIMIT $3",
+                )
+                .bind(id)
+                .bind(default_excluded)
+                .bind(limit + 1)
+                .fetch_all(&mut *tx)
+                .await
+            }
+        }
+    }
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    // 5. Cursor-next trick: pop last if we fetched limit+1.
+    let has_more = rows.len() > limit as usize;
+    let mut rows = rows;
+    let next_cursor = if has_more {
+        rows.pop().map(|r| r.user_id)
+    } else {
+        None
+    };
+
+    let items = rows
+        .into_iter()
+        .map(|r| MemberSummary {
+            user_id: r.user_id,
+            role: r.role,
+            status: r.status,
+            joined_at: r.joined_at,
+            invited_by: r.invited_by,
+        })
+        .collect();
+
+    Ok(Json(ListMembersResponse { items, next_cursor }))
+}
+
+/// `GET /v1/groups/{id}/invites` — cursor-paginated list of pending group invites (plan 0097, GAR-574).
+///
+/// Requires `Action::MembersManage` (owner/admin) because `invited_email` is PII.
+/// Only returns invites where `accepted_at IS NULL` (pending).
+/// `token_hash` is never exposed.
+///
+/// ## Cursor scheme
+///
+/// Ordered by `(created_at ASC, id ASC)`. Cursor = `id` UUID of the last invite
+/// received. Next page: `WHERE id > $cursor` (approximation — stable enough for
+/// low-cardinality invite lists; exact keyset would need compound cursor encoding).
+#[utoipa::path(
+    get,
+    path = "/v1/groups/{id}/invites",
+    params(
+        ("id" = Uuid, Path, description = "Group UUID."),
+        ListInvitesQuery
+    ),
+    responses(
+        (status = 200, description = "Paginated pending invite list.", body = ListInvitesResponse),
+        (status = 400, description = "Missing or mismatched X-Group-Id header.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller lacks `members.manage` capability.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn list_invites(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(id): Path<Uuid>,
+    Query(params): Query<ListInvitesQuery>,
+) -> Result<Json<ListInvitesResponse>, RestError> {
+    // 1. Path/header coherence.
+    match principal.group_id {
+        Some(hdr) if hdr == id => {}
+        Some(_) => {
+            return Err(RestError::BadRequest(
+                "X-Group-Id header and path id must match".into(),
+            ));
+        }
+        None => {
+            return Err(RestError::BadRequest(
+                "X-Group-Id header is required".into(),
+            ));
+        }
+    }
+
+    // 2. Capability check — email is PII, owner/admin only.
+    if !can(&principal, Action::MembersManage) {
+        return Err(RestError::Forbidden);
+    }
+
+    // 3. Clamp limit.
+    let limit = params
+        .limit
+        .unwrap_or(DEFAULT_LIST_LIMIT)
+        .min(MAX_LIST_LIMIT) as i64;
+
+    // 4. Open tx + SET LOCAL (defensive).
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(principal.user_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    // 5. Fetch pending invites. token_hash is deliberately excluded from SELECT.
+    #[derive(sqlx::FromRow)]
+    struct InviteRow {
+        id: Uuid,
+        invited_email: String,
+        proposed_role: String,
+        expires_at: DateTime<Utc>,
+        created_by: Uuid,
+        created_at: DateTime<Utc>,
+    }
+
+    let rows: Vec<InviteRow> = if let Some(cursor_id) = params.cursor {
+        sqlx::query_as(
+            "SELECT id, invited_email, proposed_role, expires_at, created_by, created_at \
+             FROM group_invites \
+             WHERE group_id = $1 AND accepted_at IS NULL \
+               AND (created_at, id) > (\
+                   SELECT created_at, id FROM group_invites WHERE id = $2\
+               ) \
+             ORDER BY created_at ASC, id ASC LIMIT $3",
+        )
+        .bind(id)
+        .bind(cursor_id)
+        .bind(limit + 1)
+        .fetch_all(&mut *tx)
+        .await
+    } else {
+        sqlx::query_as(
+            "SELECT id, invited_email, proposed_role, expires_at, created_by, created_at \
+             FROM group_invites \
+             WHERE group_id = $1 AND accepted_at IS NULL \
+             ORDER BY created_at ASC, id ASC LIMIT $2",
+        )
+        .bind(id)
+        .bind(limit + 1)
+        .fetch_all(&mut *tx)
+        .await
+    }
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    // 6. Cursor-next trick.
+    let has_more = rows.len() > limit as usize;
+    let mut rows = rows;
+    let next_cursor = if has_more {
+        rows.pop().map(|r| r.id)
+    } else {
+        None
+    };
+
+    let items = rows
+        .into_iter()
+        .map(|r| InviteSummary {
+            id: r.id,
+            invited_email: r.invited_email,
+            proposed_role: r.proposed_role,
+            expires_at: r.expires_at,
+            created_by: r.created_by,
+            created_at: r.created_at,
+        })
+        .collect();
+
+    Ok(Json(ListInvitesResponse { items, next_cursor }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1477,6 +1913,22 @@ mod tests {
             req.validate().unwrap_err(),
             "cannot promote to owner via setRole"
         );
+    }
+
+    #[test]
+    fn list_members_query_default_limit() {
+        let q: ListMembersQuery = serde_json::from_str("{}").unwrap();
+        assert!(q.cursor.is_none());
+        assert!(q.limit.is_none());
+        assert!(q.role.is_none());
+        assert!(q.status.is_none());
+    }
+
+    #[test]
+    fn list_invites_query_default_limit() {
+        let q: ListInvitesQuery = serde_json::from_str("{}").unwrap();
+        assert!(q.cursor.is_none());
+        assert!(q.limit.is_none());
     }
 
     #[test]

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -268,7 +268,12 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     "/v1/groups/{id}",
                     get(groups::get_group).patch(groups::patch_group),
                 )
-                .route("/v1/groups/{id}/invites", post(groups::create_invite))
+                .route(
+                    "/v1/groups/{id}/invites",
+                    post(groups::create_invite).get(groups::list_invites),
+                )
+                // Plan 0097 (GAR-574) — groups slice 2: list members + invites.
+                .route("/v1/groups/{id}/members", get(groups::list_members))
                 // Plan 0054 (GAR-506) — chats slice 1.
                 .route(
                     "/v1/groups/{group_id}/chats",
@@ -455,7 +460,12 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     "/v1/groups/{id}",
                     get(unconfigured_handler).patch(unconfigured_handler),
                 )
-                .route("/v1/groups/{id}/invites", post(unconfigured_handler))
+                .route(
+                    "/v1/groups/{id}/invites",
+                    post(unconfigured_handler).get(unconfigured_handler),
+                )
+                // Plan 0097 (GAR-574) — groups slice 2, fail-soft 503.
+                .route("/v1/groups/{id}/members", get(unconfigured_handler))
                 .route(
                     "/v1/groups/{id}/members/{user_id}/setRole",
                     post(unconfigured_handler),
@@ -625,7 +635,12 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     "/v1/groups/{id}",
                     get(unconfigured_handler).patch(unconfigured_handler),
                 )
-                .route("/v1/groups/{id}/invites", post(unconfigured_handler))
+                .route(
+                    "/v1/groups/{id}/invites",
+                    post(unconfigured_handler).get(unconfigured_handler),
+                )
+                // Plan 0097 (GAR-574) — groups slice 2, no-auth stub.
+                .route("/v1/groups/{id}/members", get(unconfigured_handler))
                 .route(
                     "/v1/groups/{id}/members/{user_id}/setRole",
                     post(unconfigured_handler),

--- a/crates/garraia-gateway/tests/rest_v1_groups_members_invites.rs
+++ b/crates/garraia-gateway/tests/rest_v1_groups_members_invites.rs
@@ -1,0 +1,362 @@
+//! Integration tests for `GET /v1/groups/{id}/members` and
+//! `GET /v1/groups/{id}/invites` (plan 0097, GAR-574).
+//!
+//! All scenarios are bundled into ONE `#[tokio::test]` to avoid the
+//! sqlx runtime-teardown race (see commit `4f8be37` for the post-mortem).
+//!
+//! Scenarios:
+//!   GM1 — GET /members 200 — owner lists members; at least the owner is present.
+//!   GM2 — GET /members 400 — missing X-Group-Id header.
+//!   GM3 — GET /members 403 — non-member cannot list members of a different group.
+//!   GI1 — GET /invites 200 — owner sees pending invites; token_hash absent.
+//!   GI2 — GET /invites 403 — plain member gets 403.
+//!   GI3 — GET /invites 200 empty — no pending invites returns empty list.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use common::fixtures::{seed_member_via_admin, seed_user_with_group};
+use common::{Harness, harness_get};
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("failed to collect body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("response body is not JSON")
+}
+
+fn get_members(token: &str, group_id: &str, x_group_id: Option<&str>) -> Request<Body> {
+    let mut req = harness_get(&format!("/v1/groups/{group_id}/members"));
+    req.headers_mut().insert(
+        HeaderName::from_static("authorization"),
+        HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+    );
+    if let Some(g) = x_group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    req
+}
+
+fn get_invites(
+    token: &str,
+    group_id: &str,
+    x_group_id: Option<&str>,
+    cursor: Option<&str>,
+) -> Request<Body> {
+    let uri = match cursor {
+        Some(c) => format!("/v1/groups/{group_id}/invites?cursor={c}"),
+        None => format!("/v1/groups/{group_id}/invites"),
+    };
+    let mut req = harness_get(&uri);
+    req.headers_mut().insert(
+        HeaderName::from_static("authorization"),
+        HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+    );
+    if let Some(g) = x_group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    req
+}
+
+/// Insert a pending invite directly via the admin pool (bypasses rate limiting
+/// and Argon2 hashing — for test setup only).
+async fn seed_invite_via_admin(
+    h: &Harness,
+    group_id: Uuid,
+    invited_email: &str,
+    proposed_role: &str,
+    created_by: Uuid,
+) -> anyhow::Result<Uuid> {
+    let invite_id = Uuid::new_v4();
+    // token_hash is a placeholder — the actual value is opaque to the list endpoint.
+    sqlx::query(
+        "INSERT INTO group_invites \
+             (id, group_id, invited_email, proposed_role, token_hash, expires_at, created_by) \
+         VALUES ($1, $2, $3, $4, 'test-hash-placeholder', now() + interval '7 days', $5)",
+    )
+    .bind(invite_id)
+    .bind(group_id)
+    .bind(invited_email)
+    .bind(proposed_role)
+    .bind(created_by)
+    .execute(&h.admin_pool)
+    .await?;
+    Ok(invite_id)
+}
+
+#[tokio::test]
+async fn v1_groups_members_invites_scenarios() {
+    let h = Harness::get().await;
+
+    // Shared fixture: one group with an owner, one admin member, one plain member.
+    let (_owner_id, owner_group_id, owner_token) =
+        seed_user_with_group(&h, "gmi-owner@test.example")
+            .await
+            .expect("GM: seed owner");
+    let (admin_id, admin_token) =
+        seed_member_via_admin(&h, owner_group_id, "admin", "gmi-admin@test.example")
+            .await
+            .expect("GM: seed admin");
+    let (_member_id, member_token) =
+        seed_member_via_admin(&h, owner_group_id, "member", "gmi-member@test.example")
+            .await
+            .expect("GM: seed member");
+
+    let group_id_str = owner_group_id.to_string();
+
+    // ─ GM1: GET /members 200 — owner lists members ──────────────────────────
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_members(
+                &owner_token,
+                &group_id_str,
+                Some(&group_id_str),
+            ))
+            .await
+            .expect("GM1: oneshot");
+        assert_eq!(resp.status(), StatusCode::OK, "GM1: should return 200");
+        let v = body_json(resp).await;
+        assert!(v["items"].is_array(), "GM1: items should be array");
+        let items = v["items"].as_array().unwrap();
+        // At minimum the owner + admin + member we seeded are present.
+        assert!(
+            items.len() >= 3,
+            "GM1: at least 3 members expected, got {}",
+            items.len()
+        );
+        // Verify response shape: each item has user_id, role, status, joined_at.
+        for item in items {
+            assert!(item["user_id"].is_string(), "GM1: user_id must be a string");
+            assert!(item["role"].is_string(), "GM1: role must be a string");
+            assert!(item["status"].is_string(), "GM1: status must be a string");
+            assert!(
+                item["joined_at"].is_string(),
+                "GM1: joined_at must be a string"
+            );
+        }
+        // next_cursor may be null on first page with few members.
+        assert!(
+            v["next_cursor"].is_null() || v["next_cursor"].is_string(),
+            "GM1: next_cursor must be null or string"
+        );
+        // Verify no token_hash in any item (not applicable for members, sanity check).
+        for item in v["items"].as_array().unwrap() {
+            assert!(
+                item.get("token_hash").is_none(),
+                "GM1: token_hash must never appear"
+            );
+        }
+    }
+
+    // ─ GM1b: admin member can also list members ──────────────────────────────
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_members(
+                &admin_token,
+                &group_id_str,
+                Some(&group_id_str),
+            ))
+            .await
+            .expect("GM1b: oneshot");
+        assert_eq!(resp.status(), StatusCode::OK, "GM1b: admin should 200");
+        // Plain member can too.
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_members(
+                &member_token,
+                &group_id_str,
+                Some(&group_id_str),
+            ))
+            .await
+            .expect("GM1b-member: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "GM1b-member: member should 200"
+        );
+    }
+
+    // ─ GM2: GET /members 400 — missing X-Group-Id ───────────────────────────
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_members(&owner_token, &group_id_str, None))
+            .await
+            .expect("GM2: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "GM2: missing X-Group-Id should 400"
+        );
+    }
+
+    // ─ GM3: GET /members 403 — non-member (cross-group isolation) ───────────
+    {
+        // Create a second group; the owner of group 2 tries to read group 1's members.
+        let (_g2_owner_id, g2_group_id, g2_token) =
+            seed_user_with_group(&h, "gmi-g2owner@test.example")
+                .await
+                .expect("GM3: seed g2 owner");
+        let g2_id_str = g2_group_id.to_string();
+
+        // X-Group-Id = group1, path = group1, but JWT is for a user who is
+        // a member of group2 only — the Principal extractor returns 403.
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_members(&g2_token, &group_id_str, Some(&group_id_str)))
+            .await
+            .expect("GM3: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "GM3: non-member should get 403"
+        );
+
+        // Accessing own group still works for g2 owner.
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_members(&g2_token, &g2_id_str, Some(&g2_id_str)))
+            .await
+            .expect("GM3b: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "GM3b: g2 owner reads g2 = 200"
+        );
+        let _ = g2_id_str;
+    }
+
+    // ─ GI1: GET /invites 200 — owner sees pending invites ───────────────────
+    {
+        // Seed a pending invite via admin pool.
+        let invite_id = seed_invite_via_admin(
+            &h,
+            owner_group_id,
+            "pending@test.example",
+            "member",
+            admin_id,
+        )
+        .await
+        .expect("GI1: seed invite");
+
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_invites(
+                &owner_token,
+                &group_id_str,
+                Some(&group_id_str),
+                None,
+            ))
+            .await
+            .expect("GI1: oneshot");
+        assert_eq!(resp.status(), StatusCode::OK, "GI1: owner should 200");
+        let v = body_json(resp).await;
+        assert!(v["items"].is_array(), "GI1: items must be array");
+        let items = v["items"].as_array().unwrap();
+        assert!(!items.is_empty(), "GI1: should have at least one invite");
+
+        // Verify shape: id, invited_email, proposed_role, expires_at, created_by, created_at present.
+        let found = items
+            .iter()
+            .find(|i| i["id"].as_str() == Some(&invite_id.to_string()));
+        assert!(found.is_some(), "GI1: seeded invite must appear in list");
+        let inv = found.unwrap();
+        assert_eq!(inv["invited_email"], "pending@test.example", "GI1: email");
+        assert_eq!(inv["proposed_role"], "member", "GI1: role");
+        assert!(
+            inv["expires_at"].is_string(),
+            "GI1: expires_at must be string"
+        );
+        assert!(
+            inv["created_by"].is_string(),
+            "GI1: created_by must be string"
+        );
+        assert!(
+            inv["created_at"].is_string(),
+            "GI1: created_at must be string"
+        );
+
+        // token_hash must NEVER appear.
+        for item in items {
+            assert!(
+                item.get("token_hash").is_none(),
+                "GI1: token_hash must never appear in invite list response"
+            );
+        }
+    }
+
+    // ─ GI2: GET /invites 403 — plain member gets 403 ────────────────────────
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_invites(
+                &member_token,
+                &group_id_str,
+                Some(&group_id_str),
+                None,
+            ))
+            .await
+            .expect("GI2: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "GI2: plain member should 403 on invites (PII gate)"
+        );
+    }
+
+    // ─ GI3: GET /invites 200 empty — group with no pending invites ──────────
+    {
+        // Create a fresh group with no invites.
+        let (_g3_owner_id, g3_group_id, g3_token) =
+            seed_user_with_group(&h, "gmi-g3owner@test.example")
+                .await
+                .expect("GI3: seed g3 owner");
+        let g3_id_str = g3_group_id.to_string();
+
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_invites(&g3_token, &g3_id_str, Some(&g3_id_str), None))
+            .await
+            .expect("GI3: oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "GI3: empty invites should 200"
+        );
+        let v = body_json(resp).await;
+        assert_eq!(
+            v["items"].as_array().map(|a| a.len()).unwrap_or(1),
+            0,
+            "GI3: empty group should have 0 invites"
+        );
+        assert!(
+            v["next_cursor"].is_null(),
+            "GI3: no next_cursor on empty list"
+        );
+    }
+}

--- a/plans/0097-gar-574-groups-members-invites-api.md
+++ b/plans/0097-gar-574-groups-members-invites-api.md
@@ -1,0 +1,176 @@
+# Plan 0097 — GAR-574: REST /v1 groups slice 2 — GET members + GET invites
+
+**Status:** Em execução
+**Autor:** Claude Sonnet 4.6 (garra-routine 2026-05-11, America/New_York)
+**Data:** 2026-05-11 (America/New_York)
+**Issue:** [GAR-574](https://linear.app/chatgpt25/issue/GAR-574)
+**Branch:** `routine/202505110023-groups-members-invites-api`
+**Epic:** `epic:ws-api`
+**Parent:** GAR-393
+
+---
+
+## §1 Goal
+
+Add the two missing read endpoints for group membership management, completing
+the `/v1/groups` surface and unblocking any UI that needs to display who is in
+a group or which invitations are pending.
+
+**Endpoints:**
+- `GET /v1/groups/{id}/members?cursor=<uuid>&limit=<n>&role=<str>&status=<str>` — cursor-paginated list of `group_members` rows; any active group member can read; keyset on `user_id ASC`; default excludes `removed`/`banned`.
+- `GET /v1/groups/{id}/invites?cursor=<uuid>&limit=<n>` — cursor-paginated list of pending `group_invites` (accepted_at IS NULL); requires `Action::MembersManage`; keyset on `(created_at ASC, id ASC)`.
+
+---
+
+## §2 Architecture
+
+### Tenant isolation
+
+`group_members` and `group_invites` are **tenant-root tables** (no FORCE RLS —
+they are the "roots" from which tenant identity is derived). Cross-group
+isolation is enforced at the SQL level via explicit `WHERE group_id = $path_id`
+predicates. The Principal extractor already validates the caller is an active
+member of `principal.group_id`; the path/header coherence guard ensures
+`path_id == principal.group_id`.
+
+### Cursor scheme
+
+- **list_members**: ORDER BY `(user_id ASC)`. Cursor = `user_id` UUID of last
+  item seen. Next page: `WHERE group_id = $1 AND user_id > $cursor`. Stable
+  because user_id is part of the composite PK.
+- **list_invites**: ORDER BY `(created_at ASC, id ASC)`. Cursor = `id` UUID of
+  last invite seen. Next page: `WHERE group_id = $1 AND accepted_at IS NULL
+  AND (created_at, id) > (SELECT (created_at, id) FROM group_invites WHERE id = $cursor)`.
+  Simplified to `WHERE id > $cursor` (UUID v4 ordering is not time-monotonic,
+  but `(created_at ASC, id ASC)` is stable + the limit+1 trick gives correct
+  next_cursor regardless of UUID collation within the same second).
+
+### Response shape
+
+```
+GET /v1/groups/{id}/members
+→ { items: [{ user_id, role, status, joined_at, invited_by? }], next_cursor? }
+
+GET /v1/groups/{id}/invites
+→ { items: [{ id, invited_email, proposed_role, expires_at, created_by, created_at }], next_cursor? }
+```
+
+`token_hash` is **never** in the response (it is an auth secret).
+
+---
+
+## §3 Tech stack
+
+- Axum 0.8 + `RestV1FullState` (same as groups.rs)
+- `sqlx::query_as` parameterized (no SQL string concat)
+- `garraia_auth::{Action, Principal, can}` — `MembersManage` for invites
+- `utoipa` OpenAPI annotations
+- No new migrations (schema from migration 001)
+
+---
+
+## §4 Design invariants
+
+1. Path/header coherence: `path_id == principal.group_id` → 400 if mismatch, 400 if header absent.
+2. No FORCE RLS tables touched — SET LOCAL `app.current_user_id` only (for consistency; no `app.current_group_id` needed).
+3. `group_invites.token_hash` is NEVER in any response field.
+4. `invited_email` is PII — only accessible to owners/admins (`Action::MembersManage`).
+5. No `unwrap()` in production; no SQL string concat.
+6. Cursor-next trick: fetch `limit + 1` rows, pop last to detect next page.
+7. Default limit: 50; max limit: 100.
+
+---
+
+## §5 Validações pré-plano
+
+- [x] `group_members` schema confirmed in migration 001: (group_id, user_id) PK, role CHECK 5 vals, status CHECK 4 vals, joined_at, invited_by.
+- [x] `group_invites` schema confirmed: id PK, group_id, invited_email (citext), proposed_role, token_hash, expires_at, created_by, created_at, accepted_at.
+- [x] No FORCE RLS on group_members/group_invites (confirmed from migration 007 scope).
+- [x] `Action::MembersManage` confirmed in garraia-auth capability table.
+- [x] Pattern reference: audit.rs (cursor pagination), chats.rs (list_chat_members).
+
+---
+
+## §6 Out of scope
+
+- Sending or revoking invites (create_invite already done in plan 0020).
+- Adding members directly (done via invite flow).
+- Searching members by name (FTS on users table deferred).
+- `PATCH /v1/groups/{id}/invites/{invite_id}` (resend/extend — future slice).
+
+---
+
+## §7 Rollback
+
+Handlers are additive (no schema changes, no data migrations). Remove the two
+handler functions and the route registrations to revert.
+
+---
+
+## §8 Open questions
+
+None — schema and auth foundation are in place.
+
+---
+
+## §9 File structure
+
+```
+crates/garraia-gateway/src/rest_v1/
+  groups.rs                    ← add list_members + list_invites handlers + DTOs
+  mod.rs                       ← register 2 new GET routes in all 3 router arms
+  tests/rest_v1_groups_members_invites.rs   ← new integration test file (6+ tests)
+```
+
+---
+
+## §10 Tasks M1
+
+- [x] T1: Write plan 0097, create GAR-574, update plans/README.md
+- [ ] T2: Add DTOs + list_members handler to groups.rs
+- [ ] T3: Add list_invites handler to groups.rs
+- [ ] T4: Register routes in mod.rs (full + unconfigured 503 + no-auth 503 arms)
+- [ ] T5: Write integration tests (GM1–GM3 + GI1–GI3)
+- [ ] T6: `cargo check -p garraia-gateway` + clippy clean + fmt
+- [ ] T7: Commit + push + open PR
+- [ ] T8: Update ROADMAP.md + plans/README.md after merge
+
+---
+
+## §11 Risk register
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|-----------|
+| `invited_email` PII leak via logs | Low | Never log body; `#[instrument(skip_all)]` on handlers |
+| UUID cursor ordering instability | Low | UUIDs from same group_id; keyset on unique PK column |
+| Missing route in unconfigured/no-auth arms | Low | Register in all 3 router arms in mod.rs |
+
+---
+
+## §12 Acceptance criteria
+
+1. `GET /v1/groups/{id}/members` → 200 `{ items, next_cursor }` for active member.
+2. `GET /v1/groups/{id}/invites` → 200 for owner/admin; 403 for plain member.
+3. Cursor pagination: second page returns next batch correctly.
+4. Cross-group isolation: member of group A cannot see group B's member list (400 header mismatch enforced).
+5. `token_hash` never appears in any response.
+6. 6+ integration tests (GM1–GM3 + GI1–GI3) green.
+7. `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` clean.
+
+---
+
+## §13 Cross-references
+
+- ROADMAP §3.4 "Grupos" — `GET /v1/groups/{id}/members` and `GET /v1/groups/{id}/invites` (now added as `[ ]`)
+- GAR-393 — parent epic (groups REST surface)
+- Migration 001 — `group_members` + `group_invites` schema
+- Plan 0020 / GAR-425 — `POST /v1/groups/{id}/invites`, `setRole`, `DELETE member`
+- Plan 0070 / GAR-522 — audit list (cursor pagination reference)
+
+---
+
+## §14 Estimativa
+
+- T2-T5: ~3h implementation
+- T6-T7: ~30min CI + push
+- Total: ~3.5h

--- a/plans/README.md
+++ b/plans/README.md
@@ -120,6 +120,7 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0094 | [GAR-567 — Files REST API slice 7: POST /v1/groups/{group_id}/files/{file_id}/versions (new version)](0094-gar-565-files-api-slice7-new-version.md) | [GAR-567](https://linear.app/chatgpt25/issue/GAR-567) | ✅ Merged 2026-05-10 via PR #254 (`5b0c5fd`) |
 | 0095 | [GAR-569 — Files REST API slice 8: GET /v1/groups/{group_id}/files/{file_id}/versions (list versions)](0095-gar-569-files-api-slice8-list-versions.md) | [GAR-569](https://linear.app/chatgpt25/issue/GAR-569) | ✅ Merged 2026-05-10 via PR #253 (`0cc9a85`) |
 | 0096 | [GAR-572 — Tasks REST API slice 9: task_attachments (migration 017 + POST/GET/DELETE)](0096-gar-572-task-attachments-api.md) | [GAR-572](https://linear.app/chatgpt25/issue/GAR-572) | ✅ Merged 2026-05-10 via PR #257 (`2c1460c`) |
+| 0097 | [GAR-574 — Groups REST API slice 2: GET /v1/groups/{id}/members + GET /v1/groups/{id}/invites](0097-gar-574-groups-members-invites-api.md) | [GAR-574](https://linear.app/chatgpt25/issue/GAR-574) | 🔵 Em execução 2026-05-11 |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

- Adds `GET /v1/groups/{group_id}/members` — paginated member list (owner/admin/member access)
- Adds `GET /v1/groups/{group_id}/invites` — paginated pending invite list (owner/admin only, `token_hash` never exposed)
- Requires `X-Group-Id` header (400 if missing); enforces cross-group isolation (403 for non-members)
- Integration tests: GM1/GM1b (200 list), GM2 (400 missing header), GM3 (403 cross-group), GI1 (200 with invite shape), GI2 (403 plain member), GI3 (200 empty)

## Test plan

- [ ] `cargo test -p garraia-gateway --features test-helpers` passes all scenarios
- [ ] GM1: owner gets 200 with items array containing user_id/role/status/joined_at; no token_hash
- [ ] GM1b: admin and plain member also get 200
- [ ] GM2: missing X-Group-Id → 400
- [ ] GM3: non-member (cross-group) → 403; own group still 200
- [ ] GI1: owner sees seeded invite; no token_hash; shape has id/invited_email/proposed_role/expires_at/created_by/created_at
- [ ] GI2: plain member → 403 on invites
- [ ] GI3: fresh group with no invites → 200 + empty items + null next_cursor
- [ ] Clippy + fmt pass

Closes GAR-574. Plan: [0097](plans/0097-gar-574-groups-members-invites-api.md).

https://claude.ai/code/session_019HKFVs9jQoCjMCRN44Q3tP

---
_Generated by [Claude Code](https://claude.ai/code/session_019HKFVs9jQoCjMCRN44Q3tP)_