### PR TITLE
fix(security): configure Dependabot updates for cargo, npm, github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,28 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
+# Dependabot configuration — see GAR-590.
+# Tracks: cargo workspace (root), npm test deps (tests/), and GitHub Actions.
+# Out of scope: pub (Flutter, no Dependabot support), pip (services/voice, deferred).
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "cargo"
+    directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      patch-and-minor:
+        update-types:
+          - "patch"
+          - "minor"
+
+  - package-ecosystem: "npm"
+    directory: "/tests"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"


### PR DESCRIPTION
## Summary

Slice A of the Dependabot remediation plan. Replaces the unfilled template in `.github/dependabot.yml` (`package-ecosystem: ""` — empty string, silently ignored) with real config covering the three ecosystems Dependabot supports natively for this repo.

- **cargo** at `/` — workspace root, auto-discovers all 19 crate Cargo.toml files. Weekly Monday. `open-pull-requests-limit: 10`. Patch+minor grouped to reduce noise; majors stay one-per-PR.
- **npm** at `/tests` — Playwright E2E test deps. Weekly Monday.
- **github-actions** at `/` — pins action versions across `.github/workflows/*.yml`. Weekly Monday.

Closes [GAR-590](https://linear.app/chatgpt25/issue/GAR-590).

## Out of scope (separate slices)

- `pub` (Flutter pubspec) — Dependabot has no official pub support.
- `pip` (services/voice/requirements.txt) — deferred until voice service activity is confirmed.
- The 7 existing Security Advisory alerts (1 high / 2 moderate / 4 low) — addressed by triage Slices B (rustls-webpki via serenity, closes 4), C (glib), D (lru), E (rand build-dep).
- Any Cargo.lock or manifest change.

## Validation done locally

- [x] `python -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` parses, returns `version=2`, 3 updates, ecosystems `['cargo', 'npm', 'github-actions']`.
- [x] `git diff --name-only` shows only `.github/dependabot.yml` (+24/-7).
- [x] No Cargo.lock change. No manifest change. No workflow change.

## Test plan

- [ ] CI green on this PR (no Rust code touched, so just lint/build/test stays green).
- [ ] No `--admin` bypass on merge.
- [ ] 24-48h post-merge: `gh pr list --search "is:open author:app/dependabot"` starts returning PRs.
- [ ] If still no Dependabot PRs after 48h → file follow-up to debug Dependabot itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)