### PR TITLE
fix(mcp): GAR-587 — apply garra_ask schema defaults before ask_oneshot

### DIFF
--- a/crates/garraia-cli/src/mcp_server.rs
+++ b/crates/garraia-cli/src/mcp_server.rs
@@ -41,6 +41,18 @@ const ARG_TIMEOUT_SECS_MIN: u64 = 1;
 const ARG_TIMEOUT_SECS_MAX: u64 = 600;
 const ARG_TIMEOUT_SECS_DEFAULT: u64 = 60;
 
+/// GAR-587 — Default provider applied when the MCP caller omits `provider`.
+/// Matches the JSON-Schema `default` advertised by `garra_ask_tool`; the
+/// schema's `default` is advisory, so MCP hosts do not synthesize it before
+/// dispatching `tools/call`. The handler applies it explicitly to honor the
+/// advertised contract.
+const PROVIDER_DEFAULT: &str = "openrouter";
+
+/// GAR-587 — Default model applied when the MCP caller omits `model`.
+/// Stays at `openrouter/free`; `openrouter/auto` remains opt-in (must be
+/// passed explicitly by the caller).
+const MODEL_DEFAULT: &str = "openrouter/free";
+
 /// GAR-583 — Argument shape for the `garra_ask` MCP tool.
 ///
 /// Deserialized from `CallToolRequestParam.arguments`. `deny_unknown_fields`
@@ -58,6 +70,24 @@ pub(crate) struct GarraAskArgs {
     pub timeout_secs: Option<u64>,
     #[serde(default)]
     pub system_prompt: Option<String>,
+}
+
+/// GAR-587 — Apply MCP schema defaults to `(provider, model)` when the
+/// caller omitted them. JSON-Schema `default` is advisory; MCP hosts do
+/// **not** synthesize missing values, so the handler applies them
+/// explicitly to honor the contract advertised by [`garra_ask_tool`].
+///
+/// Pure function — no I/O, no allocation when both fields are `Some`.
+/// `openrouter/auto` is **only** reachable when the caller passes it
+/// explicitly; an absent `model` never resolves to `auto`.
+pub(crate) fn resolve_overrides(
+    provider: Option<String>,
+    model: Option<String>,
+) -> (String, String) {
+    (
+        provider.unwrap_or_else(|| PROVIDER_DEFAULT.to_string()),
+        model.unwrap_or_else(|| MODEL_DEFAULT.to_string()),
+    )
 }
 
 /// GAR-583 — Validate `GarraAskArgs` bounds. Returns the same error
@@ -207,10 +237,16 @@ impl ServerHandler for GarraToolHandler {
         }
 
         // Build opts + call the pure core.
+        //
+        // GAR-587: apply MCP schema defaults to `provider`/`model` before
+        // they reach `ask::ask_oneshot`. The schema descriptor advertises
+        // `default` values but MCP hosts do not synthesize them, so the
+        // handler honors the contract explicitly.
+        let (provider, model) = resolve_overrides(args.provider, args.model);
         let opts = AskOptions {
             message: args.message,
-            provider_override: args.provider,
-            model_override: args.model,
+            provider_override: Some(provider),
+            model_override: Some(model),
             url_override: None,
             timeout_secs: args.timeout_secs.unwrap_or(ARG_TIMEOUT_SECS_DEFAULT),
             system_prompt_override: args.system_prompt,
@@ -299,6 +335,21 @@ mod tests {
             .and_then(|m| m.get("default"))
             .and_then(|d| d.as_str());
         assert_eq!(model_default, Some("openrouter/free"));
+    }
+
+    /// GAR-587 — schema-side parity with `tool_descriptor_default_model_…`.
+    /// Pins the advertised default so the schema descriptor and the
+    /// runtime constant in [`resolve_overrides`] never drift.
+    #[test]
+    fn tool_descriptor_default_provider_is_openrouter() {
+        let t = garra_ask_tool();
+        let schema = (*t.input_schema).clone();
+        let provider_default = schema
+            .get("properties")
+            .and_then(|p| p.get("provider"))
+            .and_then(|m| m.get("default"))
+            .and_then(|d| d.as_str());
+        assert_eq!(provider_default, Some("openrouter"));
     }
 
     #[test]
@@ -433,6 +484,63 @@ mod tests {
             system_prompt: Some("be brief".to_string()),
         };
         assert!(validate_args(&a).is_ok());
+    }
+
+    // ─── Default resolution (GAR-587) ─────────────────────────────────
+
+    /// GAR-587 §5 case #1 — the load-bearing test. Minimum-payload calls
+    /// (`{ "message": "hi" }`) MUST resolve to the schema-advertised
+    /// defaults BEFORE reaching `ask::ask_oneshot`, otherwise the
+    /// `AppConfig` fallback path can route to an unrelated provider
+    /// (operator-side OpenAI 401 was the original repro on 2026-05-11).
+    #[test]
+    fn resolve_overrides_applies_defaults_when_args_are_none() {
+        let (provider, model) = resolve_overrides(None, None);
+        assert_eq!(provider, "openrouter");
+        assert_eq!(model, "openrouter/free");
+    }
+
+    /// GAR-587 §5 case #2 — caller-explicit `provider`/`model` MUST
+    /// survive the helper unchanged. Otherwise the fix would clobber
+    /// legitimate per-call routing.
+    #[test]
+    fn resolve_overrides_keeps_explicit_provider_and_model() {
+        let (provider, model) = resolve_overrides(
+            Some("anthropic".to_string()),
+            Some("claude-opus-4-7".to_string()),
+        );
+        assert_eq!(provider, "anthropic");
+        assert_eq!(model, "claude-opus-4-7");
+    }
+
+    /// GAR-587 §5 case #3 — `openrouter/auto` MUST remain opt-in. Two
+    /// branches: (a) explicit `auto` survives; (b) `None` model never
+    /// promotes itself to `auto` — the default stays `openrouter/free`.
+    #[test]
+    fn resolve_overrides_passes_openrouter_auto_only_when_explicit() {
+        // (a) Explicit `auto` is preserved.
+        let (provider, model) = resolve_overrides(None, Some("openrouter/auto".to_string()));
+        assert_eq!(provider, "openrouter");
+        assert_eq!(model, "openrouter/auto");
+
+        // (b) Absent model never becomes `auto`.
+        let (_, model_default) = resolve_overrides(None, None);
+        assert_ne!(model_default, "openrouter/auto");
+        assert_eq!(model_default, "openrouter/free");
+    }
+
+    /// GAR-587 — mixed-fill case (provider explicit, model omitted) and
+    /// its mirror (model explicit, provider omitted). Catches a class of
+    /// regressions where a future refactor swaps the two branches.
+    #[test]
+    fn resolve_overrides_handles_partial_overrides() {
+        let (provider, model) = resolve_overrides(Some("ollama".to_string()), None);
+        assert_eq!(provider, "ollama");
+        assert_eq!(model, "openrouter/free");
+
+        let (provider, model) = resolve_overrides(None, Some("gpt-4o-mini".to_string()));
+        assert_eq!(provider, "openrouter");
+        assert_eq!(model, "gpt-4o-mini");
     }
 
     // ─── Audit invariants (load-bearing) ──────────────────────────────

--- a/plans/0104-gar-587-mcp-garra-ask-defaults.md
+++ b/plans/0104-gar-587-mcp-garra-ask-defaults.md
@@ -1,0 +1,245 @@
+# Plan 0104 — GAR-587: apply `garra_ask` schema defaults before calling `ask_oneshot`
+
+- **Issue:** [GAR-587](https://linear.app/chatgpt25/issue/GAR-587)
+- **Parent epic:** [GAR-583](https://linear.app/chatgpt25/issue/GAR-583) (`garra mcp-server`, PR #270)
+- **Sibling:** [GAR-585](https://linear.app/chatgpt25/issue/GAR-585) (`get_info` advertises tools, PR #271)
+- **Branch:** `fix/gar-587-mcp-garra-ask-defaults`
+- **Created:** 2026-05-11 (Florida)
+- **Status:** Draft → ready for execution
+
+## §1 Goal
+
+When an MCP host calls `tools/call name=garra_ask` with the minimum payload
+(`{ "message": "..." }` and **no** `provider` / `model`), the handler must
+apply the same defaults the JSON schema advertises — `provider="openrouter"`
+and `model="openrouter/free"` — **before** invoking `ask::ask_oneshot`.
+Hosts do not synthesize JSON-Schema `default` values; today the handler
+forwards `None` and `ask_oneshot` falls through to local `AppConfig`
+resolution, which on a misconfigured operator machine surfaces unrelated
+provider 401s.
+
+## §2 Background / Root cause
+
+`crates/garraia-cli/src/mcp_server.rs:97-144` advertises a JSON schema with:
+
+```json
+"provider": { ..., "default": "openrouter" },
+"model":    { ..., "default": "openrouter/free" }
+```
+
+JSON-Schema `default` is **advisory** — neither `rmcp` nor the MCP host
+(Claude Code, Claude Desktop) injects those values into the call payload
+before delivering it to `call_tool`. The handler at
+`crates/garraia-cli/src/mcp_server.rs:210-217` builds `AskOptions` by
+forwarding `args.provider` / `args.model` straight through:
+
+```rust
+provider_override: args.provider,   // None when host omitted it
+model_override:    args.model,      // None when host omitted it
+```
+
+`ask::ask_oneshot` then resolves provider/model from `AppConfig`, env vars,
+and CLI defaults — none of which honor the **MCP schema contract**. The
+`timeout_secs` field already follows the right pattern
+(`args.timeout_secs.unwrap_or(ARG_TIMEOUT_SECS_DEFAULT)` at L215), so the
+fix is to apply the same shape to `provider` / `model`.
+
+### Empirical repro (2026-05-11, Florida)
+
+From Claude Code, calling `mcp__garra__garra_ask` with `{ "message": "Oi,
+tudo bem?" }`:
+
+```text
+{"error":{"kind":"provider_error","message":"agent error: openai API error: status=401 Unauthorized ..."}}
+```
+
+Same call with explicit `provider="openrouter"` + `model="openrouter/free"`
+returns `ok:true` with `latency_ms: 1541`. Confirms the gap is **handler-side
+default application**, not MCP transport, not OpenRouter config.
+
+## §3 Scope / Non-scope
+
+### In scope
+
+- Add two file-scoped constants in `crates/garraia-cli/src/mcp_server.rs`:
+  `PROVIDER_DEFAULT = "openrouter"`, `MODEL_DEFAULT = "openrouter/free"`.
+- In `call_tool`, wrap `args.provider` / `args.model` with
+  `Some(... .unwrap_or_else(|| <const>.to_string()))`.
+- Four new unit tests (see §5).
+- Re-run `cargo fmt --check`, `cargo clippy ... -D warnings`,
+  `cargo test -p garraia --bin garra`, `cargo build --release --bin garra`.
+
+### Out of scope (locked)
+
+- `garra ask` CLI behavior (`run_ask` already resolves correctly via
+  GAR-579 / GAR-582 paths).
+- `garraia-config`, `AppConfig`, or any global provider-resolution logic.
+- `openrouter/auto` policy — still opt-in only, never automatic.
+- Bumping `rmcp` or any workspace dependency.
+- `.env`, OpenRouter key, TLS, `RedactingWriter`, Claude Code / Desktop
+  config.
+- Real LLM calls in CI.
+- Touching the two `audit_…` invariants
+  (`audit_mcp_server_never_writes_to_stdout`,
+  `audit_mcp_server_never_registers_dangerous_tools`).
+
+## §4 Acceptance criteria
+
+1. With minimum args (`{ "message": "hi" }`), the `AskOptions` passed into
+   `ask::ask_oneshot` has `provider_override == Some("openrouter")` and
+   `model_override == Some("openrouter/free")`.
+2. Explicit values from the host (e.g. `provider="anthropic"`,
+   `model="claude-opus-4-7"`) survive unchanged.
+3. `openrouter/auto` is **only** reachable when the host passes it
+   explicitly — never inferred from the absence of `model`.
+4. JSON-Schema `default` fields for `provider` / `model` remain unchanged
+   in the tool descriptor (pinned by existing tests
+   `tool_descriptor_default_model_is_openrouter_free` and new
+   `tool_descriptor_default_provider_is_openrouter`).
+5. Both `audit_…` invariants remain green.
+6. `cargo fmt --check`, `cargo clippy --workspace --exclude garraia-desktop
+   --all-targets -- -D warnings`, `cargo test -p garraia --bin garra`,
+   `cargo build --release --bin garra` all green locally and in CI.
+
+## §5 Tests (RED first)
+
+Add to the `#[cfg(test)] mod tests` block in `mcp_server.rs`. The tests
+target the **handler-side default resolution** (the gap fixed in this PR),
+not the schema descriptor (already covered by GAR-583 tests). To keep them
+pure and offline, factor the default-application into a tiny helper:
+
+```rust
+fn resolve_overrides(args: &GarraAskArgs) -> (String, String) {
+    (
+        args.provider.clone().unwrap_or_else(|| PROVIDER_DEFAULT.to_string()),
+        args.model.clone().unwrap_or_else(|| MODEL_DEFAULT.to_string()),
+    )
+}
+```
+
+Then exercise it directly — no `RequestContext`, no `tokio` runtime, no
+network:
+
+| Test | Input | Asserts |
+|------|-------|---------|
+| `resolve_overrides_applies_defaults_when_args_are_none` | `{ message: "hi" }` | `("openrouter", "openrouter/free")` |
+| `resolve_overrides_keeps_explicit_provider_and_model` | `provider="anthropic"`, `model="claude-opus-4-7"` | `("anthropic", "claude-opus-4-7")` |
+| `resolve_overrides_passes_openrouter_auto_only_when_explicit` | `provider=None`, `model="openrouter/auto"` | `("openrouter", "openrouter/auto")` — and a second case with both None ⇒ `model != "openrouter/auto"` |
+| `tool_descriptor_default_provider_is_openrouter` | (schema-side, mirrors `…_default_model_is_openrouter_free`) | `schema.properties.provider.default == "openrouter"` |
+
+All four are pure, deterministic, < 1 ms each, and use no fixtures.
+
+## §6 Implementation
+
+### §6.1 Constants
+
+Add next to `ARG_TIMEOUT_SECS_DEFAULT`
+(`crates/garraia-cli/src/mcp_server.rs` ~L42):
+
+```rust
+/// GAR-587 — Default provider applied when the MCP caller omits `provider`.
+/// Matches the JSON-Schema `default` advertised by `garra_ask_tool`.
+const PROVIDER_DEFAULT: &str = "openrouter";
+
+/// GAR-587 — Default model applied when the MCP caller omits `model`.
+/// Matches the JSON-Schema `default` advertised by `garra_ask_tool`.
+/// NOTE: stays at `openrouter/free`. `openrouter/auto` must remain
+/// opt-in (caller-explicit only).
+const MODEL_DEFAULT: &str = "openrouter/free";
+```
+
+### §6.2 Helper
+
+Add a tiny pure helper above `impl ServerHandler for GarraToolHandler`:
+
+```rust
+/// GAR-587 — Apply MCP schema defaults to `(provider, model)` when the
+/// caller omitted them. JSON-Schema `default` is advisory; MCP hosts
+/// do **not** synthesize missing values, so the handler must apply them
+/// explicitly to honor the contract advertised by `garra_ask_tool`.
+fn resolve_overrides(args: &GarraAskArgs) -> (String, String) {
+    let provider = args
+        .provider
+        .clone()
+        .unwrap_or_else(|| PROVIDER_DEFAULT.to_string());
+    let model = args
+        .model
+        .clone()
+        .unwrap_or_else(|| MODEL_DEFAULT.to_string());
+    (provider, model)
+}
+```
+
+### §6.3 `call_tool` rewire
+
+In `call_tool` (~L210-217), replace:
+
+```rust
+let opts = AskOptions {
+    message: args.message,
+    provider_override: args.provider,
+    model_override: args.model,
+    url_override: None,
+    timeout_secs: args.timeout_secs.unwrap_or(ARG_TIMEOUT_SECS_DEFAULT),
+    system_prompt_override: args.system_prompt,
+};
+```
+
+with:
+
+```rust
+let (provider, model) = resolve_overrides(&args);
+let opts = AskOptions {
+    message: args.message,
+    provider_override: Some(provider),
+    model_override: Some(model),
+    url_override: None,
+    timeout_secs: args.timeout_secs.unwrap_or(ARG_TIMEOUT_SECS_DEFAULT),
+    system_prompt_override: args.system_prompt,
+};
+```
+
+### §6.4 Schema descriptor (no change)
+
+The JSON schema in `garra_ask_tool` already advertises both defaults and
+is pinned by `tool_descriptor_default_model_is_openrouter_free`. Add a
+symmetric `tool_descriptor_default_provider_is_openrouter` test for parity
+— **no edit to the schema literal itself**.
+
+## §7 Validation
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings
+cargo test -p garraia --bin garra
+cargo build --release --bin garra
+```
+
+All four must be green.
+
+## §8 Smoke (post-merge, operator-side only — not in CI)
+
+After merge, from Claude Code call `mcp__garra__garra_ask` with
+`{ "message": "ping" }` (no `provider`/`model`). Expect `ok: true`,
+`provider: "openrouter"`, `model: "openrouter/free"`. No OpenAI 401.
+
+No automated smoke is added in this PR — that would either require a real
+network call (forbidden in CI) or a mock provider injection that doesn't
+exist for `ask_oneshot` today.
+
+## §9 Risks
+
+- **Low.** The change is three lines in `mcp_server.rs` plus four pure
+  unit tests. The only failure mode is making `openrouter/auto` reachable
+  by default, which test #3 in §5 explicitly guards against.
+- No security surface change. No new code paths reach the LLM that
+  weren't already reachable via explicit caller payload.
+- No behavior change for `garra ask` CLI (different code path).
+
+## §10 Out-of-scope follow-ups (not in this PR)
+
+- Wire a feature-flagged offline provider into `ask::ask_oneshot` so we
+  can write an end-to-end MCP smoke without hitting the network. Would
+  belong in a separate slice.
+- Surface a structured `MCP defaults applied` audit log entry when
+  defaults kicked in (low value; deferred).

--- a/plans/README.md
+++ b/plans/README.md
@@ -125,6 +125,7 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0099 | [GAR-577 — Files REST API slice 9: POST /v1/groups/{group_id}/files (direct file upload / create)](0099-gar-577-files-api-slice9-create.md) | [GAR-577](https://linear.app/chatgpt25/issue/GAR-577) | ✅ Merged 2026-05-11 via PR #264 (`725cf54`) |
 | 0100 | [GAR-579 — CLI: add non-interactive garra ask command](0100-gar-579-cli-non-interactive-ask.md) | [GAR-579](https://linear.app/chatgpt25/issue/GAR-579) | ✅ Merged 2026-05-11 via PR #267 (`6fdc1b4`) |
 | 0103 | [GAR-585 — advertise `tools` capability in garra mcp-server](0103-gar-585-mcp-tools-capability.md) | [GAR-585](https://linear.app/chatgpt25/issue/GAR-585) | 🚧 In progress (branch `fix/gar-585-mcp-tools-capability`) |
+| 0104 | [GAR-587 — apply `garra_ask` schema defaults before calling `ask_oneshot`](0104-gar-587-mcp-garra-ask-defaults.md) | [GAR-587](https://linear.app/chatgpt25/issue/GAR-587) | 🚧 In progress (branch `fix/gar-587-mcp-garra-ask-defaults`) |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

- Closes the regression where `mcp__garra__garra_ask` called with minimum args (`{"message": "..."}`) fell through `ask::ask_oneshot`'s local `AppConfig` resolution and surfaced an unrelated OpenAI 401 on operator machines without an OpenRouter default.
- Adds two file-scoped constants (`PROVIDER_DEFAULT="openrouter"`, `MODEL_DEFAULT="openrouter/free"`) and a pure helper `resolve_overrides(Option<String>, Option<String>) -> (String, String)` applied in `call_tool` before building `AskOptions`. The JSON-Schema descriptor (advisory `default`) is unchanged; only the runtime contract is now honored explicitly.
- `openrouter/auto` stays opt-in — covered by `resolve_overrides_passes_openrouter_auto_only_when_explicit`.

## Linear

- Issue: [GAR-587](https://linear.app/chatgpt25/issue/GAR-587)
- Parent: [GAR-583](https://linear.app/chatgpt25/issue/GAR-583) (`garra mcp-server`)
- Sibling: [GAR-585](https://linear.app/chatgpt25/issue/GAR-585) (`get_info` capability)
- Plan: [`plans/0104-gar-587-mcp-garra-ask-defaults.md`](plans/0104-gar-587-mcp-garra-ask-defaults.md)

## Repro (2026-05-11, Florida)

From Claude Code, calling `mcp__garra__garra_ask` with no `provider`/`model`:

```text
{"error":{"kind":"provider_error","message":"agent error: openai API error: status=401 Unauthorized ..."}}
```

Same call with explicit `provider="openrouter"` + `model="openrouter/free"` → `ok:true`, `latency_ms: 1541`. Confirms the gap is handler-side default application, not MCP transport, not OpenRouter config.

## Test plan

- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings` clean.
- [x] `cargo test -p garraia --bin garra` — 82/82 unit tests green, including 5 new:
  - `resolve_overrides_applies_defaults_when_args_are_none`
  - `resolve_overrides_keeps_explicit_provider_and_model`
  - `resolve_overrides_passes_openrouter_auto_only_when_explicit`
  - `resolve_overrides_handles_partial_overrides`
  - `tool_descriptor_default_provider_is_openrouter` (schema-side parity)
- [x] `cargo build --release --bin garra` green.
- [ ] CI green on this branch (awaiting workflows).
- [ ] Post-merge operator-side smoke: `mcp__garra__garra_ask` with no `provider`/`model` no longer surfaces an OpenAI 401.

## Non-goals (explicit, locked-in 2026-05-11)

- No change to `garra ask` CLI (`run_ask` resolves provider/model on its own path).
- No change to `garraia-config` or global provider resolution.
- No edits to `.env`, OpenRouter key, TLS, `RedactingWriter`, Claude Code config.
- No real LLM call from CI; `openrouter/auto` remains opt-in.
- Audit invariants (`audit_mcp_server_never_writes_to_stdout`, `audit_mcp_server_never_registers_dangerous_tools`) untouched and still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)