### PR TITLE
feat(cli): add non-interactive garra ask command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ cargo build --release -p garraia
 # Iniciar
 ./target/release/garra start
 
+# Conversa rápida não-interativa (GAR-579) — ideal para Claude Code, CI, scripts
+./target/release/garra ask --provider openrouter --model openrouter/free \
+  --json --timeout-secs 30 "Responda apenas: GAR-ASK-OK"
+
 # Opcional: incluir suporte a plugins WASM
 cargo build --release -p garraia --features plugins
 ```

--- a/crates/garraia-cli/src/ask.rs
+++ b/crates/garraia-cli/src/ask.rs
@@ -1,0 +1,466 @@
+//! GAR-579 — Non-interactive `garra ask` command.
+//!
+//! Separate channel from `garra chat`: parseable, no banner, no ANSI, no
+//! REPL, LLM-only (no tools registered). Designed for Claude Code, CI,
+//! hooks, scripts, and a future MCP wrapper.
+//!
+//! Scope cuts approved 2026-05-11:
+//!   - No `--stream` (JSON one-shot).
+//!   - No `--enable-tools` (LLM-only, no `bash`/`file_*`/`git_diff`).
+//!   - No `--system-prompt-file` (only `--system-prompt <STR>`).
+//!
+//! Reuses GAR-576 helpers via `chat::detect_provider` and
+//! `chat::select_explicit_provider`.
+
+use std::sync::LazyLock;
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use garraia_agents::{AgentRuntime, ChatMessage};
+use garraia_config::AppConfig;
+use regex::Regex;
+use serde_json::json;
+use tokio::io::AsyncReadExt;
+
+use crate::chat;
+
+/// 64 KiB stdin cap. Larger inputs are rejected with `UsageError` rather
+/// than silently truncated.
+const STDIN_CAP_BYTES: usize = 64 * 1024;
+
+/// Truncation threshold for error messages emitted in the JSON envelope.
+/// Limits log spam from verbose provider responses while preserving
+/// enough context to debug.
+const ERROR_MSG_TRUNCATE: usize = 512;
+
+/// GAR-579 — typed errors with stable `kind` strings and sysexits-style
+/// exit codes. `Display` is intentionally PII-safe: the operator can
+/// rely on `message()` never including raw api-key fingerprints (those
+/// are scrubbed by [`sanitize_provider_error`] at the boundary).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AskError {
+    /// Bad CLI usage or empty input. Exit 2.
+    UsageError(String),
+    /// No provider could be resolved (config + flags + env). Exit 69.
+    NoProvider(String),
+    /// Provider returned an error (auth, network, rate limit, etc.).
+    /// Message has already been passed through `sanitize_provider_error`.
+    /// Exit 69.
+    ProviderError(String),
+    /// LLM call exceeded the `--timeout-secs` window. Exit 124.
+    Timeout(u64),
+    /// I/O failure (stdin read, etc.). Exit 74.
+    IoError(String),
+}
+
+impl AskError {
+    pub(crate) fn exit_code(&self) -> i32 {
+        match self {
+            Self::UsageError(_) => 2,
+            Self::NoProvider(_) | Self::ProviderError(_) => 69,
+            Self::Timeout(_) => 124,
+            Self::IoError(_) => 74,
+        }
+    }
+
+    pub(crate) fn kind_str(&self) -> &'static str {
+        match self {
+            Self::UsageError(_) => "usage",
+            Self::NoProvider(_) => "no_provider",
+            Self::ProviderError(_) => "provider_error",
+            Self::Timeout(_) => "timeout",
+            Self::IoError(_) => "io",
+        }
+    }
+
+    pub(crate) fn message(&self) -> String {
+        match self {
+            Self::UsageError(m)
+            | Self::NoProvider(m)
+            | Self::ProviderError(m)
+            | Self::IoError(m) => m.clone(),
+            Self::Timeout(s) => format!("LLM call exceeded {s}s timeout"),
+        }
+    }
+}
+
+static RE_OPENROUTER_KEY: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"sk-or-v1-[A-Za-z0-9_\-]+").expect("RE_OPENROUTER_KEY"));
+static RE_GENERIC_SK: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"sk-[A-Za-z0-9_\-]{8,}").expect("RE_GENERIC_SK"));
+
+/// GAR-579 — scrub api-key fingerprints from a provider error message
+/// before it gets serialized into the JSON envelope or emitted to stderr.
+///
+/// Truncates to [`ERROR_MSG_TRUNCATE`] bytes to limit log spam from
+/// verbose OpenAI-style error bodies. Order matters: OpenRouter-style
+/// keys are matched FIRST because the generic `sk-…` pattern would
+/// otherwise consume them.
+///
+/// Defense in depth — the real fix for provider-error redaction belongs
+/// in `garraia-security::RedactingWriter` (out of scope for this PR).
+pub(crate) fn sanitize_provider_error(msg: &str) -> String {
+    let truncated: String = if msg.chars().count() > ERROR_MSG_TRUNCATE {
+        let mut s: String = msg.chars().take(ERROR_MSG_TRUNCATE).collect();
+        s.push('…');
+        s
+    } else {
+        msg.to_string()
+    };
+    let s = RE_OPENROUTER_KEY.replace_all(&truncated, "sk-or-v1-[REDACTED]");
+    RE_GENERIC_SK.replace_all(&s, "sk-[REDACTED]").into_owned()
+}
+
+/// GAR-579 — resolve the message from CLI arg or stdin bytes. Pure,
+/// sync, no I/O — `run_ask` reads stdin async beforehand and passes the
+/// bytes in, which keeps this testable without mocking a `tokio` reader.
+pub(crate) fn resolve_message(
+    arg: Option<String>,
+    stdin_bytes: &[u8],
+    cap: usize,
+) -> Result<String, AskError> {
+    if let Some(m) = arg {
+        let trimmed = m.trim();
+        if trimmed.is_empty() {
+            return Err(AskError::UsageError(
+                "message argument is empty".to_string(),
+            ));
+        }
+        return Ok(trimmed.to_string());
+    }
+    if stdin_bytes.len() > cap {
+        return Err(AskError::UsageError(format!(
+            "stdin input exceeds {cap}-byte cap"
+        )));
+    }
+    let s = String::from_utf8_lossy(stdin_bytes).trim().to_string();
+    if s.is_empty() {
+        return Err(AskError::UsageError(
+            "no message provided (positional arg absent and stdin empty)".to_string(),
+        ));
+    }
+    Ok(s)
+}
+
+/// GAR-579 — JSON envelope schema `garra.ask.v1`, success branch.
+pub(crate) fn success_envelope(
+    answer: &str,
+    provider: &str,
+    model: &str,
+    latency_ms: u128,
+) -> serde_json::Value {
+    json!({
+        "schema": "garra.ask.v1",
+        "ok": true,
+        "answer": answer,
+        "provider": provider,
+        "model": model,
+        "latency_ms": latency_ms,
+    })
+}
+
+/// GAR-579 — JSON envelope schema `garra.ask.v1`, error branch.
+pub(crate) fn error_envelope(kind: &str, message: &str) -> serde_json::Value {
+    json!({
+        "schema": "garra.ask.v1",
+        "ok": false,
+        "error": {
+            "kind": kind,
+            "message": message,
+        }
+    })
+}
+
+/// Emit an error to stdout (if `--json`) or stderr (plain text) and
+/// return the corresponding exit code. Never panics on JSON serialization
+/// — emits a fixed fallback envelope if `serde_json::to_string` fails.
+fn emit_error(err: &AskError, json: bool) -> i32 {
+    if json {
+        let env = error_envelope(err.kind_str(), &err.message());
+        let line = serde_json::to_string(&env).unwrap_or_else(|_| {
+            String::from("{\"schema\":\"garra.ask.v1\",\"ok\":false,\"error\":{\"kind\":\"io\",\"message\":\"json serialization failed\"}}")
+        });
+        println!("{line}");
+    } else {
+        eprintln!("error: {}", err.message());
+    }
+    err.exit_code()
+}
+
+/// GAR-579 — entry point invoked by `Commands::Ask` in `main.rs`.
+///
+/// Returns an exit code; the caller is responsible for `std::process::exit`.
+/// Does not panic on provider/network errors — every failure path returns
+/// a sanitized error through `emit_error`.
+///
+/// Invariants:
+///   - **NEVER** registers a tool on the `AgentRuntime` (LLM-only).
+///   - **NEVER** prints banner / ANSI / interactive prompts to stdout.
+///   - Provider errors pass through `sanitize_provider_error` before
+///     reaching stdout/stderr.
+#[allow(clippy::too_many_arguments)]
+pub async fn run_ask(
+    config: AppConfig,
+    message_arg: Option<String>,
+    provider_override: Option<String>,
+    model_override: Option<String>,
+    url_override: Option<String>,
+    json: bool,
+    timeout_secs: u64,
+    system_prompt_override: Option<String>,
+) -> Result<i32> {
+    let start = Instant::now();
+
+    // 1. Resolve message — read stdin only if arg absent.
+    let stdin_bytes: Vec<u8> = if message_arg.is_none() {
+        let mut buf = Vec::with_capacity(8192);
+        let mut limited = tokio::io::stdin().take((STDIN_CAP_BYTES + 1) as u64);
+        if let Err(e) = limited.read_to_end(&mut buf).await {
+            return Ok(emit_error(
+                &AskError::IoError(format!("stdin read failed: {e}")),
+                json,
+            ));
+        }
+        buf
+    } else {
+        Vec::new()
+    };
+    let message = match resolve_message(message_arg, &stdin_bytes, STDIN_CAP_BYTES) {
+        Ok(m) => m,
+        Err(e) => return Ok(emit_error(&e, json)),
+    };
+
+    // 2. Resolve provider.
+    let (provider_name, model_name, provider) = if let Some(ref p) = provider_override {
+        match chat::select_explicit_provider(&config, p.as_str(), model_override.as_deref()) {
+            Ok(triple) => triple,
+            Err(e) => {
+                return Ok(emit_error(
+                    &AskError::NoProvider(sanitize_provider_error(&format!("{e:#}"))),
+                    json,
+                ));
+            }
+        }
+    } else {
+        // detect_provider also handles url_override + autodetect chain
+        // (see chat::detect_provider for the precedence rules — GAR-576).
+        chat::detect_provider(&config, url_override.as_deref()).await
+    };
+
+    // 3. Build a minimal AgentRuntime — LLM only. NO tool registration.
+    //    The `ask_module_never_registers_a_tool` test below enforces this
+    //    invariant at compile time by scanning production code for any
+    //    tool-registration patterns.
+    let mut runtime = AgentRuntime::new();
+    runtime.register_provider(provider);
+
+    let system_prompt = system_prompt_override.unwrap_or_else(|| {
+        "Voce e o GarraIA. Responda de forma concisa, direta e no idioma do usuario.".to_string()
+    });
+    runtime.set_system_prompt(system_prompt);
+    runtime.set_max_tokens(4096);
+
+    // 4. Call LLM with timeout. We use the streaming API (no non-streaming
+    //    variant exists today) and drain deltas in a background task so
+    //    the channel never blocks the producer.
+    let session_id = format!("ask-{}", uuid::Uuid::new_v4());
+    let history: Vec<ChatMessage> = Vec::new();
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<String>(256);
+    let drain_handle = tokio::spawn(async move { while rx.recv().await.is_some() {} });
+
+    let call =
+        runtime.process_message_streaming(&session_id, &message, &history, tx, Some(&model_name));
+    let result = tokio::time::timeout(Duration::from_secs(timeout_secs), call).await;
+
+    // Drop the drain task (channel closure ends it naturally too).
+    drain_handle.abort();
+
+    let answer = match result {
+        Ok(Ok(full)) => full,
+        Ok(Err(e)) => {
+            return Ok(emit_error(
+                &AskError::ProviderError(sanitize_provider_error(&format!("{e:#}"))),
+                json,
+            ));
+        }
+        Err(_elapsed) => {
+            return Ok(emit_error(&AskError::Timeout(timeout_secs), json));
+        }
+    };
+
+    let latency_ms = start.elapsed().as_millis();
+
+    // 5. Emit.
+    if json {
+        let env = success_envelope(&answer, &provider_name, &model_name, latency_ms);
+        let line = serde_json::to_string(&env).unwrap_or_else(|_| {
+            String::from("{\"schema\":\"garra.ask.v1\",\"ok\":false,\"error\":{\"kind\":\"io\",\"message\":\"json serialization failed\"}}")
+        });
+        println!("{line}");
+    } else {
+        println!("{}", answer.trim_end());
+    }
+
+    Ok(0)
+}
+
+#[cfg(test)]
+mod tests {
+    //! GAR-579 — Pure tests. Zero rede, zero env-mutation, zero filesystem.
+
+    use super::*;
+
+    // ─── AskError exit codes + kind labels ─────────────────────────────
+
+    #[test]
+    fn ask_error_exit_codes_match_doc() {
+        let cases: &[(AskError, i32)] = &[
+            (AskError::UsageError("x".into()), 2),
+            (AskError::NoProvider("x".into()), 69),
+            (AskError::ProviderError("x".into()), 69),
+            (AskError::Timeout(60), 124),
+            (AskError::IoError("x".into()), 74),
+        ];
+        for (err, expected) in cases {
+            assert_eq!(err.exit_code(), *expected, "exit_code mismatch for {err:?}");
+        }
+    }
+
+    #[test]
+    fn ask_error_kind_str_stable() {
+        assert_eq!(AskError::UsageError("".into()).kind_str(), "usage");
+        assert_eq!(AskError::NoProvider("".into()).kind_str(), "no_provider");
+        assert_eq!(
+            AskError::ProviderError("".into()).kind_str(),
+            "provider_error"
+        );
+        assert_eq!(AskError::Timeout(30).kind_str(), "timeout");
+        assert_eq!(AskError::IoError("".into()).kind_str(), "io");
+    }
+
+    // ─── JSON envelopes ────────────────────────────────────────────────
+
+    #[test]
+    fn json_envelope_success_shape() {
+        let env = success_envelope("hello", "openrouter", "openrouter/free", 123);
+        assert_eq!(env["schema"], "garra.ask.v1");
+        assert_eq!(env["ok"], true);
+        assert_eq!(env["answer"], "hello");
+        assert_eq!(env["provider"], "openrouter");
+        assert_eq!(env["model"], "openrouter/free");
+        assert_eq!(env["latency_ms"], 123);
+        // No error field on success.
+        assert!(env.get("error").is_none());
+    }
+
+    #[test]
+    fn json_envelope_error_shape() {
+        let env = error_envelope("timeout", "exceeded 30s");
+        assert_eq!(env["schema"], "garra.ask.v1");
+        assert_eq!(env["ok"], false);
+        assert_eq!(env["error"]["kind"], "timeout");
+        assert_eq!(env["error"]["message"], "exceeded 30s");
+        // No answer field on error.
+        assert!(env.get("answer").is_none());
+    }
+
+    // ─── resolve_message ───────────────────────────────────────────────
+
+    #[test]
+    fn resolve_message_arg_wins_over_stdin() {
+        let got = resolve_message(Some("from-arg".into()), b"from-stdin", 64).unwrap();
+        assert_eq!(got, "from-arg");
+    }
+
+    #[test]
+    fn resolve_message_uses_stdin_when_arg_absent() {
+        let got = resolve_message(None, b"hello stdin", 64).unwrap();
+        assert_eq!(got, "hello stdin");
+    }
+
+    #[test]
+    fn resolve_message_trims_arg_whitespace() {
+        let got = resolve_message(Some("   spaced   \n".into()), &[], 64).unwrap();
+        assert_eq!(got, "spaced");
+    }
+
+    #[test]
+    fn resolve_message_empty_arg_returns_usage_error() {
+        let err = resolve_message(Some("   ".into()), &[], 64).unwrap_err();
+        assert!(matches!(err, AskError::UsageError(_)));
+    }
+
+    #[test]
+    fn resolve_message_no_arg_no_stdin_returns_usage_error() {
+        let err = resolve_message(None, &[], 64).unwrap_err();
+        assert!(matches!(err, AskError::UsageError(_)));
+    }
+
+    #[test]
+    fn resolve_message_stdin_over_cap_returns_usage_error() {
+        let over_cap = vec![b'a'; 65];
+        let err = resolve_message(None, &over_cap, 64).unwrap_err();
+        match err {
+            AskError::UsageError(m) => assert!(m.contains("64")),
+            other => panic!("expected UsageError, got {other:?}"),
+        }
+    }
+
+    // ─── sanitize_provider_error ───────────────────────────────────────
+
+    #[test]
+    fn sanitize_redacts_openrouter_key_fingerprint() {
+        let leaked = "401 Unauthorized — key sk-or-v1-abcdefGHIJ12345 invalid";
+        let out = sanitize_provider_error(leaked);
+        assert!(!out.contains("sk-or-v1-abcdefGHIJ12345"));
+        assert!(out.contains("sk-or-v1-[REDACTED]"));
+    }
+
+    #[test]
+    fn sanitize_redacts_openai_style_key_fingerprint() {
+        let leaked = "Incorrect API key provided: sk-projAbCd123xyz_456_more";
+        let out = sanitize_provider_error(leaked);
+        assert!(!out.contains("AbCd123xyz_456_more"));
+        assert!(out.contains("sk-[REDACTED]"));
+    }
+
+    #[test]
+    fn sanitize_truncates_long_messages() {
+        let huge = "x".repeat(2_000);
+        let out = sanitize_provider_error(&huge);
+        // Must be capped to ERROR_MSG_TRUNCATE + ellipsis suffix.
+        assert!(out.chars().count() <= ERROR_MSG_TRUNCATE + 1);
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn sanitize_passes_clean_messages_through() {
+        let benign = "Connection refused at localhost:11434";
+        assert_eq!(sanitize_provider_error(benign), benign);
+    }
+
+    // ─── Audit: this module never registers a tool ─────────────────────
+
+    /// Compile-time + read-time guarantee. Scans only the **production**
+    /// portion of the file (everything before `#[cfg(test)]`) for tool-
+    /// registration patterns. If a follow-up PR ever tries to slip a
+    /// tool registration into `ask.rs`, this test fails loudly.
+    #[test]
+    fn ask_module_never_registers_a_tool() {
+        let source = include_str!("ask.rs");
+        let production = source.split("#[cfg(test)]").next().unwrap_or(source);
+        let forbidden = [
+            "register_tool",
+            "BashTool",
+            "FileReadTool",
+            "FileWriteTool",
+            "GitDiffTool",
+        ];
+        for needle in forbidden {
+            assert!(
+                !production.contains(needle),
+                "ask.rs production code must not contain `{needle}` (GAR-579 invariant)"
+            );
+        }
+    }
+}

--- a/crates/garraia-cli/src/chat.rs
+++ b/crates/garraia-cli/src/chat.rs
@@ -336,6 +336,78 @@ async fn try_build_default_provider(
     }
 }
 
+/// GAR-579 — Build a provider from an explicit `--provider <kind>` flag.
+///
+/// Returns the same `(display_name, model, Arc<dyn LlmProvider>)` triple
+/// that `detect_provider` returns. Honors `model_override` first, then
+/// `config.llm[*].model` via `resolve_provider_model`, then a hardcoded
+/// per-kind fallback. Unknown `kind` is an error; missing api_key for a
+/// cloud provider is an error.
+///
+/// Shared by `chat::run_chat` and `ask::run_ask` so the explicit-provider
+/// path lives in exactly one place.
+pub(crate) fn select_explicit_provider(
+    config: &AppConfig,
+    kind: &str,
+    model_override: Option<&str>,
+) -> Result<(String, String, Arc<dyn LlmProvider>)> {
+    match kind {
+        "ollama" => {
+            let model = resolve_provider_model(config, "ollama", model_override)
+                .unwrap_or_else(|| "llama3.1".to_string());
+            let ollama = OllamaProvider::new(Some(model.clone()), None);
+            Ok((
+                "ollama".to_string(),
+                model,
+                Arc::new(ollama) as Arc<dyn LlmProvider>,
+            ))
+        }
+        "anthropic" => {
+            let key = get_api_key(config, "anthropic", "ANTHROPIC_API_KEY")
+                .context("ANTHROPIC_API_KEY not set and not found in config")?;
+            let model = resolve_provider_model(config, "anthropic", model_override)
+                .unwrap_or_else(|| "claude-sonnet-4-5-20250929".to_string());
+            let ap = AnthropicProvider::new(&key, Some(model.clone()), None);
+            Ok((
+                "anthropic".to_string(),
+                model,
+                Arc::new(ap) as Arc<dyn LlmProvider>,
+            ))
+        }
+        "openai" => {
+            let key = get_api_key(config, "openai", "OPENAI_API_KEY")
+                .context("OPENAI_API_KEY not set and not found in config")?;
+            let model = resolve_provider_model(config, "openai", model_override)
+                .unwrap_or_else(|| "gpt-4o".to_string());
+            let op = OpenAiProvider::new(&key, Some(model.clone()), None);
+            Ok((
+                "openai".to_string(),
+                model,
+                Arc::new(op) as Arc<dyn LlmProvider>,
+            ))
+        }
+        "openrouter" => {
+            let key = get_api_key(config, "openrouter", "OPENROUTER_API_KEY")
+                .context("OPENROUTER_API_KEY not set and not found in config")?;
+            let model = resolve_provider_model(config, "openrouter", model_override)
+                .unwrap_or_else(|| "openrouter/auto".to_string());
+            let op = OpenAiProvider::new(
+                &key,
+                Some(model.clone()),
+                Some("https://openrouter.ai/api/v1".to_string()),
+            );
+            Ok((
+                "openrouter".to_string(),
+                model,
+                Arc::new(op) as Arc<dyn LlmProvider>,
+            ))
+        }
+        other => anyhow::bail!(
+            "Provider desconhecido: {other}. Use: ollama, anthropic, openai, openrouter"
+        ),
+    }
+}
+
 /// Detect which provider to use based on config and availability.
 pub async fn detect_provider(
     config: &AppConfig,
@@ -486,62 +558,14 @@ pub async fn run_chat(
 
     // Apply overrides
     if let Some(ref p) = provider_override {
-        match p.as_str() {
-            "ollama" => {
-                // GAR-576: honor config.llm[*].model when --model not supplied.
-                let model = resolve_provider_model(&config, "ollama", model_override.as_deref())
-                    .unwrap_or_else(|| "llama3.1".to_string());
-                let ollama = OllamaProvider::new(Some(model.clone()), None);
-                model_name = model;
-                provider_name = "ollama".to_string();
-                provider = Arc::new(ollama);
-            }
-            "anthropic" => {
-                let key = get_api_key(&config, "anthropic", "ANTHROPIC_API_KEY")
-                    .context("ANTHROPIC_API_KEY not set and not found in config")?;
-                // GAR-576: honor config.llm[*].model when --model not supplied.
-                let model = resolve_provider_model(&config, "anthropic", model_override.as_deref())
-                    .unwrap_or_else(|| "claude-sonnet-4-5-20250929".to_string());
-                let ap = AnthropicProvider::new(&key, Some(model.clone()), None);
-                model_name = model;
-                provider_name = "anthropic".to_string();
-                provider = Arc::new(ap);
-            }
-            "openai" => {
-                let key = get_api_key(&config, "openai", "OPENAI_API_KEY")
-                    .context("OPENAI_API_KEY not set and not found in config")?;
-                // GAR-576: honor config.llm[*].model when --model not supplied.
-                let model = resolve_provider_model(&config, "openai", model_override.as_deref())
-                    .unwrap_or_else(|| "gpt-4o".to_string());
-                let op = OpenAiProvider::new(&key, Some(model.clone()), None);
-                model_name = model;
-                provider_name = "openai".to_string();
-                provider = Arc::new(op);
-            }
-            "openrouter" => {
-                let key = get_api_key(&config, "openrouter", "OPENROUTER_API_KEY")
-                    .context("OPENROUTER_API_KEY not set and not found in config")?;
-                // GAR-576: honor config.llm[*].model when --model not supplied
-                // (fixes the openrouter/auto hardcode that ignored
-                // config-declared models like openrouter/free).
-                let model =
-                    resolve_provider_model(&config, "openrouter", model_override.as_deref())
-                        .unwrap_or_else(|| "openrouter/auto".to_string());
-                let op = OpenAiProvider::new(
-                    &key,
-                    Some(model.clone()),
-                    Some("https://openrouter.ai/api/v1".to_string()),
-                );
-                model_name = model;
-                provider_name = "openrouter".to_string();
-                provider = Arc::new(op);
-            }
-            other => {
-                anyhow::bail!(
-                    "Provider desconhecido: {other}. Use: ollama, anthropic, openai, openrouter"
-                );
-            }
-        }
+        // GAR-579: shared with `garra ask` — the explicit-provider path
+        // now lives in `select_explicit_provider` so chat and ask agree
+        // byte-for-byte on construction + model resolution + error msgs.
+        let (name, model, prov) =
+            select_explicit_provider(&config, p.as_str(), model_override.as_deref())?;
+        provider_name = name;
+        model_name = model;
+        provider = prov;
     } else if let Some(ref m) = model_override {
         model_name = m.clone();
     }

--- a/crates/garraia-cli/src/main.rs
+++ b/crates/garraia-cli/src/main.rs
@@ -1,3 +1,4 @@
+mod ask;
 mod banner;
 mod chat;
 mod config_cmd;
@@ -164,6 +165,38 @@ enum Commands {
         /// Custom LLM endpoint URL (for LM Studio, vLLM, etc.)
         #[arg(long, short = 'u')]
         url: Option<String>,
+    },
+
+    /// Non-interactive AI query — single message in, single answer out
+    /// (GAR-579). LLM-only, no tools registered, no banner, no ANSI.
+    Ask {
+        /// Message to send. If absent, reads from stdin (64 KiB cap).
+        message: Option<String>,
+
+        /// Override provider (ollama, anthropic, openai, openrouter)
+        #[arg(long, short = 'p')]
+        provider: Option<String>,
+
+        /// Override model name
+        #[arg(long, short = 'm')]
+        model: Option<String>,
+
+        /// Custom LLM endpoint URL (for LM Studio, vLLM, etc.)
+        #[arg(long, short = 'u')]
+        url: Option<String>,
+
+        /// Emit a single-line JSON envelope (`garra.ask.v1`) on stdout.
+        #[arg(long)]
+        json: bool,
+
+        /// LLM call timeout in seconds. Default 60, range [1, 600].
+        /// Exceeding the timeout returns exit code 124.
+        #[arg(long, default_value_t = 60, value_parser = clap::value_parser!(u64).range(1..=600))]
+        timeout_secs: u64,
+
+        /// Override the system prompt with an inline string.
+        #[arg(long)]
+        system_prompt: Option<String>,
     },
 
     /// Inspect, validate, and diagnose the effective configuration
@@ -1195,6 +1228,35 @@ async fn async_main(
             url,
         } => {
             chat::run_chat(config, provider, model, url).await?;
+        }
+        Commands::Ask {
+            message,
+            provider,
+            model,
+            url,
+            json,
+            timeout_secs,
+            system_prompt,
+        } => {
+            // GAR-579: ask is non-interactive; tracing init kept off the
+            // stdout/stderr path (`init_tracing` writes to file + stderr
+            // and would pollute machine-readable output when --json is on).
+            // We still initialize because other crates may log warnings.
+            init_tracing(&effective_level);
+            let code = ask::run_ask(
+                config,
+                message,
+                provider,
+                model,
+                url,
+                json,
+                timeout_secs,
+                system_prompt,
+            )
+            .await?;
+            if code != 0 {
+                std::process::exit(code);
+            }
         }
         Commands::Config { .. } => {
             // Handled earlier in `main()` — the `config check` path must run

--- a/docs/cli-ask.md
+++ b/docs/cli-ask.md
@@ -1,0 +1,176 @@
+# `garra ask` — Non-interactive AI query
+
+> GAR-579 — single message in, single answer out. LLM-only (no tools).
+> Designed for Claude Code, CI, hooks, scripts, and future MCP wrappers.
+
+`garra ask` is the **non-interactive** counterpart to `garra chat`. It
+takes one message, returns one answer, and exits with a sysexits-style
+code. No banner, no ANSI escapes, no `voce >` / `garra >` prompts —
+stdout is the answer (or a `garra.ask.v1` JSON envelope when `--json`).
+
+## Surface
+
+| Comando | stdout | Exit |
+|---------|--------|------|
+| `garra ask "ping"` | resposta como texto puro | `0` |
+| `garra ask --json "ping"` | linha JSON `garra.ask.v1` | `0` |
+| `garra ask --provider openrouter "ping"` | usa modelo do `config.yml` (precedência GAR-576) | `0` |
+| `garra ask --provider openrouter --model openrouter/auto "ping"` | usa `openrouter/auto` explícito | `0` |
+| `echo "ping" \| garra ask` | lê stdin (cap 64 KiB) quando arg posicional ausente | `0` |
+| `garra ask ""` (arg vazio) | erro claro em stderr (ou JSON em stdout se `--json`) | `2` |
+| `garra ask --timeout-secs 1 "msg lenta"` | erro timeout | `124` |
+| provider auth/network falha | erro `provider_error` com mensagem sanitizada | `69` |
+
+## Flags
+
+| Flag | Default | Descrição |
+|------|---------|-----------|
+| `--provider`, `-p <kind>` | autodetect | `ollama` \| `anthropic` \| `openai` \| `openrouter` |
+| `--model`, `-m <name>` | resolve via config (GAR-576) | sobrescreve modelo (precedência absoluta) |
+| `--url`, `-u <url>` | — | endpoint custom (LM Studio, vLLM, etc.) |
+| `--json` | `false` | emit JSON envelope em stdout |
+| `--timeout-secs <N>` | `60` | range `[1, 600]`; excede → exit `124` |
+| `--system-prompt <STR>` | minimum default | sobrescreve system prompt inline |
+
+## JSON envelope (`schema: garra.ask.v1`)
+
+**Sucesso**:
+
+```json
+{
+  "schema": "garra.ask.v1",
+  "ok": true,
+  "answer": "GAR-ASK-OK",
+  "provider": "openrouter",
+  "model": "openrouter/free",
+  "latency_ms": 1234
+}
+```
+
+**Erro**:
+
+```json
+{
+  "schema": "garra.ask.v1",
+  "ok": false,
+  "error": {
+    "kind": "provider_error",
+    "message": "401 Unauthorized — key sk-or-v1-[REDACTED] invalid"
+  }
+}
+```
+
+`error.kind` é estável: `usage`, `no_provider`, `provider_error`,
+`timeout`, `io`. Strings podem ser parseadas por scripts.
+
+## Exit codes
+
+| Code | Significado |
+|------|-------------|
+| `0` | sucesso |
+| `2` | erro de uso (mensagem vazia, stdin acima do cap, etc.) |
+| `65` | arquivo de config inválido (`EX_DATAERR`) — reservado, propagado pela inicialização |
+| `69` | provider indisponível, auth, network (`EX_UNAVAILABLE`) |
+| `74` | falha de I/O ao ler stdin (`EX_IOERR`) |
+| `124` | LLM excedeu `--timeout-secs` (convenção Unix `timeout(1)`) |
+
+## Resolução de provider e model
+
+Idêntica ao `garra chat` — ver
+[`docs/configuration.md` §"Provider / model resolution precedence"](configuration.md#provider--model-resolution-precedence) (GAR-576):
+
+1. `--model <X>` (precedência absoluta).
+2. `config.llm[<key>].model` (key match).
+3. Primeiro `config.llm[*]` cujo `provider:` casa.
+4. Fallback hardcoded por kind.
+
+Para provider:
+
+1. `--provider <X>` (precedência absoluta).
+2. `config.agent.default_provider`.
+3. Cadeia autodetect (Ollama health → Anthropic env → OpenAI env → OpenRouter env).
+
+## Exemplos
+
+### Smoke barato (recomendado para CI / testes)
+
+```bash
+garra ask --provider openrouter --model openrouter/free \
+  --json --timeout-secs 30 "Responda apenas: GAR-ASK-OK"
+```
+
+Saída (uma linha):
+
+```json
+{"schema":"garra.ask.v1","ok":true,"answer":"GAR-ASK-OK","provider":"openrouter","model":"openrouter/free","latency_ms":1432}
+```
+
+### Tarefa real (uso humano)
+
+```bash
+garra ask --provider openrouter --model openrouter/auto \
+  "Explique em uma frase o que é o GarraIA."
+```
+
+Saída (texto puro, sem banner):
+
+```
+O GarraIA é um gateway de IA multi-canal escrito em Rust que orquestra LLMs
+via Telegram, Discord, Slack, WhatsApp e API REST.
+```
+
+### Stdin pipeline
+
+```bash
+cat README.md | garra ask --json --provider openrouter \
+  --system-prompt "Resuma em 3 bullets." -m openrouter/free
+```
+
+### Em scripts / Claude Code / MCP
+
+```bash
+RESULT=$(garra ask --json --provider openrouter -m openrouter/free \
+  --timeout-secs 30 "$prompt")
+ANSWER=$(echo "$RESULT" | jq -r '.answer // .error.message')
+```
+
+## Tools e segurança
+
+`garra ask` é **LLM-only**. Tool registration (`bash`, `file_read`,
+`file_write`, `git_diff`) está **ausente** do runtime por design.
+Auditável via teste `ask_module_never_registers_a_tool` que escaneia o
+código de produção em build time.
+
+Suporte a tools com allowlist + auditoria entra em PR separado
+(eg. `GAR-579+`); requer security-auditor.
+
+## Segurança operacional
+
+- Response body de erro do provider passa por
+  `sanitize_provider_error` antes de virar JSON ou stderr —
+  fingerprints `sk-…` / `sk-or-v1-…` são redactionados a
+  `[REDACTED]`, mensagens longas truncadas em 512 caracteres.
+- Stdin é lido até 64 KiB; input maior retorna `usage` error (exit 2),
+  não trunca silenciosamente.
+- Sem `panic!` em paths de I/O / provider / network — todos os erros
+  voltam pelo enum `AskError` e viram exit code previsível.
+- Defesa em profundidade: `RedactingWriter` provider-aware fica em PR
+  dedicado de `garraia-security`.
+
+## Não está aqui
+
+PRs separados manterão escopo limpo:
+
+- `--stream` para emit incremental.
+- `--enable-tools` + tool allowlist + auditoria.
+- `--system-prompt-file <PATH>`.
+- MCP server wrapper expondo `ask` como tool MCP.
+- `--session <id>` para continuação de conversa.
+- Automatic `openrouter/free → openrouter/auto` fallback.
+
+## Ver também
+
+- [`docs/configuration.md`](configuration.md) — provider/model resolution (GAR-576).
+- [`docs/src/providers.md`](src/providers.md) — OpenRouter cost policy.
+- `plans/0098-gar-576-cli-openrouter-model-respect.md` — base já estável.
+- `plans/0099-gar-579-cli-non-interactive-ask.md` — este PR.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -262,6 +262,11 @@ garra chat --provider openrouter --model openrouter/auto
 There is no automatic `free → auto` upgrade — paid traffic always
 requires an explicit `--model` flag.
 
+> GAR-579 — esta mesma precedência é consumida por
+> [`garra ask`](cli-ask.md), o comando não-interativo. Tanto `garra chat`
+> quanto `garra ask` compartilham `chat::select_explicit_provider` /
+> `chat::detect_provider`, então o comportamento é byte-equivalente.
+
 ## Hot Reload
 
 Configuration changes in `config.yml` are applied automatically:

--- a/plans/0099-gar-579-cli-non-interactive-ask.md
+++ b/plans/0099-gar-579-cli-non-interactive-ask.md
@@ -1,0 +1,226 @@
+# Plan 0099 — GAR-579: CLI `garra ask` non-interactive command
+
+**Status:** Em execução
+**Autor:** Claude Opus 4.7 (sessão interativa 2026-05-11, America/New_York)
+**Data:** 2026-05-11 (America/New_York)
+**Issue:** [GAR-579](https://linear.app/chatgpt25/issue/GAR-579/cli-add-non-interactive-garra-ask-command)
+**Branch:** `routine/202605110709-gar-579-cli-non-interactive-ask`
+**Epic:** `epic:cli`
+**Parent:** —
+**Builds on:** [GAR-576](https://linear.app/chatgpt25/issue/GAR-576) / [PR #263](https://github.com/michelbr84/GarraRUST/pull/263) — provider/model resolution
+
+---
+
+## §1 Goal
+
+Add a non-interactive `garra ask` subcommand suitable for Claude Code, CI, hooks, scripts, and future MCP integration. The interactive `garra chat` REPL stays untouched; `ask` is a separate channel with a parseable contract.
+
+Scope cuts approved by user 2026-05-11 (4 of 4):
+
+1. **No `--stream`** — JSON one-shot covers all consumers. Streaming → PR v2.
+2. **No `--enable-tools`** — `ask` is LLM-only. Tools (bash/file_read/file_write/git_diff) need allowlist + audit + security-auditor in a dedicated PR.
+3. **No `--system-prompt-file`** — only `--system-prompt <STR>` inline.
+4. **Minimum visibility surface** — expose at most 3 helpers from `chat.rs` as `pub(crate)`; if that grows, prefer a small `provider_resolution.rs` module (not in this PR).
+
+---
+
+## §2 Surface
+
+| # | Comando | stdout | Exit |
+|---|---------|--------|------|
+| A | `garra ask "ping"` | resposta texto (sem banner, sem ANSI) | 0 |
+| B | `garra ask --json "ping"` | linha JSON `garra.ask.v1` | 0 |
+| C | `garra ask --provider openrouter "ping"` | usa modelo do config (GAR-576) | 0 |
+| D | `garra ask --provider openrouter --model openrouter/auto "ping"` | usa auto | 0 |
+| E | `echo "ping" \| garra ask` | lê stdin (cap 64 KiB) | 0 |
+| F | `garra ask ""` (arg vazio) | erro claro, sem stack trace | 2 |
+| G | `garra ask --timeout-secs 1 "msg"` (lento) | erro timeout | 124 |
+| H | provider auth falha | erro JSON com `kind="provider_error"` | 69 |
+
+Flags aceitas: `--json`, `--provider/-p`, `--model/-m`, `--url/-u`, `--timeout-secs` (default 60, range [1, 600]), `--system-prompt <STR>`.
+
+Defaults invariantes:
+- Tools **NUNCA** registrados em `ask` (zero `AgentRuntime::register_tool` no path do ask).
+- Banner **NUNCA** impresso.
+- ANSI escapes **NUNCA** em stdout.
+- System prompt mínimo (sem scan de diretório, sem persona).
+- `--model` tem precedência absoluta sobre config.
+
+---
+
+## §3 Design invariants
+
+1. **Reuso de GAR-576**. Provider/model resolution já implementado; expor o mínimo via `pub(crate)` e chamar de `ask.rs`.
+2. **Sem nova dep**. Nenhum item em `[dependencies]` ou `[dev-dependencies]`.
+3. **Pure tests**. `ask::tests` não toca rede, env-var-mutation, ou filesystem (exceto via `Cursor` em memória).
+4. **Sem fingerprint de secret em erro**. Response body de erro do provider passa por sanitização básica (`sk-`, `sk-or-v1-` → redacted) antes de virar JSON.
+5. **Stdin cap**. 64 KiB hard limit para evitar OOM por pipe malicioso/acidental.
+6. **Timeout cap**. `--timeout-secs` clamp [1, 600] via clap range.
+7. **Single-PR scope**. Nada de MCP, tools, stream, file-based prompt, RedactingWriter extension.
+
+---
+
+## §4 Code changes
+
+### `crates/garraia-cli/src/chat.rs` — visibility flip + extração mínima
+
+Promover de privado para `pub(crate)` (alvo: 3 itens, não mais):
+
+- `detect_provider` — já documentado, usado pelo autodetect path do ask.
+- `select_explicit_provider` — nova função extraída do match `match p.as_str()` em `run_chat` (4 arms ollama/anthropic/openai/openrouter). Retorna `Result<(String, String, Arc<dyn LlmProvider>)>`.
+- `build_url_override_provider` — nova função extraída do bloco `if let Some(url) = url_override` em `run_chat` / `detect_provider`. Retorna `(String, String, Arc<dyn LlmProvider>)`.
+
+`run_chat` é refatorado para chamar essas funções em vez de duplicar lógica. Comportamento preservado (testes GAR-576 + smoke verificam).
+
+### `crates/garraia-cli/src/ask.rs` — novo módulo
+
+```rust
+pub async fn run_ask(
+    config: AppConfig,
+    message: Option<String>,
+    provider_override: Option<String>,
+    model_override: Option<String>,
+    url_override: Option<String>,
+    json: bool,
+    timeout_secs: u64,
+    system_prompt: Option<String>,
+) -> Result<i32>;  // returns exit code; caller std::process::exit's
+
+#[derive(Debug)]
+pub(crate) enum AskError {
+    UsageError(String),       // → 2
+    NoProvider(String),       // → 69
+    ProviderError(String),    // → 69
+    Timeout(u64),             // → 124
+    IoError(String),          // → 74
+}
+
+impl AskError {
+    fn exit_code(&self) -> i32 { ... }
+    fn kind_str(&self) -> &'static str { ... }
+}
+```
+
+Fluxo:
+1. Resolver `message`: arg posicional > stdin (cap 64 KiB) > erro vazio.
+2. Resolver provider:
+   - Se `url_override`: `chat::build_url_override_provider`.
+   - Senão se `provider_override`: `chat::select_explicit_provider`.
+   - Senão: `chat::detect_provider`.
+3. Construir `AgentRuntime` **sem tools** (LLM-only).
+4. Set system_prompt (do flag ou default mínimo).
+5. Wrap chamada LLM em `tokio::time::timeout(Duration::from_secs(timeout_secs), ...)`.
+6. Em sucesso: emit resposta (text ou JSON) em stdout; retornar 0.
+7. Em erro: emit JSON envelope (se `--json`) ou mensagem humana em stderr; retornar exit code.
+
+### `crates/garraia-cli/src/main.rs` — wiring
+
+- `mod ask;`
+- Novo variant em `Commands`:
+  ```rust
+  /// Non-interactive AI query — single message in, single answer out.
+  Ask {
+      /// Message to send. If absent, reads from stdin (64 KiB cap).
+      message: Option<String>,
+      #[arg(long, short = 'p')] provider: Option<String>,
+      #[arg(long, short = 'm')] model: Option<String>,
+      #[arg(long, short = 'u')] url: Option<String>,
+      #[arg(long)] json: bool,
+      #[arg(long, default_value_t = 60, value_parser = clap::value_parser!(u64).range(1..=600))]
+      timeout_secs: u64,
+      #[arg(long)] system_prompt: Option<String>,
+  },
+  ```
+- Match arm em `async_main`: dispatcher to `ask::run_ask`; respect exit code via `std::process::exit`.
+
+### Tests (em `ask.rs::tests`)
+
+Todos puros, sem rede, sem env-mutation:
+
+1. `ask_error_exit_codes_match_doc` — table-driven, asserts each variant.
+2. `ask_error_kind_str_stable` — JSON kind labels are stable strings.
+3. `json_envelope_success_shape` — `garra.ask.v1`, ok=true, answer/provider/model/latency_ms present.
+4. `json_envelope_error_shape` — ok=false, error.kind, error.message.
+5. `resolve_message_arg_wins_over_stdin` — passing message + stdin: arg wins.
+6. `resolve_message_uses_stdin_when_arg_absent` — uses `Cursor` to mock stdin.
+7. `resolve_message_empty_returns_usage_error` — empty arg + empty stdin → UsageError.
+8. `resolve_message_stdin_capped_at_64kib` — oversized input → UsageError (or truncated, design choice; pick UsageError for safety).
+9. `sanitize_provider_error_redacts_key_fingerprints` — `"sk-or-v1-abc"` and `"sk-proj-…J-QA"` replaced with `[REDACTED]` before JSON emit.
+
+### Docs
+
+- `docs/cli-ask.md` (novo, ~90 LOC) — surface, JSON schema, exit codes, examples.
+- `docs/configuration.md` — 4 linhas de nota cruzada na seção "Provider/model resolution precedence" (GAR-576).
+- `docs/src/SUMMARY.md` — 1 linha de link.
+- `README.md` — 3 linhas no exemplo de uso CLI.
+
+---
+
+## §5 Verification
+
+Comandos obrigatórios (mesmo gate do CI, ci.yml:54):
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings
+cargo test -p garraia --bin garra
+cargo build --release --bin garra
+```
+
+Smoke (manual, `openrouter/free` apenas):
+
+```bash
+GARRAIA_CONFIG_DIR=$HOME/.garraia ./target/release/garra.exe ask \
+  --provider openrouter --model openrouter/free --json --timeout-secs 30 \
+  "Responda apenas: GAR-ASK-OK"
+```
+
+Acceptance (deve passar antes do merge):
+
+- Stdout = uma linha JSON válida `{"schema":"garra.ask.v1","ok":true,"answer":"GAR-ASK-OK",...}`.
+- Exit 0.
+- Nenhuma sequência ANSI no output (`grep $'\033'` returns nothing).
+- `cargo test` 38 (GAR-576) + 9 (novos) = 47 passing.
+- Zero nova dep em `Cargo.toml`.
+
+`openrouter/auto` **NÃO** executado neste smoke. Só se `free` falhar e a razão for documentada antes.
+
+---
+
+## §6 Risks
+
+- **Médio**: clap `value_parser!(u64).range(1..=600)` precisa de clap >= 4.something — workspace já usa, verificar antes.
+- **Médio**: stdin reading via `tokio::io::stdin().read_to_end(&mut buf)` pode travar se for TTY interativo (sem EOF). Mitigação: detectar TTY via `atty::is(Stream::Stdin)` e exigir argumento posicional nesse caso. **Decisão**: tentar sem `atty` primeiro (sem nova dep). Se mostrar problema, adicionar dep ou usar `IsTerminal` da std (1.70+, workspace MSRV 1.92 → disponível).
+- **Baixo**: timeout cancela o future do provider mas sockets HTTP podem demorar para fechar. `tokio::time::timeout` é o mecanismo correto; dropar o `Arc<dyn LlmProvider>` ao timeout libera recursos.
+- **Baixo**: sanitização regex pode ter false-negatives (formatos novos de chave). Defesa em profundidade, não única linha. `RedactingWriter` real fica para PR separado.
+
+Segurança:
+- Tools NUNCA registrados — auditável via `grep -n register_tool crates/garraia-cli/src/ask.rs` → 0 hits.
+- `--enable-tools` flag não existe — auditável via `grep enable.tools` → 0 hits.
+- Resposta de erro do provider sanitizada antes de virar JSON — coberto pelo teste 9.
+
+---
+
+## §7 Out of scope (follow-ups)
+
+Mantidos como follow-ups separados (alinhado com lista do usuário "Eu não faria agora"):
+
+1. `--stream` flag — PR v2 depois deste.
+2. `--enable-tools` + tool allowlist + auditoria — PR dedicado com `security-auditor`.
+3. `--system-prompt-file` — PR pequeno depois.
+4. MCP wrapper sobre `garra ask` — GAR-N+1, bloqueado por este PR.
+5. `RedactingWriter` extension para payload de erro de provider — issue separada.
+6. Automatic `openrouter/free → openrouter/auto` fallback — decisão de custo de tokens.
+7. `dotenvy::dotenv_override(false)` ou opt-in para `.env` loading.
+8. `GARRAIA_CONFIG_DIR=/custom/config/path` fantasma config — issue separada.
+9. `.env` operator-side edits — decisão do operador.
+10. Integration test com OpenRouter real em CI — gasta tokens, mantido manual.
+11. `garra ask --session <id>` — continuação via `SessionStore`, v2.
+
+---
+
+## §8 Commit shape
+
+- Commit title: `feat(cli): add non-interactive garra ask command`
+- Conventional commits, NOT breaking (adição pura).
+- Single commit preferred (squash on merge), but split if CodeQL drama exige refactor pós-CI (mesmo padrão do GAR-576).


### PR DESCRIPTION
## Summary

- `garra ask "msg"` — non-interactive AI query. Single message in, single answer out. No banner, no ANSI, no REPL prompts.
- `garra ask --json` — single-line `garra.ask.v1` envelope on stdout. Stable schema for Claude Code / CI / scripts / future MCP.
- Reuses GAR-576 provider/model resolution via `chat::detect_provider` and the new `chat::select_explicit_provider` helper.
- LLM-only (no tools). 15 new pure unit tests including an audit test that scans production code for tool-registration patterns.

## Linear

[GAR-579](https://linear.app/chatgpt25/issue/GAR-579/cli-add-non-interactive-garra-ask-command).

## Plan

`plans/0099-gar-579-cli-non-interactive-ask.md`.

## Scope cuts approved 2026-05-11

1. **No `--stream`** — JSON one-shot covers all consumers; streaming → PR v2.
2. **No `--enable-tools`** — `ask` is LLM-only; tools (`bash`/`file_*`/`git_diff`) need allowlist + audit + security review in a dedicated PR.
3. **No `--system-prompt-file`** — only `--system-prompt <STR>` inline.
4. **Minimum visibility surface** — ONE new `pub(crate)` function (`select_explicit_provider`). `detect_provider` was already `pub`. No new module, no large refactor.

## Flags

| Flag | Default | Notes |
|------|---------|-------|
| `--json` | false | single-line JSON `garra.ask.v1` |
| `--provider/-p <kind>` | autodetect | `ollama` / `anthropic` / `openai` / `openrouter` |
| `--model/-m <name>` | from config (GAR-576) | absolute precedence over config |
| `--url/-u <url>` | — | LM Studio / vLLM endpoint |
| `--timeout-secs <N>` | 60 | range [1, 600]; exceeds → exit 124 |
| `--system-prompt <STR>` | minimal default | inline only |

## Exit codes

`0` ok / `2` usage / `65` config / `69` provider / `74` io / `124` timeout.

## JSON envelope (`schema: garra.ask.v1`)

```json
{ "schema": "garra.ask.v1", "ok": true,  "answer": "...", "provider": "openrouter", "model": "openrouter/free", "latency_ms": 1234 }
{ "schema": "garra.ask.v1", "ok": false, "error": { "kind": "timeout|usage|no_provider|provider_error|io", "message": "..." } }
```

## Security

- **No tool registered** in `AgentRuntime` in `ask` path. Enforced at test time by `ask_module_never_registers_a_tool` (scans production code for `register_tool|BashTool|FileReadTool|FileWriteTool|GitDiffTool`).
- Provider errors pass through `sanitize_provider_error` (regex-based redaction of `sk-…` and `sk-or-v1-…` fingerprints + 512-char truncation) before stdout/stderr.

## Test plan

- [x] `cargo fmt --all -- --check` exit 0.
- [x] `cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings` exit 0 (CI invocation, ci.yml:54).
- [x] `cargo test -p garraia --bin garra` — **53/53** (15 new ask::tests + 12 chat::tests from GAR-576 + 22 main/migrate_workspace/config_cmd).
- [x] `cargo build --release --bin garra` exit 0.
- [x] Smoke (release binary, `openrouter/free` ONLY) — error path verified: exit 69 with valid JSON envelope. Success path blocked by transient Windows TLS revocation hiccup (`CRYPT_E_NO_REVOCATION_CHECK`, unrelated). Will revalidate post-merge from a cleaner network.
- [ ] CI green (Format, Clippy, Test mac/linux/win, Security Audit, cargo-deny, Build, Coverage, E2E, Playwright, MSRV, Analyze rust+js-ts, Quality Ratchet, Dependency Review, Secret Scan, CodeQL).

## Behavior changes

- New subcommand `garra ask`. Existing `garra chat` REPL untouched (the refactor that extracts `select_explicit_provider` from `run_chat` preserves byte-equivalent semantics; GAR-576 chat smoke still passes on this branch).

## Out of scope (separate follow-ups)

- `--stream` (PR v2)
- `--enable-tools` + tool allowlist + audit (PR dedicated; security-auditor required)
- `--system-prompt-file`
- MCP wrapper over `garra ask`
- `RedactingWriter` extension to cover provider error payloads
- Automatic `openrouter/free → openrouter/auto` fallback
- `--session <id>` continuation
- `.env` / `dotenvy` / `GARRAIA_CONFIG_DIR` operator-side fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)