### PR TITLE
fix(cli): name OpenRouter provider explicitly to silence runtime WARN

### DIFF
--- a/crates/garraia-cli/src/chat.rs
+++ b/crates/garraia-cli/src/chat.rs
@@ -329,7 +329,11 @@ async fn try_build_default_provider(
                 .base_url
                 .clone()
                 .unwrap_or_else(|| "https://openrouter.ai/api/v1".to_string());
-            let op = OpenAiProvider::new(&key, Some(model.to_string()), Some(base));
+            // GAR-582: name the provider "openrouter" so AgentRuntime's
+            // lookup-by-name resolves correctly. Without this, the runtime
+            // emits `WARN Provider 'openrouter' not found, falling back to default`.
+            let op = OpenAiProvider::new(&key, Some(model.to_string()), Some(base))
+                .with_name("openrouter");
             Some(Arc::new(op) as Arc<dyn LlmProvider>)
         }
         _ => None,
@@ -391,11 +395,14 @@ pub(crate) fn select_explicit_provider(
                 .context("OPENROUTER_API_KEY not set and not found in config")?;
             let model = resolve_provider_model(config, "openrouter", model_override)
                 .unwrap_or_else(|| "openrouter/auto".to_string());
+            // GAR-582: name the provider "openrouter" so AgentRuntime's
+            // lookup-by-name resolves correctly (avoids WARN at request time).
             let op = OpenAiProvider::new(
                 &key,
                 Some(model.clone()),
                 Some("https://openrouter.ai/api/v1".to_string()),
-            );
+            )
+            .with_name("openrouter");
             Ok((
                 "openrouter".to_string(),
                 model,
@@ -523,11 +530,14 @@ pub async fn detect_provider(
             .and_then(|c| c.model.as_deref())
             .unwrap_or("openrouter/auto")
             .to_string();
+        // GAR-582: name the provider "openrouter" so AgentRuntime's
+        // lookup-by-name resolves correctly (avoids WARN at request time).
         let provider = OpenAiProvider::new(
             &key,
             Some(model.clone()),
             Some("https://openrouter.ai/api/v1".to_string()),
-        );
+        )
+        .with_name("openrouter");
         return (
             "openrouter".to_string(),
             model,

--- a/plans/0101-gar-582-cli-openrouter-provider-name.md
+++ b/plans/0101-gar-582-cli-openrouter-provider-name.md
@@ -1,0 +1,109 @@
+# Plan 0101 — GAR-582: name OpenRouter provider explicitly in chat.rs
+
+**Status:** Em execução
+**Autor:** Claude Opus 4.7 (sessão interativa 2026-05-11, America/New_York)
+**Data:** 2026-05-11 (America/New_York)
+**Issue:** [GAR-582](https://linear.app/chatgpt25/issue/GAR-582)
+**Branch:** `routine/202605110956-gar-581-cli-openrouter-provider-name`
+**Epic:** `epic:cli`
+**Parent:** —
+**Builds on:** GAR-576 (PR #263), GAR-579 (PR #267)
+
+> Branch name retains the `gar-581` prefix because the issue was opened
+> as GAR-581 in this session's prompt; Linear then assigned the next
+> available number (`GAR-582`) since 580/581 were already taken. The
+> plan + commit reference the actual ID `GAR-582`.
+
+---
+
+## §1 Goal
+
+Eliminate the runtime WARN observed during the GAR-579 smoke test:
+
+```
+WARN garraia_agents::runtime: Provider 'openrouter' not found, falling back to default
+```
+
+Trivial 3-LOC fix in `crates/garraia-cli/src/chat.rs` — chain
+`.with_name("openrouter")` onto every `OpenAiProvider::new(...)` whose
+`base_url` points at OpenRouter. Same pattern already used for LM
+Studio at `chat.rs:174` (`.with_name("lmstudio")`).
+
+---
+
+## §2 Cause
+
+`OpenAiProvider::new(_, _, _)` defaults its internal `name()` to
+`"openai"`. When `AgentRuntime` later resolves a provider by name —
+because we registered it and want to address it by the same string —
+the lookup misses for `"openrouter"` and the runtime emits the WARN +
+silently uses its default provider. The HTTP request still routes
+correctly (via `base_url`), so the call works; only the log output is
+noisy and the internal lookup is wrong.
+
+Three call sites:
+
+1. `chat::detect_provider` step 4 (autodetect openrouter, ~line 234).
+2. `chat::select_explicit_provider` `"openrouter"` arm (~line 397, GAR-579).
+3. `chat::try_build_default_provider` `"openrouter"` arm (~line 329, GAR-576).
+
+---
+
+## §3 Change
+
+```rust
+let op = OpenAiProvider::new(
+    &key,
+    Some(model.clone()),
+    Some("https://openrouter.ai/api/v1".to_string()),
+)
+.with_name("openrouter");
+```
+
+Three identical chains. No other changes.
+
+---
+
+## §4 Design invariants
+
+1. **No behavior change to HTTP path** — `base_url` already correct, request still goes to `openrouter.ai/api/v1/chat/completions`.
+2. **No new dependency**.
+3. **No change to LM Studio / OpenAI / Anthropic / Ollama paths** — they already either have correct naming (`with_name("lmstudio")`) or use a default that matches their kind.
+4. **No new tests required** — smoke validation is the regression check. Existing 53 unit tests must pass unchanged.
+5. **Single-commit scope** — `fix(cli): …`, NOT breaking.
+
+---
+
+## §5 Verification
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings
+cargo test -p garraia --bin garra
+cargo build --release --bin garra
+```
+
+Smoke (cheap, `openrouter/free` only — `openrouter/auto` NOT executed):
+
+```bash
+GARRAIA_CONFIG_DIR="$HOME/.garraia" ./target/release/garra.exe ask \
+  --provider openrouter --model openrouter/free \
+  --json --timeout-secs 30 "Responda apenas: GAR-ASK-OK" \
+  >stdout.txt 2>stderr.txt
+```
+
+Acceptance:
+- `grep -F "Provider 'openrouter' not found" stderr.txt` → **0 matches** (WARN gone).
+- `stdout.txt` is a single valid line JSON envelope `garra.ask.v1`.
+- No api-key fingerprint in stdout/stderr.
+- If network/TLS still blocks success path, error path JSON envelope remains valid.
+
+---
+
+## §6 Out of scope (follow-ups)
+
+- MCP wrapper over `garra ask` (next slice, GAR-580).
+- `RedactingWriter` extension to cover provider error payloads.
+- Other provider naming inconsistencies (LM Studio explicit `--provider openai --url …` path; custom OpenAI-compat backends in default_provider).
+- `.env` / `dotenvy` / `GARRAIA_CONFIG_DIR` operator-side fixes.
+- Automatic `openrouter/free → openrouter/auto` fallback.


### PR DESCRIPTION
## Summary

- 3 LOC in `crates/garraia-cli/src/chat.rs`: chain `.with_name("openrouter")` onto every `OpenAiProvider::new(...)` whose `base_url` points at OpenRouter.
- Silences the `WARN garraia_agents::runtime: Provider 'openrouter' not found, falling back to default` that was observed on every `garra ask --provider openrouter` invocation since GAR-579.
- Smoke confirms WARN absent + stderr now shows `provider=openrouter` consistently.

## Linear

[GAR-582](https://linear.app/chatgpt25/issue/GAR-582). Branch name keeps `gar-581` prefix because the issue was opened as 581 in the session prompt; Linear assigned the next free ID (582) since 580 and 581 were already taken.

## Plan

`plans/0101-gar-582-cli-openrouter-provider-name.md`.

## Files changed

| File | Change |
|------|--------|
| `crates/garraia-cli/src/chat.rs` | +13 / -3 (3 sites + GAR-582 comments) |
| `plans/0101-gar-582-cli-openrouter-provider-name.md` | new |

Three call sites patched (all openrouter, matching the LM Studio precedent at `chat.rs:174`):

1. `chat::detect_provider` step 4 (autodetect chain).
2. `chat::select_explicit_provider` openrouter arm (GAR-579 helper).
3. `chat::try_build_default_provider` openrouter arm (GAR-576 default path).

## Test plan

- [x] `cargo fmt --all -- --check` → 0.
- [x] `cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings` → 0 (CI invocation, ci.yml:54).
- [x] `cargo test -p garraia --bin garra` → 53/53 (unchanged from GAR-579 baseline).
- [x] `cargo build --release --bin garra` → 0.
- [x] Smoke (release binary, `openrouter/free` only — `openrouter/auto` NOT executed):
  - `grep -F "Provider 'openrouter' not found" stderr` → **0 matches** (WARN gone).
  - stderr now shows `INFO registered LLM provider: openrouter` + `INFO Resolved provider 'openrouter' from model override 'openrouter/free'` + `INFO Sending LlmRequest to provider=openrouter`.
  - stdout: single-line JSON envelope `garra.ask.v1`, parseable, schema correct.
  - Success path still blocked by transient Windows TLS revocation hiccup (`CRYPT_E_NO_REVOCATION_CHECK`, unrelated); error path JSON envelope remains valid (`ok:false`, `error.kind:provider_error`, `exit:69`).
  - No api-key fingerprint in any stream (audited via `grep -Ec 'sk-[A-Za-z0-9_-]{8,}|sk-or-v1-'` → 0 in both).
- [ ] CI green.

## Behavior changes

- Only the internal `LlmProvider::name()` string changes from `"openai"` → `"openrouter"` for OpenRouter-backed providers.
- HTTP request URL (`https://openrouter.ai/api/v1/chat/completions`) is unchanged — already correct via `base_url`.
- No public API change. No new dependency. No schema change.

## Out of scope (separate follow-ups)

- MCP wrapper over `garra ask` (next slice).
- `RedactingWriter` extension for provider error payloads.
- Other provider naming inconsistencies (LM Studio explicit `--provider openai --url` path, custom OpenAI-compat backends in `default_provider`).
- `.env` / `dotenvy` / `GARRAIA_CONFIG_DIR` operator-side fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)