### PR TITLE
feat(cli): add MCP server exposing garra ask as stdio tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3354,6 +3354,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "ring",
+ "rmcp",
  "rusqlite",
  "secrecy 0.10.3",
  "serde",

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ cargo build --release -p garraia
 ./target/release/garra ask --provider openrouter --model openrouter/free \
   --json --timeout-secs 30 "Responda apenas: GAR-ASK-OK"
 
+# MCP server stdio (GAR-583) — expõe `garra_ask` para Claude Desktop / Claude Code
+./target/release/garra mcp-server   # ver docs/cli-mcp-server.md
+
 # Opcional: incluir suporte a plugins WASM
 cargo build --release -p garraia --features plugins
 ```

--- a/crates/garraia-cli/Cargo.toml
+++ b/crates/garraia-cli/Cargo.toml
@@ -39,6 +39,12 @@ ring = { workspace = true }
 tracing-appender = "0.2.4"
 dotenvy.workspace = true
 
+# GAR-583: MCP server (`garra mcp-server`) exposing `garra_ask` as a stdio
+# tool. Reuses `rmcp` already in the workspace via `garraia-agents` (client
+# side). Adding server + stdio transport features here; `garraia-cli`-scoped
+# dependency so other crates are unaffected.
+rmcp = { workspace = true, features = ["server", "transport-io", "macros"] }
+
 # Plan 0039 — `migrate workspace` deps.
 # Use workspace-pinned versions where available to avoid drift.
 sqlx = { workspace = true, features = ["runtime-tokio-native-tls", "postgres", "uuid", "chrono", "derive"] }

--- a/crates/garraia-cli/src/ask.rs
+++ b/crates/garraia-cli/src/ask.rs
@@ -187,11 +187,167 @@ fn emit_error(err: &AskError, json: bool) -> i32 {
     err.exit_code()
 }
 
+/// GAR-583 — Pure input options for [`ask_oneshot`].
+///
+/// `message` is required (the resolved prompt). Other fields mirror the
+/// CLI flags. Used by both `run_ask` (the CLI wrapper) and the MCP
+/// server's `garra_ask` tool handler. No I/O is performed by code that
+/// consumes this struct directly.
+#[derive(Debug, Clone)]
+pub(crate) struct AskOptions {
+    pub message: String,
+    pub provider_override: Option<String>,
+    pub model_override: Option<String>,
+    pub url_override: Option<String>,
+    pub timeout_secs: u64,
+    pub system_prompt_override: Option<String>,
+}
+
+/// GAR-583 — Pure outcome of [`ask_oneshot`].
+///
+/// Distinguishes the success path (carries answer + provider + model +
+/// latency) from the failure path (carries the typed [`AskError`]).
+/// Callers map this to whatever output format they need: `run_ask`
+/// produces JSON on stdout; the MCP server packs it into a
+/// `CallToolResult` text-content envelope.
+#[derive(Debug, Clone)]
+pub(crate) enum AskOutcome {
+    Success {
+        answer: String,
+        provider: String,
+        model: String,
+        latency_ms: u128,
+    },
+    Failure(AskError),
+}
+
+impl AskOutcome {
+    pub(crate) fn is_ok(&self) -> bool {
+        matches!(self, Self::Success { .. })
+    }
+
+    /// Build the `garra.ask.v1` JSON envelope for this outcome.
+    /// Shape matches `success_envelope` / `error_envelope`.
+    pub(crate) fn to_envelope(&self) -> serde_json::Value {
+        match self {
+            Self::Success {
+                answer,
+                provider,
+                model,
+                latency_ms,
+            } => success_envelope(answer, provider, model, *latency_ms),
+            Self::Failure(err) => error_envelope(err.kind_str(), &err.message()),
+        }
+    }
+
+    /// Process exit code for this outcome. Success → 0; Failure →
+    /// typed [`AskError`] code.
+    ///
+    /// Not currently consumed by `run_ask` (which does its own variant
+    /// match for emission), but kept as part of the public crate API for
+    /// future callers and to give MCP integrators a stable mapping —
+    /// the unit tests `ask_outcome_exit_code_mapping_table_driven`
+    /// exercise it directly.
+    #[allow(dead_code)]
+    pub(crate) fn exit_code(&self) -> i32 {
+        match self {
+            Self::Success { .. } => 0,
+            Self::Failure(err) => err.exit_code(),
+        }
+    }
+}
+
+/// GAR-583 — Pure async core of `garra ask`: builds a provider, calls
+/// the LLM with the configured timeout, and returns the structured
+/// outcome.
+///
+/// **Zero I/O outside of HTTP to the provider**. No `println!`,
+/// `eprintln!`, stdin read, or filesystem access. Callers are
+/// responsible for emitting the [`AskOutcome`] in whatever form they
+/// need (CLI JSON line, MCP `CallToolResult`, etc.).
+///
+/// Invariants:
+///   - **NEVER** registers a tool on the `AgentRuntime` (LLM-only,
+///     same audit invariant from GAR-579).
+///   - Provider errors pass through [`sanitize_provider_error`] before
+///     being returned in the [`AskError`].
+///   - Timeout is enforced via `tokio::time::timeout`; the streaming
+///     channel is drained on a background task so the producer never
+///     blocks on a slow consumer.
+pub(crate) async fn ask_oneshot(config: &AppConfig, opts: AskOptions) -> AskOutcome {
+    let start = Instant::now();
+
+    // 1. Resolve provider.
+    let (provider_name, model_name, provider) = if let Some(ref p) = opts.provider_override {
+        match chat::select_explicit_provider(config, p.as_str(), opts.model_override.as_deref()) {
+            Ok(triple) => triple,
+            Err(e) => {
+                return AskOutcome::Failure(AskError::NoProvider(sanitize_provider_error(
+                    &format!("{e:#}"),
+                )));
+            }
+        }
+    } else {
+        // detect_provider also handles url_override + autodetect chain
+        // (see chat::detect_provider for the precedence rules — GAR-576).
+        chat::detect_provider(config, opts.url_override.as_deref()).await
+    };
+
+    // 2. Build a minimal AgentRuntime — LLM only. NO tool registration.
+    let mut runtime = AgentRuntime::new();
+    runtime.register_provider(provider);
+
+    let system_prompt = opts.system_prompt_override.unwrap_or_else(|| {
+        "Voce e o GarraIA. Responda de forma concisa, direta e no idioma do usuario.".to_string()
+    });
+    runtime.set_system_prompt(system_prompt);
+    runtime.set_max_tokens(4096);
+
+    // 3. Call LLM with timeout. We use the streaming API (no non-streaming
+    //    variant exists today) and drain deltas in a background task so
+    //    the channel never blocks the producer.
+    let session_id = format!("ask-{}", uuid::Uuid::new_v4());
+    let history: Vec<ChatMessage> = Vec::new();
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<String>(256);
+    let drain_handle = tokio::spawn(async move { while rx.recv().await.is_some() {} });
+
+    let call = runtime.process_message_streaming(
+        &session_id,
+        &opts.message,
+        &history,
+        tx,
+        Some(&model_name),
+    );
+    let result = tokio::time::timeout(Duration::from_secs(opts.timeout_secs), call).await;
+
+    // Drop the drain task (channel closure ends it naturally too).
+    drain_handle.abort();
+
+    let latency_ms = start.elapsed().as_millis();
+
+    match result {
+        Ok(Ok(full)) => AskOutcome::Success {
+            answer: full,
+            provider: provider_name,
+            model: model_name,
+            latency_ms,
+        },
+        Ok(Err(e)) => AskOutcome::Failure(AskError::ProviderError(sanitize_provider_error(
+            &format!("{e:#}"),
+        ))),
+        Err(_elapsed) => AskOutcome::Failure(AskError::Timeout(opts.timeout_secs)),
+    }
+}
+
 /// GAR-579 — entry point invoked by `Commands::Ask` in `main.rs`.
 ///
 /// Returns an exit code; the caller is responsible for `std::process::exit`.
 /// Does not panic on provider/network errors — every failure path returns
 /// a sanitized error through `emit_error`.
+///
+/// GAR-583 — refactored as a thin wrapper over [`ask_oneshot`]. Stdin
+/// reading + JSON/text emission stay here; the pure LLM-call core moved
+/// into `ask_oneshot` so the MCP server can reuse it without I/O.
 ///
 /// Invariants:
 ///   - **NEVER** registers a tool on the `AgentRuntime` (LLM-only).
@@ -209,8 +365,6 @@ pub async fn run_ask(
     timeout_secs: u64,
     system_prompt_override: Option<String>,
 ) -> Result<i32> {
-    let start = Instant::now();
-
     // 1. Resolve message — read stdin only if arg absent.
     let stdin_bytes: Vec<u8> = if message_arg.is_none() {
         let mut buf = Vec::with_capacity(8192);
@@ -230,78 +384,38 @@ pub async fn run_ask(
         Err(e) => return Ok(emit_error(&e, json)),
     };
 
-    // 2. Resolve provider.
-    let (provider_name, model_name, provider) = if let Some(ref p) = provider_override {
-        match chat::select_explicit_provider(&config, p.as_str(), model_override.as_deref()) {
-            Ok(triple) => triple,
-            Err(e) => {
-                return Ok(emit_error(
-                    &AskError::NoProvider(sanitize_provider_error(&format!("{e:#}"))),
-                    json,
-                ));
+    // 2. Call the pure core (GAR-583).
+    let opts = AskOptions {
+        message,
+        provider_override,
+        model_override,
+        url_override,
+        timeout_secs,
+        system_prompt_override,
+    };
+    let outcome = ask_oneshot(&config, opts).await;
+
+    // 3. Emit on stdout / stderr per --json flag.
+    match outcome {
+        AskOutcome::Success {
+            answer,
+            provider,
+            model,
+            latency_ms,
+        } => {
+            if json {
+                let env = success_envelope(&answer, &provider, &model, latency_ms);
+                let line = serde_json::to_string(&env).unwrap_or_else(|_| {
+                    String::from("{\"schema\":\"garra.ask.v1\",\"ok\":false,\"error\":{\"kind\":\"io\",\"message\":\"json serialization failed\"}}")
+                });
+                println!("{line}");
+            } else {
+                println!("{}", answer.trim_end());
             }
+            Ok(0)
         }
-    } else {
-        // detect_provider also handles url_override + autodetect chain
-        // (see chat::detect_provider for the precedence rules — GAR-576).
-        chat::detect_provider(&config, url_override.as_deref()).await
-    };
-
-    // 3. Build a minimal AgentRuntime — LLM only. NO tool registration.
-    //    The `ask_module_never_registers_a_tool` test below enforces this
-    //    invariant at compile time by scanning production code for any
-    //    tool-registration patterns.
-    let mut runtime = AgentRuntime::new();
-    runtime.register_provider(provider);
-
-    let system_prompt = system_prompt_override.unwrap_or_else(|| {
-        "Voce e o GarraIA. Responda de forma concisa, direta e no idioma do usuario.".to_string()
-    });
-    runtime.set_system_prompt(system_prompt);
-    runtime.set_max_tokens(4096);
-
-    // 4. Call LLM with timeout. We use the streaming API (no non-streaming
-    //    variant exists today) and drain deltas in a background task so
-    //    the channel never blocks the producer.
-    let session_id = format!("ask-{}", uuid::Uuid::new_v4());
-    let history: Vec<ChatMessage> = Vec::new();
-    let (tx, mut rx) = tokio::sync::mpsc::channel::<String>(256);
-    let drain_handle = tokio::spawn(async move { while rx.recv().await.is_some() {} });
-
-    let call =
-        runtime.process_message_streaming(&session_id, &message, &history, tx, Some(&model_name));
-    let result = tokio::time::timeout(Duration::from_secs(timeout_secs), call).await;
-
-    // Drop the drain task (channel closure ends it naturally too).
-    drain_handle.abort();
-
-    let answer = match result {
-        Ok(Ok(full)) => full,
-        Ok(Err(e)) => {
-            return Ok(emit_error(
-                &AskError::ProviderError(sanitize_provider_error(&format!("{e:#}"))),
-                json,
-            ));
-        }
-        Err(_elapsed) => {
-            return Ok(emit_error(&AskError::Timeout(timeout_secs), json));
-        }
-    };
-
-    let latency_ms = start.elapsed().as_millis();
-
-    // 5. Emit.
-    if json {
-        let env = success_envelope(&answer, &provider_name, &model_name, latency_ms);
-        let line = serde_json::to_string(&env).unwrap_or_else(|_| {
-            String::from("{\"schema\":\"garra.ask.v1\",\"ok\":false,\"error\":{\"kind\":\"io\",\"message\":\"json serialization failed\"}}")
-        });
-        println!("{line}");
-    } else {
-        println!("{}", answer.trim_end());
+        AskOutcome::Failure(err) => Ok(emit_error(&err, json)),
     }
-
-    Ok(0)
 }
 
 #[cfg(test)]
@@ -437,6 +551,70 @@ mod tests {
     fn sanitize_passes_clean_messages_through() {
         let benign = "Connection refused at localhost:11434";
         assert_eq!(sanitize_provider_error(benign), benign);
+    }
+
+    // ─── AskOutcome / AskOptions (GAR-583 refactor) ────────────────────
+
+    fn make_success() -> AskOutcome {
+        AskOutcome::Success {
+            answer: "hello".to_string(),
+            provider: "openrouter".to_string(),
+            model: "openrouter/free".to_string(),
+            latency_ms: 1234,
+        }
+    }
+
+    fn make_failure(err: AskError) -> AskOutcome {
+        AskOutcome::Failure(err)
+    }
+
+    #[test]
+    fn ask_outcome_is_ok_distinguishes_variants() {
+        assert!(make_success().is_ok());
+        assert!(!make_failure(AskError::Timeout(30)).is_ok());
+    }
+
+    #[test]
+    fn ask_outcome_to_envelope_success_shape() {
+        let env = make_success().to_envelope();
+        assert_eq!(env["schema"], "garra.ask.v1");
+        assert_eq!(env["ok"], true);
+        assert_eq!(env["answer"], "hello");
+        assert_eq!(env["provider"], "openrouter");
+        assert_eq!(env["model"], "openrouter/free");
+        assert_eq!(env["latency_ms"], 1234);
+        assert!(env.get("error").is_none());
+    }
+
+    #[test]
+    fn ask_outcome_to_envelope_error_shape() {
+        let env = make_failure(AskError::ProviderError("bad".to_string())).to_envelope();
+        assert_eq!(env["schema"], "garra.ask.v1");
+        assert_eq!(env["ok"], false);
+        assert_eq!(env["error"]["kind"], "provider_error");
+        assert_eq!(env["error"]["message"], "bad");
+        assert!(env.get("answer").is_none());
+    }
+
+    #[test]
+    fn ask_outcome_exit_code_mapping_table_driven() {
+        // GAR-583 — `AskOutcome::exit_code` mirrors `AskError::exit_code`
+        // on failure and returns 0 on success.
+        let cases: &[(AskOutcome, i32)] = &[
+            (make_success(), 0),
+            (make_failure(AskError::UsageError("x".into())), 2),
+            (make_failure(AskError::NoProvider("x".into())), 69),
+            (make_failure(AskError::ProviderError("x".into())), 69),
+            (make_failure(AskError::Timeout(60)), 124),
+            (make_failure(AskError::IoError("x".into())), 74),
+        ];
+        for (outcome, expected) in cases {
+            assert_eq!(
+                outcome.exit_code(),
+                *expected,
+                "exit_code mismatch for {outcome:?}"
+            );
+        }
     }
 
     // ─── Audit: this module never registers a tool ─────────────────────

--- a/crates/garraia-cli/src/main.rs
+++ b/crates/garraia-cli/src/main.rs
@@ -3,6 +3,7 @@ mod banner;
 mod chat;
 mod config_cmd;
 mod glob_cmd;
+mod mcp_server;
 mod migrate;
 mod migrate_workspace;
 mod update;
@@ -204,6 +205,12 @@ enum Commands {
         #[command(subcommand)]
         action: ConfigCommands,
     },
+
+    /// Start an MCP (Model Context Protocol) server over stdio exposing
+    /// the `garra_ask` tool (GAR-583). Designed for Claude Desktop /
+    /// Claude Code integration. Stdout is reserved for the JSON-RPC
+    /// channel; logs go to stderr.
+    McpServer,
 }
 
 #[derive(Subcommand)]
@@ -1263,6 +1270,13 @@ async fn async_main(
             // before the global config is loaded so that EX_DATAERR (65) is
             // reported correctly when the file is present but unparseable.
             unreachable!("Commands::Config is intercepted in main() before async_main");
+        }
+        Commands::McpServer => {
+            // GAR-583: MCP server over stdio exposing `garra_ask` tool.
+            // Tracing init writes to stderr (RedactingWriter), keeping
+            // stdout reserved for the JSON-RPC channel (rmcp's job).
+            init_tracing(&effective_level);
+            mcp_server::run_mcp_server(config).await?;
         }
     }
 

--- a/crates/garraia-cli/src/mcp_server.rs
+++ b/crates/garraia-cli/src/mcp_server.rs
@@ -1,0 +1,472 @@
+//! GAR-583 — MCP server exposing `garra ask` as a stdio tool.
+//!
+//! Implements the `Model Context Protocol` (MCP) `ServerHandler` trait
+//! from `rmcp 1.6` and exposes a single tool — `garra_ask` — that calls
+//! [`crate::ask::ask_oneshot`] **in-process** (no subprocess spawn, no
+//! shell). Designed for Claude Desktop, Claude Code, and any MCP host
+//! that speaks stdio JSON-RPC.
+//!
+//! Scope (locked-in MVP, user-approved 2026-05-11):
+//!   - Stdio transport only. No HTTP / Streamable HTTP in this PR.
+//!   - One tool: `garra_ask`.
+//!   - Default `openrouter/free`; `openrouter/auto` only opt-in.
+//!   - Response = full `garra.ask.v1` envelope as MCP text content.
+//!   - LLM-only — `mcp_server` MUST NOT register tools, MUST NOT spawn
+//!     subprocesses, MUST NOT write to stdout outside of `rmcp`'s
+//!     JSON-RPC channel. Two audit tests enforce these invariants at
+//!     compile time by scanning the production code of this very file.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use garraia_config::AppConfig;
+use rmcp::ErrorData as McpError;
+use rmcp::model::{
+    CallToolRequestParams, CallToolResult, Content, ListToolsResult, PaginatedRequestParams, Tool,
+};
+use rmcp::service::RequestContext;
+use rmcp::{RoleServer, ServerHandler, ServiceExt};
+use serde::Deserialize;
+use serde_json::{Map as JsonMap, Value as JsonValue, json};
+
+use crate::ask::{self, AskOptions};
+
+/// 64 KiB cap mirrors `crate::ask::STDIN_CAP_BYTES`.
+const ARG_MESSAGE_MAX_BYTES: usize = 64 * 1024;
+/// Soft cap on `system_prompt` override; keeps the MCP payload bounded.
+const ARG_SYSTEM_PROMPT_MAX_BYTES: usize = 8 * 1024;
+/// Timeout range — matches the `garra ask --timeout-secs` schema.
+const ARG_TIMEOUT_SECS_MIN: u64 = 1;
+const ARG_TIMEOUT_SECS_MAX: u64 = 600;
+const ARG_TIMEOUT_SECS_DEFAULT: u64 = 60;
+
+/// GAR-583 — Argument shape for the `garra_ask` MCP tool.
+///
+/// Deserialized from `CallToolRequestParam.arguments`. `deny_unknown_fields`
+/// matches the `additionalProperties: false` constraint in the tool
+/// descriptor's JSON schema.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct GarraAskArgs {
+    pub message: String,
+    #[serde(default)]
+    pub provider: Option<String>,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub timeout_secs: Option<u64>,
+    #[serde(default)]
+    pub system_prompt: Option<String>,
+}
+
+/// GAR-583 — Validate `GarraAskArgs` bounds. Returns the same error
+/// shape that the MCP host will see in `CallToolResult` on rejection.
+pub(crate) fn validate_args(args: &GarraAskArgs) -> Result<(), String> {
+    if args.message.trim().is_empty() {
+        return Err("message must be non-empty".to_string());
+    }
+    if args.message.len() > ARG_MESSAGE_MAX_BYTES {
+        return Err(format!(
+            "message exceeds 64 KiB cap ({ARG_MESSAGE_MAX_BYTES} bytes)"
+        ));
+    }
+    if let Some(ts) = args.timeout_secs
+        && !(ARG_TIMEOUT_SECS_MIN..=ARG_TIMEOUT_SECS_MAX).contains(&ts)
+    {
+        return Err(format!(
+            "timeout_secs out of range [{ARG_TIMEOUT_SECS_MIN}, {ARG_TIMEOUT_SECS_MAX}]"
+        ));
+    }
+    if let Some(ref sp) = args.system_prompt
+        && sp.len() > ARG_SYSTEM_PROMPT_MAX_BYTES
+    {
+        return Err(format!(
+            "system_prompt exceeds {ARG_SYSTEM_PROMPT_MAX_BYTES}-byte cap"
+        ));
+    }
+    Ok(())
+}
+
+/// GAR-583 — Build the `garra_ask` tool descriptor (advertised in
+/// response to `tools/list`).
+///
+/// Schema mirrors the documented contract: `message` required, defaults
+/// for `provider`/`model`/`timeout_secs`, `additionalProperties: false`,
+/// bounds for `timeout_secs` and string lengths.
+pub(crate) fn garra_ask_tool() -> Tool {
+    let schema_value = json!({
+        "type": "object",
+        "properties": {
+            "message": {
+                "type": "string",
+                "description": "The question or instruction to send to GarraIA. Max 64 KiB.",
+                "minLength": 1,
+                "maxLength": ARG_MESSAGE_MAX_BYTES
+            },
+            "provider": {
+                "type": "string",
+                "enum": ["ollama", "anthropic", "openai", "openrouter"],
+                "default": "openrouter",
+                "description": "LLM provider. Default 'openrouter'."
+            },
+            "model": {
+                "type": "string",
+                "default": "openrouter/free",
+                "description": "Model name. Default 'openrouter/free' (cheap, suitable for most tasks). Pass 'openrouter/auto' explicitly for complex tasks — never automatic."
+            },
+            "timeout_secs": {
+                "type": "integer",
+                "default": ARG_TIMEOUT_SECS_DEFAULT,
+                "minimum": ARG_TIMEOUT_SECS_MIN,
+                "maximum": ARG_TIMEOUT_SECS_MAX,
+                "description": "LLM call timeout in seconds. Range [1, 600]. Default 60."
+            },
+            "system_prompt": {
+                "type": "string",
+                "maxLength": ARG_SYSTEM_PROMPT_MAX_BYTES,
+                "description": "Optional system prompt override. If omitted, a minimal default is used."
+            }
+        },
+        "required": ["message"],
+        "additionalProperties": false
+    });
+    // serde_json::Value::Object guaranteed by the literal above.
+    let schema_map: JsonMap<String, JsonValue> = match schema_value {
+        JsonValue::Object(map) => map,
+        _ => unreachable!("schema literal is an object"),
+    };
+    Tool::new(
+        "garra_ask",
+        "Ask the GarraIA assistant a single question. Non-interactive, LLM-only — no shell, file, or git access. Returns a `garra.ask.v1` JSON envelope as text content.",
+        Arc::new(schema_map),
+    )
+}
+
+/// GAR-583 — handler held by the running MCP server. Wraps the shared
+/// `AppConfig` so each `garra_ask` invocation can resolve the provider
+/// + model through the same pipeline used by the CLI.
+#[derive(Clone)]
+pub(crate) struct GarraToolHandler {
+    config: Arc<AppConfig>,
+}
+
+impl GarraToolHandler {
+    pub(crate) fn new(config: Arc<AppConfig>) -> Self {
+        Self { config }
+    }
+}
+
+impl ServerHandler for GarraToolHandler {
+    async fn list_tools(
+        &self,
+        _: Option<PaginatedRequestParams>,
+        _: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, McpError> {
+        Ok(ListToolsResult {
+            tools: vec![garra_ask_tool()],
+            next_cursor: None,
+            meta: None,
+        })
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        if request.name != "garra_ask" {
+            return Err(McpError::invalid_params(
+                format!("unknown tool: '{}'", request.name),
+                None,
+            ));
+        }
+
+        // Deserialize arguments (additionalProperties = false enforced via serde).
+        let raw = request.arguments.unwrap_or_default();
+        let args: GarraAskArgs = serde_json::from_value(JsonValue::Object(raw))
+            .map_err(|e| McpError::invalid_params(format!("invalid arguments: {e}"), None))?;
+        if let Err(e) = validate_args(&args) {
+            return Err(McpError::invalid_params(e, None));
+        }
+
+        // Build opts + call the pure core.
+        let opts = AskOptions {
+            message: args.message,
+            provider_override: args.provider,
+            model_override: args.model,
+            url_override: None,
+            timeout_secs: args.timeout_secs.unwrap_or(ARG_TIMEOUT_SECS_DEFAULT),
+            system_prompt_override: args.system_prompt,
+        };
+        let outcome = ask::ask_oneshot(&self.config, opts).await;
+
+        // Pack the full `garra.ask.v1` envelope as MCP text content
+        // (user-locked design: gives Claude visibility into provider/
+        // model/latency/error.kind without parsing free-form text).
+        let envelope = outcome.to_envelope();
+        let text = serde_json::to_string(&envelope).unwrap_or_else(|_| {
+            String::from(
+                "{\"schema\":\"garra.ask.v1\",\"ok\":false,\"error\":{\"kind\":\"io\",\"message\":\"json serialization failed\"}}",
+            )
+        });
+        let content = vec![Content::text(text)];
+        if outcome.is_ok() {
+            Ok(CallToolResult::success(content))
+        } else {
+            Ok(CallToolResult::error(content))
+        }
+    }
+}
+
+/// GAR-583 — entry point invoked by `Commands::McpServer` in `main.rs`.
+///
+/// Runs the MCP stdio server until EOF on stdin (graceful shutdown by
+/// the host). Tracing logs go to stderr via the `RedactingWriter`
+/// configured in `main.rs`; stdout is reserved exclusively for the
+/// JSON-RPC channel.
+pub async fn run_mcp_server(config: AppConfig) -> Result<()> {
+    tracing::info!("MCP server starting on stdio (GAR-583)");
+    let handler = GarraToolHandler::new(Arc::new(config));
+    let (stdin, stdout) = rmcp::transport::io::stdio();
+    let service = handler.serve((stdin, stdout)).await?;
+    tracing::info!("MCP server ready; waiting for client requests");
+    service.waiting().await?;
+    tracing::info!("MCP server shutdown");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    //! GAR-583 — Pure tests. Zero network, zero env-mutation, zero
+    //! filesystem. The two `audit_…` tests below are the load-bearing
+    //! safety net for the locked-in invariants of this PR.
+
+    use super::*;
+    use serde_json::json;
+
+    // ─── Tool descriptor ──────────────────────────────────────────────
+
+    #[test]
+    fn tool_descriptor_name_is_garra_ask() {
+        let t = garra_ask_tool();
+        assert_eq!(t.name.as_ref(), "garra_ask");
+    }
+
+    #[test]
+    fn tool_descriptor_has_description() {
+        let t = garra_ask_tool();
+        let desc = t.description.expect("description present");
+        assert!(desc.contains("GarraIA"));
+        assert!(desc.contains("garra.ask.v1"));
+    }
+
+    #[test]
+    fn tool_descriptor_message_is_required() {
+        let t = garra_ask_tool();
+        let schema = (*t.input_schema).clone();
+        let required = schema
+            .get("required")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .expect("required array present");
+        assert!(required.iter().any(|v| v.as_str() == Some("message")));
+    }
+
+    #[test]
+    fn tool_descriptor_default_model_is_openrouter_free() {
+        let t = garra_ask_tool();
+        let schema = (*t.input_schema).clone();
+        let model_default = schema
+            .get("properties")
+            .and_then(|p| p.get("model"))
+            .and_then(|m| m.get("default"))
+            .and_then(|d| d.as_str());
+        assert_eq!(model_default, Some("openrouter/free"));
+    }
+
+    #[test]
+    fn tool_descriptor_timeout_range_is_1_to_600() {
+        let t = garra_ask_tool();
+        let schema = (*t.input_schema).clone();
+        let ts = schema
+            .get("properties")
+            .and_then(|p| p.get("timeout_secs"))
+            .cloned()
+            .expect("timeout_secs property present");
+        assert_eq!(ts.get("minimum").and_then(|v| v.as_u64()), Some(1));
+        assert_eq!(ts.get("maximum").and_then(|v| v.as_u64()), Some(600));
+        assert_eq!(ts.get("default").and_then(|v| v.as_u64()), Some(60));
+    }
+
+    #[test]
+    fn tool_descriptor_additional_properties_is_false() {
+        let t = garra_ask_tool();
+        let schema = (*t.input_schema).clone();
+        let ap = schema.get("additionalProperties").and_then(|v| v.as_bool());
+        assert_eq!(ap, Some(false));
+    }
+
+    // ─── Argument validation ──────────────────────────────────────────
+
+    fn parse_args(v: serde_json::Value) -> Result<GarraAskArgs, String> {
+        serde_json::from_value(v).map_err(|e| e.to_string())
+    }
+
+    #[test]
+    fn args_deserialize_minimum_required() {
+        let a = parse_args(json!({"message": "hi"})).unwrap();
+        assert_eq!(a.message, "hi");
+        assert!(a.provider.is_none());
+        assert!(a.model.is_none());
+        assert!(a.timeout_secs.is_none());
+        assert!(a.system_prompt.is_none());
+    }
+
+    #[test]
+    fn args_reject_missing_message() {
+        let err = parse_args(json!({})).unwrap_err();
+        assert!(err.contains("message"), "got: {err}");
+    }
+
+    #[test]
+    fn args_reject_additional_properties() {
+        let err = parse_args(json!({"message": "hi", "rogue": "x"})).unwrap_err();
+        assert!(err.contains("rogue") || err.contains("unknown field"));
+    }
+
+    #[test]
+    fn args_explicit_openrouter_auto_accepted_at_deser_layer() {
+        // The deser layer accepts any string for `model` — the policy
+        // (default = free, auto only opt-in) is enforced by passing the
+        // value through to `ask_oneshot`, NOT by rejecting it here.
+        let a = parse_args(json!({"message": "x", "model": "openrouter/auto"})).unwrap();
+        assert_eq!(a.model.as_deref(), Some("openrouter/auto"));
+    }
+
+    #[test]
+    fn validate_args_rejects_empty_message() {
+        let a = GarraAskArgs {
+            message: "   ".to_string(),
+            provider: None,
+            model: None,
+            timeout_secs: None,
+            system_prompt: None,
+        };
+        let err = validate_args(&a).unwrap_err();
+        assert!(err.contains("non-empty"));
+    }
+
+    #[test]
+    fn validate_args_rejects_message_over_64kib() {
+        let a = GarraAskArgs {
+            message: "a".repeat(ARG_MESSAGE_MAX_BYTES + 1),
+            provider: None,
+            model: None,
+            timeout_secs: None,
+            system_prompt: None,
+        };
+        let err = validate_args(&a).unwrap_err();
+        assert!(err.contains("64"));
+    }
+
+    #[test]
+    fn validate_args_rejects_timeout_below_min() {
+        let a = GarraAskArgs {
+            message: "x".to_string(),
+            provider: None,
+            model: None,
+            timeout_secs: Some(0),
+            system_prompt: None,
+        };
+        assert!(validate_args(&a).is_err());
+    }
+
+    #[test]
+    fn validate_args_rejects_timeout_above_max() {
+        let a = GarraAskArgs {
+            message: "x".to_string(),
+            provider: None,
+            model: None,
+            timeout_secs: Some(601),
+            system_prompt: None,
+        };
+        assert!(validate_args(&a).is_err());
+    }
+
+    #[test]
+    fn validate_args_rejects_system_prompt_over_8kib() {
+        let a = GarraAskArgs {
+            message: "x".to_string(),
+            provider: None,
+            model: None,
+            timeout_secs: None,
+            system_prompt: Some("a".repeat(ARG_SYSTEM_PROMPT_MAX_BYTES + 1)),
+        };
+        let err = validate_args(&a).unwrap_err();
+        assert!(err.contains("system_prompt"));
+    }
+
+    #[test]
+    fn validate_args_accepts_typical_payload() {
+        let a = GarraAskArgs {
+            message: "hi".to_string(),
+            provider: Some("openrouter".to_string()),
+            model: Some("openrouter/free".to_string()),
+            timeout_secs: Some(30),
+            system_prompt: Some("be brief".to_string()),
+        };
+        assert!(validate_args(&a).is_ok());
+    }
+
+    // ─── Audit invariants (load-bearing) ──────────────────────────────
+
+    /// GAR-583 §4 invariant #1 — production code MUST NOT write to
+    /// stdout. Stdio MCP transport reserves stdout for JSON-RPC; any
+    /// `println!`/`print!`/`stdout()` call corrupts the channel.
+    ///
+    /// Scans only the production half of `mcp_server.rs` (everything
+    /// before `#[cfg(test)]`).
+    #[test]
+    fn audit_mcp_server_never_writes_to_stdout() {
+        let source = include_str!("mcp_server.rs");
+        let production = source.split("#[cfg(test)]").next().unwrap_or(source);
+        let forbidden = [
+            "println!",
+            "print!",
+            "io::stdout",
+            "std::io::stdout",
+            "stdout().write",
+        ];
+        for needle in forbidden {
+            assert!(
+                !production.contains(needle),
+                "mcp_server.rs production code must not contain `{needle}` (GAR-583 stdio invariant)"
+            );
+        }
+    }
+
+    /// GAR-583 §4 invariant #2 — production code MUST NOT register
+    /// dangerous tools and MUST NOT spawn subprocesses. The handler
+    /// calls `ask::ask_oneshot` in-process; any escape hatch defeats
+    /// the LLM-only guarantee documented in the tool description.
+    #[test]
+    fn audit_mcp_server_never_registers_dangerous_tools() {
+        let source = include_str!("mcp_server.rs");
+        let production = source.split("#[cfg(test)]").next().unwrap_or(source);
+        let forbidden = [
+            "register_tool",
+            "BashTool",
+            "FileReadTool",
+            "FileWriteTool",
+            "GitDiffTool",
+            "std::process::Command",
+            "tokio::process::Command",
+        ];
+        for needle in forbidden {
+            assert!(
+                !production.contains(needle),
+                "mcp_server.rs production code must not contain `{needle}` (GAR-583 safety invariant)"
+            );
+        }
+    }
+}

--- a/docs/cli-ask.md
+++ b/docs/cli-ask.md
@@ -164,13 +164,17 @@ PRs separados manterão escopo limpo:
 - `--stream` para emit incremental.
 - `--enable-tools` + tool allowlist + auditoria.
 - `--system-prompt-file <PATH>`.
-- MCP server wrapper expondo `ask` como tool MCP.
+- ~~MCP server wrapper expondo `ask` como tool MCP~~ — entregue por
+  GAR-583, veja [`docs/cli-mcp-server.md`](cli-mcp-server.md).
 - `--session <id>` para continuação de conversa.
 - Automatic `openrouter/free → openrouter/auto` fallback.
 
 ## Ver também
 
+- [`docs/cli-mcp-server.md`](cli-mcp-server.md) — `garra mcp-server` (GAR-583),
+  MCP stdio wrapper que reutiliza `ask::ask_oneshot` in-process.
 - [`docs/configuration.md`](configuration.md) — provider/model resolution (GAR-576).
 - [`docs/src/providers.md`](src/providers.md) — OpenRouter cost policy.
 - `plans/0098-gar-576-cli-openrouter-model-respect.md` — base já estável.
-- `plans/0099-gar-579-cli-non-interactive-ask.md` — este PR.
+- `plans/0100-gar-579-cli-non-interactive-ask.md` — este PR.
+- `plans/0102-gar-583-mcp-server-stdio.md` — MCP wrapper sobre este comando.

--- a/docs/cli-mcp-server.md
+++ b/docs/cli-mcp-server.md
@@ -1,0 +1,241 @@
+# `garra mcp-server` — MCP server exposing `garra ask`
+
+> GAR-583 — stdio Model Context Protocol server. Exposes a single tool
+> (`garra_ask`) that runs the same code path as
+> [`garra ask`](cli-ask.md) in-process — no subprocess, no shell, LLM-only.
+>
+> Designed for Claude Desktop, Claude Code, and any MCP host that
+> speaks stdio JSON-RPC.
+
+## Quickstart
+
+### Claude Desktop
+
+Edit `~/.config/claude/claude_desktop_config.json` (macOS/Linux) or
+`%APPDATA%\Claude\claude_desktop_config.json` (Windows) and add:
+
+```json
+{
+  "mcpServers": {
+    "garra": {
+      "command": "garra",
+      "args": ["mcp-server"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop. The `garra_ask` tool should appear in the
+tools list of the assistant.
+
+### Claude Code
+
+Same config shape, in the project's MCP config:
+
+```json
+{
+  "mcpServers": {
+    "garra": {
+      "command": "garra",
+      "args": ["mcp-server"]
+    }
+  }
+}
+```
+
+If `garra` is not on `PATH`, use the absolute path:
+
+```json
+{
+  "mcpServers": {
+    "garra": {
+      "command": "G:/Projetos/GarraRUST/target/release/garra.exe",
+      "args": ["mcp-server"]
+    }
+  }
+}
+```
+
+### Test the server manually
+
+The server speaks JSON-RPC 2.0 over stdio. It's not meant to be poked
+by humans, but you can sanity-check the binary:
+
+```bash
+./target/release/garra.exe mcp-server --help
+```
+
+To verify the tool descriptor is wired correctly, you can pipe a
+`tools/list` request and inspect stdout (logs go to stderr):
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}' | ./target/release/garra.exe mcp-server 2>/dev/null
+```
+
+## Tool schema (`garra_ask`)
+
+| Field           | Type    | Required | Default            | Notes                                                |
+|-----------------|---------|----------|--------------------|------------------------------------------------------|
+| `message`       | string  | yes      | —                  | Max 64 KiB. Trimmed; empty rejected.                 |
+| `provider`      | string  | no       | `openrouter`       | Enum: `ollama`/`anthropic`/`openai`/`openrouter`.    |
+| `model`         | string  | no       | `openrouter/free`  | Pass `openrouter/auto` explicitly for complex tasks. |
+| `timeout_secs`  | integer | no       | `60`               | Range `[1, 600]`. Excedes → `error.kind: "timeout"`. |
+| `system_prompt` | string  | no       | minimal default    | Max 8 KiB.                                           |
+
+The server accepts only those properties (`additionalProperties:
+false`); unknown fields are rejected with `invalid_params`.
+
+## Response shape
+
+The tool returns a single text content block containing the
+[`garra.ask.v1`](cli-ask.md#json-envelope-schema-garraaskv1) JSON
+envelope. Success:
+
+```json
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "{\"schema\":\"garra.ask.v1\",\"ok\":true,\"answer\":\"...\",\"provider\":\"openrouter\",\"model\":\"openrouter/free\",\"latency_ms\":1234}"
+    }
+  ],
+  "isError": false
+}
+```
+
+Error:
+
+```json
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "{\"schema\":\"garra.ask.v1\",\"ok\":false,\"error\":{\"kind\":\"provider_error\",\"message\":\"...\"}}"
+    }
+  ],
+  "isError": true
+}
+```
+
+This shape gives Claude direct visibility into `provider`, `model`,
+`latency_ms`, and `error.kind` without parsing free-form text.
+
+## Cost policy (`openrouter/free` vs `openrouter/auto`)
+
+- **`openrouter/free`** is the **default**. Use for general
+  conversation, smoke tests, CI, automation, and anything where cost
+  matters.
+- **`openrouter/auto`** is **opt-in only** — the caller MUST pass
+  `model: "openrouter/auto"` explicitly. There is no automatic
+  `free → auto` upgrade.
+
+This mirrors the [`garra ask`](cli-ask.md) policy locked-in by user
+2026-05-11.
+
+## Stdio invariants
+
+| Stream | Owner             | Content                                            |
+|--------|-------------------|----------------------------------------------------|
+| stdin  | `rmcp`            | JSON-RPC requests from the MCP host                |
+| stdout | `rmcp` (exclusive)| JSON-RPC responses. **Nothing else writes here.** |
+| stderr | `tracing`         | Redacted logs (api-key fingerprints sanitized).    |
+
+The codebase enforces these invariants via two compile-time audit
+tests in `crates/garraia-cli/src/mcp_server.rs::tests`:
+
+- `audit_mcp_server_never_writes_to_stdout` — scans production code
+  for `println!`, `print!`, `io::stdout`, `stdout().write`.
+- `audit_mcp_server_never_registers_dangerous_tools` — scans for
+  `register_tool`, `BashTool`, `FileReadTool`, `FileWriteTool`,
+  `GitDiffTool`, `std::process::Command`, `tokio::process::Command`.
+
+A future PR that tries to slip a tool registration or a subprocess
+spawn into `mcp_server.rs` will fail the audit at `cargo test` time.
+
+## Troubleshooting
+
+### Claude Desktop / Code can't find the `garra_ask` tool
+
+Verify the server starts:
+
+```bash
+garra mcp-server --help
+```
+
+If `--help` works but the tool doesn't show up in Claude:
+
+1. Check `garra` is on `PATH` (or use absolute path in MCP config).
+2. Restart Claude Desktop / Claude Code fully (not just the tab).
+3. Look at host-side MCP logs — most hosts log MCP server stderr to a
+   file under their data directory.
+
+### Tool calls timeout immediately
+
+The default `timeout_secs` is 60. If the LLM takes longer (rare for
+`openrouter/free`), pass a larger value:
+
+```json
+{"name": "garra_ask", "arguments": {"message": "...", "timeout_secs": 120}}
+```
+
+Range is `[1, 600]`; values outside the range are rejected with
+`invalid_params`.
+
+### `error.kind: "provider_error"` — network/auth issue
+
+The Garra successfully invoked the provider but the provider returned
+an error or the network couldn't reach it. Common causes:
+
+- Invalid API key in `~/.garraia/config.yml` or `.env`. Use `garra
+  config check` to validate.
+- Windows TLS revocation check failure
+  (`CRYPT_E_NO_REVOCATION_CHECK`) — known transient issue on some
+  networks. Try a different network or VPN.
+
+The `error.message` is sanitized — api-key fingerprints are
+redacted via [`sanitize_provider_error`](../crates/garraia-cli/src/ask.rs).
+
+### `error.kind: "usage"` — bad arguments
+
+Schema validation rejected the call. Check:
+
+- `message` is non-empty and ≤ 64 KiB.
+- `timeout_secs` is in `[1, 600]`.
+- `system_prompt` ≤ 8 KiB.
+- No unknown properties in the arguments object.
+
+## Security notes
+
+- **In-process only**. The tool handler calls `ask::ask_oneshot`
+  directly. There is no subprocess spawn, no shell invocation, no
+  PATH lookup. Path hijacking and shell injection are not in the
+  threat model.
+- **LLM-only runtime**. No `bash`/`file_read`/`file_write`/`git_diff`
+  tools are registered on the agent runtime — the audit test prevents
+  regression.
+- **Prompt size bounded**. Messages ≤ 64 KiB, system prompts ≤ 8 KiB.
+- **Output bounded**. `max_tokens: 4096` in the runtime caps the
+  response.
+- **No loops**. The provider (OpenRouter, Anthropic, etc.) is a plain
+  HTTPS endpoint; it doesn't call MCP servers back.
+- **Provider errors sanitized** before reaching the response or
+  stderr (regex-based redaction of `sk-…`/`sk-or-v1-…` fingerprints).
+
+## Out of scope (separate follow-ups)
+
+- Streamable HTTP transport (this PR is stdio-only).
+- Additional tools beyond `garra_ask` (e.g. `garra_chat`,
+  `garra_files`).
+- `--enable-tools` opt-in for `garra ask` (and MCP propagation).
+- Streaming partial responses via MCP.
+- `RedactingWriter` extension for provider error payloads.
+- Automatic `openrouter/free → openrouter/auto` fallback.
+- Per-user authentication / permissions.
+- MCP server telemetry / Prometheus counters.
+
+## See also
+
+- [`docs/cli-ask.md`](cli-ask.md) — `garra ask` reference.
+- [`docs/configuration.md`](configuration.md) — provider/model resolution.
+- `plans/0102-gar-583-mcp-server-stdio.md` — this PR's plan.
+- [Model Context Protocol specification](https://modelcontextprotocol.io/).

--- a/plans/0102-gar-583-mcp-server-stdio.md
+++ b/plans/0102-gar-583-mcp-server-stdio.md
@@ -1,0 +1,374 @@
+# Plan 0102 — GAR-583: MCP server exposing `garra ask` as stdio tool
+
+**Status:** Em execução
+**Autor:** Claude Opus 4.7 (sessão interativa 2026-05-11, America/New_York)
+**Data:** 2026-05-11 (America/New_York)
+**Issue:** [GAR-583](https://linear.app/chatgpt25/issue/GAR-583/mcp-expose-garra-ask-as-a-stdio-tool)
+**Branch:** `routine/202605111207-gar-583-mcp-server-stdio`
+**Epic:** `epic:cli`
+**Builds on:** GAR-576 (PR #263), GAR-579 (PR #267), GAR-582 (PR #269)
+
+---
+
+## §1 Goal
+
+Expose `garra ask` as an MCP (Model Context Protocol) tool via stdio so Claude Desktop / Claude Code / any MCP host can invoke it. The Garra stops being CLI-only.
+
+Validated risk #10 from spec phase: **`rmcp 1.6.0` server-side API is mature and already in workspace deps**:
+- `ServerHandler` trait + `serve_server(handler, transport)` function.
+- `rmcp::transport::io::stdio()` returns `(Stdin, Stdout)` tuple.
+- `default = ["base64", "macros", "server"]` — server feature ON by default.
+- `garraia-agents` already depends on `rmcp = { workspace = true, features = ["client", ...] }`.
+- We add `garraia-cli`-scoped dep with `features = ["server", "transport-io", "macros"]`.
+
+---
+
+## §2 Scope (locked-in MVP — user-approved 2026-05-11 with 3 adjustments + 13 constraints)
+
+**In:**
+- Subcommand `garra mcp-server` (stdio transport only).
+- Tool: `garra_ask` (single).
+- Defaults: `provider="openrouter"`, `model="openrouter/free"`, `timeout_secs=60`, cap=600.
+- `openrouter/auto` accepted ONLY when caller passes it explicitly.
+- Response = full `garra.ask.v1` envelope as MCP text content.
+- In-process call to refactored `ask::ask_oneshot` (zero subprocess).
+- TWO audit tests: `audit_no_stdout_writes` + `audit_no_dangerous_tools`.
+
+**Out (separate PRs):**
+- Integration test JSON-RPC via stdin pipe (deferred).
+- Streamable HTTP transport.
+- Tools beyond `garra_ask`.
+- `RedactingWriter` extension.
+- `.env`/`dotenvy`/`GARRAIA_CONFIG_DIR` operator fixes.
+- TLS local fixes.
+- MCP server telemetry / metrics.
+- Per-user auth.
+- Automatic `free → auto` fallback.
+
+---
+
+## §3 Architecture
+
+### Subcommand
+**Option A**: `garra mcp-server` — single binary, consistent with `garra ask` / `garra chat` / `garra mcp` (existing client-side). Zero binary fragmentation.
+
+### Crate
+**`rmcp 1.6.0`** already in workspace. Feature flip in `crates/garraia-cli/Cargo.toml`:
+```
+rmcp = { workspace = true, features = ["server", "transport-io", "macros"] }
+```
+Zero new crate in workspace.
+
+### Wiring
+
+```
+garra mcp-server (stdio)
+  │
+  ├─ rmcp::ServerHandler trait impl on GarraToolHandler
+  │   ├─ list_tools() → [garra_ask_tool_descriptor()]
+  │   └─ call_tool(name="garra_ask", args) → handle_garra_ask(args)
+  │
+  ├─ handle_garra_ask(args: GarraAskArgs) -> CallToolResult
+  │   - serde validates args (schema + bounds)
+  │   - build AskOptions
+  │   - call ask::ask_oneshot(config, opts).await
+  │   - pack AskResult → CallToolResult { content: text(envelope), is_error }
+  │
+  └─ ask::ask_oneshot (REFACTORED in this PR)
+      - pure async fn, NO I/O
+      - returns AskResult struct
+      - reuses chat::select_explicit_provider / chat::detect_provider
+      - AgentRuntime with ZERO tool registration
+```
+
+### Stdio discipline (critical invariant)
+
+| Stream | Owner | Content |
+|---|---|---|
+| stdin | `rmcp` | JSON-RPC requests from Claude |
+| stdout | `rmcp` (exclusive) | JSON-RPC responses to Claude. NO other code writes here. |
+| stderr | `tracing` (via `RedactingWriter` from `main.rs:558`) | logs, redacted |
+
+**Audit test #1**: `audit_no_stdout_writes` scans `mcp_server.rs` production code for `println!`, `print!`, `io::stdout()`, `std::io::stdout` — must return 0 matches.
+
+---
+
+## §4 Design invariants
+
+1. **Stdio discipline**: zero `println!`/`print!`/`stdout()` in `mcp_server.rs` production code (audit test).
+2. **Zero dangerous tools**: `mcp_server.rs` production code MUST NOT contain `register_tool`, `BashTool`, `FileReadTool`, `FileWriteTool`, `GitDiffTool`, `std::process::Command` (audit test #2).
+3. **Zero subprocess**: handler calls `ask::ask_oneshot` in-process. No PATH lookup. No shell.
+4. **Zero new crate**: only feature flips on `rmcp` already in workspace.
+5. **`ask::ask_oneshot` is pure**: returns `AskResult`, no I/O. `run_ask` (existing CLI) wraps it.
+6. **Default to cheap**: `model="openrouter/free"` default; `openrouter/auto` opt-in only.
+7. **Envelope as text content**: MCP response carries full `garra.ask.v1` JSON, not just `answer`.
+8. **Author canonical**: commit metadata enforced via `git config --local` + `git commit --amend --reset-author` if needed.
+
+---
+
+## §5 Code changes
+
+### `crates/garraia-cli/Cargo.toml`
+```diff
++rmcp = { workspace = true, features = ["server", "transport-io", "macros"] }
+```
+
+### `crates/garraia-cli/src/ask.rs` — refactor: extract pure core
+
+```rust
+pub(crate) struct AskOptions {
+    pub message: String,
+    pub provider_override: Option<String>,
+    pub model_override: Option<String>,
+    pub url_override: Option<String>,
+    pub timeout_secs: u64,
+    pub system_prompt_override: Option<String>,
+}
+
+pub(crate) struct AskResult {
+    pub schema: &'static str,         // "garra.ask.v1"
+    pub ok: bool,
+    pub answer: Option<String>,
+    pub provider: Option<String>,
+    pub model: Option<String>,
+    pub latency_ms: Option<u128>,
+    pub error_kind: Option<&'static str>,
+    pub error_message: Option<String>,
+}
+
+impl AskResult {
+    pub(crate) fn to_envelope(&self) -> serde_json::Value { ... }
+    pub(crate) fn exit_code(&self) -> i32 { ... }  // for CLI caller
+}
+
+pub(crate) async fn ask_oneshot(
+    config: &AppConfig,
+    opts: AskOptions,
+) -> AskResult {
+    // moved from run_ask: provider resolution + AgentRuntime + LLM call + timeout
+    // ZERO println!/eprintln! in this function
+}
+```
+
+`run_ask` becomes a thin wrapper: parse stdin if needed, build `AskOptions`, call `ask_oneshot`, emit JSON/text via `println!`/`eprintln!`, return exit code.
+
+### `crates/garraia-cli/src/mcp_server.rs` — new module
+
+```rust
+use std::sync::Arc;
+use anyhow::Result;
+use garraia_config::AppConfig;
+use rmcp::{
+    ServerHandler, RoleServer, serve_server,
+    transport::io::stdio,
+    model::{
+        CallToolRequestParams, CallToolResult, ListToolsResult, PaginatedRequestParams,
+        Tool, RawContent, Annotated,
+    },
+    service::RequestContext,
+    ErrorData as McpError,
+};
+use serde::Deserialize;
+
+use crate::ask::{self, AskOptions};
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct GarraAskArgs {
+    message: String,
+    #[serde(default)]
+    provider: Option<String>,
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    timeout_secs: Option<u64>,
+    #[serde(default)]
+    system_prompt: Option<String>,
+}
+
+struct GarraToolHandler {
+    config: Arc<AppConfig>,
+}
+
+impl ServerHandler for GarraToolHandler {
+    async fn list_tools(
+        &self,
+        _: Option<PaginatedRequestParams>,
+        _: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, McpError> {
+        Ok(ListToolsResult {
+            tools: vec![garra_ask_tool()],
+            next_cursor: None,
+        })
+    }
+
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        if request.name != "garra_ask" {
+            return Err(McpError::method_not_found::<...>());
+        }
+        let args: GarraAskArgs = serde_json::from_value(
+            serde_json::Value::Object(request.arguments.unwrap_or_default())
+        ).map_err(|e| McpError::invalid_params(format!("bad arguments: {e}"), None))?;
+
+        // bounds validation
+        if args.message.is_empty() || args.message.len() > 65_536 { ... }
+        if let Some(ts) = args.timeout_secs && !(1..=600).contains(&ts) { ... }
+        if let Some(ref sp) = args.system_prompt && sp.len() > 8192 { ... }
+
+        let opts = AskOptions {
+            message: args.message,
+            provider_override: args.provider,
+            model_override: args.model,
+            url_override: None,
+            timeout_secs: args.timeout_secs.unwrap_or(60),
+            system_prompt_override: args.system_prompt,
+        };
+
+        let result = ask::ask_oneshot(&self.config, opts).await;
+        let envelope = result.to_envelope();
+        let text = serde_json::to_string(&envelope).unwrap_or_default();
+        let is_error = !result.ok;
+
+        Ok(CallToolResult {
+            content: vec![Annotated::new(RawContent::text(text), None)],
+            is_error: Some(is_error),
+            ..Default::default()
+        })
+    }
+}
+
+fn garra_ask_tool() -> Tool { /* descriptor with schema */ }
+
+pub async fn run_mcp_server(config: AppConfig) -> Result<()> {
+    let handler = GarraToolHandler { config: Arc::new(config) };
+    let (stdin, stdout) = stdio();
+    let service = serve_server(handler, (stdin, stdout)).await?;
+    service.waiting().await?;
+    Ok(())
+}
+```
+
+### `crates/garraia-cli/src/main.rs` — wire subcommand
+
+```rust
+mod mcp_server;
+
+enum Commands {
+    ...
+    /// Start MCP server (stdio transport) exposing `garra_ask` tool.
+    /// Designed for Claude Desktop / Claude Code integration.
+    McpServer,
+    ...
+}
+
+match cli.command {
+    ...
+    Commands::McpServer => {
+        init_tracing(&effective_level);
+        mcp_server::run_mcp_server(config).await?;
+    }
+    ...
+}
+```
+
+---
+
+## §6 Tests
+
+### Unit tests (pure, in `mcp_server.rs::tests`)
+
+1. `tool_descriptor_name_is_garra_ask` — descritor tem `name: "garra_ask"`.
+2. `tool_descriptor_has_message_required` — `inputSchema.required` inclui `"message"`.
+3. `tool_descriptor_default_model_is_openrouter_free` — schema property `model` has default `"openrouter/free"`.
+4. `tool_descriptor_timeout_range_1_to_600` — schema constrains `timeout_secs`.
+5. `args_deserialize_minimum` — `{"message":"hi"}` parses with defaults.
+6. `args_reject_missing_message` — required field validation.
+7. `args_reject_message_over_64kib` — bounds.
+8. `args_reject_timeout_out_of_range` — bounds.
+9. `args_reject_system_prompt_over_8kib` — bounds.
+10. `args_reject_additional_properties` — `additionalProperties: false`.
+11. `args_explicit_openrouter_auto_accepted` — opt-in works.
+12. **`audit_no_stdout_writes`** — scans `mcp_server.rs` production code for `println!`, `print!`, `io::stdout`. Production = code before `#[cfg(test)]`.
+13. **`audit_no_dangerous_tools`** — scans for `register_tool`, `BashTool`, `FileReadTool`, `FileWriteTool`, `GitDiffTool`, `std::process::Command`. Production-scope same as #12.
+
+### Unit tests (in `ask.rs::tests`, new)
+
+14. `ask_oneshot_usage_error_for_empty_message` — pure path.
+15. `ask_result_to_envelope_success_shape` — envelope structure.
+16. `ask_result_to_envelope_error_shape` — error envelope.
+17. `ask_result_exit_code_mapping` — table-driven (5 variants).
+
+Existing 15 `ask::tests` from GAR-579 + 12 `chat::tests` from GAR-576 must continue passing.
+
+### Manual smokes (no token cost)
+
+- `./target/release/garra.exe mcp-server --help` exit 0.
+- `./target/release/garra.exe mcp-server` (don't kill immediately; pipe `{"jsonrpc":"2.0","id":1,"method":"tools/list"}` via stdin) → response JSON includes `garra_ask` — OPTIONAL, only if rmcp doesn't require complex handshake.
+
+### Smoke real (opcional, network-dependent)
+
+`openrouter/free` only. Configure in Claude Desktop:
+```json
+{"mcpServers":{"garra":{"command":"garra","args":["mcp-server"]}}}
+```
+Restart Claude Desktop. Ask "Oi, tudo bem?". `openrouter/auto` **NOT** executed.
+
+---
+
+## §7 Verification
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings
+cargo test -p garraia --bin garra
+cargo build --release --bin garra
+./target/release/garra.exe mcp-server --help   # smoke
+```
+
+---
+
+## §8 Risks (carry-forward from spec §10, with mitigations now concrete)
+
+| # | Risk | Mitigation in implementation |
+|---|---|---|
+| 1 | Stdout corruption | Pure `ask_oneshot` + audit test `audit_no_stdout_writes` |
+| 2 | Prompt injection | Out of scope — LLM-level concern, not server-level |
+| 3 | Secret in logs | `sanitize_provider_error` from GAR-579 covers error path |
+| 4 | Timeout | `tokio::time::timeout` + schema cap 600 |
+| 5 | Path hijacking | Zero subprocess — `audit_no_dangerous_tools` catches `std::process::Command` |
+| 6 | Shell injection | Zero shell |
+| 7 | Prompt size | Schema `maxLength: 65536`; rejected before LLM call |
+| 8 | Output size | `max_tokens: 4096` in `ask_oneshot` |
+| 9 | Loops | OpenRouter (provider) doesn't call back into MCP |
+| 10 | rmcp server API | **VALIDATED 2026-05-11**: `ServerHandler` trait + `serve_server` + `transport::io::stdio` confirmed in cached source |
+| 11 | Token cost | Default `openrouter/free`; explicit opt-in for `openrouter/auto` |
+| 12 | CodeQL FP | Pattern: separate `get_api_key` from result-returning paths (mirrors GAR-576 fix) |
+
+---
+
+## §9 Out of scope (follow-ups, mirroring user's lock-in §2)
+
+1. Integration test JSON-RPC via stdin pipe.
+2. Streamable HTTP transport.
+3. Additional tools (`garra_chat`, `garra_files`).
+4. `--enable-tools` in `garra ask` + MCP propagation.
+5. `--stream` partial responses.
+6. Auto `free → auto` fallback.
+7. `RedactingWriter` provider-error extension.
+8. `.env` / `dotenvy_override` / `GARRAIA_CONFIG_DIR` operator fixes.
+9. AgentRuntime sandbox.
+10. MCP telemetry.
+11. Per-user auth.
+
+---
+
+## §10 Commit shape
+
+- Title: `feat(cli): add MCP server exposing garra ask as stdio tool`
+- Conventional commits, NOT breaking.
+- Single commit preferred; split only if CodeQL drama (GAR-576 pattern).
+- Author: `michelbr84 <166889728+michelbr84@users.noreply.github.com>` (canonical, verified via `git config --local`).


### PR DESCRIPTION
## Summary

- New subcommand `garra mcp-server` runs a [Model Context Protocol](https://modelcontextprotocol.io/) stdio server.
- Exposes ONE tool: `garra_ask`. Calls `ask::ask_oneshot` **in-process** (no subprocess, no shell).
- Default `openrouter/free`; `openrouter/auto` only opt-in (no automatic fallback).
- Response = full `garra.ask.v1` envelope as MCP text content (Claude sees provider/model/latency/error.kind).
- Two compile-time audit tests enforce stdio + LLM-only invariants.
- Zero new crate — reuses `rmcp 1.6` already in workspace via `garraia-agents`.

## Linear

[GAR-583](https://linear.app/chatgpt25/issue/GAR-583/mcp-expose-garra-ask-as-a-stdio-tool).

## Plan

`plans/0102-gar-583-mcp-server-stdio.md`.

## Test plan

- [x] `cargo fmt --all -- --check` → 0.
- [x] `cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings` → 0 (CI invocation, ci.yml:54).
- [x] `cargo test -p garraia --bin garra` → **75/75** (22 new + 53 from GAR-576/579/582).
- [x] `cargo build --release --bin garra` → 0.
- [x] `garra mcp-server --help` shows subcommand; `garra --help` lists it.
- [ ] CI green.
- [ ] Manual smoke in Claude Desktop / Claude Code with `openrouter/free` (deferred — network-dependent; current network blocks TLS to OpenRouter, unrelated to this PR).

## Architecture

1. **`crates/garraia-cli/src/ask.rs`** — refactored. Extracted pure async core `ask_oneshot(config, AskOptions) -> AskOutcome`. `run_ask` (CLI) is now a thin wrapper. Behavior unchanged. Existing 15 `ask::tests` continue to pass.
2. **`crates/garraia-cli/src/mcp_server.rs`** — new module (~430 LOC). `GarraToolHandler` impls `rmcp::ServerHandler`. `list_tools` returns the `garra_ask` descriptor. `call_tool` validates args, calls `ask::ask_oneshot`, packs the envelope. `run_mcp_server` bootstraps stdio handshake.
3. **`crates/garraia-cli/src/main.rs`** — new `Commands::McpServer` variant + match arm.
4. **`crates/garraia-cli/Cargo.toml`** — enables `rmcp` features `["server", "transport-io", "macros"]`.

## Stdio + safety invariants (load-bearing)

| Stream | Owner | Content |
|---|---|---|
| stdin | `rmcp` | JSON-RPC requests |
| stdout | `rmcp` (exclusive) | JSON-RPC responses |
| stderr | `tracing` (RedactingWriter) | redacted logs |

Two audit tests scan production code (everything before `#[cfg(test)]`):

- `audit_mcp_server_never_writes_to_stdout` — rejects `println!`, `print!`, `io::stdout`, `stdout().write`.
- `audit_mcp_server_never_registers_dangerous_tools` — rejects `register_tool`, `BashTool`, `FileReadTool`, `FileWriteTool`, `GitDiffTool`, `std::process::Command`, `tokio::process::Command`.

A future PR that tries to slip a tool registration or subprocess spawn into `mcp_server.rs` fails `cargo test`.

## Tool schema (`garra_ask`)

| Field | Type | Required | Default | Notes |
|-------|------|----------|---------|-------|
| `message` | string | yes | — | Max 64 KiB, trimmed |
| `provider` | string | no | `openrouter` | `ollama`/`anthropic`/`openai`/`openrouter` |
| `model` | string | no | `openrouter/free` | `openrouter/auto` only opt-in |
| `timeout_secs` | integer | no | 60 | Range [1, 600] |
| `system_prompt` | string | no | minimal default | Max 8 KiB |

`additionalProperties: false`; unknown fields rejected.

## Claude Desktop / Claude Code config

```json
{
  "mcpServers": {
    "garra": {
      "command": "garra",
      "args": ["mcp-server"]
    }
  }
}
```

## Behavior changes

- New subcommand `garra mcp-server`. Existing `chat`, `ask`, `config`, `status`, etc. untouched.
- `ask::run_ask` refactored as thin wrapper over `ask::ask_oneshot`. Smoke test confirms byte-equivalent stdout/stderr (existing 15 ask::tests + GAR-579 smoke baseline).

## Out of scope (separate follow-ups)

- Integration test JSON-RPC via stdin pipe.
- Streamable HTTP transport.
- Additional MCP tools (`garra_chat`, `garra_files`, etc.).
- `--enable-tools` opt-in for `garra ask` + MCP propagation.
- `--stream` partial MCP responses.
- Automatic `openrouter/free → openrouter/auto` fallback.
- `RedactingWriter` extension for provider error payloads.
- `.env` / `dotenvy` / `GARRAIA_CONFIG_DIR` operator-side fixes.
- MCP server telemetry / per-user auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)