### PR TITLE
feat(groups): GAR-580 — GET /v1/groups (list user's groups, plan 0105)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -384,6 +384,7 @@ Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
 
 **Grupos**
 
+- [x] `GET /v1/groups` — plan 0105 / [GAR-580](https://linear.app/chatgpt25/issue/GAR-580), implementado 2026-05-12 (Florida)
 - [x] `POST /v1/groups` — plan 0016 M4, entregue 2026-04-14
 - [x] `GET /v1/groups/{group_id}` — plan 0016 M4, entregue 2026-04-14
 - [x] `PATCH /v1/groups/{group_id}` — plan 0017, entregue 2026-04-16

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -390,8 +390,8 @@ Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
 - [x] `POST /v1/groups/{group_id}/invites` — plan 0018, entregue 2026-04-16
 - [x] `POST /v1/groups/{group_id}/members/{user_id}:setRole` — plan 0020, entregue 2026-04-20
 - [x] `DELETE /v1/groups/{group_id}/members/{user_id}` — plan 0020, entregue 2026-04-20
-- [ ] `GET /v1/groups/{group_id}/members` — plan 0097 / [GAR-574](https://linear.app/chatgpt25/issue/GAR-574)
-- [ ] `GET /v1/groups/{group_id}/invites` — plan 0097 / [GAR-574](https://linear.app/chatgpt25/issue/GAR-574)
+- [x] `GET /v1/groups/{group_id}/members` — plan 0097 / [GAR-574](https://linear.app/chatgpt25/issue/GAR-574), implementado 2026-05-11 (Florida)
+- [x] `GET /v1/groups/{group_id}/invites` — plan 0097 / [GAR-574](https://linear.app/chatgpt25/issue/GAR-574), implementado 2026-05-11 (Florida)
 - [x] `GET /v1/me` — plan 0015 (skeleton Fase 3.4), entregue 2026-04-14
 
 **Chats**

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -249,7 +249,7 @@ name = "rest_v1_tasks"
 path = "tests/rest_v1_tasks.rs"
 required-features = ["test-helpers"]
 
-# Plan 0070 (GAR-522) — audit API slice 1: GET /v1/groups/{group_id}/audit.
+# Plan 0070 (GAR-572) — audit API slice 1: GET /v1/groups/{group_id}/audit.
 # Feature-gated so plain `cargo test -p garraia-gateway` (without
 # --features test-helpers) skips compilation cleanly.
 [[test]]
@@ -351,6 +351,13 @@ required-features = ["test-helpers"]
 [[test]]
 name = "rest_v1_groups_members_invites"
 path = "tests/rest_v1_groups_members_invites.rs"
+required-features = ["test-helpers"]
+
+# Plan 0105 (GAR-580) — GET /v1/groups list scenarios (GL1-GL6).
+# Requires test-helpers so `--all-targets` without the feature skips it.
+[[test]]
+name = "rest_v1_groups_list"
+path = "tests/rest_v1_groups_list.rs"
 required-features = ["test-helpers"]
 
 [dev-dependencies]

--- a/crates/garraia-gateway/src/rest_v1/groups.rs
+++ b/crates/garraia-gateway/src/rest_v1/groups.rs
@@ -1713,6 +1713,203 @@ pub async fn list_invites(
     Ok(Json(ListInvitesResponse { items, next_cursor }))
 }
 
+// ─── DTOs: list_groups ────────────────────────────────────────────────────────
+
+/// Query parameters for `GET /v1/groups`.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ListGroupsQuery {
+    /// Keyset cursor — `group_id` UUID of the last group received. Omit on first page.
+    pub cursor: Option<Uuid>,
+    /// Page size. Default 50, max 100.
+    pub limit: Option<u32>,
+    /// Filter by the caller's role in the group (`owner`, `admin`, `member`, `guest`, `child`).
+    pub role: Option<String>,
+}
+
+/// One group entry in the list response.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct GroupListItem {
+    pub id: Uuid,
+    pub name: String,
+    #[serde(rename = "type")]
+    pub group_type: String,
+    pub created_at: DateTime<Utc>,
+    pub created_by: Uuid,
+    /// The caller's role in this group.
+    pub role: String,
+    /// When the caller joined this group.
+    pub joined_at: DateTime<Utc>,
+}
+
+/// Response body for `GET /v1/groups`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ListGroupsResponse {
+    pub items: Vec<GroupListItem>,
+    pub next_cursor: Option<Uuid>,
+}
+
+// ─── Handler: list_groups ─────────────────────────────────────────────────────
+
+/// `GET /v1/groups` — cursor-paginated list of groups the caller belongs to (plan 0105, GAR-580).
+///
+/// Returns every group where the authenticated user has an **active** membership,
+/// ordered by `group_id ASC` (stable keyset). No `X-Group-Id` header is required or
+/// expected — this endpoint is inherently cross-group.
+///
+/// ## Cursor scheme
+///
+/// Ordered by `group_id ASC`. Cursor = `group_id` UUID of the last item received.
+/// Pass `?cursor=<uuid>` for subsequent pages.
+///
+/// ## Authz
+///
+/// Bearer JWT only. The handler sets `app.current_user_id` in a transaction for
+/// defensive forward-compat (neither `groups` nor `group_members` has FORCE RLS today,
+/// but they may in future migrations).
+#[utoipa::path(
+    get,
+    path = "/v1/groups",
+    params(ListGroupsQuery),
+    responses(
+        (status = 200, description = "Paginated list of the caller's groups.", body = ListGroupsResponse),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn list_groups(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Query(params): Query<ListGroupsQuery>,
+) -> Result<Json<ListGroupsResponse>, RestError> {
+    // 1. Clamp limit.
+    let limit = params
+        .limit
+        .unwrap_or(DEFAULT_LIST_LIMIT)
+        .min(MAX_LIST_LIMIT) as i64;
+
+    // 2. Open tx + SET LOCAL (defensive; group_members has no FORCE RLS).
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(principal.user_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    // 3. Build query. Only active memberships.
+    //    Cursor: WHERE gm.group_id > $cursor (keyset on group_id ASC).
+    //    Role filter is optional.
+    //    Fetch limit+1 to detect whether a next page exists.
+
+    #[derive(sqlx::FromRow)]
+    struct GroupRow {
+        group_id: Uuid,
+        name: String,
+        group_type: String,
+        created_at: DateTime<Utc>,
+        created_by: Uuid,
+        role: String,
+        joined_at: DateTime<Utc>,
+    }
+
+    let rows: Vec<GroupRow> = match (&params.cursor, &params.role) {
+        (Some(cursor_id), Some(role)) => sqlx::query_as(
+            "SELECT gm.group_id, g.name, g.type AS group_type, g.created_at, \
+                        g.created_by, gm.role, gm.joined_at \
+                 FROM group_members gm \
+                 JOIN groups g ON g.id = gm.group_id \
+                 WHERE gm.user_id = $1 AND gm.status = 'active' \
+                   AND gm.group_id > $2 AND gm.role = $3 \
+                 ORDER BY gm.group_id ASC LIMIT $4",
+        )
+        .bind(principal.user_id)
+        .bind(cursor_id)
+        .bind(role)
+        .bind(limit + 1)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?,
+        (Some(cursor_id), None) => sqlx::query_as(
+            "SELECT gm.group_id, g.name, g.type AS group_type, g.created_at, \
+                        g.created_by, gm.role, gm.joined_at \
+                 FROM group_members gm \
+                 JOIN groups g ON g.id = gm.group_id \
+                 WHERE gm.user_id = $1 AND gm.status = 'active' \
+                   AND gm.group_id > $2 \
+                 ORDER BY gm.group_id ASC LIMIT $3",
+        )
+        .bind(principal.user_id)
+        .bind(cursor_id)
+        .bind(limit + 1)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?,
+        (None, Some(role)) => sqlx::query_as(
+            "SELECT gm.group_id, g.name, g.type AS group_type, g.created_at, \
+                        g.created_by, gm.role, gm.joined_at \
+                 FROM group_members gm \
+                 JOIN groups g ON g.id = gm.group_id \
+                 WHERE gm.user_id = $1 AND gm.status = 'active' \
+                   AND gm.role = $2 \
+                 ORDER BY gm.group_id ASC LIMIT $3",
+        )
+        .bind(principal.user_id)
+        .bind(role)
+        .bind(limit + 1)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?,
+        (None, None) => sqlx::query_as(
+            "SELECT gm.group_id, g.name, g.type AS group_type, g.created_at, \
+                        g.created_by, gm.role, gm.joined_at \
+                 FROM group_members gm \
+                 JOIN groups g ON g.id = gm.group_id \
+                 WHERE gm.user_id = $1 AND gm.status = 'active' \
+                 ORDER BY gm.group_id ASC LIMIT $2",
+        )
+        .bind(principal.user_id)
+        .bind(limit + 1)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?,
+    };
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    // 4. Cursor-next trick: pop last if we fetched limit+1.
+    let has_more = rows.len() > limit as usize;
+    let mut rows = rows;
+    if has_more {
+        rows.pop();
+    }
+    let next_cursor = if has_more {
+        rows.last().map(|r| r.group_id)
+    } else {
+        None
+    };
+
+    let items = rows
+        .into_iter()
+        .map(|r| GroupListItem {
+            id: r.group_id,
+            name: r.name,
+            group_type: r.group_type,
+            created_at: r.created_at,
+            created_by: r.created_by,
+            role: r.role,
+            joined_at: r.joined_at,
+        })
+        .collect();
+
+    Ok(Json(ListGroupsResponse { items, next_cursor }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -263,7 +263,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
 
             Router::new()
                 .route("/v1/me", get(me::get_me))
-                .route("/v1/groups", post(groups::create_group))
+                // Plan 0105 (GAR-580) — groups slice 3: list user's groups.
+                .route(
+                    "/v1/groups",
+                    post(groups::create_group).get(groups::list_groups),
+                )
                 .route(
                     "/v1/groups/{id}",
                     get(groups::get_group).patch(groups::patch_group),

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -88,9 +88,12 @@ impl Modify for SecurityAddon {
     paths(
         super::me::get_me,
         super::groups::create_group,
+        super::groups::list_groups,
         super::groups::get_group,
         super::groups::patch_group,
         super::groups::create_invite,
+        super::groups::list_invites,
+        super::groups::list_members,
         super::groups::set_member_role,
         super::groups::delete_member,
         super::invites::accept_invite,

--- a/crates/garraia-gateway/tests/rest_v1_groups_list.rs
+++ b/crates/garraia-gateway/tests/rest_v1_groups_list.rs
@@ -1,0 +1,285 @@
+//! Integration tests for `GET /v1/groups` — list user's groups (plan 0105, GAR-580).
+//!
+//! All scenarios are bundled into ONE `#[tokio::test]` to avoid the
+//! sqlx runtime-teardown race (see commit `4f8be37` for the post-mortem).
+//!
+//! Scenarios:
+//!   GL1 — 200 — owner of one group sees it in the list.
+//!   GL2 — 401 — missing JWT returns 401.
+//!   GL3 — 200 empty — user with no memberships returns empty list.
+//!   GL4 — 200 paginated — user in 3 groups, limit=2 returns cursor; page 2 correct.
+//!   GL5 — 200 role filter — ?role=owner filters to only owned groups.
+//!   GL6 — cross-group — user A cannot see user B's groups.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use common::fixtures::seed_user_with_group;
+use common::{Harness, harness_get};
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("failed to collect body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("response body is not JSON")
+}
+
+fn get_groups(token: Option<&str>, query: &str) -> Request<Body> {
+    let uri = if query.is_empty() {
+        "/v1/groups".to_string()
+    } else {
+        format!("/v1/groups?{query}")
+    };
+    let mut req = harness_get(&uri);
+    if let Some(t) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {t}")).unwrap(),
+        );
+    }
+    req
+}
+
+/// Seed a user who belongs to multiple groups.
+///
+/// Returns `(user_id, [group_id_1, group_id_2, group_id_3], token)`.
+/// Groups are inserted in UUID order to match the keyset cursor ordering.
+async fn seed_user_with_multiple_groups(
+    h: &Harness,
+    email: &str,
+) -> anyhow::Result<(Uuid, Vec<Uuid>, String)> {
+    let user_id = Uuid::new_v4();
+    // Generate fixed group IDs so we can predict sort order (ASC by group_id UUID).
+    let mut group_ids: Vec<Uuid> = (0..3).map(|_| Uuid::new_v4()).collect();
+    group_ids.sort(); // ensure deterministic keyset order
+
+    let mut tx = h.admin_pool.begin().await?;
+
+    sqlx::query(
+        "INSERT INTO users (id, email, display_name, status) VALUES ($1, $2, $3, 'active')",
+    )
+    .bind(user_id)
+    .bind(email)
+    .bind(format!("Multi {email}"))
+    .execute(&mut *tx)
+    .await?;
+
+    for (i, &gid) in group_ids.iter().enumerate() {
+        sqlx::query("INSERT INTO groups (id, name, type, created_by) VALUES ($1, $2, 'team', $3)")
+            .bind(gid)
+            .bind(format!("Group {i} for {email}"))
+            .bind(user_id)
+            .execute(&mut *tx)
+            .await?;
+
+        sqlx::query(
+            "INSERT INTO group_members (group_id, user_id, role, status) \
+             VALUES ($1, $2, 'owner', 'active')",
+        )
+        .bind(gid)
+        .bind(user_id)
+        .execute(&mut *tx)
+        .await?;
+    }
+
+    tx.commit().await?;
+    let token = h.jwt.issue_access_for_test(user_id);
+    Ok((user_id, group_ids, token))
+}
+
+/// Seed a plain user with no group memberships.
+async fn seed_user_no_groups(h: &Harness, email: &str) -> anyhow::Result<(Uuid, String)> {
+    let user_id = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO users (id, email, display_name, status) VALUES ($1, $2, $3, 'active')",
+    )
+    .bind(user_id)
+    .bind(email)
+    .bind(format!("NoGroup {email}"))
+    .execute(&h.admin_pool)
+    .await?;
+    let token = h.jwt.issue_access_for_test(user_id);
+    Ok((user_id, token))
+}
+
+#[tokio::test]
+async fn test_list_groups_scenarios() {
+    let h = Harness::get().await;
+    let router = h.router.clone();
+
+    // ── Setup ────────────────────────────────────────────────────────────────
+
+    // GL1 + GL5: single-group user
+    let (_u1, g1_id, tok1) = seed_user_with_group(&h, "gl1-owner@example.com")
+        .await
+        .expect("GL1 fixture");
+
+    // GL3: user with no groups
+    let (_u3, tok3) = seed_user_no_groups(&h, "gl3-nogroups@example.com")
+        .await
+        .expect("GL3 fixture");
+
+    // GL4: user in 3 groups (sorted by group_id ASC)
+    let (_u4, g4_ids, tok4) = seed_user_with_multiple_groups(&h, "gl4-multi@example.com")
+        .await
+        .expect("GL4 fixture");
+
+    // GL6: separate user to test cross-group isolation
+    let (_u6, _g6_id, tok6) = seed_user_with_group(&h, "gl6-other@example.com")
+        .await
+        .expect("GL6 fixture");
+
+    // ── GL1: 200 — owner sees their group ────────────────────────────────────
+    {
+        let resp = router
+            .clone()
+            .oneshot(get_groups(Some(&tok1), ""))
+            .await
+            .expect("GL1 request");
+        assert_eq!(resp.status(), StatusCode::OK, "GL1: expected 200");
+        let body = body_json(resp).await;
+        let items = body["items"].as_array().expect("GL1: items must be array");
+        assert!(!items.is_empty(), "GL1: items must not be empty");
+        let found = items.iter().any(|it| {
+            it["id"]
+                .as_str()
+                .map(|s| s == g1_id.to_string())
+                .unwrap_or(false)
+        });
+        assert!(found, "GL1: group {g1_id} must appear in items");
+    }
+
+    // ── GL2: 401 — no JWT ────────────────────────────────────────────────────
+    {
+        let resp = router
+            .clone()
+            .oneshot(get_groups(None, ""))
+            .await
+            .expect("GL2 request");
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED, "GL2: expected 401");
+    }
+
+    // ── GL3: 200 empty — user with no groups ─────────────────────────────────
+    {
+        let resp = router
+            .clone()
+            .oneshot(get_groups(Some(&tok3), ""))
+            .await
+            .expect("GL3 request");
+        assert_eq!(resp.status(), StatusCode::OK, "GL3: expected 200");
+        let body = body_json(resp).await;
+        let items = body["items"].as_array().expect("GL3: items must be array");
+        assert!(
+            items.is_empty(),
+            "GL3: items must be empty for user with no groups"
+        );
+        assert!(
+            body["next_cursor"].is_null(),
+            "GL3: next_cursor must be null when no items"
+        );
+    }
+
+    // ── GL4: pagination — limit=2 returns cursor, page 2 has remainder ───────
+    {
+        // Page 1: limit=2
+        let resp1 = router
+            .clone()
+            .oneshot(get_groups(Some(&tok4), "limit=2"))
+            .await
+            .expect("GL4 page1 request");
+        assert_eq!(resp1.status(), StatusCode::OK, "GL4 page1: expected 200");
+        let body1 = body_json(resp1).await;
+        let items1 = body1["items"].as_array().expect("GL4 p1: items array");
+        assert_eq!(items1.len(), 2, "GL4 page1: must have exactly 2 items");
+        let next_cursor = body1["next_cursor"]
+            .as_str()
+            .expect("GL4 page1: must have next_cursor");
+
+        // Page 2: use cursor
+        let resp2 = router
+            .clone()
+            .oneshot(get_groups(
+                Some(&tok4),
+                &format!("limit=2&cursor={next_cursor}"),
+            ))
+            .await
+            .expect("GL4 page2 request");
+        assert_eq!(resp2.status(), StatusCode::OK, "GL4 page2: expected 200");
+        let body2 = body_json(resp2).await;
+        let items2 = body2["items"].as_array().expect("GL4 p2: items array");
+        assert_eq!(items2.len(), 1, "GL4 page2: must have 1 remaining item");
+        assert!(
+            body2["next_cursor"].is_null(),
+            "GL4 page2: next_cursor must be null on last page"
+        );
+
+        // All 3 groups must appear across both pages, in group_id ASC order.
+        let page1_ids: Vec<&str> = items1.iter().map(|it| it["id"].as_str().unwrap()).collect();
+        let page2_ids: Vec<&str> = items2.iter().map(|it| it["id"].as_str().unwrap()).collect();
+        let all_ids: Vec<&str> = [page1_ids, page2_ids].concat();
+        let expected_ids: Vec<String> = g4_ids.iter().map(|u| u.to_string()).collect();
+        assert_eq!(
+            all_ids,
+            expected_ids.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+            "GL4: pages must cover all 3 groups in group_id ASC order"
+        );
+    }
+
+    // ── GL5: role filter — ?role=owner ───────────────────────────────────────
+    {
+        let resp = router
+            .clone()
+            .oneshot(get_groups(Some(&tok1), "role=owner"))
+            .await
+            .expect("GL5 request");
+        assert_eq!(resp.status(), StatusCode::OK, "GL5: expected 200");
+        let body = body_json(resp).await;
+        let items = body["items"].as_array().expect("GL5: items array");
+        let found = items.iter().any(|it| {
+            it["id"]
+                .as_str()
+                .map(|s| s == g1_id.to_string())
+                .unwrap_or(false)
+        });
+        assert!(found, "GL5: owner group must appear with role=owner filter");
+        // All returned items must carry role=owner.
+        for it in items {
+            assert_eq!(
+                it["role"].as_str().unwrap_or(""),
+                "owner",
+                "GL5: role filter must return only owner rows"
+            );
+        }
+    }
+
+    // ── GL6: cross-group isolation — tok6 sees only their groups ─────────────
+    {
+        let resp = router
+            .clone()
+            .oneshot(get_groups(Some(&tok6), ""))
+            .await
+            .expect("GL6 request");
+        assert_eq!(resp.status(), StatusCode::OK, "GL6: expected 200");
+        let body = body_json(resp).await;
+        let items = body["items"].as_array().expect("GL6: items array");
+        // tok1's group must NOT appear in tok6's results.
+        let contains_g1 = items.iter().any(|it| {
+            it["id"]
+                .as_str()
+                .map(|s| s == g1_id.to_string())
+                .unwrap_or(false)
+        });
+        assert!(
+            !contains_g1,
+            "GL6: user B must not see user A's group {g1_id}"
+        );
+    }
+}

--- a/plans/0105-gar-580-groups-list-api.md
+++ b/plans/0105-gar-580-groups-list-api.md
@@ -1,0 +1,168 @@
+# Plan 0105 — GAR-580: GET /v1/groups (list user's groups)
+
+**Status:** Em execução  
+**Autor:** Claude Sonnet 4.6 (routine/202605120022-groups-list, 2026-05-12, America/New_York)  
+**Issue Linear:** [GAR-580](https://linear.app/chatgpt25/issue/GAR-580)  
+**Branch:** `routine/202605120022-groups-list`
+
+---
+
+## §1 Goal
+
+Deliver `GET /v1/groups` — cursor-paginated list of every group where the authenticated
+user is an **active** member. Closes GAR-580 (Groups REST API slice 3).
+
+This is the only missing Groups endpoint in the Fase 3.4 checklist: every client app
+needs to enumerate a user's groups to build navigation, group-switching UIs, etc.
+
+---
+
+## §2 Architecture
+
+No schema change required — `groups` and `group_members` (migration 001) already hold
+the data. The query is a JOIN:
+
+```sql
+SELECT g.id, g.name, g.type, g.created_at, g.created_by, gm.role, gm.joined_at
+FROM group_members gm
+JOIN groups g ON g.id = gm.group_id
+WHERE gm.user_id = $user_id
+  AND gm.status = 'active'
+  [AND (gm.joined_at, gm.group_id) > ($cursor_joined_at, $cursor_group_id)]
+  [AND gm.role = $role_filter]
+ORDER BY gm.joined_at ASC, gm.group_id ASC
+LIMIT $limit + 1
+```
+
+Compound keyset cursor `(joined_at, group_id)` is stable even when multiple groups share
+the same `joined_at` timestamp (possible in bulk imports). Cursor is encoded as
+`<joined_at_iso8601>/<group_id_uuid>` in the query string.
+
+No `X-Group-Id` header required — this endpoint is inherently cross-group (listing all of
+a user's groups). `groups` and `group_members` have no FORCE RLS, so no
+`SET LOCAL app.current_group_id` is needed; `app.current_user_id` is set defensively.
+
+---
+
+## §3 Tech stack
+
+- Rust / Axum 0.8 — handler in `crates/garraia-gateway/src/rest_v1/groups.rs`
+- `sqlx` parameterized queries (no string concat)
+- `utoipa` for OpenAPI 3.1 spec generation
+- `garraia_auth::Principal` extractor (JWT-only, no `X-Group-Id`)
+
+---
+
+## §4 Design invariants
+
+1. **No `X-Group-Id` header** — this is a cross-group listing endpoint; requiring a
+   group header would be circular. The `Principal` extractor can work with only a JWT.
+2. **Compound cursor** — `joined_at` alone is not unique; compound `(joined_at, group_id)`
+   ensures stable pagination. Encoded as `<iso8601>/<uuid>` in the `cursor` param.
+3. **Active-only** — only `status = 'active'` members are returned. Removed/banned
+   users' memberships are invisible.
+4. **`app.current_user_id` set in tx** — defensive (no FORCE RLS today), but ensures
+   forward-compat if RLS is extended to `group_members`.
+5. **PII-safe audit** — no user-identifying data in log/trace fields.
+6. **Cross-group authz test** — a user in group A must not see group B's members via
+   this endpoint (test T4 below).
+
+---
+
+## §5 Validações pré-plano
+
+- [x] `groups` table exists: migration 001 ✅
+- [x] `group_members` table exists with `status`, `role`, `joined_at`: migration 001 ✅
+- [x] `Principal` extractor works without `X-Group-Id` (JWT-only path) — verified by
+      `GET /v1/me` which uses `RestV1AuthState` with only JWT.
+- [x] Cursor pagination pattern established in `list_members` / `list_invites` (plan 0097) ✅
+- [x] No Linear duplicate: GAR-580 already exists as Backlog item ✅
+
+---
+
+## §6 Out of scope
+
+- `DELETE /v1/groups/{id}` (group deletion)
+- `GET /v1/groups` with `types=` filter (not needed by any current client)
+- Pagination via `offset` (keyset is the project standard)
+- Group soft-delete / archived groups (not in schema today)
+
+---
+
+## §7 Rollback plan
+
+This is a pure addition: a new `GET` handler on an existing route path and a new OpenAPI
+entry. Rollback = revert the commit. No schema change, no migration, no data risk.
+
+---
+
+## §8 File structure (changes)
+
+```
+crates/garraia-gateway/src/rest_v1/groups.rs      — new handler + DTOs
+crates/garraia-gateway/src/rest_v1/mod.rs         — wire GET /v1/groups
+crates/garraia-gateway/src/rest_v1/openapi.rs     — register list_groups
+crates/garraia-gateway/tests/rest_v1_groups_list.rs  — integration tests
+ROADMAP.md                                         — check off GAR-580
+plans/README.md                                    — add plan row
+```
+
+---
+
+## §9 M1 task list
+
+- [x] T0 — bookkeeping: fix README + ROADMAP for plans 0101–0104 + GAR-574 items
+- [ ] T1 — write integration test skeleton (red)
+- [ ] T2 — implement `ListGroupsQuery`, `GroupListItem`, `ListGroupsResponse` DTOs
+- [ ] T3 — implement `list_groups` handler with compound cursor
+- [ ] T4 — add cross-group isolation test (user A cannot see user B's groups)
+- [ ] T5 — wire route `GET /v1/groups` in `mod.rs`
+- [ ] T6 — register in `openapi.rs`
+- [ ] T7 — `cargo check -p garraia-gateway` + `cargo clippy` clean
+- [ ] T8 — update ROADMAP.md + plans/README.md (mark GAR-580 done)
+
+---
+
+## §10 Risk register
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| Compound cursor parsing fails for edge timestamps | Low | Unit test with same-second joined_at |
+| `Principal` extractor rejects JWT-only (no X-Group-Id) | Low | Covered by `GET /v1/me` precedent |
+| Cross-group data leak via `user_id` join | Low | Explicit `WHERE gm.user_id = $principal.user_id` |
+
+---
+
+## §11 Acceptance criteria
+
+1. `GET /v1/groups` with valid JWT returns 200 + list of user's active groups.
+2. `?cursor=<iso8601>/<uuid>` advances the page correctly.
+3. `?role=member` filters to only groups where the user has that role.
+4. `?limit=2` returns at most 2 items + `next_cursor` when more exist.
+5. User with no group memberships → 200 `{ items: [], next_cursor: null }`.
+6. No JWT → 401.
+7. Invalid cursor format → 400.
+8. Cross-group: user A's token cannot list user B's groups.
+9. `cargo clippy --workspace --tests --exclude garraia-desktop --no-deps -- -D warnings` clean.
+10. CI ≥16 checks all green.
+
+---
+
+## §12 Open questions
+
+None — all resolved by precedent (plan 0097, `list_members` pattern).
+
+---
+
+## Cross-references
+
+- GAR-580: https://linear.app/chatgpt25/issue/GAR-580
+- Parent epic: GAR-393 (Groups API)
+- Plan 0097 (list_members/list_invites pattern)
+- ROADMAP.md §3.4 "Grupos"
+
+---
+
+## Estimativa
+
+~200 LOC implementation + ~150 LOC tests. Low risk. 1–2 hours.

--- a/plans/README.md
+++ b/plans/README.md
@@ -124,8 +124,11 @@ Histórico de planos de execução do GarraIA. Cada plano está atrelado a uma i
 | 0098 | [GAR-576 — fix(cli): respect configured OpenRouter model and default provider](0098-gar-576-cli-openrouter-model-respect.md) | [GAR-576](https://linear.app/chatgpt25/issue/GAR-576) | ✅ Merged 2026-05-11 via PR #263 (`c952b6b`) |
 | 0099 | [GAR-577 — Files REST API slice 9: POST /v1/groups/{group_id}/files (direct file upload / create)](0099-gar-577-files-api-slice9-create.md) | [GAR-577](https://linear.app/chatgpt25/issue/GAR-577) | ✅ Merged 2026-05-11 via PR #264 (`725cf54`) |
 | 0100 | [GAR-579 — CLI: add non-interactive garra ask command](0100-gar-579-cli-non-interactive-ask.md) | [GAR-579](https://linear.app/chatgpt25/issue/GAR-579) | ✅ Merged 2026-05-11 via PR #267 (`6fdc1b4`) |
-| 0103 | [GAR-585 — advertise `tools` capability in garra mcp-server](0103-gar-585-mcp-tools-capability.md) | [GAR-585](https://linear.app/chatgpt25/issue/GAR-585) | 🚧 In progress (branch `fix/gar-585-mcp-tools-capability`) |
-| 0104 | [GAR-587 — apply `garra_ask` schema defaults before calling `ask_oneshot`](0104-gar-587-mcp-garra-ask-defaults.md) | [GAR-587](https://linear.app/chatgpt25/issue/GAR-587) | 🚧 In progress (branch `fix/gar-587-mcp-garra-ask-defaults`) |
+| 0101 | [GAR-582 — name OpenRouter provider explicitly in chat.rs](0101-gar-582-cli-openrouter-provider-name.md) | [GAR-582](https://linear.app/chatgpt25/issue/GAR-582) | ✅ Merged 2026-05-11 via PR #269 (`753f881`) |
+| 0102 | [GAR-583 — MCP server exposing garra ask as stdio tool](0102-gar-583-mcp-server-stdio.md) | [GAR-583](https://linear.app/chatgpt25/issue/GAR-583) | ✅ Merged 2026-05-11 via PR #270 (`47be4a4`) |
+| 0103 | [GAR-585 — advertise `tools` capability in garra mcp-server](0103-gar-585-mcp-tools-capability.md) | [GAR-585](https://linear.app/chatgpt25/issue/GAR-585) | ✅ Merged 2026-05-11 via PR #271 (`97403c7`) |
+| 0104 | [GAR-587 — apply `garra_ask` schema defaults before calling `ask_oneshot`](0104-gar-587-mcp-garra-ask-defaults.md) | [GAR-587](https://linear.app/chatgpt25/issue/GAR-587) | ✅ Merged 2026-05-12 via PR #272 (`3dc1932`) |
+| 0105 | [GAR-580 — REST /v1 groups slice 3: GET /v1/groups (list user's groups)](0105-gar-580-groups-list-api.md) | [GAR-580](https://linear.app/chatgpt25/issue/GAR-580) | 🚧 In progress (branch `routine/202605120022-groups-list`) |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

- Adds `GET /v1/groups` — cursor-paginated list of all groups where the authenticated user has an active membership (Fase 3.4, Groups slice 3).
- No `X-Group-Id` header required (cross-group listing by design).
- Keyset cursor on `group_id ASC`; default page size 50, max 100; optional `?role=` filter.
- OpenAPI spec updated; `list_invites` and `list_members` (plan 0097) also registered in openapi.rs.
- Bookkeeping: plans/README.md adds rows 0101–0104 (all previously merged); ROADMAP.md checks off GAR-574 items (GET members + GET invites, merged PR #261).

## Closes

[GAR-580](https://linear.app/chatgpt25/issue/GAR-580)

## Test plan

- [ ] GL1 — `GET /v1/groups` with valid JWT returns 200 + user's group(s) in list
- [ ] GL2 — missing JWT returns 401
- [ ] GL3 — user with no memberships returns `{ items: [], next_cursor: null }`
- [ ] GL4 — user in 3 groups: `?limit=2` returns 2 items + cursor; page 2 returns 1 item + null cursor; all 3 IDs span both pages in `group_id ASC` order
- [ ] GL5 — `?role=owner` returns only groups where caller is owner
- [ ] GL6 — cross-group isolation: user A's token cannot see user B's groups
- [ ] `cargo fmt --check` clean
- [ ] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` clean

https://claude.ai/code/session_01N18z4yk66LgaAjoRAv2p8e

---
_Generated by [Claude Code](https://claude.ai/code/session_01N18z4yk66LgaAjoRAv2p8e)_