### PR TITLE
feat(security): FORCE RLS on groups + group_members tables (GAR-589, plan 0106)

### DIFF
--- a/crates/garraia-gateway/src/rest_v1/groups.rs
+++ b/crates/garraia-gateway/src/rest_v1/groups.rs
@@ -19,11 +19,11 @@
 //! evaporates in Postgres auto-commit mode. Both handlers below
 //! follow this rule.
 //!
-//! For M4 the `SET LOCAL` is defensive scaffolding — `groups` and
-//! `group_members` are not under FORCE RLS (see migrations 001 and
-//! 007). The `garraia_app` role has direct INSERT grants. The
-//! setting becomes load-bearing in M5+ once RLS is extended to
-//! these tables.
+//! Migration 018 (GAR-589) added FORCE RLS to `groups` and `group_members`.
+//! `SET LOCAL app.current_user_id` is now load-bearing for every handler
+//! that reads or writes those tables. `SET LOCAL app.current_group_id` is
+//! additionally required for handlers that need to see ALL members of a
+//! specific group (list_members, set_member_role, delete_member, get_group).
 //!
 //! ## Tenant-context SQL
 //!
@@ -410,29 +410,44 @@ pub async fn get_group(
         }
     }
 
-    // 2. Fetch the group row. `groups` is not under FORCE RLS today
-    //    (migration 001 line 100 + migration 007), so no
-    //    tenant-context `SET LOCAL` is needed for this SELECT and
-    //    `fetch_optional` runs directly on the pool without a
-    //    transaction wrapper. `garraia_app` has direct SELECT
-    //    grants on `groups`.
-    //
-    //    FIXME(plan-0016-M5 or whenever `groups` gains FORCE RLS):
-    //    convert this to a `tx = pool.begin()` + `SET LOCAL
-    //    app.current_user_id` sequence mirroring `create_group`
-    //    above. The M4 security-auditor flagged this as a
-    //    forward-compat hazard — silent `groups` SELECT bypass
-    //    if RLS is later applied and this handler is left
-    //    untouched.
+    // 2. Fetch the group row inside a transaction with SET LOCAL tenant context.
+    //    Migration 018 (GAR-589) added FORCE RLS to `groups`; without SET LOCAL
+    //    the garraia_app role sees 0 rows and the handler would return 404.
+    //    Both app.current_user_id and app.current_group_id are set:
+    //    - current_user_id: required by groups_member_access USING clause.
+    //    - current_group_id: not strictly required for this SELECT (the USING
+    //      subquery only checks group_members.user_id), but set as defensive
+    //      forward-compat for any future policy that may use it.
     let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(principal.user_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_group_id', $1, true)")
+        .bind(id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
     let row: Option<(Uuid, String, String, DateTime<Utc>, Uuid)> =
         sqlx::query_as("SELECT id, name, type, created_at, created_by FROM groups WHERE id = $1")
             .bind(id)
-            .fetch_optional(pool)
+            .fetch_optional(&mut *tx)
             .await
             .map_err(|e| RestError::Internal(e.into()))?;
 
     let (id, name, group_type, created_at, created_by) = row.ok_or(RestError::NotFound)?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
 
     // 3. Assemble response. The caller's `Principal.role` MUST be
     //    `Some(_)` here: the extractor only populates `group_id`
@@ -1397,7 +1412,11 @@ pub async fn list_members(
         .unwrap_or(DEFAULT_LIST_LIMIT)
         .min(MAX_LIST_LIMIT) as i64;
 
-    // 3. Open tx + SET LOCAL (defensive; group_members has no FORCE RLS).
+    // 3. Open tx + SET LOCAL tenant context.
+    //    Migration 018 (GAR-589) added FORCE RLS to `group_members`.
+    //    app.current_group_id is now load-bearing: the group_members_visible
+    //    policy Branch 1 (`group_id = current_group_id`) must be set so all
+    //    members of the group are visible, not just the caller's own row.
     let pool = state.app_pool.pool_for_handlers();
     let mut tx = pool
         .begin()
@@ -1406,6 +1425,12 @@ pub async fn list_members(
 
     sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
         .bind(principal.user_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_group_id', $1, true)")
+        .bind(id.to_string())
         .execute(&mut *tx)
         .await
         .map_err(|e| RestError::Internal(e.into()))?;
@@ -1787,7 +1812,10 @@ pub async fn list_groups(
         .unwrap_or(DEFAULT_LIST_LIMIT)
         .min(MAX_LIST_LIMIT) as i64;
 
-    // 2. Open tx + SET LOCAL (defensive; group_members has no FORCE RLS).
+    // 2. Open tx + SET LOCAL. Migration 018 (GAR-589) made app.current_user_id
+    //    load-bearing: groups_member_access USING subquery reads group_members under
+    //    FORCE RLS, which allows only rows where user_id = current_user_id (Branch 2).
+    //    app.current_group_id is intentionally NOT set — this is a cross-group endpoint.
     let pool = state.app_pool.pool_for_handlers();
     let mut tx = pool
         .begin()

--- a/crates/garraia-workspace/migrations/018_rls_groups_and_members.sql
+++ b/crates/garraia-workspace/migrations/018_rls_groups_and_members.sql
@@ -1,0 +1,155 @@
+-- 018_rls_groups_and_members.sql
+-- GAR-589 — Add FORCE ROW LEVEL SECURITY to `groups` and `group_members`.
+-- Plan:     plans/0106-gar-589-rls-groups-and-members.md
+-- Depends:  migration 007 (garraia_app role + RLS on 10 tenant tables),
+--           migration 001 (groups + group_members schema).
+-- Forward-only. No DROP TABLE, no destructive ALTER.
+--
+-- ─── Motivation ──────────────────────────────────────────────────────────
+--
+-- Migration 007 intentionally excluded `groups` and `group_members` from
+-- FORCE RLS (see migration 007 comment lines 15-25). Plan 0105 (GAR-580)
+-- added `GET /v1/groups` which sets `app.current_user_id` "defensively",
+-- and GAR-589 was filed to make that defensive hook load-bearing.
+--
+-- Without FORCE RLS, cross-group isolation relies entirely on the WHERE
+-- clause in each handler (app-layer enforcement). With FORCE RLS, the
+-- database enforces isolation at the garraia_app role level even if a
+-- handler bug omits the WHERE clause (defense-in-depth).
+--
+-- ─── Policy design ───────────────────────────────────────────────────────
+--
+-- `groups` — membership-visible policy
+--
+--   USING:      visible iff the current user has an active `group_members` row.
+--   WITH CHECK: for UPDATE — same as USING (group stays visible after edit).
+--               for INSERT — same OR `created_by = current_user_id`.
+--               The OR branch covers the window between INSERT INTO groups
+--               and INSERT INTO group_members in create_group: the new group
+--               has no `group_members` row yet, so the subquery returns 0 rows,
+--               but `created_by = current_user_id` passes.
+--
+-- `group_members` — dual-context policy
+--
+--   Branch 1 (group-scoped endpoints): `group_id = app.current_group_id`
+--     — covers list_members, set_member_role, delete_member.
+--   Branch 2 (cross-group endpoints): `user_id = app.current_user_id`
+--     — covers list_groups (user sees only their own membership rows)
+--       and create_group (INSERT creator's own owner row).
+--
+--   No circular dependency: groups → group_members (one direction only).
+--   group_members policy does NOT reference groups.
+--
+-- ─── Handler contract update ─────────────────────────────────────────────
+--
+-- These two handlers must be updated in the same PR (groups.rs):
+--
+--   get_group:    currently runs SELECT on `groups` WITHOUT a transaction or
+--                 SET LOCAL — silently returns 404 with FORCE RLS.
+--                 Fix: wrap in pool.begin() + set_config(user_id + group_id).
+--
+--   list_members: sets app.current_user_id but NOT app.current_group_id.
+--                 Fix: add set_config('app.current_group_id', id, true).
+--
+-- All other group handlers already set the required context variables.
+--
+-- ─── Idempotency ─────────────────────────────────────────────────────────
+--
+-- DROP POLICY IF EXISTS is used before CREATE POLICY (same pattern as
+-- migration 013). ENABLE/FORCE ROW LEVEL SECURITY are naturally idempotent
+-- in Postgres (re-running is a no-op without error).
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Part 1: groups
+-- ═══════════════════════════════════════════════════════════════════════════
+
+ALTER TABLE groups ENABLE ROW LEVEL SECURITY;
+ALTER TABLE groups FORCE ROW LEVEL SECURITY;
+
+-- Drop before re-create for idempotency (same pattern as migration 013).
+DROP POLICY IF EXISTS groups_member_access ON groups;
+
+-- Single PERMISSIVE FOR ALL policy.
+-- USING  applies to SELECT, the old-row filter in UPDATE, and DELETE.
+-- WITH CHECK applies to INSERT and the new-row filter in UPDATE.
+CREATE POLICY groups_member_access ON groups
+    AS PERMISSIVE
+    FOR ALL
+    USING (
+        -- A group is visible to the current user iff they have an active
+        -- membership row in group_members.
+        -- Fail-closed: if app.current_user_id is not set, NULLIF returns NULL,
+        -- the cast to uuid succeeds (NULL::uuid = NULL), and the subquery
+        -- returns 0 rows → group is not visible.
+        id IN (
+            SELECT group_id
+            FROM group_members
+            WHERE user_id = NULLIF(current_setting('app.current_user_id', true), '')::uuid
+              AND status = 'active'
+        )
+    )
+    WITH CHECK (
+        -- UPDATE: group_id is unchanged by patch_group → USING branch still holds
+        --         after the update → same subquery passes.
+        -- INSERT (create_group): the new group has no group_members row yet.
+        --         Branch 1 (subquery) returns 0 rows. Branch 2 (created_by) passes
+        --         because the handler binds principal.user_id = current_user_id.
+        id IN (
+            SELECT group_id
+            FROM group_members
+            WHERE user_id = NULLIF(current_setting('app.current_user_id', true), '')::uuid
+              AND status = 'active'
+        )
+        OR
+        created_by = NULLIF(current_setting('app.current_user_id', true), '')::uuid
+    );
+
+COMMENT ON POLICY groups_member_access ON groups IS
+    'Class: membership. USING: group visible iff caller has active group_members row '
+    '(app.current_user_id). WITH CHECK: same for UPDATE; for INSERT, also allows '
+    'created_by = current_user_id (new group has no members row yet). '
+    'Part of GAR-589 / migration 018. No circular dependency: group_members policy '
+    'does not reference groups.';
+
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Part 2: group_members
+-- ═══════════════════════════════════════════════════════════════════════════
+
+ALTER TABLE group_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE group_members FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS group_members_visible ON group_members;
+
+-- Dual-context PERMISSIVE FOR ALL policy.
+-- Branch 1 (group-scoped): list_members / set_member_role / delete_member
+--   all set app.current_group_id → all members of the current group are visible.
+-- Branch 2 (cross-group): list_groups / create_group
+--   only app.current_user_id is set → only the caller's own membership rows are
+--   visible, which is exactly what those handlers need.
+CREATE POLICY group_members_visible ON group_members
+    AS PERMISSIVE
+    FOR ALL
+    USING (
+        -- Branch 1: group-scoped context (set_member_role, delete_member, list_members).
+        group_id = NULLIF(current_setting('app.current_group_id', true), '')::uuid
+        OR
+        -- Branch 2: cross-group context (list_groups, create_group INSERT).
+        user_id = NULLIF(current_setting('app.current_user_id', true), '')::uuid
+    )
+    WITH CHECK (
+        -- UPDATE (set_member_role / delete_member soft-delete): group_id unchanged →
+        --   Branch 1 still satisfies after the update.
+        -- INSERT (create_group owner row): user_id = creator = current_user_id →
+        --   Branch 2 satisfies.
+        group_id = NULLIF(current_setting('app.current_group_id', true), '')::uuid
+        OR
+        user_id = NULLIF(current_setting('app.current_user_id', true), '')::uuid
+    );
+
+COMMENT ON POLICY group_members_visible ON group_members IS
+    'Class: dual-context. Branch 1 (group-scoped): row visible when group_id = '
+    'app.current_group_id — covers list_members, set_member_role, delete_member. '
+    'Branch 2 (cross-group): row visible when user_id = app.current_user_id — '
+    'covers list_groups (user sees own memberships) and create_group INSERT. '
+    'No circular reference back to groups table. '
+    'Part of GAR-589 / migration 018.';

--- a/plans/0106-gar-589-rls-groups-and-members.md
+++ b/plans/0106-gar-589-rls-groups-and-members.md
@@ -1,0 +1,129 @@
+# Plan 0106 — GAR-589: FORCE RLS on `groups` + `group_members` tables
+
+## Goal
+
+Add database-level Row-Level Security (FORCE RLS) to the `groups` and `group_members`
+tables, making the `app.current_user_id` / `app.current_group_id` session variables
+that several handlers already set **load-bearing** rather than forward-compat stubs.
+
+Closes [GAR-589](https://linear.app/chatgpt25/issue/GAR-589).
+
+## Context
+
+Migration 007 (plan 0007, GAR-408) added FORCE RLS to 10 tenant-scoped tables but
+intentionally left `groups` and `group_members` out (see migration 007 comment lines
+15-25: "app-layer join is cleaner in v1"). PR #273 / plan 0105 (GAR-580) introduced
+`GET /v1/groups` which sets `app.current_user_id` "as a defensive forward-compat hook".
+GAR-589 was filed immediately after merge to make that hook load-bearing.
+
+Today, cross-group isolation for these tables relies exclusively on `WHERE gm.user_id = $1`
+in handlers. FORCE RLS adds defense-in-depth: even if a handler bug omits the WHERE clause,
+the database enforces isolation at the role level.
+
+## Architecture
+
+### Migration 018 — new policies
+
+**`groups` table**:
+- `ENABLE + FORCE ROW LEVEL SECURITY`
+- Policy `groups_member_access` (FOR ALL, PERMISSIVE):
+  - USING: `id IN (SELECT group_id FROM group_members WHERE user_id = current_user_id AND status = 'active')`
+  - WITH CHECK: same subquery **OR** `created_by = current_user_id`
+    (allows INSERT of a new group before the creator's `group_members` row exists)
+
+**`group_members` table**:
+- `ENABLE + FORCE ROW LEVEL SECURITY`
+- Policy `group_members_visible` (FOR ALL, PERMISSIVE):
+  - USING: `group_id = current_group_id OR user_id = current_user_id`
+  - WITH CHECK: same (symmetric — allows both group-scoped writes and self-membership)
+
+### Handler code changes
+
+| Handler | Problem | Fix |
+|---------|---------|-----|
+| `get_group` | No tx, no SET LOCAL → silently fails with FORCE RLS on `groups` | Wrap in `pool.begin()` + `set_config('app.current_user_id')` + `set_config('app.current_group_id')` |
+| `list_members` | Missing `app.current_group_id` → only caller's own row visible | Add `set_config('app.current_group_id', id, true)` after existing `set_config('app.current_user_id')` |
+
+All other group handlers already set the necessary context variables.
+
+## Tech stack
+
+- PostgreSQL 16 FORCE RLS (same as migration 007)
+- `sqlx::migrate!` (forward-only migration)
+- Axum 0.8 handlers in `crates/garraia-gateway/src/rest_v1/groups.rs`
+
+## Design invariants
+
+1. **Forward-only**: no DROP TABLE, no destructive ALTER.
+2. **Fail-closed**: missing `SET LOCAL` → empty results, not cross-tenant leak.
+3. **No BYPASSRLS**: `garraia_app` role must always go through RLS. The `garraia_login` and `garraia_signup` BYPASSRLS roles do not touch `groups` or `group_members`.
+4. **No circular dependency**: `groups` policy references `group_members` (which has its own FORCE RLS). `group_members` policy does NOT reference `groups`. Directionality is one-way.
+5. **Idempotent CREATE POLICY**: use `DROP POLICY IF EXISTS` before `CREATE POLICY` (same pattern as migration 013).
+6. **Explicit WITH CHECK** (plan 0021 lesson): always set WITH CHECK explicitly, never rely on Postgres implicit fallback from USING.
+
+## Validações pré-plano
+
+- [x] Migration slot 018 is free (`ls migrations/` confirms 017 is the latest).
+- [x] `groups` and `group_members` are currently NOT under FORCE RLS (confirmed in migration 007 comment, line 15-25).
+- [x] `get_group` FIXME acknowledged in source (groups.rs line 420-426).
+- [x] `list_members` missing `set_config('app.current_group_id')` confirmed (groups.rs line 1400-1410).
+- [x] No other handler INSERTs into `group_members` with a third-party `user_id` outside of a `SET LOCAL app.current_group_id` context. (Exception: `create_group` INSERTs own membership — covered by WITH CHECK Branch 2.)
+
+## Out of scope
+
+- `group_invites` — token-based access, handled by separate endpoint. Left for a future slice.
+- RBAC capabilities `groups.read`, `groups.write` — app-layer authz already enforces via Principal extractor.
+- Updating the 81-case RLS matrix in `garraia-auth/tests/rls_matrix.rs` with `groups`/`group_members` rows — tracked as follow-up in GAR-589 acceptance criteria item 4. **This plan delivers the migration + handler fixes only** (the matrix extension is a separate concern that requires test-support Harness changes beyond the migration scope).
+
+## Rollback
+
+Postgres DDL is transactional: if the migration fails mid-run, it rolls back entirely.
+Manual rollback (only if needed post-deploy): `ALTER TABLE groups DISABLE ROW LEVEL SECURITY; ALTER TABLE group_members DISABLE ROW LEVEL SECURITY;`
+
+## File structure
+
+```
+crates/garraia-workspace/migrations/018_rls_groups_and_members.sql  [NEW]
+crates/garraia-gateway/src/rest_v1/groups.rs                        [EDIT: get_group, list_members]
+plans/0106-gar-589-rls-groups-and-members.md                        [THIS FILE]
+plans/README.md                                                      [EDIT: add row]
+```
+
+## Tasks
+
+- [x] M1: Write `018_rls_groups_and_members.sql`
+- [x] M2: Fix `get_group` — add tx + SET LOCAL user_id + group_id
+- [x] M3: Fix `list_members` — add SET LOCAL group_id
+- [x] M4: `cargo check -p garraia-gateway` green
+- [x] M5: `cargo clippy --workspace --tests --exclude garraia-desktop --no-deps -- -D warnings` green
+- [x] M6: Push + open PR
+
+## Risk register
+
+| Risk | Mitigation |
+|------|-----------|
+| `get_group` test returns 404 after FORCE RLS | Covered by existing `v1_groups_scenarios` test hitting the fixed handler. |
+| INSERT into `groups` fails (new group not in `group_members` yet) | WITH CHECK Branch 2 (`created_by = current_user_id`) covers the INSERT window. |
+| `set_member_role` / `delete_member` UPDATE fails WITH CHECK | Both set `app.current_group_id`; after UPDATE `group_id` unchanged → Branch 1 passes. |
+| `list_groups` broken by `group_members` FORCE RLS | `list_groups` sets `app.current_user_id`; Branch 2 of `group_members` policy passes. `groups` policy subquery also evaluates under Branch 2 → ✓. |
+| Performance regression from RLS subqueries | Subquery is indexed (`group_members.user_id` is FK with index). Acceptable for v1 scale. |
+
+## Acceptance criteria
+
+1. `cargo test -p garraia-gateway --test rest_v1_groups -- --nocapture` green.
+2. `cargo test -p garraia-gateway --test rest_v1_groups_list -- --nocapture` green.
+3. `cargo test -p garraia-gateway --test rest_v1_groups_members_invites -- --nocapture` green.
+4. `git grep 'FORCE ROW LEVEL SECURITY' crates/garraia-workspace/migrations/018_*` shows both `groups` and `group_members`.
+5. `git grep 'group_members has no FORCE RLS' crates/garraia-gateway/src/rest_v1/groups.rs` returns 0 hits (comments updated).
+
+## Cross-references
+
+- GAR-589 (Linear issue)
+- Migration 007 (original RLS setup — plan 0007 / GAR-408)
+- Migration 013 (WITH CHECK pattern for explicit policy — plan 0021 / GAR-425)
+- Plan 0105 / GAR-580 (`GET /v1/groups` — triggered this follow-up)
+- CLAUDE.md rule 10: cross-group authz tests required before merge
+
+## Estimativa
+
+0.5 / 1 / 1.5 hours. Two handler edits + one SQL migration file. All scaffolding in place.

--- a/plans/README.md
+++ b/plans/README.md
@@ -112,6 +112,7 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0103 | [GAR-585 — advertise `tools` capability in garra mcp-server](0103-gar-585-mcp-tools-capability.md) | [GAR-585](https://linear.app/chatgpt25/issue/GAR-585) | ✅ Merged 2026-05-11 via PR #271 (`97403c7`) |
 | 0104 | [GAR-587 — apply `garra_ask` schema defaults before calling `ask_oneshot`](0104-gar-587-mcp-garra-ask-defaults.md) | [GAR-587](https://linear.app/chatgpt25/issue/GAR-587) | ✅ Merged 2026-05-12 via PR #272 (`3dc1932`) |
 | 0105 | [GAR-580 — REST /v1 groups slice 3: GET /v1/groups (list user's groups)](0105-gar-580-groups-list-api.md) | [GAR-580](https://linear.app/chatgpt25/issue/GAR-580) | ✅ Merged 2026-05-12 via PR #273 (`84115c2`) |
+| 0106 | [GAR-589 — FORCE RLS on groups + group_members tables](0106-gar-589-rls-groups-and-members.md) | [GAR-589](https://linear.app/chatgpt25/issue/GAR-589) | 🔄 In Progress |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

Closes [GAR-589](https://linear.app/chatgpt25/issue/GAR-589). Adds `FORCE ROW LEVEL SECURITY` to `groups` and `group_members` (migration 018), making the `app.current_user_id` / `app.current_group_id` session variables that handlers already set **load-bearing** rather than forward-compat stubs.

Previously, cross-group isolation for these tables relied exclusively on `WHERE gm.user_id = $1` in handlers. With FORCE RLS the database enforces isolation at the `garraia_app` role level — defense-in-depth that cannot be accidentally bypassed by a handler bug.

### Policy design

**`groups_member_access`** (FOR ALL, PERMISSIVE):
- USING: group visible iff caller has an active `group_members` row (`app.current_user_id`)
- WITH CHECK for INSERT: same subquery **OR** `created_by = current_user_id` — covers the window between `INSERT INTO groups` and `INSERT INTO group_members` in `create_group` where the new group has no members row yet

**`group_members_visible`** (FOR ALL, PERMISSIVE):
- Branch 1 (`group_id = current_group_id`): group-scoped endpoints — `list_members`, `set_member_role`, `delete_member`
- Branch 2 (`user_id = current_user_id`): cross-group endpoints — `list_groups`, `create_group` INSERT

No circular dependency: `groups` policy references `group_members`; `group_members` policy does NOT reference `groups`.

### Handler fixes (required before migration lands)

| Handler | Problem | Fix |
|---------|---------|-----|
| `get_group` | Long-standing FIXME — no tx, no SET LOCAL → returns 404 with FORCE RLS | Wrap in `pool.begin()` + `set_config(user_id + group_id)` |
| `list_members` | Missing `app.current_group_id` → only caller's own row visible | Add `set_config('app.current_group_id', id, true)` |

### Files changed

```
crates/garraia-workspace/migrations/018_rls_groups_and_members.sql  [NEW]
crates/garraia-gateway/src/rest_v1/groups.rs                        [fix get_group + list_members]
plans/0106-gar-589-rls-groups-and-members.md                        [NEW]
plans/README.md                                                      [row added]
```

## Test plan

- [ ] CI: `Test (ubuntu-latest)` runs `cargo test -p garraia-gateway --test rest_v1_groups` — covers CREATE, GET (fixed FIXME), PATCH, invite, set-role, delete-member scenarios
- [ ] CI: `Test (ubuntu-latest)` runs `cargo test -p garraia-gateway --test rest_v1_groups_list` — GL6 cross-group isolation is now backed by DB-level RLS
- [ ] CI: `Test (ubuntu-latest)` runs `cargo test -p garraia-gateway --test rest_v1_groups_members_invites` — list-members now uses `app.current_group_id`
- [ ] `cargo clippy --workspace ... -D warnings` green (already verified locally)
- [ ] `git grep 'FORCE ROW LEVEL SECURITY' crates/garraia-workspace/migrations/018_*` returns both `groups` and `group_members` entries
- [ ] `git grep 'group_members has no FORCE RLS' crates/garraia-gateway/src/rest_v1/groups.rs` returns 0 hits

https://claude.ai/code/session_01Hiicq3t6etoH9AhmcPbV87

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hiicq3t6etoH9AhmcPbV87)_