### PR TITLE
chore(security): GAR-593 — drop stale RUSTSEC-2026-0002 (lru) after lru 0.16.4

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -16,24 +16,22 @@
 # fix availability honestly, (5) must have an expiration date.
 #
 # SYNC NOTE — `audit.toml` vs `deny.toml` (HONEST asymmetry,
-# refreshed 2026-04-27 by GAR-458 PR #75):
+# refreshed 2026-05-12 by health-routine / GAR-593):
 #
 #   * `audit.toml` controls vulnerabilities flagged by `cargo audit`.
 #     It carries every RUSTSEC ID that would otherwise make `cargo audit`
 #     exit non-zero on `Cargo.lock`.
 #   * `deny.toml` controls advisories flagged by `cargo deny check
 #     advisories` (now invoked in CI via cargo-deny-action default
-#     `command: check`). It carries the same RUSTSEC wasmtime IDs AND
-#     the same 4 rustls-webpki residual IDs (mandatory sync, see below)
-#     PLUS 23 `unmaintained-only` advisories that `cargo audit`
+#     `command: check`). It mirrors the same vuln/unsound IDs (rsa, glib,
+#     rand) PLUS 22 `unmaintained-only` advisories that `cargo audit`
 #     auto-classifies as "allowed warnings" and does NOT require
 #     explicit ignore here.
-#   * **Mandatory sync between the two files: wasmtime IDs (15) AND
-#     rustls-webpki residuals (4).** When GAR-454 (Q7b) bumps wasmtime
-#     to ≥ 40.0.4 / ≥ 41.0.4, ALL 15 wasmtime IDs below MUST be dropped
-#     from BOTH files atomically. When GAR-455 closes (serenity 0.13 +
-#     aws-smithy upgrade), ALL 4 rustls-webpki IDs below MUST be
-#     dropped from BOTH files atomically.
+#   * **Mandatory sync (remaining mirrored IDs): RUSTSEC-2023-0071 (rsa /
+#     GAR-456), RUSTSEC-2024-0429 (glib / GAR-513), RUSTSEC-2026-0097
+#     (rand / GAR-513). Drop any of these atomically from BOTH files when
+#     the upstream fix lands. Closed history: wasmtime ×15 (GAR-454),
+#     webpki ×4 (GAR-455 / PR #295), lru ×1 (GAR-593 / this PR).**
 #   * The 22 unmaintained-only IDs in `deny.toml` (7 directly named +
 #     10 gtk-rs + 5 unic-*) are intentionally NOT mirrored here. Do not
 #     "fix" the asymmetry by mass-mirroring; that would change runtime
@@ -105,15 +103,13 @@ ignore = [
     # Removed: RUSTSEC-2026-0049, RUSTSEC-2026-0098, RUSTSEC-2026-0099, RUSTSEC-2026-0104.
 
     # =========================================================================
-    # GAR-513 carve-out — unsound warnings (glib + lru + rand)
+    # GAR-513 carve-out — unsound warnings (glib + rand)
     # =========================================================================
-    # GAR-437 (Q7 RUSTSEC triage) was marked Done 2026-04-27. These three
-    # suppressions are now tracked under GAR-513 (created 2026-05-05 by
-    # daily security routine). All 3 crates remain in `Cargo.lock` (verified
-    # empirically 2026-05-05). Without these ignores, the nightly
-    # `cargo audit --no-fetch --deny unsound` workflow (cargo-audit.yml)
-    # fails because cargo-audit treats `unsound` as denied. Expirations
-    # force re-triage 2026-07-31.
+    # GAR-437 (Q7 RUSTSEC triage) was marked Done 2026-04-27. Originally
+    # 3 crates (glib, lru, rand); lru closed 2026-05-12 by GAR-593 when
+    # aws-sdk-s3 1.132.0 pulled lru 0.16.4 (patched). 2 crates remain.
+    # Without these ignores, the nightly `cargo audit --no-fetch --deny
+    # unsound` workflow (cargo-audit.yml) fails. Expirations: 2026-07-31.
     #
     # glib 0.18.5 — `VariantStrIter` unsound Iterator impls. Pulled via
     # Tauri surface (garraia-desktop), excluded from CI builds. Zero
@@ -121,13 +117,10 @@ ignore = [
     # (Tauri-side decision). Tracked by: GAR-513. Expires: 2026-07-31.
     "RUSTSEC-2024-0429",
 
-    # lru 0.12.5 — `IterMut` stacked-borrows violation. Pulled
-    # transitively via `aws-sdk-s3 1.119.0 → garraia-storage` (feature
-    # `storage-s3`). Verified 2026-05-05: aws-sdk-s3 1.131.0 available but
-    # cargo update is solver-blocked; lru patch requires ≥ 0.16.3. Fix
-    # path: wait for aws-sdk-s3 to bump lru (see GAR-455 aws-smithy chain).
-    # Tracked by: GAR-513. Expires: 2026-07-31.
-    "RUSTSEC-2026-0002",
+    # NOTE: RUSTSEC-2026-0002 (lru 0.12.5 IterMut stacked-borrows violation)
+    # closed by GAR-593 (2026-05-12, health routine PR health/202605121530).
+    # Resolution: aws-sdk-s3 1.119→1.132 (PR #297) pulled lru 0.16.4 which
+    # patches the advisory. Removed from BOTH audit.toml and deny.toml.
 
     # rand 0.7.3 — `thread_rng` unsound custom-logger reentrance. This
     # version is a BUILD-TIME dep only: phf_codegen → phf_generator →

--- a/deny.toml
+++ b/deny.toml
@@ -8,13 +8,11 @@
 #   * `deny.toml` controls advisories flagged by `cargo deny check
 #     advisories`. Now invoked in CI via `cargo-deny-action` default
 #     `command: check` (since GAR-458 enabled the advisories category).
-#   * **Mandatory sync between the two files: wasmtime IDs (15),
-#     rustls-webpki residuals (4), AND 4 audit.toml mirrors that
-#     cargo-deny ALSO requires (rsa, glib, lru, rand — differing
-#     severity classification between cargo-deny and cargo-audit).**
-#     When the upstream blockers close, the IDs MUST be dropped from
-#     BOTH files atomically. (quinn-proto previously here was closed
-#     by GAR-457 on 2026-04-27.)
+#   * **Mandatory sync (remaining mirrored IDs): RUSTSEC-2023-0071 (rsa /
+#     GAR-456), RUSTSEC-2024-0429 (glib / GAR-513), RUSTSEC-2026-0097
+#     (rand / GAR-513). Closed: wasmtime ×15 (GAR-454), webpki ×4
+#     (GAR-455 / PR #295), lru ×1 (GAR-593 / health/202605121530). Drop
+#     atomically from BOTH files when an upstream fix lands.**
 #   * The 22 unmaintained-only IDs (7 directly named: daemonize,
 #     derivative, fxhash, instant, proc-macro-error, async-std,
 #     rustls-pemfile + 10× gtk-rs + 5× unic-*) are intentionally NOT
@@ -80,13 +78,13 @@ ignore = [
     # audit.toml under GAR-437 carve-out. Desktop-only via Tauri surface.
     # Expires 2026-07-31.
     "RUSTSEC-2024-0429",
-    # lru 0.12.5 — IterMut stacked-borrows violation. Mirror of audit.toml
-    # under GAR-437 carve-out. Pulled via aws-sdk-s3 → garraia-storage
-    # (feature `storage-s3`). Expires 2026-07-31.
-    "RUSTSEC-2026-0002",
+    # NOTE: RUSTSEC-2026-0002 (lru IterMut stacked-borrows) closed by
+    # GAR-593 (2026-05-12). aws-sdk-s3 1.132.0 pulled lru 0.16.4 (patched).
+    # Removed from BOTH audit.toml and deny.toml atomically (PR #297+this).
     # NOTE: RUSTSEC-2026-0037 (quinn-proto) closed by GAR-457 (2026-04-27)
     # via lockfile-only `cargo update -p quinn-proto --precise 0.11.14`.
     # Removed from BOTH audit.toml and deny.toml.
+
     # rand 0.10.1 — custom logger unsound in rand::rng(). Mirror of
     # audit.toml under GAR-437 carve-out. Used broadly; semver-incompatible
     # bump path under audit. Expires 2026-07-31.

--- a/docs/security/dependabot-status.md
+++ b/docs/security/dependabot-status.md
@@ -1,6 +1,6 @@
 # Dependabot Status
 
-> Last updated: **2026-05-12** (health routine — PR #293 / GAR-591 merged; 4 rustls-webpki alerts pending auto-close via Dependabot rescan within 24-48h).
+> Last updated: **2026-05-12** (health routine run 2 — PR #299 / GAR-593: stale RUSTSEC-2026-0002 (lru) ignore removed after lru 0.16.4 landed via PR #297).
 > Source of truth: `.cargo/audit.toml` and `deny.toml` (the suppression
 > rationale lives there, this file is the alert-to-rationale index).
 
@@ -38,6 +38,27 @@ Health routine ran on 2026-05-12. **PR #293 (GAR-591)** merged at commit `69c357
 
 Alert count: **8 open** (pre-rescan) → **4 expected** (post-rescan, within 24-48h).
 Remaining 4 alerts: rsa/RUSTSEC-2023-0071 (GAR-456), glib/RUSTSEC-2024-0429, lru/RUSTSEC-2026-0002, rand/RUSTSEC-2026-0097 (all GAR-513).
+
+## Confirmed 2026-05-12 run 2 (health routine — GAR-593: lru RUSTSEC-2026-0002 stale ignore removed)
+
+Health routine ran on 2026-05-12 (run 2, after PR #295 merged). **PR #297** (`8f73144`, `fix(security): bump aws-sdk-s3 1.119->1.132 to pull lru 0.16.4`) had already landed the fix; this run removes the stale audit config entries.
+
+| Change | Result |
+|---|---|
+| `lru` in `Cargo.lock` | ✅ **0.16.4** (patched; RUSTSEC-2026-0002 requires < 0.16.3) |
+| `RUSTSEC-2026-0002` in `audit.toml` | ✅ **REMOVED** — lru 0.16.4 patches advisory (PR #299, GAR-593) |
+| `RUSTSEC-2026-0002` in `deny.toml` | ✅ **REMOVED** atomically with audit.toml |
+| SYNC NOTE in both files | ✅ updated: mandatory-sync set now rsa + glib + rand only |
+| GAR-513 carve-out header | ✅ updated: `glib + lru + rand` → `glib + rand` |
+| PR #299 CI | ⏳ IN PROGRESS (queued 2026-05-12 ~12:56 UTC) |
+
+Residuals (3 remaining, all expires 2026-07-31):
+
+| Advisory | Crate | Owner | Status |
+|---|---|---|---|
+| RUSTSEC-2023-0071 | rsa 0.9.10 | GAR-456 | Active — no upstream fix |
+| RUSTSEC-2024-0429 | glib 0.18.5 | GAR-513 | Active — Tauri gtk-rs blocker |
+| RUSTSEC-2026-0097 | rand 0.7.3 | GAR-513 | Active — build-time dep only |
 
 ## Confirmed 2026-05-11 (health routine — all surfaces green)
 
@@ -242,9 +263,9 @@ No new untracked alerts. Count reconciled: 8 open (2 HIGH, 2 MEDIUM, 4 LOW) matc
 
 Dependabot rescan expected within 24-48h. Until rescan completes, GH UI still shows 8 open.
 
-## Residuals (4 open post-rescan, updated 2026-05-12)
+## Residuals (3 open post-rescan, updated 2026-05-12 run 2)
 
-All 4 remaining alerts have:
+All 3 remaining alerts have:
 - A specific RUSTSEC ID matching `Cargo.lock`.
 - A documented rationale block in `.cargo/audit.toml` and/or `deny.toml`.
 - A concrete Linear owner.
@@ -258,12 +279,17 @@ is intentionally allowlisted, not silenced.
 | — | — | HIGH | `rsa` | RUSTSEC-2023-0071 (Marvin Attack timing sidechannel) | GAR-456 | `rsa 0.9.10` enters tree via two paths: (1) `sqlx-mysql` lockfile residual even with `default-features = false` on all sqlx deps; (2) `jsonwebtoken 10 rust_crypto` backend (added 2026-04-30). GarraRUST emits/verifies HS256 only (`Algorithm::HS256` in `garraia-auth/src/jwt.rs`) — no RSA code path is reachable. Fix paths: (a) `jsonwebtoken` upstream isolates `rsa` behind `asymmetric` feature; (b) migrate to `sqlx-postgres` direct or sqlx 0.9. |
 | #2  | GHSA-wrw7-89jp-8q8g | MEDIUM | `glib` | RUSTSEC-2024-0429 (`VariantStrIter` Iterator unsoundness) | GAR-513 | Tauri-only path (`crates/garraia-desktop`), excluded from server CI builds. Low runtime risk in deployments. Fix path: bump glib OR gate ignore behind `desktop` feature. |
 | #25 | GHSA-cq8v-f236-94qc | LOW | `rand` | RUSTSEC-2026-0097 (custom logger unsoundness in `rand::rng()`) | GAR-513 | Build-time dep only: `phf_codegen → phf_generator → selectors → tauri-utils → garraia-desktop`. Zero server runtime risk. No 0.7.x patch; fix requires phf_codegen to bump rand. |
-| #5  | GHSA-rhfx-m35p-ff5j | LOW | `lru` | RUSTSEC-2026-0002 (`IterMut` Stacked Borrows violation) | GAR-513 | Transitive via `aws-sdk-s3 1.119.0` (feature `storage-s3` of `garraia-storage`). `Cargo.lock` resolution is feature-agnostic — alert appears even when feature off. Closes when aws-sdk-s3 bumps lru, OR when `storage-s3` is excluded from cargo audit surface. |
+
+## Closed 2026-05-12 run 2 (PR #297 + PR #299 / GAR-593)
+
+| GH # | RUSTSEC | Crate | Closure mechanism |
+|---|---|---|---|
+| #5 | RUSTSEC-2026-0002 | `lru` | PR #297 (`8f73144`) bumped aws-sdk-s3 1.119→1.132, pulling lru 0.16.4 (patched ≥ 0.16.3). Audit config cleanup via PR #299 (GAR-593). |
 
 ## Linear ownership map
 
 - **GAR-455** — ✅ CLOSED 2026-05-12. `rustls-webpki` legacy chains fully removed. Both chains eliminated: aws-smithy (plan 0087, 2026-05-09) + serenity (PR #293, 2026-05-12). 4 of 8 former alerts (#37, #11, #23, #22) closing pending Dependabot rescan.
-- **GAR-513** — Unsound triage carve-out (created 2026-05-05; GAR-437 closed 2026-04-27). 3 of 4 remaining alerts (#2 glib, #25 rand, #5 lru). Each tracked individually as upstream fixes ship.
+- **GAR-513** — Unsound triage carve-out (created 2026-05-05; GAR-437 closed 2026-04-27). 2 of 3 remaining alerts (#2 glib, #25 rand). lru (#5 / RUSTSEC-2026-0002) closed 2026-05-12 by GAR-593 / PR #299. Each remaining entry tracked individually as upstream fixes ship.
 - **GAR-456** — Marvin Attack timing sidechannel (`rsa 0.9.10`). 1 of 4 remaining alerts (RUSTSEC-2023-0071; GH alert number unknown — cargo audit detects it as workspace advisory). GarraRUST emits and verifies HS256 only; no RSA call site is reachable. Same `2026-07-31` expiration.
 
 ## Re-triage cadence
@@ -288,8 +314,8 @@ gh api repos/michelbr84/GarraRUST/dependabot/alerts --paginate \
 # Audit allowlist consistency check
 grep -E "^\s*\"RUSTSEC-" .cargo/audit.toml | sort
 grep -E "^\s*\"RUSTSEC-" deny.toml | sort
-# (the two MUST share the wasmtime IDs (15) AND rustls-webpki residuals (4)
-#  per .cargo/audit.toml SYNC NOTE.)
+# (the two MUST share the mandatory-sync IDs: rsa, glib, rand
+#  per .cargo/audit.toml SYNC NOTE — refreshed 2026-05-12 by GAR-593)
 
 # Verify cargo audit / cargo deny stay green with the allowlist active
 cargo audit

--- a/plans/0108-gar-593-lru-advisory-cleanup.md
+++ b/plans/0108-gar-593-lru-advisory-cleanup.md
@@ -1,0 +1,119 @@
+# Plan 0108 — GAR-593: Drop stale RUSTSEC-2026-0002 (lru) after lru 0.16.4
+
+**Status:** In Progress  
+**Linear:** [GAR-593](https://linear.app/chatgpt25/issue/GAR-593)  
+**Branch:** `health/202605121530-gar593-lru-advisory-cleanup`  
+**Created:** 2026-05-12 (Florida time)
+
+---
+
+## Goal
+
+Remove the now-stale `RUSTSEC-2026-0002` ignore entry from `.cargo/audit.toml`
+and `deny.toml` atomically, following the SYNC NOTE invariant. The advisory
+(lru IterMut stacked-borrows violation) is patched in lru ≥ 0.16.3; PR #297
+(`fix(security): bump aws-sdk-s3 1.119->1.132 to pull lru 0.16.4`, merged
+2026-05-12 as `8f73144`) landed the patch in `Cargo.lock`.
+
+---
+
+## Architecture
+
+Config-only change. No code, no schema, no runtime impact.
+
+---
+
+## Tech Stack
+
+- `.cargo/audit.toml` — cargo-audit ignore list
+- `deny.toml` — cargo-deny advisories ignore list
+
+---
+
+## Design Invariants
+
+1. SYNC NOTE invariant: any ID that appears in both files MUST be dropped
+   from BOTH atomically in the same PR/commit.
+2. Only drop RUSTSEC-2026-0002. The remaining GAR-513 carve-outs (glib
+   RUSTSEC-2024-0429, rand RUSTSEC-2026-0097) still have valid upstream
+   blockers — do NOT touch them.
+3. Update the SYNC NOTE header in both files to reflect the current state.
+
+---
+
+## Out of Scope
+
+- glib (RUSTSEC-2024-0429) — Tauri-side upstream blocker
+- rand (RUSTSEC-2026-0097) — phf_codegen build-time dep, no patch
+- Any Dependabot version-bump PRs
+
+---
+
+## Rollback
+
+Revert the two config edits. No migration or database change involved.
+
+---
+
+## Open Questions
+
+_None — the fix is deterministic: lru 0.16.4 is in Cargo.lock and patched._
+
+---
+
+## File Structure
+
+```
+.cargo/audit.toml          — remove lru block + closure note + update SYNC NOTE
+deny.toml                  — remove lru mirror + closure note + update SYNC NOTE
+plans/0108-gar-593-lru-advisory-cleanup.md  ← this file (renumbered from 0106; 0106/0107 already taken by GAR-589/GAR-592)
+plans/README.md            — add row 0108
+```
+
+---
+
+## Tasks
+
+### M1 — Config cleanup
+
+- [x] T1: Update SYNC NOTE in `.cargo/audit.toml` (stale wasmtime/webpki refs)
+- [x] T2: Remove lru block + add closure note in `.cargo/audit.toml`
+- [x] T3: Update SYNC NOTE in `deny.toml`
+- [x] T4: Remove lru mirror + add closure note in `deny.toml`
+- [x] T5: Write plan file + update `plans/README.md`
+- [ ] T6: Commit + push + open PR
+- [ ] T7: Verify CI 18/18 green
+- [ ] T8: Merge + mark GAR-593 Done
+
+---
+
+## Risk Register
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| cargo-deny warns on RUSTSEC-2026-0002 as still-needed | Low | lru 0.16.4 confirmed in Cargo.lock |
+| Merge conflict with PR #295 | None | PR #295 already merged; branch rebased |
+
+---
+
+## Acceptance Criteria
+
+- `cargo deny check advisories` passes with no `advisory-not-detected` for RUSTSEC-2026-0002
+- `cargo audit --deny unsound` passes (lru 0.16.4 patched)
+- CI 18/18 green
+
+---
+
+## Cross-References
+
+- GAR-513: parent tracking issue for glib/lru/rand carve-outs
+- GAR-593: this issue
+- PR #297 (`8f73144`): lru 0.16.4 landed in main
+- PR #295 (`1d0d332`): webpki cleanup (sister health PR, merged same day)
+- Plan 0053 PR-6 / GAR-452: original audit.toml cleanup convention
+
+---
+
+## Estimativa
+
+~30 min total (config-only, no code changes).

--- a/plans/README.md
+++ b/plans/README.md
@@ -114,6 +114,7 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0105 | [GAR-580 — REST /v1 groups slice 3: GET /v1/groups (list user's groups)](0105-gar-580-groups-list-api.md) | [GAR-580](https://linear.app/chatgpt25/issue/GAR-580) | ✅ Merged 2026-05-12 via PR #273 (`84115c2`) |
 | 0106 | [GAR-589 — FORCE RLS on groups + group\_members tables](0106-gar-589-rls-groups-and-members.md) | [GAR-589](https://linear.app/chatgpt25/issue/GAR-589) | ✅ Merged 2026-05-12 via PR #294 (`36b2b72`) |
 | 0107 | [GAR-592 — messages slice 5: PATCH + DELETE /v1/messages/{id}](0107-gar-592-messages-edit-delete.md) | [GAR-592](https://linear.app/chatgpt25/issue/GAR-592) | ✅ Merged 2026-05-12 via PR #300 (`3c843e4`) |
+| 0108 | [GAR-593 — drop stale RUSTSEC-2026-0002 (lru) after lru 0.16.4](0108-gar-593-lru-advisory-cleanup.md) | [GAR-593](https://linear.app/chatgpt25/issue/GAR-593) | 🔄 In Progress |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

Follow-up bookkeeping after PR #297 (`8f73144`) merged `fix(security): bump aws-sdk-s3 1.119->1.132 to pull lru 0.16.4`.

`RUSTSEC-2026-0002` (lru IterMut stacked-borrows violation) is patched in lru ≥ 0.16.3. `Cargo.lock` now contains only `lru 0.16.4`. The ignore entries for this advisory are **stale** and must be removed per the SYNC NOTE invariant.

## Changes

| File | Change |
|---|---|
| `.cargo/audit.toml` | Remove lru block (RUSTSEC-2026-0002) + add closure note; update SYNC NOTE header (stale refs to wasmtime ×15 / webpki ×4 removed); GAR-513 section header: `glib + lru + rand` → `glib + rand` |
| `deny.toml` | Remove lru mirror entry + add closure note; update SYNC NOTE header |
| `plans/0106-gar-593-lru-advisory-cleanup.md` | New plan file |
| `plans/README.md` | Add row 0106 |

## Verification

- `cargo audit` will pass: `lru 0.16.4` is patched, advisory no longer fires
- `cargo deny check advisories` will pass: no `advisory-not-detected` warning for RUSTSEC-2026-0002
- No code changes; config + docs only

## Test plan

- [ ] All 18 CI checks green (Format, Clippy, Test×3, Build, MSRV, cargo-deny, Security Audit, Coverage, Analyze rust, Analyze js-ts, Playwright, E2E, Secret Scan, Dependency Review, Quality Ratchet, CodeQL)
- [ ] `cargo-deny` check: no `advisory-not-detected` warning for RUSTSEC-2026-0002

## Originating alert

Closes GAR-593 (Linear). RUSTSEC-2026-0002 advisory — stale ignore after PR #297 fixed the triggering crate.

Sister PR: #295 (webpki cleanup, merged 2026-05-12 as `1d0d332`).

https://claude.ai/code/session_01XeXmLt34s3NtCS7X1dSQsR

---
_Generated by [Claude Code](https://claude.ai/code/session_01XeXmLt34s3NtCS7X1dSQsR)_