### PR TITLE
feat(messages): GAR-592 — PATCH + DELETE /v1/messages/{id} (plan 0107)

### DIFF
--- a/crates/garraia-auth/src/audit_workspace.rs
+++ b/crates/garraia-auth/src/audit_workspace.rs
@@ -125,6 +125,20 @@ pub enum WorkspaceAuditAction {
     /// via `GET /v1/chats/{id}/messages`.
     MessageSent,
 
+    /// A message body was edited via `PATCH /v1/messages/{message_id}`
+    /// (plan 0107 / GAR-592, epic GAR-WS-CHAT slice 5).
+    ///
+    /// `resource_type = "messages"`, `resource_id = "{message_id}"`.
+    /// Metadata: `{ body_len }`. Body content is PII — never logged.
+    MessageEdited,
+
+    /// A message was soft-deleted via `DELETE /v1/messages/{message_id}`
+    /// (plan 0107 / GAR-592, epic GAR-WS-CHAT slice 5).
+    ///
+    /// `resource_type = "messages"`, `resource_id = "{message_id}"`.
+    /// Metadata: `{ admin_override: bool }`.
+    MessageDeleted,
+
     /// A thread was created from a message via
     /// `POST /v1/messages/{message_id}/threads` (plan 0058 / GAR-509,
     /// epic GAR-WS-CHAT slice 3).
@@ -482,6 +496,8 @@ impl WorkspaceAuditAction {
             WorkspaceAuditAction::UploadExpired => "upload.expired",
             WorkspaceAuditAction::ChatCreated => "chat.created",
             WorkspaceAuditAction::MessageSent => "message.sent",
+            WorkspaceAuditAction::MessageEdited => "message.edited",
+            WorkspaceAuditAction::MessageDeleted => "message.deleted",
             WorkspaceAuditAction::ThreadCreated => "thread.created",
             WorkspaceAuditAction::MemoryCreated => "memory.created",
             WorkspaceAuditAction::MemoryDeleted => "memory.deleted",
@@ -612,6 +628,14 @@ mod tests {
         assert_eq!(WorkspaceAuditAction::ChatCreated.as_str(), "chat.created");
         assert_eq!(WorkspaceAuditAction::MessageSent.as_str(), "message.sent");
         assert_eq!(
+            WorkspaceAuditAction::MessageEdited.as_str(),
+            "message.edited"
+        );
+        assert_eq!(
+            WorkspaceAuditAction::MessageDeleted.as_str(),
+            "message.deleted"
+        );
+        assert_eq!(
             WorkspaceAuditAction::ThreadCreated.as_str(),
             "thread.created"
         );
@@ -738,6 +762,8 @@ mod tests {
             WorkspaceAuditAction::UploadExpired.as_str(),
             WorkspaceAuditAction::ChatCreated.as_str(),
             WorkspaceAuditAction::MessageSent.as_str(),
+            WorkspaceAuditAction::MessageEdited.as_str(),
+            WorkspaceAuditAction::MessageDeleted.as_str(),
             WorkspaceAuditAction::ThreadCreated.as_str(),
             WorkspaceAuditAction::MemoryCreated.as_str(),
             WorkspaceAuditAction::MemoryDeleted.as_str(),

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -360,6 +360,14 @@ name = "rest_v1_groups_list"
 path = "tests/rest_v1_groups_list.rs"
 required-features = ["test-helpers"]
 
+# Plan 0107 (GAR-592) — PATCH + DELETE /v1/messages/{id}: edit + soft-delete
+# (ME1-ME5, MD1-MD5 including cross-group isolation). Requires test-helpers so
+# `cargo clippy --all-targets` without `--features test-helpers` skips it.
+[[test]]
+name = "rest_v1_messages_edit_delete"
+path = "tests/rest_v1_messages_edit_delete.rs"
+required-features = ["test-helpers"]
+
 [dev-dependencies]
 # Plan 0024 T4 (GAR-412): metrics_exporter tests and the
 # metrics_auth_integration binary build a `PrometheusRecorder` directly

--- a/crates/garraia-gateway/src/rest_v1/messages.rs
+++ b/crates/garraia-gateway/src/rest_v1/messages.rs
@@ -651,6 +651,299 @@ pub async fn create_thread(
     ))
 }
 
+/// Request body for `PATCH /v1/messages/{message_id}`.
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct PatchMessageRequest {
+    /// New message text. Must be non-empty after trim. Max 100,000 characters.
+    pub body: String,
+}
+
+impl PatchMessageRequest {
+    pub fn validate(&self) -> Result<(), &'static str> {
+        if self.body.trim().is_empty() {
+            return Err("message body must not be empty");
+        }
+        if self.body.chars().count() > MAX_BODY_CHARS {
+            return Err("message body must be 100,000 characters or fewer");
+        }
+        Ok(())
+    }
+}
+
+/// Response body for `PATCH /v1/messages/{message_id}` (200 OK).
+#[derive(Debug, Serialize, ToSchema)]
+pub struct EditedMessageResponse {
+    pub id: Uuid,
+    pub body: String,
+    pub edited_at: DateTime<Utc>,
+    pub group_id: Uuid,
+}
+
+/// `PATCH /v1/messages/{message_id}` — edit the body of a message.
+///
+/// Only the original sender may edit their own message. Editing a deleted
+/// message or a message sent by another user returns 404 (no existence leak).
+///
+/// `body_tsv` is `GENERATED ALWAYS AS … STORED` — Postgres regenerates it
+/// automatically when `body` is updated; it must NOT appear in the UPDATE list.
+///
+/// ## Error matrix
+///
+/// | Condition                                      | Status | Source         |
+/// |------------------------------------------------|--------|----------------|
+/// | Missing/invalid JWT                            | 401    | Principal ext. |
+/// | Non-member of group                            | 403    | Principal ext. |
+/// | `X-Group-Id` header missing                   | 400    | this handler   |
+/// | Body empty or > 100,000 chars                  | 400    | validate()     |
+/// | Message not found / deleted / wrong sender     | 404    | this handler   |
+/// | Happy path                                     | 200    |                |
+#[utoipa::path(
+    patch,
+    path = "/v1/messages/{message_id}",
+    params(
+        ("message_id" = Uuid, Path, description = "Message UUID."),
+    ),
+    request_body = PatchMessageRequest,
+    responses(
+        (status = 200, description = "Message edited.", body = EditedMessageResponse),
+        (status = 400, description = "Validation error or header mismatch.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member of the group.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Message not found, already deleted, or sent by a different user.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn patch_message(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(message_id): Path<Uuid>,
+    Json(body): Json<PatchMessageRequest>,
+) -> Result<Json<EditedMessageResponse>, RestError> {
+    // 1. X-Group-Id header required.
+    let group_id = match principal.group_id {
+        Some(hdr) => hdr,
+        None => {
+            return Err(RestError::BadRequest(
+                "X-Group-Id header is required".into(),
+            ));
+        }
+    };
+
+    // 2. Capability gate.
+    if !can(&principal, Action::ChatsWrite) {
+        return Err(RestError::Forbidden);
+    }
+
+    // 3. Structural validation.
+    body.validate()
+        .map_err(|msg| RestError::BadRequest(msg.into()))?;
+
+    let new_body = body.body.trim().to_string();
+
+    // 4. Open transaction with RLS context.
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    // 5. Tenant context.
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(principal.user_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_group_id', $1, true)")
+        .bind(group_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    // 6. UPDATE — sender-only, non-deleted.
+    //    body_tsv is GENERATED ALWAYS AS — must NOT appear in the column list.
+    let row: Option<(DateTime<Utc>,)> = sqlx::query_as(
+        "UPDATE messages \
+         SET body = $1, edited_at = now() \
+         WHERE id = $2 \
+           AND group_id = $3 \
+           AND sender_user_id = $4 \
+           AND deleted_at IS NULL \
+         RETURNING edited_at",
+    )
+    .bind(&new_body)
+    .bind(message_id)
+    .bind(group_id)
+    .bind(principal.user_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let (edited_at,) = match row {
+        Some(r) => r,
+        None => return Err(RestError::NotFound),
+    };
+
+    // 7. Audit — structural metadata only; body content is PII.
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::MessageEdited,
+        principal.user_id,
+        group_id,
+        "messages",
+        message_id.to_string(),
+        json!({ "body_len": new_body.chars().count() }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(Json(EditedMessageResponse {
+        id: message_id,
+        body: new_body,
+        edited_at,
+        group_id,
+    }))
+}
+
+/// `DELETE /v1/messages/{message_id}` — soft-delete a message.
+///
+/// Sets `deleted_at = now()`. Deleted messages are excluded from list
+/// endpoints and full-text search. The original sender may always delete
+/// their own message. Group Owners and Admins (role tier ≥ 80) may delete
+/// any message in their group.
+///
+/// Returns 404 if the message is not found, already deleted, or the caller
+/// lacks permission to delete it.
+///
+/// ## Error matrix
+///
+/// | Condition                                        | Status | Source         |
+/// |--------------------------------------------------|--------|----------------|
+/// | Missing/invalid JWT                              | 401    | Principal ext. |
+/// | Non-member of group                              | 403    | Principal ext. |
+/// | `X-Group-Id` header missing                     | 400    | this handler   |
+/// | Message not found / already deleted / no perms  | 404    | this handler   |
+/// | Happy path                                       | 204    |                |
+#[utoipa::path(
+    delete,
+    path = "/v1/messages/{message_id}",
+    params(
+        ("message_id" = Uuid, Path, description = "Message UUID."),
+    ),
+    responses(
+        (status = 204, description = "Message deleted."),
+        (status = 400, description = "Header mismatch.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member of the group.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Message not found, already deleted, or insufficient permission.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn delete_message(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(message_id): Path<Uuid>,
+) -> Result<StatusCode, RestError> {
+    // 1. X-Group-Id header required.
+    let group_id = match principal.group_id {
+        Some(hdr) => hdr,
+        None => {
+            return Err(RestError::BadRequest(
+                "X-Group-Id header is required".into(),
+            ));
+        }
+    };
+
+    // 2. Capability gate.
+    if !can(&principal, Action::ChatsWrite) {
+        return Err(RestError::Forbidden);
+    }
+
+    // 3. Open transaction with RLS context.
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    // 4. Tenant context.
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(principal.user_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_group_id', $1, true)")
+        .bind(group_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    // 5. Determine if caller has admin-override permission (Owner/Admin).
+    let is_admin = principal.role.map(|r| r.tier() >= 80).unwrap_or(false);
+
+    // 6. Soft-delete. Admin/Owner may delete any message; others only their own.
+    let row: Option<(Uuid,)> = if is_admin {
+        sqlx::query_as(
+            "UPDATE messages \
+             SET deleted_at = now() \
+             WHERE id = $1 \
+               AND group_id = $2 \
+               AND deleted_at IS NULL \
+             RETURNING id",
+        )
+        .bind(message_id)
+        .bind(group_id)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?
+    } else {
+        sqlx::query_as(
+            "UPDATE messages \
+             SET deleted_at = now() \
+             WHERE id = $1 \
+               AND group_id = $2 \
+               AND sender_user_id = $3 \
+               AND deleted_at IS NULL \
+             RETURNING id",
+        )
+        .bind(message_id)
+        .bind(group_id)
+        .bind(principal.user_id)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?
+    };
+
+    if row.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    // 7. Audit.
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::MessageDeleted,
+        principal.user_id,
+        group_id,
+        "messages",
+        message_id.to_string(),
+        json!({ "admin_override": is_admin }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -308,6 +308,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     "/v1/messages/{message_id}/threads",
                     post(messages::create_thread),
                 )
+                // Plan 0107 (GAR-592) — messages slice 5: edit + soft-delete.
+                .route(
+                    "/v1/messages/{message_id}",
+                    patch(messages::patch_message).delete(messages::delete_message),
+                )
                 // Plan 0062 (GAR-514) — memory API slice 1.
                 .route(
                     "/v1/memory",
@@ -513,6 +518,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     "/v1/messages/{message_id}/threads",
                     post(unconfigured_handler),
                 )
+                // Plan 0107 (GAR-592) — messages slice 5, fail-soft 503.
+                .route(
+                    "/v1/messages/{message_id}",
+                    patch(unconfigured_handler).delete(unconfigured_handler),
+                )
                 // Plan 0062 (GAR-514) — memory API slice 1, fail-soft 503.
                 .route(
                     "/v1/memory",
@@ -691,6 +701,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 .route(
                     "/v1/messages/{message_id}/threads",
                     post(unconfigured_handler),
+                )
+                // Plan 0107 (GAR-592) — messages slice 5, no-auth stub.
+                .route(
+                    "/v1/messages/{message_id}",
+                    patch(unconfigured_handler).delete(unconfigured_handler),
                 )
                 // Plan 0062 (GAR-514) — memory API slice 1, no-auth stub.
                 .route(

--- a/crates/garraia-gateway/tests/rest_v1_messages_edit_delete.rs
+++ b/crates/garraia-gateway/tests/rest_v1_messages_edit_delete.rs
@@ -1,0 +1,481 @@
+//! Integration tests for `PATCH /v1/messages/{id}` and
+//! `DELETE /v1/messages/{id}` (plan 0107, GAR-592).
+//!
+//! All scenarios are bundled into ONE `#[tokio::test]` function to
+//! avoid the sqlx runtime-teardown race documented in plan 0016 M3
+//! commit `4f8be37`.
+//!
+//! Edit scenarios (10):
+//!   ME1. PATCH 200 — sender edits own message; body + edited_at updated.
+//!   ME2. PATCH 404 — non-existent message_id.
+//!   ME3. PATCH 404 — message sent by another user (sender check).
+//!   ME4. PATCH 404 — message already soft-deleted.
+//!   ME5. PATCH 400 — empty body rejected.
+//!
+//! Delete scenarios (5):
+//!   MD1. DELETE 204 — sender deletes own message; subsequent PATCH → 404.
+//!   MD2. DELETE 404 — already-deleted message (idempotent guard).
+//!   MD3. DELETE 404 — member tries to delete another user's message.
+//!   MD4. DELETE 204 — admin deletes another user's message (admin override).
+//!   MD5. DELETE 404 — cross-group: group-B message invisible to group-A caller.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+
+use common::Harness;
+use common::fixtures::{fetch_audit_events_for_group, seed_member_via_admin, seed_user_with_group};
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("failed to collect response body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("response body is not JSON")
+}
+
+fn patch_message(
+    token: Option<&str>,
+    message_id: &str,
+    x_group_id: Option<&str>,
+    body: serde_json::Value,
+) -> Request<Body> {
+    let mut req = Request::builder()
+        .method("PATCH")
+        .uri(format!("/v1/messages/{message_id}"))
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .expect("request builder");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    if let Some(t) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {t}")).unwrap(),
+        );
+    }
+    if let Some(g) = x_group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    req
+}
+
+fn delete_message(
+    token: Option<&str>,
+    message_id: &str,
+    x_group_id: Option<&str>,
+) -> Request<Body> {
+    let mut req = Request::builder()
+        .method("DELETE")
+        .uri(format!("/v1/messages/{message_id}"))
+        .body(Body::empty())
+        .expect("request builder");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    if let Some(t) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {t}")).unwrap(),
+        );
+    }
+    if let Some(g) = x_group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    req
+}
+
+/// Create a chat via `POST /v1/groups/{group_id}/chats`, return chat_id.
+async fn create_chat(h: &Harness, token: &str, group_id: &str, name: &str) -> String {
+    let resp = h
+        .router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/groups/{group_id}/chats"))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {token}"))
+                .header("x-group-id", group_id)
+                .extension(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+                    "127.0.0.1:1".parse().unwrap(),
+                ))
+                .body(Body::from(
+                    json!({"name": name, "type": "channel"}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .expect("create_chat oneshot");
+    let b = body_json(resp).await;
+    b["id"].as_str().unwrap().to_string()
+}
+
+/// Send one message to a chat, return the message_id.
+async fn send_message(
+    h: &Harness,
+    token: &str,
+    chat_id: &str,
+    group_id: &str,
+    text: &str,
+) -> String {
+    let resp = h
+        .router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/chats/{chat_id}/messages"))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {token}"))
+                .header("x-group-id", group_id)
+                .extension(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+                    "127.0.0.1:1".parse().unwrap(),
+                ))
+                .body(Body::from(json!({"body": text}).to_string()))
+                .unwrap(),
+        )
+        .await
+        .expect("send_message oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::CREATED,
+        "seed message should 201"
+    );
+    let b = body_json(resp).await;
+    b["id"].as_str().unwrap().to_string()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rest_v1_messages_edit_delete_scenarios() {
+    let h = Harness::get().await;
+
+    // Primary actor: owner of group1.
+    let (owner_id, group1_id, owner_token) = seed_user_with_group(&h, "owner@msg-edit-delete.test")
+        .await
+        .expect("seed owner+group1");
+    let group1_str = group1_id.to_string();
+
+    let chat_id = create_chat(&h, &owner_token, &group1_str, "edit-delete-general").await;
+
+    // Second actor in group1 — Member (tier 50, cannot delete others' messages).
+    let (member_id, member_token) =
+        seed_member_via_admin(&h, group1_id, "member", "member@msg-edit-delete.test")
+            .await
+            .expect("seed member");
+
+    // Third actor in group1 — Admin (tier 80, can delete others' messages).
+    let (_admin_id, admin_token) =
+        seed_member_via_admin(&h, group1_id, "admin", "admin@msg-edit-delete.test")
+            .await
+            .expect("seed admin");
+
+    // Independent group2 + owner for cross-group isolation tests.
+    let (_, group2_id, owner2_token) = seed_user_with_group(&h, "owner2@msg-edit-delete.test")
+        .await
+        .expect("seed owner2+group2");
+    let group2_str = group2_id.to_string();
+    let chat2_id = create_chat(&h, &owner2_token, &group2_str, "edit-delete-g2").await;
+
+    // Pre-seed messages used across multiple scenarios.
+    // msg_owner: sent by owner — used in ME1, ME3, ME4, MD1, MD2.
+    let msg_owner = send_message(&h, &owner_token, &chat_id, &group1_str, "Original body").await;
+    // msg_member: sent by member — used in ME3, MD3, MD4.
+    let msg_member = send_message(&h, &member_token, &chat_id, &group1_str, "Member message").await;
+    // msg_in_g2: sent by owner2 in group2 — used in MD5.
+    let msg_in_g2 = send_message(&h, &owner2_token, &chat2_id, &group2_str, "Group2 message").await;
+
+    // ── ME1. PATCH 200 — sender edits own message ────────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(patch_message(
+            Some(&owner_token),
+            &msg_owner,
+            Some(&group1_str),
+            json!({"body": "Updated body"}),
+        ))
+        .await
+        .expect("ME1 oneshot");
+    assert_eq!(resp.status(), StatusCode::OK, "ME1 status");
+    let me1_body = body_json(resp).await;
+    assert_eq!(me1_body["body"], "Updated body", "ME1 body updated");
+    assert_eq!(me1_body["id"], msg_owner, "ME1 id matches");
+    assert_eq!(me1_body["group_id"], group1_str, "ME1 group_id matches");
+    assert!(
+        !me1_body["edited_at"].is_null(),
+        "ME1 edited_at must be present"
+    );
+
+    // ME1 — audit row: structural only, no body content.
+    let events = fetch_audit_events_for_group(&h, group1_id)
+        .await
+        .expect("ME1 fetch audit");
+    let edit_event = events
+        .iter()
+        .find(|e| e.0 == "message.edited" && e.3 == msg_owner)
+        .expect("ME1 message.edited audit row missing");
+    let (_, actor, resource_type, _, metadata) = edit_event;
+    assert_eq!(actor, &Some(owner_id), "ME1 audit actor");
+    assert_eq!(resource_type, "messages", "ME1 audit resource_type");
+    assert_eq!(
+        metadata["body_len"],
+        "Updated body".chars().count() as i64,
+        "ME1 audit body_len"
+    );
+    assert!(
+        metadata.get("body").is_none(),
+        "ME1 audit MUST NOT carry body content"
+    );
+
+    // ── ME2. PATCH 404 — non-existent message_id ──────────────────────
+    let nonexistent = uuid::Uuid::new_v4().to_string();
+    let resp = h
+        .router
+        .clone()
+        .oneshot(patch_message(
+            Some(&owner_token),
+            &nonexistent,
+            Some(&group1_str),
+            json!({"body": "Any body"}),
+        ))
+        .await
+        .expect("ME2 oneshot");
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND, "ME2 status");
+
+    // ── ME3. PATCH 404 — edit another user's message (sender check) ──────
+    // owner tries to edit msg_member (which was sent by member).
+    let resp = h
+        .router
+        .clone()
+        .oneshot(patch_message(
+            Some(&owner_token),
+            &msg_member,
+            Some(&group1_str),
+            json!({"body": "Owner trying to edit member's message"}),
+        ))
+        .await
+        .expect("ME3 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "ME3 status (wrong sender → 404)"
+    );
+
+    // ── ME4. PATCH 404 — already-deleted message ─────────────────────
+    // Soft-delete msg_member first via its sender, then try to edit it.
+    let del_resp = h
+        .router
+        .clone()
+        .oneshot(delete_message(
+            Some(&member_token),
+            &msg_member,
+            Some(&group1_str),
+        ))
+        .await
+        .expect("ME4 pre-delete");
+    assert_eq!(
+        del_resp.status(),
+        StatusCode::NO_CONTENT,
+        "ME4 pre-delete should 204"
+    );
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(patch_message(
+            Some(&member_token),
+            &msg_member,
+            Some(&group1_str),
+            json!({"body": "Edit after delete"}),
+        ))
+        .await
+        .expect("ME4 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "ME4 status (deleted → 404)"
+    );
+
+    // ── ME5. PATCH 400 — empty body rejected ────────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(patch_message(
+            Some(&owner_token),
+            &msg_owner,
+            Some(&group1_str),
+            json!({"body": "   "}),
+        ))
+        .await
+        .expect("ME5 oneshot");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "ME5 status");
+
+    // ── MD1. DELETE 204 — sender deletes own message ────────────────────
+    // Seed a fresh message to use for MD1 (msg_owner was edited, still live).
+    let msg_for_md1 = send_message(
+        &h,
+        &owner_token,
+        &chat_id,
+        &group1_str,
+        "To be deleted by owner",
+    )
+    .await;
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(delete_message(
+            Some(&owner_token),
+            &msg_for_md1,
+            Some(&group1_str),
+        ))
+        .await
+        .expect("MD1 oneshot");
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT, "MD1 status");
+
+    // MD1 — verify deleted_at set in DB.
+    let (deleted_at,): (Option<chrono::DateTime<chrono::Utc>>,) =
+        sqlx::query_as("SELECT deleted_at FROM messages WHERE id = $1")
+            .bind(uuid::Uuid::parse_str(&msg_for_md1).unwrap())
+            .fetch_one(&h.admin_pool)
+            .await
+            .expect("MD1 DB check");
+    assert!(deleted_at.is_some(), "MD1 deleted_at must be set");
+
+    // MD1 — audit row.
+    let events = fetch_audit_events_for_group(&h, group1_id)
+        .await
+        .expect("MD1 fetch audit");
+    let del_event = events
+        .iter()
+        .find(|e| e.0 == "message.deleted" && e.3 == msg_for_md1)
+        .expect("MD1 message.deleted audit row missing");
+    let (_, _, _, _, md1_meta) = del_event;
+    assert_eq!(
+        md1_meta["admin_override"], false,
+        "MD1 admin_override must be false"
+    );
+
+    // ── MD2. DELETE 404 — already-deleted message (idempotent guard) ─────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(delete_message(
+            Some(&owner_token),
+            &msg_for_md1,
+            Some(&group1_str),
+        ))
+        .await
+        .expect("MD2 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "MD2 status (already deleted → 404)"
+    );
+
+    // ── MD3. DELETE 404 — member cannot delete another user's message ─────
+    // Send a fresh message by owner; member tries to delete it.
+    let msg_for_md3 =
+        send_message(&h, &owner_token, &chat_id, &group1_str, "Owner msg for MD3").await;
+
+    let resp = h
+        .router
+        .clone()
+        .oneshot(delete_message(
+            Some(&member_token),
+            &msg_for_md3,
+            Some(&group1_str),
+        ))
+        .await
+        .expect("MD3 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "MD3 status (member, wrong sender → 404)"
+    );
+
+    // Confirm message is still live.
+    let (still_alive,): (bool,) =
+        sqlx::query_as("SELECT deleted_at IS NULL FROM messages WHERE id = $1")
+            .bind(uuid::Uuid::parse_str(&msg_for_md3).unwrap())
+            .fetch_one(&h.admin_pool)
+            .await
+            .expect("MD3 alive check");
+    assert!(still_alive, "MD3 message must not be deleted");
+
+    // ── MD4. DELETE 204 — admin override deletes another user's message ───
+    // Use msg_for_md3 (owner's message, still live); admin deletes it.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(delete_message(
+            Some(&admin_token),
+            &msg_for_md3,
+            Some(&group1_str),
+        ))
+        .await
+        .expect("MD4 oneshot");
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT, "MD4 status");
+
+    // MD4 — audit row: admin_override = true.
+    let events = fetch_audit_events_for_group(&h, group1_id)
+        .await
+        .expect("MD4 fetch audit");
+    let md4_event = events
+        .iter()
+        .find(|e| e.0 == "message.deleted" && e.3 == msg_for_md3)
+        .expect("MD4 message.deleted audit row missing");
+    let (_, _, _, _, md4_meta) = md4_event;
+    assert_eq!(
+        md4_meta["admin_override"], true,
+        "MD4 admin_override must be true"
+    );
+
+    // ── MD5. DELETE 404 — cross-group isolation ──────────────────────────
+    // owner (group1) tries to delete msg_in_g2 (group2) using group1 context.
+    let resp = h
+        .router
+        .clone()
+        .oneshot(delete_message(
+            Some(&owner_token),
+            &msg_in_g2,
+            Some(&group1_str),
+        ))
+        .await
+        .expect("MD5 oneshot");
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "MD5 status (cross-group → 404)"
+    );
+
+    // Confirm group2's message is still live.
+    let (g2_alive,): (bool,) =
+        sqlx::query_as("SELECT deleted_at IS NULL FROM messages WHERE id = $1")
+            .bind(uuid::Uuid::parse_str(&msg_in_g2).unwrap())
+            .fetch_one(&h.admin_pool)
+            .await
+            .expect("MD5 alive check");
+    assert!(g2_alive, "MD5 group2 message must not be deleted");
+
+    // Suppress unused variable warnings for IDs only referenced in
+    // cross-scenario setup assertions above.
+    let _ = owner_id;
+    let _ = member_id;
+}

--- a/plans/0107-gar-592-messages-edit-delete.md
+++ b/plans/0107-gar-592-messages-edit-delete.md
@@ -1,0 +1,186 @@
+# Plan 0107 — GAR-592: messages slice 5 — PATCH + DELETE /v1/messages/{id}
+
+## Goal
+
+Add message **edit** (`PATCH /v1/messages/{message_id}`) and **soft-delete**
+(`DELETE /v1/messages/{message_id}`) to the `/v1` messages surface. Both
+endpoints use the `garraia_app` FORCE-RLS pool and follow the tenant-context
+protocol already established by plan 0055.
+
+No schema migration is required — `edited_at timestamptz` and
+`deleted_at timestamptz` already exist in migration 004.
+
+---
+
+## Architecture
+
+```
+garraia-gateway/src/rest_v1/messages.rs   ← two new handlers
+garraia-auth/src/audit_workspace.rs       ← two new WorkspaceAuditAction variants
+garraia-gateway/src/rest_v1/mod.rs        ← two new routes
+crates/garraia-gateway/tests/rest_v1_messages_edit_delete.rs  [NEW]
+```
+
+### Endpoint matrix
+
+| Method   | Path                              | Auth              | Happy status |
+|----------|-----------------------------------|-------------------|--------------|
+| `PATCH`  | `/v1/messages/{message_id}`       | Bearer + X-Group-Id | 200 OK      |
+| `DELETE` | `/v1/messages/{message_id}`       | Bearer + X-Group-Id | 204 No Content |
+
+---
+
+## Tech stack
+
+- Rust / Axum 0.8 — same as rest of `garraia-gateway`
+- `sqlx::query!` (Postgres, `garraia_app` pool) — all queries parameterised
+- `garraia-auth`: `Principal` extractor, `can()`, `WorkspaceAuditAction`
+- `utoipa` for OpenAPI annotations
+
+---
+
+## Design invariants
+
+1. **FORCE RLS** — every handler opens a `pool.begin()` transaction and runs
+   `SELECT set_config('app.current_user_id', $1, true)` and
+   `SELECT set_config('app.current_group_id', $1, true)` before any DML.
+2. **`body_tsv` is GENERATED ALWAYS AS** — never appears in UPDATE column list.
+3. **Sender-only PATCH** — `WHERE id = $1 AND group_id = $2 AND sender_user_id = $3 AND deleted_at IS NULL`. Returns 404 if 0 rows (hides existence of other tenants' messages).
+4. **DELETE: sender OR Admin/Owner** — SQL resolves this with two conditions joined by OR, using the `principal.role` tier: `sender_user_id = caller_id OR (principal.role.tier() >= 80)`. Returns 404 on 0 rows updated.
+5. **Audit metadata is structural** — `body_len` (char count), no body content.
+6. **`X-Group-Id` required** — same guard as existing message handlers.
+7. **Idempotent DELETE** — sending DELETE on an already-deleted message returns 404.
+
+---
+
+## Validações pré-plano
+
+- [x] Migration 004 already has `edited_at timestamptz` and `deleted_at timestamptz`.
+- [x] `WorkspaceAuditAction` has no `MessageEdited` or `MessageDeleted` variants yet.
+- [x] No `PATCH /v1/messages/{id}` or `DELETE /v1/messages/{id}` routes in `mod.rs`.
+- [x] `Action::ChatsWrite` exists and is the right capability gate (all 5 roles).
+- [x] `Role` enum has `tier()` method (see `can.rs`) — Owner=100, Admin=80 → tier ≥ 80 is the admin-override threshold for delete.
+
+---
+
+## Out of scope
+
+- Bulk-delete or admin-only purge
+- Message reactions / emoji
+- `GET /v1/messages/{id}` single-message fetch
+- WebSocket push on edit/delete
+- Hard delete (LGPD erasure path lives in GAR-400 export/delete)
+
+---
+
+## Rollback
+
+Pure handler + audit enum addition. If needed, remove the two routes from `mod.rs`
+and the two enum variants from `audit_workspace.rs`. No migration to revert.
+
+---
+
+## §12 Open questions
+
+| # | Question | Decision |
+|---|----------|----------|
+| 1 | Should PATCH return full message or minimal diff? | Full `EditedMessageResponse` (id, body, edited_at) — consistent with existing response shapes. |
+| 2 | Admin override for PATCH (edit others' messages)? | Out of scope for slice 5. Sender-only edit is standard chat behaviour. |
+| 3 | Role tier threshold for delete override? | Admin (tier ≥ 80): Owner + Admin. Member/Guest/Child cannot delete others' messages. |
+
+---
+
+## File structure
+
+```
+crates/garraia-auth/src/audit_workspace.rs          ← +2 variants + 2 match arms + 2 test rows
+crates/garraia-gateway/src/rest_v1/messages.rs      ← +2 structs + 2 utoipa handlers (~180 LOC)
+crates/garraia-gateway/src/rest_v1/mod.rs           ← +2 route registrations (auth + test-helpers)
+crates/garraia-gateway/tests/rest_v1_messages_edit_delete.rs  [NEW ~250 LOC]
+```
+
+**Estimated total delta:** ~430 LOC added, ~10 LOC modified.
+
+---
+
+## M1 tasks
+
+### T1 — audit variants
+
+- [x] Add `MessageEdited` and `MessageDeleted` to `WorkspaceAuditAction` enum in `audit_workspace.rs`
+- [x] Add match arms `"message.edited"` / `"message.deleted"` to `as_str()`, `from_str()`, and `audit_all_action_strings_are_unique` test row vectors
+
+### T2 — PATCH handler
+
+- [x] Add `PatchMessageRequest { body: String }` struct with `validate()` (non-empty, ≤ 100k chars)
+- [x] Add `EditedMessageResponse { id, body, edited_at, group_id }` struct
+- [x] Implement `patch_message` handler
+- [x] Add `utoipa::path` annotation
+
+### T3 — DELETE handler
+
+- [x] Implement `delete_message` handler
+- [x] Add `utoipa::path` annotation
+
+### T4 — router wiring
+
+- [x] In `mod.rs` auth-router: add `.route("/v1/messages/:message_id", patch(messages::patch_message).delete(messages::delete_message))`
+- [x] In `mod.rs` test-helpers router: add same (no-auth stub)
+- [x] In `mod.rs` fail-soft router: add same (503 stub)
+
+### T5 — integration tests
+
+- [x] Create `crates/garraia-gateway/tests/rest_v1_messages_edit_delete.rs`
+- [x] All 10 scenarios present (ME1-ME5, MD1-MD5)
+
+### T6 — workspace-wide lint and format
+
+- [x] `cargo fmt --check --all`
+- [x] `SWAGGER_UI_DOWNLOAD_URL=file:///tmp/swagger-ui-cache/v5.17.14.zip cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings`
+
+### T7 — push + PR
+
+- [x] Open PR via GitHub MCP (base=main)
+- [x] Wait for all CI checks green
+
+### T8 — bookkeeping
+
+- [ ] Update `ROADMAP.md §3.4` — add two `[x]` lines for PATCH + DELETE `/v1/messages/{id}`
+- [ ] Add plan row to `plans/README.md`
+- [ ] Mark GAR-592 Done in Linear
+
+---
+
+## Risk register
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| `body_tsv` GENERATED regen on UPDATE causes unexpected latency | Low | Low | Postgres handles GENERATED ALWAYS AS atomically; no extra round-trip |
+| Admin-override delete leaks cross-group message existence | Medium | High | `AND group_id = $2` in WHERE ensures RLS + explicit FK prevent cross-group leak |
+| `role.tier()` missing or name mismatch | Low | Medium | Verified `can.rs` — use `principal.role.map(\|r\| r.tier()).unwrap_or(0)` |
+
+---
+
+## Acceptance criteria
+
+1. `cargo test -p garraia-gateway --test rest_v1_messages_edit_delete` — ≥ 10 scenarios, all pass.
+2. `cargo clippy --workspace … -D warnings` — zero warnings.
+3. CI: all 18 checks green.
+4. `ROADMAP.md §3.4` has `[x] PATCH /v1/messages/{message_id}` and `[x] DELETE /v1/messages/{message_id}`.
+5. Cross-group isolation test `MD5` present and passing.
+
+---
+
+## Cross-references
+
+- Plan 0055 (GAR-507) — messages slice 2, established tenant-context protocol
+- Plan 0076 (GAR-530) — chats slice 4, admin-override delete pattern
+- GAR-400 — LGPD hard-delete (out of scope for this plan)
+- Migration 004 — `edited_at` and `deleted_at` columns
+
+---
+
+## Estimativa
+
+- Low: 2h | Provável: 3h | Alta: 5h
+- Branch: `routine/202605121215-messages-edit-delete-v2`

--- a/plans/README.md
+++ b/plans/README.md
@@ -112,7 +112,8 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0103 | [GAR-585 — advertise `tools` capability in garra mcp-server](0103-gar-585-mcp-tools-capability.md) | [GAR-585](https://linear.app/chatgpt25/issue/GAR-585) | ✅ Merged 2026-05-11 via PR #271 (`97403c7`) |
 | 0104 | [GAR-587 — apply `garra_ask` schema defaults before calling `ask_oneshot`](0104-gar-587-mcp-garra-ask-defaults.md) | [GAR-587](https://linear.app/chatgpt25/issue/GAR-587) | ✅ Merged 2026-05-12 via PR #272 (`3dc1932`) |
 | 0105 | [GAR-580 — REST /v1 groups slice 3: GET /v1/groups (list user's groups)](0105-gar-580-groups-list-api.md) | [GAR-580](https://linear.app/chatgpt25/issue/GAR-580) | ✅ Merged 2026-05-12 via PR #273 (`84115c2`) |
-| 0106 | [GAR-589 — FORCE RLS on groups + group_members tables](0106-gar-589-rls-groups-and-members.md) | [GAR-589](https://linear.app/chatgpt25/issue/GAR-589) | 🔄 In Progress |
+| 0106 | [GAR-589 — FORCE RLS on groups + group\_members tables](0106-gar-589-rls-groups-and-members.md) | [GAR-589](https://linear.app/chatgpt25/issue/GAR-589) | 🔄 In Progress |
+| 0107 | [GAR-592 — messages slice 5: PATCH + DELETE /v1/messages/{id}](0107-gar-592-messages-edit-delete.md) | [GAR-592](https://linear.app/chatgpt25/issue/GAR-592) | 🔄 In Progress |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

- **PATCH /v1/messages/{message_id}** — sender edits own message body; `edited_at` updated; `body_tsv` regenerated automatically by Postgres GENERATED ALWAYS AS; audit `message.edited` with `{ body_len }` (no PII body content).
- **DELETE /v1/messages/{message_id}** — soft-delete: sender may delete own message; Owner/Admin (role tier ≥ 80) may delete any message in their group; audit `message.deleted` with `{ admin_override: bool }`.
- Two new `WorkspaceAuditAction` variants: `MessageEdited` / `MessageDeleted` in `garraia-auth`.
- Plan document: `plans/0107-gar-592-messages-edit-delete.md`.

This PR replaces PR #298 which had an unresolvable 3-way merge conflict in `plans/README.md` due to byte-level encoding differences introduced in a prior session's push_files commits.

## Files changed

| File | Change |
|------|--------|
| `crates/garraia-auth/src/audit_workspace.rs` | +2 audit variants + match arms + test assertions |
| `crates/garraia-gateway/Cargo.toml` | +`[[test]]` entry for `rest_v1_messages_edit_delete` |
| `crates/garraia-gateway/src/rest_v1/messages.rs` | +`patch_message` / `delete_message` handlers |
| `crates/garraia-gateway/src/rest_v1/mod.rs` | +routes in all 3 router modes |
| `crates/garraia-gateway/tests/rest_v1_messages_edit_delete.rs` | +10 integration test scenarios |
| `plans/0107-gar-592-messages-edit-delete.md` | New plan document |
| `plans/README.md` | +row 0107 |

## Test plan

- [x] ME1 — PATCH 200: sender edits own message; verifies body, id, group_id, edited_at, audit row (body_len, no body content)
- [x] ME2 — PATCH 404: non-existent message UUID
- [x] ME3 — PATCH 404: wrong sender (owner tries to edit member's message)
- [x] ME4 — PATCH 404: message already soft-deleted
- [x] ME5 — PATCH 400: empty/whitespace body
- [x] MD1 — DELETE 204: sender deletes own; verifies deleted_at in DB, audit `admin_override: false`
- [x] MD2 — DELETE 404: already-deleted message
- [x] MD3 — DELETE 404: member tries to delete owner's message; message still alive
- [x] MD4 — DELETE 204: admin deletes another user's message; audit `admin_override: true`
- [x] MD5 — DELETE 404: cross-group isolation; group2 message untouched

## Security / RLS

- Both handlers run `SET LOCAL app.current_user_id` + `SET LOCAL app.current_group_id` before any DML (FORCE RLS protocol).
- `body_tsv` GENERATED ALWAYS — never appears in INSERT/UPDATE column lists.
- No PII in audit metadata (`body_len` count, not body content).
- Cross-group test MD5 verifies tenant isolation at the DB level.

Closes GAR-592.

https://claude.ai/code/session_01GJ9zv3kmTrxpAgWnxdiJxz

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJ9zv3kmTrxpAgWnxdiJxz)_