### PR TITLE
fix(cli): respect configured OpenRouter model and default provider

### DIFF
--- a/crates/garraia-cli/src/chat.rs
+++ b/crates/garraia-cli/src/chat.rs
@@ -153,6 +153,201 @@ fn get_api_key(config: &AppConfig, provider_name: &str, env_var: &str) -> Option
     None
 }
 
+/// GAR-576 — Resolve the model name for a given provider kind.
+///
+/// Lookup order:
+///   1. `model_override` (the CLI `--model` flag, absolute precedence).
+///   2. `config.llm[provider_kind].model` (key-match).
+///   3. The first `config.llm[*]` entry whose `provider` field equals
+///      `provider_kind` and whose `model` is `Some(non-empty)`.
+///
+/// Returns `None` only when no source supplies a usable model name; the
+/// caller is then responsible for picking a hardcoded fallback.
+fn resolve_provider_model(
+    config: &AppConfig,
+    provider_kind: &str,
+    model_override: Option<&str>,
+) -> Option<String> {
+    if let Some(m) = model_override
+        && !m.is_empty()
+    {
+        return Some(m.to_string());
+    }
+    if let Some(cfg) = config.llm.get(provider_kind)
+        && let Some(m) = cfg.model.as_deref()
+        && !m.is_empty()
+    {
+        return Some(m.to_string());
+    }
+    for cfg in config.llm.values() {
+        if cfg.provider == provider_kind
+            && let Some(m) = cfg.model.as_deref()
+            && !m.is_empty()
+        {
+            return Some(m.to_string());
+        }
+    }
+    None
+}
+
+/// GAR-576 — Decision returned by [`decide_default_provider`].
+///
+/// `UseDefault` says "the operator configured `agent.default_provider`,
+/// the matching `llm[<key>]` block is present, and a credential is
+/// reachable — go build the provider". `FallThroughToChain` says
+/// "either no default is configured, the lookup failed, or there is no
+/// usable credential — fall back to the legacy autodetect heuristic".
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DefaultProviderDecision {
+    UseDefault {
+        config_key: String,
+        provider_kind: String,
+        model: String,
+    },
+    FallThroughToChain {
+        reason: &'static str,
+    },
+}
+
+/// GAR-576 — Decide whether to honor `config.agent.default_provider`
+/// before the legacy autodetect chain.
+///
+/// Pure function: takes presence-bool flags for the relevant env vars
+/// instead of reading `std::env` directly, so unit tests can assert
+/// regression scenarios (e.g. `OPENAI_API_KEY` in `.env` no longer
+/// hijacks the provider when `agent.default_provider = "openrouter"`)
+/// without mutating process-global env state.
+fn decide_default_provider(
+    config: &AppConfig,
+    env_has_openai_key: bool,
+    env_has_openrouter_key: bool,
+    env_has_anthropic_key: bool,
+) -> DefaultProviderDecision {
+    let Some(default_key) = config.agent.default_provider.as_deref() else {
+        return DefaultProviderDecision::FallThroughToChain {
+            reason: "no agent.default_provider configured",
+        };
+    };
+    let Some(cfg) = config.llm.get(default_key) else {
+        return DefaultProviderDecision::FallThroughToChain {
+            reason: "agent.default_provider key not present in llm map",
+        };
+    };
+    let provider_kind = cfg.provider.as_str();
+
+    let cfg_has_key = cfg.api_key.as_deref().is_some_and(|k| !k.is_empty());
+    let credential_ok = match provider_kind {
+        // Local — health-checked by the caller.
+        "ollama" => true,
+        "anthropic" => env_has_anthropic_key || cfg_has_key,
+        // OpenAI-compatible local backends (e.g. LM Studio) commonly omit
+        // the api_key and rely on `base_url` reachability. Treat them as
+        // credential-ok for the purposes of routing.
+        "openai" => cfg.base_url.is_some() || env_has_openai_key || cfg_has_key,
+        "openrouter" => env_has_openrouter_key || cfg_has_key,
+        _ => {
+            return DefaultProviderDecision::FallThroughToChain {
+                reason: "unknown provider kind in agent.default_provider",
+            };
+        }
+    };
+
+    if !credential_ok {
+        return DefaultProviderDecision::FallThroughToChain {
+            reason: "no credential available for agent.default_provider",
+        };
+    }
+
+    let model = resolve_provider_model(config, provider_kind, None)
+        .unwrap_or_else(|| hardcoded_default_model(provider_kind));
+
+    DefaultProviderDecision::UseDefault {
+        config_key: default_key.to_string(),
+        provider_kind: provider_kind.to_string(),
+        model,
+    }
+}
+
+/// GAR-576 — Last-resort fallback model name per provider kind, used
+/// only when neither the CLI flag nor `config.llm` supplies one.
+fn hardcoded_default_model(provider_kind: &str) -> String {
+    match provider_kind {
+        "ollama" => "llama3.1",
+        "anthropic" => "claude-sonnet-4-5-20250929",
+        "openai" => "gpt-4o",
+        "openrouter" => "openrouter/auto",
+        _ => "auto",
+    }
+    .to_string()
+}
+
+/// GAR-576 — Construct an [`LlmProvider`] from a config-resolved default.
+///
+/// Returns `None` when construction is infeasible (e.g. Ollama daemon
+/// unreachable, or required api_key absent at build time); the caller
+/// then falls through to the legacy autodetect chain.
+async fn try_build_default_provider(
+    config: &AppConfig,
+    config_key: &str,
+    provider_kind: &str,
+    model: &str,
+) -> Option<(String, String, Arc<dyn LlmProvider>)> {
+    let cfg = config.llm.get(config_key)?;
+    match provider_kind {
+        "ollama" => {
+            let ollama = OllamaProvider::new(Some(model.to_string()), cfg.base_url.clone());
+            if !ollama.health_check().await.unwrap_or(false) {
+                return None;
+            }
+            Some((
+                config_key.to_string(),
+                model.to_string(),
+                Arc::new(ollama) as Arc<dyn LlmProvider>,
+            ))
+        }
+        "anthropic" => {
+            let key = get_api_key(config, "anthropic", "ANTHROPIC_API_KEY")?;
+            let ap = AnthropicProvider::new(&key, Some(model.to_string()), None);
+            Some((
+                config_key.to_string(),
+                model.to_string(),
+                Arc::new(ap) as Arc<dyn LlmProvider>,
+            ))
+        }
+        "openai" => {
+            // OpenAI-compatible local backends (e.g. LM Studio) usually
+            // omit the api_key; accept "not-needed" when `base_url` is set.
+            let key = get_api_key(config, "openai", "OPENAI_API_KEY").or_else(|| {
+                if cfg.base_url.is_some() {
+                    Some("not-needed".to_string())
+                } else {
+                    None
+                }
+            })?;
+            let op = OpenAiProvider::new(&key, Some(model.to_string()), cfg.base_url.clone());
+            Some((
+                config_key.to_string(),
+                model.to_string(),
+                Arc::new(op) as Arc<dyn LlmProvider>,
+            ))
+        }
+        "openrouter" => {
+            let key = get_api_key(config, "openrouter", "OPENROUTER_API_KEY")?;
+            let base = cfg
+                .base_url
+                .clone()
+                .unwrap_or_else(|| "https://openrouter.ai/api/v1".to_string());
+            let op = OpenAiProvider::new(&key, Some(model.to_string()), Some(base));
+            Some((
+                config_key.to_string(),
+                model.to_string(),
+                Arc::new(op) as Arc<dyn LlmProvider>,
+            ))
+        }
+        _ => None,
+    }
+}
+
 /// Detect which provider to use based on config and availability.
 pub async fn detect_provider(
     config: &AppConfig,
@@ -183,6 +378,31 @@ pub async fn detect_provider(
             model,
             Arc::new(provider) as Arc<dyn LlmProvider>,
         );
+    }
+
+    // GAR-576 — honor `config.agent.default_provider` BEFORE the env-based
+    // autodetect chain below. This prevents a stale `OPENAI_API_KEY` loaded
+    // from cwd `.env` (via `dotenvy::dotenv()` in main.rs) from hijacking the
+    // provider when the operator explicitly configured a different default.
+    let env_has = |name: &str| std::env::var(name).map(|v| !v.is_empty()).unwrap_or(false);
+    let decision = decide_default_provider(
+        config,
+        env_has("OPENAI_API_KEY"),
+        env_has("OPENROUTER_API_KEY"),
+        env_has("ANTHROPIC_API_KEY"),
+    );
+    if let DefaultProviderDecision::UseDefault {
+        config_key,
+        provider_kind,
+        model,
+    } = decision
+        && let Some(spec) =
+            try_build_default_provider(config, &config_key, &provider_kind, &model).await
+    {
+        return spec;
+        // If construction fails (e.g. Ollama health-check fails) the
+        // outer `if-let` chain shorts out and we fall through to the
+        // legacy autodetect chain below.
     }
 
     // 1. Try Ollama first (local, offline)
@@ -276,16 +496,20 @@ pub async fn run_chat(
     if let Some(ref p) = provider_override {
         match p.as_str() {
             "ollama" => {
-                let ollama = OllamaProvider::new(model_override.clone(), None);
-                model_name = model_override.unwrap_or_else(|| "llama3.1".to_string());
+                // GAR-576: honor config.llm[*].model when --model not supplied.
+                let model = resolve_provider_model(&config, "ollama", model_override.as_deref())
+                    .unwrap_or_else(|| "llama3.1".to_string());
+                let ollama = OllamaProvider::new(Some(model.clone()), None);
+                model_name = model;
                 provider_name = "ollama".to_string();
                 provider = Arc::new(ollama);
             }
             "anthropic" => {
                 let key = get_api_key(&config, "anthropic", "ANTHROPIC_API_KEY")
                     .context("ANTHROPIC_API_KEY not set and not found in config")?;
-                let model =
-                    model_override.unwrap_or_else(|| "claude-sonnet-4-5-20250929".to_string());
+                // GAR-576: honor config.llm[*].model when --model not supplied.
+                let model = resolve_provider_model(&config, "anthropic", model_override.as_deref())
+                    .unwrap_or_else(|| "claude-sonnet-4-5-20250929".to_string());
                 let ap = AnthropicProvider::new(&key, Some(model.clone()), None);
                 model_name = model;
                 provider_name = "anthropic".to_string();
@@ -294,7 +518,9 @@ pub async fn run_chat(
             "openai" => {
                 let key = get_api_key(&config, "openai", "OPENAI_API_KEY")
                     .context("OPENAI_API_KEY not set and not found in config")?;
-                let model = model_override.unwrap_or_else(|| "gpt-4o".to_string());
+                // GAR-576: honor config.llm[*].model when --model not supplied.
+                let model = resolve_provider_model(&config, "openai", model_override.as_deref())
+                    .unwrap_or_else(|| "gpt-4o".to_string());
                 let op = OpenAiProvider::new(&key, Some(model.clone()), None);
                 model_name = model;
                 provider_name = "openai".to_string();
@@ -303,7 +529,12 @@ pub async fn run_chat(
             "openrouter" => {
                 let key = get_api_key(&config, "openrouter", "OPENROUTER_API_KEY")
                     .context("OPENROUTER_API_KEY not set and not found in config")?;
-                let model = model_override.unwrap_or_else(|| "openrouter/auto".to_string());
+                // GAR-576: honor config.llm[*].model when --model not supplied
+                // (fixes the openrouter/auto hardcode that ignored
+                // config-declared models like openrouter/free).
+                let model =
+                    resolve_provider_model(&config, "openrouter", model_override.as_deref())
+                        .unwrap_or_else(|| "openrouter/auto".to_string());
                 let op = OpenAiProvider::new(
                     &key,
                     Some(model.clone()),
@@ -548,4 +779,259 @@ pub async fn run_chat(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    //! GAR-576 — Pure tests for provider/model resolution. None of these
+    //! touch `std::env` or the filesystem; env presence is passed in as
+    //! bool flags so the `OPENAI_API_KEY` hijack regression can be
+    //! asserted without mutating process-global state.
+
+    use super::*;
+    use garraia_config::{AgentConfig, AppConfig, LlmProviderConfig};
+    use std::collections::HashMap;
+
+    fn make_llm_cfg(
+        provider: &str,
+        model: Option<&str>,
+        api_key: Option<&str>,
+        base_url: Option<&str>,
+    ) -> LlmProviderConfig {
+        LlmProviderConfig {
+            provider: provider.to_string(),
+            model: model.map(String::from),
+            api_key: api_key.map(String::from),
+            base_url: base_url.map(String::from),
+            extra: HashMap::new(),
+        }
+    }
+
+    fn config_with(entries: &[(&str, LlmProviderConfig)]) -> AppConfig {
+        let mut cfg = AppConfig::default();
+        for (k, v) in entries {
+            cfg.llm.insert((*k).to_string(), v.clone());
+        }
+        cfg
+    }
+
+    fn config_with_default(default_key: &str, entries: &[(&str, LlmProviderConfig)]) -> AppConfig {
+        let mut cfg = config_with(entries);
+        cfg.agent = AgentConfig {
+            default_provider: Some(default_key.to_string()),
+            ..AgentConfig::default()
+        };
+        cfg
+    }
+
+    // ─── resolve_provider_model ────────────────────────────────────────
+
+    #[test]
+    fn resolve_provider_model_override_wins() {
+        let cfg = config_with(&[(
+            "openrouter",
+            make_llm_cfg("openrouter", Some("openrouter/free"), Some("k"), None),
+        )]);
+        let got = resolve_provider_model(&cfg, "openrouter", Some("openrouter/auto"));
+        assert_eq!(got.as_deref(), Some("openrouter/auto"));
+    }
+
+    #[test]
+    fn resolve_provider_model_key_match() {
+        let cfg = config_with(&[(
+            "openrouter",
+            make_llm_cfg("openrouter", Some("openrouter/free"), Some("k"), None),
+        )]);
+        let got = resolve_provider_model(&cfg, "openrouter", None);
+        assert_eq!(got.as_deref(), Some("openrouter/free"));
+    }
+
+    #[test]
+    fn resolve_provider_model_provider_field_match() {
+        // Key name is arbitrary (`my-router`), but the `provider` field
+        // matches the requested kind — the helper must still find the model.
+        let cfg = config_with(&[(
+            "my-router",
+            make_llm_cfg("openrouter", Some("openrouter/free"), Some("k"), None),
+        )]);
+        let got = resolve_provider_model(&cfg, "openrouter", None);
+        assert_eq!(got.as_deref(), Some("openrouter/free"));
+    }
+
+    #[test]
+    fn resolve_provider_model_no_match() {
+        let cfg = AppConfig::default();
+        assert!(resolve_provider_model(&cfg, "openrouter", None).is_none());
+    }
+
+    #[test]
+    fn resolve_provider_model_empty_string_skipped() {
+        let cfg = config_with(&[(
+            "openrouter",
+            make_llm_cfg("openrouter", Some(""), Some("k"), None),
+        )]);
+        // Empty string in config must not be returned as a valid model.
+        assert!(resolve_provider_model(&cfg, "openrouter", None).is_none());
+    }
+
+    // ─── decide_default_provider ───────────────────────────────────────
+
+    #[test]
+    fn decide_default_provider_no_default_falls_through() {
+        let cfg = AppConfig::default();
+        let decision = decide_default_provider(&cfg, false, false, false);
+        assert!(matches!(
+            decision,
+            DefaultProviderDecision::FallThroughToChain { .. }
+        ));
+    }
+
+    #[test]
+    fn decide_default_provider_missing_llm_key_falls_through() {
+        let cfg = config_with_default("missing", &[]);
+        let decision = decide_default_provider(&cfg, false, false, false);
+        assert!(matches!(
+            decision,
+            DefaultProviderDecision::FallThroughToChain { .. }
+        ));
+    }
+
+    #[test]
+    fn decide_default_provider_openrouter_wins_over_openai_env() {
+        // GAR-576 regression: this is the exact scenario from the bug
+        // report — operator configured OpenRouter as the default, but
+        // OPENAI_API_KEY is loaded from cwd `.env` and was hijacking
+        // the autodetect chain. The new branch must pick OpenRouter.
+        let cfg = config_with_default(
+            "openrouter",
+            &[(
+                "openrouter",
+                make_llm_cfg(
+                    "openrouter",
+                    Some("openrouter/free"),
+                    Some("test-key"),
+                    None,
+                ),
+            )],
+        );
+        let decision = decide_default_provider(
+            &cfg, /* env_has_openai */ true, /* env_has_openrouter */ true,
+            /* env_has_anthropic */ false,
+        );
+        match decision {
+            DefaultProviderDecision::UseDefault {
+                config_key,
+                provider_kind,
+                model,
+            } => {
+                assert_eq!(config_key, "openrouter");
+                assert_eq!(provider_kind, "openrouter");
+                assert_eq!(model, "openrouter/free");
+            }
+            other => panic!("expected UseDefault(openrouter), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decide_default_provider_falls_through_when_no_credential() {
+        // default_provider points to a kind that needs a key, but neither
+        // the env nor the config supplies one — fall through to the
+        // legacy chain rather than building a doomed provider.
+        let cfg = config_with_default(
+            "openrouter",
+            &[(
+                "openrouter",
+                make_llm_cfg("openrouter", Some("openrouter/free"), None, None),
+            )],
+        );
+        let decision = decide_default_provider(&cfg, false, false, false);
+        assert!(matches!(
+            decision,
+            DefaultProviderDecision::FallThroughToChain { .. }
+        ));
+    }
+
+    #[test]
+    fn decide_default_provider_ollama_no_credential_needed() {
+        // Ollama has no api_key concept — the credential gate is the
+        // async health-check inside try_build_default_provider, not
+        // the decision function.
+        let cfg = config_with_default(
+            "ollama-local",
+            &[(
+                "ollama-local",
+                make_llm_cfg(
+                    "ollama",
+                    Some("llama3.2"),
+                    None,
+                    Some("http://localhost:11434"),
+                ),
+            )],
+        );
+        let decision = decide_default_provider(&cfg, false, false, false);
+        match decision {
+            DefaultProviderDecision::UseDefault {
+                config_key,
+                provider_kind,
+                model,
+            } => {
+                assert_eq!(config_key, "ollama-local");
+                assert_eq!(provider_kind, "ollama");
+                assert_eq!(model, "llama3.2");
+            }
+            other => panic!("expected UseDefault(ollama), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decide_default_provider_openai_compat_with_base_url_accepts_no_key() {
+        // LM Studio scenario: provider kind is `openai` but the
+        // base_url points at a local server that does not enforce an
+        // api_key. The helper must accept the config and route there.
+        let cfg = config_with_default(
+            "lm-studio",
+            &[(
+                "lm-studio",
+                make_llm_cfg(
+                    "openai",
+                    Some("local-model"),
+                    None,
+                    Some("http://localhost:1234/v1"),
+                ),
+            )],
+        );
+        let decision = decide_default_provider(&cfg, false, false, false);
+        match decision {
+            DefaultProviderDecision::UseDefault {
+                config_key,
+                provider_kind,
+                model,
+            } => {
+                assert_eq!(config_key, "lm-studio");
+                assert_eq!(provider_kind, "openai");
+                assert_eq!(model, "local-model");
+            }
+            other => panic!("expected UseDefault(openai-compat), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decide_default_provider_uses_hardcoded_fallback_when_model_missing() {
+        // Config declares the provider but no model. The helper must
+        // fall back to hardcoded_default_model rather than refusing.
+        let cfg = config_with_default(
+            "openrouter",
+            &[(
+                "openrouter",
+                make_llm_cfg("openrouter", None, Some("test-key"), None),
+            )],
+        );
+        let decision = decide_default_provider(&cfg, false, true, false);
+        match decision {
+            DefaultProviderDecision::UseDefault { model, .. } => {
+                assert_eq!(model, "openrouter/auto");
+            }
+            other => panic!("expected UseDefault with hardcoded model, got {other:?}"),
+        }
+    }
 }

--- a/crates/garraia-cli/src/chat.rs
+++ b/crates/garraia-cli/src/chat.rs
@@ -288,31 +288,27 @@ fn hardcoded_default_model(provider_kind: &str) -> String {
 /// then falls through to the legacy autodetect chain.
 async fn try_build_default_provider(
     config: &AppConfig,
-    config_key: &str,
     provider_kind: &str,
+    cfg: &garraia_config::LlmProviderConfig,
     model: &str,
-) -> Option<(String, String, Arc<dyn LlmProvider>)> {
-    let cfg = config.llm.get(config_key)?;
+) -> Option<Arc<dyn LlmProvider>> {
+    // GAR-576: return ONLY the trait object — the display strings
+    // (config_key, model) are formed at the call site from inputs that
+    // never pass through this function. That keeps CodeQL's cleartext-
+    // logging dataflow analysis from conservatively tainting the model
+    // name through this scope, which also calls `get_api_key`.
     match provider_kind {
         "ollama" => {
             let ollama = OllamaProvider::new(Some(model.to_string()), cfg.base_url.clone());
             if !ollama.health_check().await.unwrap_or(false) {
                 return None;
             }
-            Some((
-                config_key.to_string(),
-                model.to_string(),
-                Arc::new(ollama) as Arc<dyn LlmProvider>,
-            ))
+            Some(Arc::new(ollama) as Arc<dyn LlmProvider>)
         }
         "anthropic" => {
             let key = get_api_key(config, "anthropic", "ANTHROPIC_API_KEY")?;
             let ap = AnthropicProvider::new(&key, Some(model.to_string()), None);
-            Some((
-                config_key.to_string(),
-                model.to_string(),
-                Arc::new(ap) as Arc<dyn LlmProvider>,
-            ))
+            Some(Arc::new(ap) as Arc<dyn LlmProvider>)
         }
         "openai" => {
             // OpenAI-compatible local backends (e.g. LM Studio) usually
@@ -325,11 +321,7 @@ async fn try_build_default_provider(
                 }
             })?;
             let op = OpenAiProvider::new(&key, Some(model.to_string()), cfg.base_url.clone());
-            Some((
-                config_key.to_string(),
-                model.to_string(),
-                Arc::new(op) as Arc<dyn LlmProvider>,
-            ))
+            Some(Arc::new(op) as Arc<dyn LlmProvider>)
         }
         "openrouter" => {
             let key = get_api_key(config, "openrouter", "OPENROUTER_API_KEY")?;
@@ -338,11 +330,7 @@ async fn try_build_default_provider(
                 .clone()
                 .unwrap_or_else(|| "https://openrouter.ai/api/v1".to_string());
             let op = OpenAiProvider::new(&key, Some(model.to_string()), Some(base));
-            Some((
-                config_key.to_string(),
-                model.to_string(),
-                Arc::new(op) as Arc<dyn LlmProvider>,
-            ))
+            Some(Arc::new(op) as Arc<dyn LlmProvider>)
         }
         _ => None,
     }
@@ -396,10 +384,14 @@ pub async fn detect_provider(
         provider_kind,
         model,
     } = decision
-        && let Some(spec) =
-            try_build_default_provider(config, &config_key, &provider_kind, &model).await
+        && let Some(cfg) = config.llm.get(&config_key)
+        && let Some(provider) =
+            try_build_default_provider(config, &provider_kind, cfg, &model).await
     {
-        return spec;
+        // GAR-576: form the display tuple here from the (untainted)
+        // strings returned by `decide_default_provider` — they never
+        // pass through the function that calls `get_api_key`.
+        return (config_key, model, provider);
         // If construction fails (e.g. Ollama health-check fails) the
         // outer `if-let` chain shorts out and we fall through to the
         // legacy autodetect chain below.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -195,6 +195,73 @@ Supported env var resolution:
 - `${VAR_NAME}` - Uses environment variable
 - Leave empty - Uses `GARRAIA_{PROVIDER}_API_KEY`
 
+## Provider / model resolution precedence
+
+> GAR-576 — clarifies how `garra chat` picks a provider and a model when
+> multiple signals compete (CLI flags, config blocks, environment
+> variables, `.env`).
+
+### Provider resolution
+
+When `garra chat` runs, the provider is chosen in this strict order:
+
+1. **`--provider <X>` CLI flag** — absolute precedence; the chosen kind
+   is used regardless of config or env.
+2. **`config.agent.default_provider`** — read as a *lookup key* into
+   `config.llm[...]`. If the matching block has a usable credential
+   (api_key in config, matching `*_API_KEY` env var, or, for OpenAI-
+   compatible local backends, a `base_url`), this provider wins.
+3. **Legacy autodetect chain** (compat) — Ollama health check →
+   `ANTHROPIC_API_KEY` env → `OPENAI_API_KEY` env → `OPENROUTER_API_KEY`
+   env → silent Ollama fallback.
+
+The chain in step 3 is what runs today and is preserved verbatim for
+operators who don't set `default_provider`.
+
+### Model resolution (per provider kind)
+
+Inside the chosen provider, the model is resolved in this order:
+
+1. **`--model <X>` CLI flag** — absolute precedence.
+2. **`config.llm[<key>].model`** with `<key>` matching the provider
+   name (key-match).
+3. **First `config.llm[*]` whose `provider:` field equals the chosen
+   kind** and supplies a non-empty `model` (provider-field match — lets
+   operators give blocks arbitrary names like `my-router`).
+4. **Hardcoded last-resort default** per kind: `llama3.1`,
+   `claude-sonnet-4-5-20250929`, `gpt-4o`, `openrouter/auto`.
+
+### OpenRouter cost policy
+
+The CLI ships with two recommended models for OpenRouter:
+
+| Model              | When to use                                                                                  |
+| ------------------ | -------------------------------------------------------------------------------------------- |
+| `openrouter/free`  | Smoke tests, CI sanity checks, cheap validation runs. Default suggested in `config.yml`.     |
+| `openrouter/auto`  | Real tasks / complex reasoning. Only use explicitly via `--model openrouter/auto`.            |
+
+Recommended baseline `config.yml`:
+
+```yaml
+llm:
+  openrouter:
+    provider: openrouter
+    model: openrouter/free          # default for smoke tests
+    base_url: "https://openrouter.ai/api/v1"
+
+agent:
+  default_provider: openrouter      # honored by `garra chat` autodetect
+```
+
+To run a heavier task, pass the model explicitly:
+
+```bash
+garra chat --provider openrouter --model openrouter/auto
+```
+
+There is no automatic `free → auto` upgrade — paid traffic always
+requires an explicit `--model` flag.
+
 ## Hot Reload
 
 Configuration changes in `config.yml` are applied automatically:

--- a/docs/src/providers.md
+++ b/docs/src/providers.md
@@ -156,6 +156,40 @@ Site oficial:
 
 [https://openrouter.ai](https://openrouter.ai)
 
+### Política `openrouter/free` vs `openrouter/auto`
+
+> GAR-576 — alinhamento de custo entre testes e tarefas reais.
+
+| Modelo              | Quando usar                                                                                   |
+| ------------------- | --------------------------------------------------------------------------------------------- |
+| `openrouter/free`   | Smoke tests, validações rápidas, diagnóstico. Default sugerido em `config.yml`.               |
+| `openrouter/auto`   | Tarefas reais / complexas. Use **apenas** explicitamente via `--model openrouter/auto`.       |
+
+O CLI `garra chat` resolve o modelo na seguinte ordem (ver
+`docs/configuration.md` §"Provider / model resolution precedence"):
+
+1. Flag `--model <X>` (precedência absoluta).
+2. `config.llm[<key>].model` (key match).
+3. Primeiro `config.llm[*]` cujo campo `provider:` casa com o tipo escolhido.
+4. Fallback hardcoded (`openrouter/auto`).
+
+Exemplo de uso barato:
+
+```bash
+# Smoke test — resolve openrouter/free a partir do config.yml.
+garra chat --provider openrouter
+```
+
+Exemplo de uso real:
+
+```bash
+# Tarefa pesada — força openrouter/auto.
+garra chat --provider openrouter --model openrouter/auto
+```
+
+Não existe upgrade automático `free → auto` — tráfego pago sempre
+exige `--model` explícito.
+
 ---
 
 ## Sansa

--- a/plans/0097-cli-openrouter-model-respect.md
+++ b/plans/0097-cli-openrouter-model-respect.md
@@ -1,0 +1,163 @@
+# Plan 0097 — GAR-576: CLI respects configured OpenRouter model + `default_provider`
+
+**Status:** Em execução
+**Autor:** Claude Opus 4.7 (sessão interativa 2026-05-10, America/New_York)
+**Data:** 2026-05-10 (America/New_York)
+**Issue:** [GAR-576](https://linear.app/chatgpt25/issue/GAR-576/cli-respect-configured-openrouter-model-and-default-provider)
+**Branch:** `routine/202605102242-gar-576-cli-openrouter-model-respect`
+**Epic:** `epic:cli`
+**Parent:** —
+
+---
+
+## §1 Goal
+
+Fix two interlocking CLI bugs in `garra chat`:
+
+1. `garra chat --provider openrouter` ignores `config.llm["openrouter"].model` and hardcodes `openrouter/auto` (chat.rs:306).
+2. `garra chat` (autodetect) walks a hardcoded chain (Ollama health → Anthropic env → OpenAI env → OpenRouter env) and never consults `config.agent.default_provider` (which already exists in `crates/garraia-config/src/model.rs:446`). With `OPENAI_API_KEY` loaded from cwd `.env` via `dotenvy::dotenv()` (main.rs:522), OpenAI wins even when the operator explicitly configured OpenRouter as the primary provider.
+
+Operational policy locked by user (2026-05-10):
+
+- **`openrouter/free`** is the default for smoke tests and cheap validations.
+- **`openrouter/auto`** is reserved for real / complex tasks — only when the operator passes `--model openrouter/auto` explicitly.
+
+---
+
+## §2 Resolution rules
+
+### Provider resolution precedence
+
+1. `--provider <X>` CLI flag (absolute).
+2. `config.agent.default_provider` (NEW: read as a lookup key into `config.llm[*]`).
+3. Hardcoded autodetect chain (compat).
+
+### Model resolution precedence (per provider kind)
+
+1. `--model <X>` CLI flag (absolute).
+2. `config.llm[provider_kind].model` (key-match).
+3. First `config.llm[*]` entry whose `provider` field equals `provider_kind` and has `model = Some(_)`.
+4. Hardcoded default per kind (`openrouter/auto`, `gpt-4o`, `claude-sonnet-4-5-20250929`, `llama3.1`).
+
+---
+
+## §3 Design invariants
+
+1. **Pure helpers.** `resolve_provider_model` and `decide_default_provider` are synchronous and do **not** read `std::env` directly — env presence is passed in via parameters, so unit tests need zero env mutation and zero new dev-dependencies.
+2. **Backwards compatible.** Without `config.agent.default_provider`, autodetect chain is byte-identical to today's behavior.
+3. **No new runtime dependency.** Zero changes to `Cargo.toml` (workspace or `garraia-cli`).
+4. **No secret exposure.** No new log lines. No `Display`/`Debug` impl change that could leak `api_key`.
+5. **Single-PR scope.** No `garra ask`, no MCP wrapper, no `RedactingWriter` extension, no `.env` edits.
+6. **Smoke uses `openrouter/free` only.** `openrouter/auto` is only invoked manually if `free` fails (and the failure reason is explained before retry).
+
+---
+
+## §4 Code changes
+
+### `crates/garraia-cli/src/chat.rs`
+
+**(A) New pure helper `resolve_provider_model`** (after `get_api_key`, ~25 LOC):
+
+```rust
+fn resolve_provider_model(
+    config: &AppConfig,
+    provider_kind: &str,
+    model_override: Option<&str>,
+) -> Option<String> {
+    if let Some(m) = model_override {
+        return Some(m.to_string());
+    }
+    if let Some(cfg) = config.llm.get(provider_kind)
+        && let Some(m) = cfg.model.as_deref()
+        && !m.is_empty()
+    {
+        return Some(m.to_string());
+    }
+    for cfg in config.llm.values() {
+        if cfg.provider == provider_kind
+            && let Some(m) = cfg.model.as_deref()
+            && !m.is_empty()
+        {
+            return Some(m.to_string());
+        }
+    }
+    None
+}
+```
+
+**(B) New pure helper `decide_default_provider`** (~40 LOC) — returns a `DefaultProviderDecision` enum that says either "use this config_key" or "fall through, reason=...". Tests assert against the enum; production then async-constructs the `LlmProvider` impl.
+
+**(C) Refactor `match p.as_str()` branches in `run_chat`** (4 branches, ~16 LOC delta): each branch replaces `model_override.unwrap_or_else(|| "<hardcoded>".to_string())` with `resolve_provider_model(&config, "<kind>", model_override.as_deref()).unwrap_or_else(|| "<hardcoded>".to_string())`.
+
+**(D) New branch at top of `detect_provider`** (~30 LOC) — calls `decide_default_provider`; on `UseDefault`, constructs the corresponding `LlmProvider` (Ollama health-checked, others built directly). Falls through to legacy chain on `FallThroughToChain` or construction failure.
+
+### Tests (in `chat.rs::tests`)
+
+| # | Name | Asserts |
+|---|------|---------|
+| 1 | `resolve_provider_model_override_wins` | `--model` wins over everything |
+| 2 | `resolve_provider_model_key_match` | `llm["openrouter"].model = "openrouter/free"` is returned |
+| 3 | `resolve_provider_model_provider_field_match` | `llm["my-router"].provider = "openrouter"` resolves when key name differs from kind |
+| 4 | `resolve_provider_model_no_match` | empty config returns `None` |
+| 5 | `resolve_provider_model_empty_string_skipped` | empty `model: ""` is not considered |
+| 6 | `decide_default_provider_no_default_falls_through` | no `agent.default_provider` → FallThrough |
+| 7 | `decide_default_provider_missing_llm_key_falls_through` | `default_provider = "missing"` → FallThrough |
+| 8 | `decide_default_provider_openrouter_wins_over_openai_env` | `default_provider = "openrouter"` + `env_has_openai=true` → UseDefault(openrouter) — the regression test for the OPENAI_API_KEY hijack |
+| 9 | `decide_default_provider_falls_through_when_no_credential` | `default_provider = "openrouter"` + no env + no `cfg.api_key` → FallThrough |
+| 10 | `decide_default_provider_ollama_no_credential_needed` | `provider: "ollama"` doesn't need an api key (health-check happens later) |
+| 11 | `decide_default_provider_openai_compat_with_base_url_accepts_no_key` | LM Studio scenario: `provider: "openai"` + `base_url: Some(...)` → UseDefault even without key |
+
+### `docs/configuration.md`
+
+Add a new section "Provider/model resolution precedence" with both precedence ladders from §2 above, plus the policy note about `openrouter/free` vs `openrouter/auto`.
+
+### `docs/src/providers.md`
+
+Add a "Política de teste — `openrouter/free` vs `openrouter/auto`" subsection at the bottom of the OpenRouter section (around line 158).
+
+---
+
+## §5 Verification
+
+Mandatory commands:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo test --workspace --all-features
+```
+
+Smoke (manual, cheap — `openrouter/free` only):
+
+```bash
+printf 'Responda apenas: GAR-FREE-OK\n/exit\n' \
+  | timeout 90 ./target/release/garra.exe chat --provider openrouter --model openrouter/free 2>&1 \
+  | sed -E 's/sk-or-v1-[A-Za-z0-9_-]+/sk-or-v1-[REDACTED]/g; s/sk-[A-Za-z0-9_-]+/sk-[REDACTED]/g'
+```
+
+Acceptance:
+
+- Banner shows `Model: openrouter/free` (NOT `openrouter/auto`) when only `--provider` is passed and config declares `model: openrouter/free`.
+- `--model openrouter/auto` still routes to `openrouter/auto`.
+- All cargo verification commands exit 0.
+- No new dependency in `Cargo.toml` (`git diff Cargo.toml` and `git diff crates/garraia-cli/Cargo.toml` are empty).
+
+---
+
+## §6 Risks
+
+- **Behavior change for users with `model: <something>` in the openrouter config block.** Today they silently get `openrouter/auto`; after this PR they get what they configured. This is the intentional fix. Documented in the PR description.
+- **Env-test isolation.** Avoided by passing env presence as bool parameters to `decide_default_provider`. No `std::env::set_var` in tests.
+- **No clippy regression.** New `let-chains` (`if let … && let …`) are already used elsewhere in `chat.rs` (e.g. `get_api_key` lines 133-154) so the workspace edition supports them.
+
+---
+
+## §7 Out of scope (follow-ups)
+
+- `garra ask` non-interactive command — separate issue.
+- MCP wrapper over CLI — blocked by `garra ask`.
+- `RedactingWriter` extension to cover provider error payloads (OpenAI 401 leaks key fingerprint to stderr) — separate issue, requires `security-auditor` review.
+- `dotenvy::dotenv_override(false)` behavior change.
+- `GARRAIA_CONFIG_DIR=/custom/config/path` fantasma config detection in `config check`.
+- Automatic `openrouter/free → openrouter/auto` fallback (token cost decision).
+- Renaming the synthetic `main` config key (defaults artifact).

--- a/plans/0098-gar-576-cli-openrouter-model-respect.md
+++ b/plans/0098-gar-576-cli-openrouter-model-respect.md
@@ -1,4 +1,8 @@
-# Plan 0097 — GAR-576: CLI respects configured OpenRouter model + `default_provider`
+# Plan 0098 — GAR-576: CLI respects configured OpenRouter model + `default_provider`
+
+> Renumbered from 0097 to 0098 on 2026-05-11 after
+> `plans/0097-gar-574-groups-members-invites-api.md` landed via PR #261
+> while this branch was in flight.
 
 **Status:** Em execução
 **Autor:** Claude Opus 4.7 (sessão interativa 2026-05-10, America/New_York)


### PR DESCRIPTION
## Summary

- `--provider openrouter` now respects `config.llm["openrouter"].model` (was hardcoded to `openrouter/auto`). `--model` retains absolute precedence.
- Autodetect now honors `config.agent.default_provider` (which already exists in the schema, `garraia-config/src/model.rs:446`) BEFORE the legacy env-based chain, so a stale `OPENAI_API_KEY` loaded from cwd `.env` via `dotenvy::dotenv()` no longer hijacks the provider.
- Operational policy: `openrouter/free` for smoke tests, `openrouter/auto` only when passed explicitly via `--model`. No automatic upgrade.

## Linear

[GAR-576](https://linear.app/chatgpt25/issue/GAR-576/cli-respect-configured-openrouter-model-and-default-provider) — opened just before this PR.

## Plan

`plans/0097-cli-openrouter-model-respect.md`

## Design

Two pure helpers in `crates/garraia-cli/src/chat.rs`:

- `resolve_provider_model(config, kind, model_override) -> Option<String>` walks `--model` > `config.llm[kind].model` > `config.llm[*]` where `.provider == kind`. Used by all four `match p.as_str()` arms in `run_chat`.
- `decide_default_provider(config, env_has_openai, env_has_openrouter, env_has_anthropic) -> DefaultProviderDecision` takes env presence as bool flags so unit tests can assert the `OPENAI_API_KEY` regression without mutating process-global env.

`detect_provider` calls `decide_default_provider` BEFORE the legacy chain; on `UseDefault`, `try_build_default_provider` constructs the `LlmProvider` (Ollama health-checked; OpenAI-compatible local backends accept `not-needed` when `base_url` is set). Construction failures fall through to the legacy chain.

## Test plan

- [x] `cargo fmt --all -- --check` exit 0.
- [x] `cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings` exit 0 (matches CI invocation at `ci.yml:54`).
- [x] `cargo test -p garraia --bin garra` 38/38 ok — includes 12 new `chat::tests`.
- [x] Smoke A2 (release binary + `GARRAIA_CONFIG_DIR=$HOME/.garraia` to bypass `.env` config-dir leak): banner shows `Model: openrouter/free`, response `GAR-FREE-OK`, `/exit` clean, exit=0.
- [ ] CI green (workspace clippy + test + audit + deny + msrv + GarraDream + Playwright + e2e).

## Smoke test evidence (redacted)

```
$ GARRAIA_CONFIG_DIR=$HOME/.garraia printf 'Responda apenas: GAR-FREE-OK\n/exit\n' | \
    GARRAIA_CONFIG_DIR=$HOME/.garraia timeout 90 ./target/release/garra.exe chat --provider openrouter

Provider: openrouter      Mode: cloud
Model:    openrouter/free
...
voce > garra > GAR-FREE-OK
voce > Ate mais! 🦀
EXIT=0
```

## Behavior changes

- Operators with `model: openrouter/free` (or any explicit model) in their openrouter config block now see that model picked up — today they silently got `openrouter/auto`. This is the intentional bug fix.
- Operators without `model:` declared continue to get the hardcoded fallback (no regression).
- Operators with `agent.default_provider` set now have it honored. Operators without it see byte-identical legacy behavior.

## Out of scope (separate follow-ups)

- `garra ask` non-interactive command (next slice).
- MCP wrapper.
- `RedactingWriter` extension to cover provider error payloads (OpenAI 401 leaks key fingerprint to stderr).
- `.env` operator-side edits.
- `GARRAIA_CONFIG_DIR=/custom/config/path` fantasma config detection in `config check`.
- Automatic `openrouter/free → openrouter/auto` fallback (token-cost decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)