### PR TITLE
feat(files): GAR-577 — POST /v1/groups/{group_id}/files (plan 0099)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -405,6 +405,7 @@ Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
 
 **Arquivos**
 
+- [x] `POST /v1/groups/{group_id}/files` (direct upload, v1 created atomically) — plan 0099 / [GAR-577](https://linear.app/chatgpt25/issue/GAR-577), implementado 2026-05-11 (Florida)
 - [ ] `POST /v1/groups/{group_id}/files:initUpload` (presigned URL + multipart)
 - [ ] `POST /v1/groups/{group_id}/files:completeUpload`
 - [x] `GET /v1/groups/{group_id}/files?folder_id=...` + `GET /v1/groups/{group_id}/folders` ✅ PR #235 GAR-555

--- a/crates/garraia-auth/src/audit_workspace.rs
+++ b/crates/garraia-auth/src/audit_workspace.rs
@@ -363,6 +363,16 @@ pub enum WorkspaceAuditAction {
     /// Metadata: `{ from_list_id, to_list_id }` — UUIDs only, never list names.
     TaskMoved,
 
+    /// A new file was created via `POST /v1/groups/{group_id}/files`
+    /// (plan 0099 / GAR-577, Fase 3.4 files slice 9).
+    ///
+    /// Emitted exactly once per successful 201 response, inside the same
+    /// transaction that inserts `files` + `file_versions` (v1).
+    /// `resource_type = "files"`, `resource_id = "{file_id}"`.
+    /// Metadata: `{ file_id, group_id, name_len: usize, size_bytes: u64,
+    /// has_folder: bool }` — never the raw file name (PII-safe, CLAUDE.md §6).
+    FileCreated,
+
     /// A file was soft-deleted via `DELETE /v1/files/{file_id}`
     /// (plan 0088 / GAR-555, Fase 3.4 files slice 1).
     ///
@@ -498,6 +508,7 @@ impl WorkspaceAuditAction {
             WorkspaceAuditAction::TaskSubscribed => "task.subscribed",
             WorkspaceAuditAction::TaskUnsubscribed => "task.unsubscribed",
             WorkspaceAuditAction::TaskMoved => "task.moved",
+            WorkspaceAuditAction::FileCreated => "file.created",
             WorkspaceAuditAction::FileDeleted => "file.deleted",
             WorkspaceAuditAction::FileRenamed => "file.renamed",
             WorkspaceAuditAction::FolderRenamed => "folder.renamed",
@@ -682,6 +693,7 @@ mod tests {
             "task.unsubscribed"
         );
         assert_eq!(WorkspaceAuditAction::TaskMoved.as_str(), "task.moved");
+        assert_eq!(WorkspaceAuditAction::FileCreated.as_str(), "file.created");
         assert_eq!(WorkspaceAuditAction::FileDeleted.as_str(), "file.deleted");
         assert_eq!(WorkspaceAuditAction::FileRenamed.as_str(), "file.renamed");
         assert_eq!(

--- a/crates/garraia-gateway/src/rest_v1/files.rs
+++ b/crates/garraia-gateway/src/rest_v1/files.rs
@@ -152,6 +152,28 @@ pub struct FolderListResponse {
     pub next_cursor: Option<Uuid>,
 }
 
+/// Response body for `POST /v1/groups/{group_id}/files` (201 Created).
+/// (plan 0099 / GAR-577, Fase 3.4 files slice 9)
+#[derive(Debug, Serialize, ToSchema)]
+pub struct FileCreatedResponse {
+    /// UUID of the newly created file (logical identity across versions).
+    pub file_id: Uuid,
+    /// Human-readable name supplied in the `X-File-Name` header.
+    pub name: String,
+    /// Group this file belongs to.
+    pub group_id: Uuid,
+    /// Parent folder, or `null` for root-level files.
+    pub folder_id: Option<Uuid>,
+    /// Always `1` for the initial upload.
+    pub version: i32,
+    /// Byte count of the uploaded content.
+    pub size_bytes: i64,
+    /// MIME type (from `Content-Type` header).
+    pub mime_type: String,
+    /// UTC timestamp of file creation.
+    pub created_at: DateTime<Utc>,
+}
+
 /// Query parameters for `GET /v1/groups/{group_id}/files`.
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct ListFilesQuery {
@@ -371,6 +393,266 @@ fn check_group_match(path_group_id: Uuid, principal_group_id: Uuid) -> Result<()
 }
 
 // ─── Handlers ─────────────────────────────────────────────────────────────────
+
+/// `POST /v1/groups/{group_id}/files` — create a new file (direct upload).
+/// (plan 0099 / GAR-577, Fase 3.4 files slice 9)
+///
+/// Accepts the file bytes as the raw request body (Content-Type = MIME type).
+/// Two required headers in addition to JWT + X-Group-Id:
+/// - `X-File-Name`: 1-500 char human name (no `/`, no control chars).
+/// - `Content-Type`: MIME type — must be in the storage allow-list.
+///
+/// One optional header:
+/// - `X-Folder-Id`: UUID of an existing, non-deleted folder in this group.
+///
+/// The handler creates `files` (v1) + `file_versions` (version=1) atomically
+/// in a single Postgres transaction. The ObjectStore PUT runs before COMMIT
+/// (two-phase ordering per ADR 0004 §5.3.1 — orphaned blobs on rollback are
+/// acceptable and reclaimed by a future maintenance job).
+///
+/// ## Error matrix
+///
+/// | Condition                               | Status |
+/// |-----------------------------------------|--------|
+/// | Missing/invalid JWT                     | 401    |
+/// | Caller lacks `FilesWrite`               | 403    |
+/// | `path_group_id` ≠ `principal.group_id` | 403    |
+/// | Missing `X-Group-Id` header             | 400    |
+/// | Missing or invalid `X-File-Name`        | 400    |
+/// | `X-Folder-Id` not found / soft-deleted  | 400    |
+/// | MIME type not in allow-list             | 415    |
+/// | Body exceeds operator cap               | 413    |
+/// | ObjectStore not configured              | 503    |
+/// | Happy path                              | 201    |
+#[utoipa::path(
+    post,
+    path = "/v1/groups/{group_id}/files",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID (must match caller's group)."),
+    ),
+    request_body(
+        content = (),
+        description = "Raw file bytes. Set Content-Type to the MIME type. \
+                       Also set X-File-Name and optionally X-Folder-Id.",
+    ),
+    responses(
+        (status = 201, description = "File created (v1).", body = FileCreatedResponse),
+        (status = 400, description = "Missing/invalid X-File-Name or bad X-Folder-Id.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller lacks FilesWrite or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 413, description = "Body exceeds operator cap.", body = super::problem::ProblemDetails),
+        (status = 415, description = "MIME type not in allow-list.", body = super::problem::ProblemDetails),
+        (status = 503, description = "Object store not configured.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn create_file(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(path_group_id): Path<Uuid>,
+    headers: HeaderMap,
+    body: Body,
+) -> Result<(StatusCode, Json<FileCreatedResponse>), RestError> {
+    let group_id = require_group_id(&principal)?;
+    if !can(&principal, Action::FilesWrite) {
+        return Err(RestError::Forbidden);
+    }
+    check_group_match(path_group_id, group_id)?;
+
+    let object_store = state
+        .storage
+        .object_store
+        .as_ref()
+        .ok_or(RestError::AuthUnconfigured)?
+        .clone();
+    let staging = state
+        .storage
+        .upload_staging
+        .as_ref()
+        .ok_or(RestError::AuthUnconfigured)?
+        .clone();
+
+    // Validate MIME type (fail fast — 415 before 413).
+    let content_type = headers
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.split(';').next().unwrap_or(s).trim().to_owned())
+        .ok_or(RestError::UnsupportedMediaType(
+            "Content-Type header missing".into(),
+        ))?;
+    if !garraia_storage::mime_allowlist::is_mime_allowed(&content_type) {
+        return Err(RestError::UnsupportedMediaType(format!(
+            "MIME type '{content_type}' is not in the allow-list"
+        )));
+    }
+
+    // Validate X-File-Name header.
+    let raw_name = headers
+        .get("x-file-name")
+        .and_then(|v| v.to_str().ok())
+        .ok_or_else(|| RestError::BadRequest("X-File-Name header is required".into()))?;
+    let file_name = validate_file_name(raw_name)
+        .map_err(|msg| RestError::BadRequest(msg.into()))?;
+    let name_len = file_name.chars().count();
+
+    // Parse optional X-Folder-Id header.
+    let folder_id: Option<Uuid> = headers
+        .get("x-folder-id")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| {
+            s.parse::<Uuid>()
+                .map_err(|_| RestError::BadRequest("X-Folder-Id is not a valid UUID".into()))
+        })
+        .transpose()?;
+
+    // Read body with operator cap.
+    let cap: usize = staging.max_patch_bytes.try_into().unwrap_or(usize::MAX);
+    let bytes = to_bytes(body, cap).await.map_err(|e| {
+        tracing::debug!(error = %e, "create_file body too large or read failed");
+        RestError::PayloadTooLarge(format!(
+            "body exceeds operator cap of {} bytes",
+            staging.max_patch_bytes
+        ))
+    })?;
+    let body_len = bytes.len() as i64;
+    let checksum_sha256 = sha256_hex_of_bytes(&bytes);
+
+    // Open DB transaction + set RLS context.
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Validate folder_id belongs to this group and is not soft-deleted.
+    if let Some(fid) = folder_id {
+        let exists: Option<(Uuid,)> = sqlx::query_as(
+            "SELECT id FROM folders WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+        )
+        .bind(fid)
+        .bind(group_id)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+        if exists.is_none() {
+            return Err(RestError::BadRequest(
+                "X-Folder-Id not found or soft-deleted in this group".into(),
+            ));
+        }
+    }
+
+    // Resolve creator label from users table.
+    let (created_by_label,): (String,) =
+        sqlx::query_as("SELECT display_name FROM users WHERE id = $1")
+            .bind(principal.user_id)
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(|e| RestError::Internal(e.into()))?;
+
+    let file_id = Uuid::new_v4();
+    let version_uuid = Uuid::new_v4();
+    let object_key =
+        format!("groups/{group_id}/files/{file_id}/v1/{version_uuid}");
+
+    // ObjectStore PUT — runs before Postgres COMMIT (two-phase ordering).
+    let put_opts = PutOptions {
+        content_type: Some(content_type.clone()),
+        hmac_secret: Some(staging.hmac_secret.clone()),
+        ..Default::default()
+    };
+    let put_meta = object_store
+        .put(&object_key, bytes, put_opts)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "ObjectStore::put failed for new file");
+            RestError::BadGateway("object store write failed; please retry".into())
+        })?;
+
+    let integrity_hmac = put_meta.integrity_hmac.ok_or_else(|| {
+        RestError::Internal(anyhow::anyhow!(
+            "ObjectStore did not return integrity_hmac; \
+             GARRAIA_UPLOAD_HMAC_SECRET misconfigured"
+        ))
+    })?;
+
+    // INSERT files row first (file_versions FK depends on it).
+    sqlx::query(
+        "INSERT INTO files \
+            (id, group_id, folder_id, name, current_version, total_versions, \
+             size_bytes, mime_type, created_by, created_by_label) \
+         VALUES ($1, $2, $3, $4, 1, 1, $5, $6, $7, $8)",
+    )
+    .bind(file_id)
+    .bind(group_id)
+    .bind(folder_id)
+    .bind(&file_name)
+    .bind(body_len)
+    .bind(&content_type)
+    .bind(principal.user_id)
+    .bind(&created_by_label)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e).context("insert files")))?;
+
+    // INSERT file_versions row (v1).
+    sqlx::query(
+        "INSERT INTO file_versions \
+            (file_id, group_id, version, object_key, etag, checksum_sha256, \
+             integrity_hmac, size_bytes, mime_type, created_by, created_by_label) \
+         VALUES ($1, $2, 1, $3, $4, $5, $6, $7, $8, $9, $10)",
+    )
+    .bind(file_id)
+    .bind(group_id)
+    .bind(&object_key)
+    .bind(&put_meta.etag_sha256[..put_meta.etag_sha256.len().min(200)])
+    .bind(&checksum_sha256)
+    .bind(&integrity_hmac)
+    .bind(body_len)
+    .bind(&content_type)
+    .bind(principal.user_id)
+    .bind(&created_by_label)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e).context("insert file_versions")))?;
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::FileCreated,
+        principal.user_id,
+        group_id,
+        "files",
+        file_id.to_string(),
+        serde_json::json!({
+            "file_id": file_id,
+            "group_id": group_id,
+            "name_len": name_len,
+            "size_bytes": body_len,
+            "has_folder": folder_id.is_some(),
+        }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(FileCreatedResponse {
+            file_id,
+            name: file_name,
+            group_id,
+            folder_id,
+            version: 1,
+            size_bytes: body_len,
+            mime_type: content_type,
+            created_at: Utc::now(),
+        }),
+    ))
+}
 
 /// `GET /v1/groups/{group_id}/files` — cursor-paginated file listing.
 ///

--- a/crates/garraia-gateway/src/rest_v1/files.rs
+++ b/crates/garraia-gateway/src/rest_v1/files.rs
@@ -491,8 +491,8 @@ pub async fn create_file(
         .get("x-file-name")
         .and_then(|v| v.to_str().ok())
         .ok_or_else(|| RestError::BadRequest("X-File-Name header is required".into()))?;
-    let file_name = validate_file_name(raw_name)
-        .map_err(|msg| RestError::BadRequest(msg.into()))?;
+    let file_name =
+        validate_file_name(raw_name).map_err(|msg| RestError::BadRequest(msg.into()))?;
     let name_len = file_name.chars().count();
 
     // Parse optional X-Folder-Id header.
@@ -553,8 +553,7 @@ pub async fn create_file(
 
     let file_id = Uuid::new_v4();
     let version_uuid = Uuid::new_v4();
-    let object_key =
-        format!("groups/{group_id}/files/{file_id}/v1/{version_uuid}");
+    let object_key = format!("groups/{group_id}/files/{file_id}/v1/{version_uuid}");
 
     // ObjectStore PUT — runs before Postgres COMMIT (two-phase ordering).
     let put_opts = PutOptions {

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -409,7 +409,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 .route("/v1/search", get(search::search))
                 // Plan 0088 (GAR-555) — files API slice 1.
                 // Plan 0092 (GAR-562) — files API slice 5: POST folder.
-                .route("/v1/groups/{group_id}/files", get(files::list_files))
+                // Plan 0099 (GAR-577) — files API slice 9: POST create file.
+                .route(
+                    "/v1/groups/{group_id}/files",
+                    get(files::list_files).post(files::create_file),
+                )
                 .route(
                     "/v1/groups/{group_id}/folders",
                     get(files::list_folders).post(files::create_folder),
@@ -544,7 +548,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 .route("/v1/search", get(unconfigured_handler))
                 // Plan 0088 (GAR-555) — files API slice 1, fail-soft 503.
                 // Plan 0092 (GAR-562) — files API slice 5: POST folder, fail-soft 503.
-                .route("/v1/groups/{group_id}/files", get(unconfigured_handler))
+                // Plan 0099 (GAR-577) — files API slice 9: POST create, fail-soft 503.
+                .route(
+                    "/v1/groups/{group_id}/files",
+                    get(unconfigured_handler).post(unconfigured_handler),
+                )
                 .route(
                     "/v1/groups/{group_id}/folders",
                     get(unconfigured_handler).post(unconfigured_handler),

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -15,9 +15,9 @@ use utoipa::{Modify, OpenApi};
 use super::audit::{AuditEventSummary, ListAuditResponse};
 use super::chats::{ChatListResponse, ChatResponse, ChatSummary, CreateChatRequest};
 use super::files::{
-    CreateFolderRequest, FileListResponse, FileSummary, FileVersionListResponse,
-    FileVersionResponse, FileVersionSummary, FolderListResponse, FolderSummary, PatchFileRequest,
-    PatchFolderRequest,
+    CreateFolderRequest, FileCreatedResponse, FileListResponse, FileSummary,
+    FileVersionListResponse, FileVersionResponse, FileVersionSummary, FolderListResponse,
+    FolderSummary, PatchFileRequest, PatchFolderRequest,
 };
 use super::groups::{
     CreateGroupRequest, CreateInviteRequest, GroupReadResponse, GroupResponse, InviteResponse,
@@ -138,6 +138,7 @@ impl Modify for SecurityAddon {
         super::audit::list_audit,
         super::search::search,
         super::files::list_files,
+        super::files::create_file,
         super::files::list_folders,
         super::files::delete_file,
         super::files::patch_file,
@@ -209,6 +210,7 @@ impl Modify for SecurityAddon {
         SearchResultType,
         FileSummary,
         FileListResponse,
+        FileCreatedResponse,
         FileVersionResponse,
         FolderSummary,
         FolderListResponse,

--- a/crates/garraia-gateway/tests/rest_v1_files_create.rs
+++ b/crates/garraia-gateway/tests/rest_v1_files_create.rs
@@ -183,10 +183,9 @@ async fn v1_files_create_scenarios() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let router = build_storage_router(&h, tmp.path()).await;
 
-    let (owner_id, group_id, owner_token) =
-        seed_user_with_group(&h, "owner@0099-create-file.test")
-            .await
-            .expect("seed owner+group");
+    let (owner_id, group_id, owner_token) = seed_user_with_group(&h, "owner@0099-create-file.test")
+        .await
+        .expect("seed owner+group");
     let gid_str = group_id.to_string();
 
     // ─── FC1. 201 happy path ──────────────────────────────────────────────────
@@ -248,16 +247,14 @@ async fn v1_files_create_scenarios() {
     // FC1 — file is readable via GET.
     let get_resp = router
         .clone()
-        .oneshot(
-            req_with_peer(
-                Request::builder()
-                    .method("GET")
-                    .uri(format!("/v1/groups/{gid_str}/files/{fc1_file_id}"))
-                    .header("authorization", format!("Bearer {owner_token}"))
-                    .header("x-group-id", &gid_str),
-                Body::empty(),
-            ),
-        )
+        .oneshot(req_with_peer(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/v1/groups/{gid_str}/files/{fc1_file_id}"))
+                .header("authorization", format!("Bearer {owner_token}"))
+                .header("x-group-id", &gid_str),
+            Body::empty(),
+        ))
         .await
         .expect("FC1 GET oneshot");
     assert_eq!(get_resp.status(), StatusCode::OK, "FC1 GET status");
@@ -300,10 +297,9 @@ async fn v1_files_create_scenarios() {
         seed_user_with_group(&h, "other@0099-create-file.test")
             .await
             .expect("FC4 seed other group");
-    let other_folder_id =
-        seed_folder(&h, other_group_id, _other_id, "foreign-folder")
-            .await
-            .expect("FC4 seed folder in other group");
+    let other_folder_id = seed_folder(&h, other_group_id, _other_id, "foreign-folder")
+        .await
+        .expect("FC4 seed folder in other group");
 
     let resp = router
         .clone()

--- a/crates/garraia-gateway/tests/rest_v1_files_create.rs
+++ b/crates/garraia-gateway/tests/rest_v1_files_create.rs
@@ -1,0 +1,434 @@
+// Gated so `cargo clippy --all-targets` without `test-helpers` skips this
+// file and doesn't try to compile the `common` harness.
+#![cfg(feature = "test-helpers")]
+//! Integration tests for `POST /v1/groups/{group_id}/files`
+//! (plan 0099, GAR-577, Fase 3.4 files slice 9).
+//!
+//! All scenarios bundled into ONE `#[tokio::test]` — same pattern as other
+//! files tests to avoid the sqlx runtime-teardown race.
+//!
+//! Scenarios:
+//! FC1. 201 happy path — file row + file_versions v1 created.
+//! FC2. 400 missing X-File-Name header.
+//! FC3. 400 invalid X-File-Name (empty string).
+//! FC4. 400 bad X-Folder-Id (folder not in this group).
+//! FC5. 403 cross-group path_group_id mismatch.
+//! FC6. 415 MIME type not in allow-list.
+//! FC7. 503 object store not configured.
+//! FC8. 403 Child role lacks FilesWrite.
+//! FC9. audit event `file.created` present in audit_events table.
+//! FC10. 201 happy path with X-Folder-Id (file inside a folder).
+
+mod common;
+
+use std::path::Path;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
+use garraia_gateway::rest_v1::uploads::UploadStaging;
+use garraia_gateway::server::build_router_for_test_with_storage;
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use common::Harness;
+use common::fixtures::{seed_member_via_admin, seed_user_with_group};
+
+fn docker_available() -> bool {
+    std::process::Command::new("docker")
+        .arg("version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn req_with_peer(builder: axum::http::request::Builder, body: Body) -> Request<Body> {
+    let mut req = builder.body(body).expect("request builder");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    req
+}
+
+fn create_file_req(
+    token: Option<&str>,
+    path_group_id: &str,
+    x_group_id: Option<&str>,
+    x_file_name: Option<&str>,
+    x_folder_id: Option<&str>,
+    content_type: Option<&str>,
+    body_bytes: Vec<u8>,
+) -> Request<Body> {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri(format!("/v1/groups/{path_group_id}/files"));
+    if let Some(ct) = content_type {
+        builder = builder.header("content-type", ct);
+    }
+    builder = builder.header("content-length", body_bytes.len().to_string());
+    let mut req = req_with_peer(builder, Body::from(body_bytes));
+    if let Some(t) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {t}")).unwrap(),
+        );
+    }
+    if let Some(g) = x_group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    if let Some(n) = x_file_name {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-file-name"),
+            HeaderValue::from_str(n).unwrap(),
+        );
+    }
+    if let Some(fid) = x_folder_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-folder-id"),
+            HeaderValue::from_str(fid).unwrap(),
+        );
+    }
+    req
+}
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("failed to collect response body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("response body is not JSON")
+}
+
+async fn build_storage_router(h: &Harness, tmp: &Path) -> axum::Router {
+    let fs_root = tmp.join("storage");
+    let staging_dir = tmp.join("staging");
+    std::fs::create_dir_all(&fs_root).unwrap();
+    std::fs::create_dir_all(&staging_dir).unwrap();
+
+    let local_fs = Arc::new(garraia_storage::LocalFs::new(&fs_root).expect("LocalFs::new"));
+    let staging = Arc::new(UploadStaging {
+        staging_dir: std::fs::canonicalize(&staging_dir).unwrap(),
+        max_patch_bytes: 10 * 1024 * 1024,
+        hmac_secret: b"test-secret-32-bytes-minimum-xxx".to_vec(),
+    });
+
+    build_router_for_test_with_storage(
+        garraia_config::AppConfig::default(),
+        h.login_pool.clone(),
+        h.signup_pool.clone(),
+        h.jwt.clone(),
+        Some(h.app_pool.clone()),
+        Some(local_fs as Arc<dyn garraia_storage::ObjectStore>),
+        Some(staging),
+    )
+    .await
+}
+
+async fn build_no_storage_router(h: &Harness) -> axum::Router {
+    let staging_dir = tempfile::tempdir().expect("tempdir").keep();
+    let staging = Arc::new(UploadStaging {
+        staging_dir,
+        max_patch_bytes: 10 * 1024 * 1024,
+        hmac_secret: b"test-secret-32-bytes-minimum-xxx".to_vec(),
+    });
+    build_router_for_test_with_storage(
+        garraia_config::AppConfig::default(),
+        h.login_pool.clone(),
+        h.signup_pool.clone(),
+        h.jwt.clone(),
+        Some(h.app_pool.clone()),
+        None,
+        Some(staging),
+    )
+    .await
+}
+
+/// Seed a `folders` row and return its id.
+async fn seed_folder(
+    h: &Harness,
+    group_id: Uuid,
+    created_by: Uuid,
+    name: &str,
+) -> anyhow::Result<Uuid> {
+    let folder_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO folders (id, group_id, parent_id, name, created_by, created_by_label) \
+         VALUES ($1, $2, NULL, $3, $4, $5)",
+    )
+    .bind(folder_id)
+    .bind(group_id)
+    .bind(name)
+    .bind(created_by)
+    .bind("Test User")
+    .execute(&h.admin_pool)
+    .await?;
+    Ok(folder_id)
+}
+
+#[tokio::test]
+async fn v1_files_create_scenarios() {
+    if !docker_available() {
+        eprintln!("docker not available; skipping v1_files_create_scenarios");
+        return;
+    }
+
+    let h = Harness::get().await;
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let router = build_storage_router(&h, tmp.path()).await;
+
+    let (owner_id, group_id, owner_token) =
+        seed_user_with_group(&h, "owner@0099-create-file.test")
+            .await
+            .expect("seed owner+group");
+    let gid_str = group_id.to_string();
+
+    // ─── FC1. 201 happy path ──────────────────────────────────────────────────
+    let fc1_payload: &[u8] = b"hello from FC1";
+    let resp = router
+        .clone()
+        .oneshot(create_file_req(
+            Some(&owner_token),
+            &gid_str,
+            Some(&gid_str),
+            Some("readme.txt"),
+            None,
+            Some("text/plain"),
+            fc1_payload.to_vec(),
+        ))
+        .await
+        .expect("FC1 oneshot");
+    assert_eq!(resp.status(), StatusCode::CREATED, "FC1 status");
+    let body = body_json(resp).await;
+    let fc1_file_id: Uuid = body["file_id"]
+        .as_str()
+        .unwrap()
+        .parse()
+        .expect("FC1 file_id parse");
+    assert_eq!(body["name"], "readme.txt", "FC1 name");
+    assert_eq!(body["group_id"], gid_str, "FC1 group_id");
+    assert_eq!(body["version"].as_i64(), Some(1), "FC1 version");
+    assert_eq!(
+        body["size_bytes"].as_i64(),
+        Some(fc1_payload.len() as i64),
+        "FC1 size_bytes"
+    );
+    assert_eq!(body["mime_type"], "text/plain", "FC1 mime_type");
+    assert!(body["folder_id"].is_null(), "FC1 folder_id null");
+
+    // FC1 — DB: files row created.
+    let (cur_ver, tot_ver, sz, mime): (i32, i32, i64, String) = sqlx::query_as(
+        "SELECT current_version, total_versions, size_bytes, mime_type \
+         FROM files WHERE id = $1",
+    )
+    .bind(fc1_file_id)
+    .fetch_one(&h.admin_pool)
+    .await
+    .expect("FC1 fetch files row");
+    assert_eq!(cur_ver, 1, "FC1 db current_version");
+    assert_eq!(tot_ver, 1, "FC1 db total_versions");
+    assert_eq!(sz, fc1_payload.len() as i64, "FC1 db size_bytes");
+    assert_eq!(mime, "text/plain", "FC1 db mime_type");
+
+    // FC1 — DB: file_versions v1 row created.
+    let (fv_ver,): (i32,) =
+        sqlx::query_as("SELECT version FROM file_versions WHERE file_id = $1 AND version = 1")
+            .bind(fc1_file_id)
+            .fetch_one(&h.admin_pool)
+            .await
+            .expect("FC1 fetch file_versions v1");
+    assert_eq!(fv_ver, 1, "FC1 db file_versions version");
+
+    // FC1 — file is readable via GET.
+    let get_resp = router
+        .clone()
+        .oneshot(
+            req_with_peer(
+                Request::builder()
+                    .method("GET")
+                    .uri(format!("/v1/groups/{gid_str}/files/{fc1_file_id}"))
+                    .header("authorization", format!("Bearer {owner_token}"))
+                    .header("x-group-id", &gid_str),
+                Body::empty(),
+            ),
+        )
+        .await
+        .expect("FC1 GET oneshot");
+    assert_eq!(get_resp.status(), StatusCode::OK, "FC1 GET status");
+
+    // ─── FC2. 400 missing X-File-Name ────────────────────────────────────────
+    let resp = router
+        .clone()
+        .oneshot(create_file_req(
+            Some(&owner_token),
+            &gid_str,
+            Some(&gid_str),
+            None, // no X-File-Name
+            None,
+            Some("text/plain"),
+            b"data".to_vec(),
+        ))
+        .await
+        .expect("FC2 oneshot");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "FC2 status");
+
+    // ─── FC3. 400 invalid X-File-Name (empty string) ─────────────────────────
+    let resp = router
+        .clone()
+        .oneshot(create_file_req(
+            Some(&owner_token),
+            &gid_str,
+            Some(&gid_str),
+            Some(""), // empty name
+            None,
+            Some("text/plain"),
+            b"data".to_vec(),
+        ))
+        .await
+        .expect("FC3 oneshot");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "FC3 status");
+
+    // ─── FC4. 400 bad X-Folder-Id (not in this group) ────────────────────────
+    // Seed a folder in a *different* group then reference it here.
+    let (_other_id, other_group_id, _other_token) =
+        seed_user_with_group(&h, "other@0099-create-file.test")
+            .await
+            .expect("FC4 seed other group");
+    let other_folder_id =
+        seed_folder(&h, other_group_id, _other_id, "foreign-folder")
+            .await
+            .expect("FC4 seed folder in other group");
+
+    let resp = router
+        .clone()
+        .oneshot(create_file_req(
+            Some(&owner_token),
+            &gid_str,
+            Some(&gid_str),
+            Some("test.txt"),
+            Some(&other_folder_id.to_string()),
+            Some("text/plain"),
+            b"data".to_vec(),
+        ))
+        .await
+        .expect("FC4 oneshot");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "FC4 status");
+
+    // ─── FC5. 403 cross-group path mismatch ──────────────────────────────────
+    // owner_token is for group_id, but path has other_group_id → 403.
+    let resp = router
+        .clone()
+        .oneshot(create_file_req(
+            Some(&owner_token),
+            &other_group_id.to_string(),
+            Some(&other_group_id.to_string()),
+            Some("test.txt"),
+            None,
+            Some("text/plain"),
+            b"data".to_vec(),
+        ))
+        .await
+        .expect("FC5 oneshot");
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN, "FC5 status");
+
+    // ─── FC6. 415 MIME not in allow-list ─────────────────────────────────────
+    let resp = router
+        .clone()
+        .oneshot(create_file_req(
+            Some(&owner_token),
+            &gid_str,
+            Some(&gid_str),
+            Some("evil.bin"),
+            None,
+            Some("application/x-evil"),
+            b"data".to_vec(),
+        ))
+        .await
+        .expect("FC6 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNSUPPORTED_MEDIA_TYPE,
+        "FC6 status"
+    );
+
+    // ─── FC7. 503 object store not configured ────────────────────────────────
+    let no_store_router = build_no_storage_router(&h).await;
+    let resp = no_store_router
+        .oneshot(create_file_req(
+            Some(&owner_token),
+            &gid_str,
+            Some(&gid_str),
+            Some("test.txt"),
+            None,
+            Some("text/plain"),
+            b"data".to_vec(),
+        ))
+        .await
+        .expect("FC7 oneshot");
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE, "FC7 status");
+
+    // ─── FC8. 403 Child role lacks FilesWrite ─────────────────────────────────
+    let child_email = "child@0099-create-file.test";
+    let (_child_id, child_token) = seed_member_via_admin(&h, group_id, "child", child_email)
+        .await
+        .expect("FC8 seed child");
+
+    let resp = router
+        .clone()
+        .oneshot(create_file_req(
+            Some(&child_token),
+            &gid_str,
+            Some(&gid_str),
+            Some("child-file.txt"),
+            None,
+            Some("text/plain"),
+            b"data".to_vec(),
+        ))
+        .await
+        .expect("FC8 oneshot");
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN, "FC8 status");
+
+    // ─── FC9. audit event `file.created` present ─────────────────────────────
+    // fc1_file_id was committed in FC1 — check audit row.
+    let (action,): (String,) = sqlx::query_as(
+        "SELECT action FROM audit_events \
+         WHERE resource_type = 'files' AND resource_id = $1 \
+         ORDER BY created_at DESC LIMIT 1",
+    )
+    .bind(fc1_file_id.to_string())
+    .fetch_one(&h.admin_pool)
+    .await
+    .expect("FC9 fetch audit event");
+    assert_eq!(action, "file.created", "FC9 audit action");
+
+    // ─── FC10. 201 happy path with X-Folder-Id ───────────────────────────────
+    let folder_id = seed_folder(&h, group_id, owner_id, "docs-folder")
+        .await
+        .expect("FC10 seed folder");
+
+    let fc10_payload: &[u8] = b"inside a folder";
+    let resp = router
+        .clone()
+        .oneshot(create_file_req(
+            Some(&owner_token),
+            &gid_str,
+            Some(&gid_str),
+            Some("nested.txt"),
+            Some(&folder_id.to_string()),
+            Some("text/plain"),
+            fc10_payload.to_vec(),
+        ))
+        .await
+        .expect("FC10 oneshot");
+    assert_eq!(resp.status(), StatusCode::CREATED, "FC10 status");
+    let body = body_json(resp).await;
+    assert_eq!(body["folder_id"], folder_id.to_string(), "FC10 folder_id");
+    assert_eq!(body["name"], "nested.txt", "FC10 name");
+    assert_eq!(body["version"].as_i64(), Some(1), "FC10 version");
+}

--- a/plans/0099-gar-577-files-api-slice9-create.md
+++ b/plans/0099-gar-577-files-api-slice9-create.md
@@ -1,0 +1,121 @@
+# Plan 0099 — GAR-577: Files REST API slice 9 — POST /v1/groups/{group_id}/files
+
+## §1 Goal
+
+Add `POST /v1/groups/{group_id}/files` — the missing file-creation endpoint. Slices 1-8 (plans 0088-0095) built every operation on existing files (list, rename, get, download, soft-delete, new version, list versions, folder CRUD) but left the initial file+v1 creation gap unfilled. This slice closes it.
+
+## §2 Architecture
+
+Reuses the same two-phase commit pattern as `post_new_version` (plan 0094):
+
+1. Validate MIME type from `Content-Type` header (fail-fast 415).
+2. Validate `X-File-Name` header (1-500 chars, no control chars, no leading/trailing whitespace).
+3. Optionally validate `X-Folder-Id` header (folder must exist in group and not be soft-deleted).
+4. Read body bytes with operator cap (`storage.max_patch_bytes`).
+5. Compute SHA-256 of body.
+6. Open Postgres transaction + set RLS context (same `set_rls_context` helper).
+7. Resolve `created_by_label` from `users.display_name` (same pattern as `create_folder`).
+8. `ObjectStore::put` (blob-first — runs **before** COMMIT).
+9. INSERT into `files` (id, group_id, folder_id, name, current_version=1, total_versions=1, size_bytes, mime_type, created_by, created_by_label).
+10. INSERT into `file_versions` (file_id, group_id, version=1, object_key, etag, checksum_sha256, integrity_hmac, size_bytes, mime_type, created_by, created_by_label).
+11. Emit `WorkspaceAuditAction::FileCreated` audit event (new variant).
+12. COMMIT → 201 + `FileCreatedResponse`.
+
+Object key scheme: `groups/{group_id}/files/{file_id}/v1/{version_uuid}` (consistent with `post_new_version`'s `groups/{group_id}/files/{file_id}/v{N}/{version_uuid}`).
+
+## §3 Tech stack
+
+- Rust stable, Axum 0.8, sqlx 0.8, garraia-storage ObjectStore trait.
+- No new dependencies; no schema migration (files/file_versions already exist — migration 003).
+- Feature: `garraia-gateway/test-helpers` for integration test harness.
+
+## §4 Design invariants
+
+- **Two-phase ordering**: ObjectStore PUT before Postgres COMMIT (orphaned blob on rollback is acceptable per ADR 0004 §5.3.1).
+- **No `unwrap()`** outside tests.
+- **No SQL string concat**: all queries use `sqlx::query()` with `bind()`.
+- **No PII in audit metadata**: carry `name_len` not `name` in audit payload.
+- **MIME allow-list**: delegate to `garraia_storage::mime_allowlist::is_mime_allowed`.
+- **Cross-group guard**: `path_group_id` must equal `principal.group_id` (same as all other file endpoints).
+- **RLS context**: set both `app.current_user_id` AND `app.current_group_id` via parameterized `set_config` (plan 0056 pattern).
+
+## §5 Validações pré-plano
+
+- [x] `files` schema: `name NOT NULL CHECK (length(name) BETWEEN 1 AND 500)`, `folder_id` nullable with compound FK → `folders(id, group_id)` (MATCH SIMPLE, so NULL is valid for root files). Verified in migration 003.
+- [x] `file_versions` schema: compound FK `(file_id, group_id) REFERENCES files(id, group_id)` + `object_key UNIQUE`. Verified in migration 003.
+- [x] `WorkspaceAuditAction` enum in `garraia-auth/src/audit_workspace.rs` already has `FileDeleted`, `FileRenamed`, `FileVersionCreated` — adding `FileCreated` follows the same pattern.
+- [x] `create_folder` handler (plan 0092) demonstrates the `display_name` lookup pattern.
+- [x] Route `/v1/groups/{group_id}/files` only has `get()` — no `post()` — confirmed in `mod.rs` line 412.
+
+## §6 Out of scope
+
+- Presigned URL initUpload/completeUpload pattern.
+- tus resumable upload (already shipped, GAR-395 / plan 0047).
+- Virus scanning hook (feature flag `av-clamav`).
+- Folder-name deduplication within a group (not required by schema).
+
+## §7 Rollback
+
+No schema migration → rollback = revert the PR. No data loss risk since no migration is included.
+
+## §8 File structure (changes)
+
+```
+crates/garraia-auth/src/audit_workspace.rs       — add FileCreated variant + as_str() + test
+crates/garraia-gateway/src/rest_v1/files.rs      — add FileCreatedResponse struct, validate_file_name(), create_file() handler
+crates/garraia-gateway/src/rest_v1/mod.rs        — add .post(files::create_file) to route + fail-soft branch
+tests/rest_v1_files_create.rs (new)              — integration tests
+plans/0099-gar-577-files-api-slice9-create.md    — this file
+plans/README.md                                  — new row
+```
+
+## §9 M1 tasks
+
+- [ ] T1: Add `FileCreated` variant to `WorkspaceAuditAction` (audit_workspace.rs) — include `as_str()` arm + unit test assertion.
+- [ ] T2: Add `FileCreatedResponse` struct + `validate_file_name()` helper in `files.rs`.
+- [ ] T3: Implement `create_file()` handler in `files.rs`.
+- [ ] T4: Register route in `mod.rs` (full + fail-soft branches).
+- [ ] T5: Write integration test file `tests/rest_v1_files_create.rs` (TDD: write tests first, verify red, then fix with T3).
+- [ ] T6: `cargo check -p garraia-gateway -p garraia-auth` green.
+- [ ] T7: `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` green.
+- [ ] T8: Update `plans/README.md` + ROADMAP.md checkboxes.
+
+## §10 Risk register
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| Compound FK insertion order (files before file_versions) | Low | INSERT files first (get file_id) then INSERT file_versions referencing it |
+| `object_key` collision (UUID-based, statistically impossible) | Negligible | UNIQUE index on `file_versions.object_key` returns 409 on conflict |
+| Body read OOM on large files | Low | `to_bytes(body, cap)` with operator cap (same as `post_new_version`) |
+| Orphaned blob on Postgres rollback | Accepted | Per ADR 0004 §5.3.1; future maintenance job reclaims |
+
+## §11 Acceptance criteria
+
+- `POST /v1/groups/{group_id}/files` returns 201 with file_id + version=1.
+- MIME not in allow-list → 415.
+- Body exceeds cap → 413.
+- Missing `X-File-Name` → 400.
+- Invalid name (empty, >500, control char) → 400.
+- Bad `X-Folder-Id` (not found / soft-deleted in group) → 400.
+- Cross-group `path_group_id` mismatch → 403.
+- No storage configured → 503.
+- Integration test: newly created file queryable via `GET /v1/groups/{group_id}/files/{file_id}`.
+- Audit event `file.created` present in `audit_events` table after happy path.
+- All CI checks green (Format, Clippy, Test×3, Build, MSRV, cargo-deny, Security Audit, Coverage, CodeQL, Playwright, E2E, Secret Scan, Dependency Review).
+
+## §12 Open questions
+
+None — all design decisions resolved by the existing `post_new_version` + `create_folder` patterns.
+
+## §13 Cross-references
+
+- Plan 0088 (GAR-555): files slice 1 (list + delete).
+- Plan 0094 (GAR-567): files slice 7 (new version — pattern reused here).
+- Plan 0092 (GAR-562): folder POST (creator_label resolution pattern reused here).
+- ADR 0004: object storage design.
+
+## §14 Estimativa
+
+- Implementação: ~3h
+- LOC: ~250 Rust + ~150 test
+- CI wall-time: ~25 min

--- a/plans/README.md
+++ b/plans/README.md
@@ -121,6 +121,8 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0095 | [GAR-569 — Files REST API slice 8: GET /v1/groups/{group_id}/files/{file_id}/versions (list versions)](0095-gar-569-files-api-slice8-list-versions.md) | [GAR-569](https://linear.app/chatgpt25/issue/GAR-569) | ✅ Merged 2026-05-10 via PR #253 (`0cc9a85`) |
 | 0096 | [GAR-572 — Tasks REST API slice 9: task_attachments (migration 017 + POST/GET/DELETE)](0096-gar-572-task-attachments-api.md) | [GAR-572](https://linear.app/chatgpt25/issue/GAR-572) | ✅ Merged 2026-05-10 via PR #257 (`2c1460c`) |
 | 0097 | [GAR-574 — Groups REST API slice 2: GET /v1/groups/{id}/members + GET /v1/groups/{id}/invites](0097-gar-574-groups-members-invites-api.md) | [GAR-574](https://linear.app/chatgpt25/issue/GAR-574) | ✅ Merged 2026-05-11 via PR #261 (`052e63c`) |
+| 0098 | [GAR-576 — fix(cli): respect configured OpenRouter model and default provider](0098-gar-576-cli-openrouter-model-respect.md) | [GAR-576](https://linear.app/chatgpt25/issue/GAR-576) | ✅ Merged 2026-05-11 via PR #263 (`c952b6b`) |
+| 0099 | [GAR-577 — Files REST API slice 9: POST /v1/groups/{group_id}/files (direct file upload / create)](0099-gar-577-files-api-slice9-create.md) | [GAR-577](https://linear.app/chatgpt25/issue/GAR-577) | 🔄 In Progress |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

- Adds `POST /v1/groups/{group_id}/files` — direct single-request file upload that atomically creates the `files` row + `file_versions` v1 row in one Postgres transaction, with ObjectStore PUT before COMMIT (two-phase ordering per ADR 0004 §5.3.1).
- Introduces `WorkspaceAuditAction::FileCreated` (`"file.created"`) with PII-safe metadata (`name_len`, not `name`).
- Registers `FileCreatedResponse` DTO in OpenAPI schema; route wired in both the full storage router and the fail-soft router.
- 10 integration test scenarios (FC1-FC10): happy path, missing headers, bad folder ref, cross-group 403, MIME 415, no storage 503, child role 403, audit event present, folder-scoped happy path.

## Test plan

- [ ] FC1 201 happy path — `files` + `file_versions` v1 created, readable via `GET /v1/groups/{group_id}/files/{file_id}`
- [ ] FC2 400 missing `X-File-Name` header
- [ ] FC3 400 invalid `X-File-Name` (empty string)
- [ ] FC4 400 bad `X-Folder-Id` (folder belongs to a different group)
- [ ] FC5 403 cross-group path_group_id mismatch
- [ ] FC6 415 MIME type not in allow-list (`application/x-evil`)
- [ ] FC7 503 object store not configured
- [ ] FC8 403 `child` role lacks `FilesWrite`
- [ ] FC9 audit event `"file.created"` present in `audit_events`
- [ ] FC10 201 with `X-Folder-Id` — `folder_id` non-null in response
- [ ] `cargo check` clean
- [ ] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` clean

https://claude.ai/code/session_01Y2hREQuc7ixSzCe5FpsDPJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2hREQuc7ixSzCe5FpsDPJ)_