### PR TITLE
feat(cli): show Config + CWD in banner; flag placeholder paths in config check

### DIFF
--- a/crates/garraia-cli/src/banner.rs
+++ b/crates/garraia-cli/src/banner.rs
@@ -2,6 +2,56 @@ use std::path::Path;
 
 use garraia_config::AppConfig;
 
+/// Maximum on-screen width for `Config:` / `CWD:` paths in the banner.
+/// Keeps the right-hand column readable on a default 80-col terminal.
+const MAX_PATH_DISPLAY_WIDTH: usize = 32;
+
+/// Render a path for display in the banner:
+/// - Collapse the user's home dir to `~` on Windows and Unix (the old
+///   implementation only honoured POSIX `$HOME` and broke on Windows).
+/// - If the result is longer than [`MAX_PATH_DISPLAY_WIDTH`], replace the
+///   middle with `…` so the head and tail stay visible.
+pub(crate) fn shorten_path(p: &Path) -> String {
+    let raw = p.to_string_lossy().into_owned();
+
+    // Home truncation. `dirs::home_dir()` returns the correct value on
+    // both Windows (USERPROFILE) and Unix (HOME).
+    let collapsed = match dirs::home_dir() {
+        Some(home) if !home.as_os_str().is_empty() => {
+            let home_str = home.to_string_lossy();
+            // Only collapse when the path actually *starts* with home — avoid
+            // accidentally rewriting something like `/foo/<home>/bar`.
+            if !home_str.is_empty() && raw.starts_with(home_str.as_ref()) {
+                let tail = &raw[home_str.len()..];
+                if tail.is_empty() {
+                    "~".to_string()
+                } else {
+                    format!("~{tail}")
+                }
+            } else {
+                raw
+            }
+        }
+        _ => raw,
+    };
+
+    if collapsed.chars().count() <= MAX_PATH_DISPLAY_WIDTH {
+        return collapsed;
+    }
+
+    // Middle-ellipsis. Keep head ~ 12 chars and tail ~ 16 chars so the
+    // last segment (usually the leaf folder) stays visible.
+    let head_n = 12;
+    let tail_n = MAX_PATH_DISPLAY_WIDTH.saturating_sub(head_n + 1); // 1 char for '…'
+    let chars: Vec<char> = collapsed.chars().collect();
+    let head: String = chars.iter().take(head_n).collect();
+    let tail: String = chars
+        .iter()
+        .skip(chars.len().saturating_sub(tail_n))
+        .collect();
+    format!("{head}…{tail}")
+}
+
 /// Print the startup banner with Ferris and config summary.
 pub fn print_banner(host: &str, port: u16, config: &AppConfig, config_dir: &Path) {
     let version = env!("CARGO_PKG_VERSION");
@@ -51,10 +101,11 @@ pub fn print_banner(host: &str, port: u16, config: &AppConfig, config_dir: &Path
     };
 
     let url = format!("http://{host}:{port}");
-    let dir_display = match std::env::var("HOME") {
-        Ok(home) if !home.is_empty() => config_dir.to_string_lossy().replace(&home, "~"),
-        _ => config_dir.to_string_lossy().to_string(),
-    };
+    let config_display = shorten_path(config_dir);
+    let cwd_display = std::env::current_dir()
+        .as_deref()
+        .map(shorten_path)
+        .unwrap_or_else(|_| "?".to_string());
 
     // Layout
     let width = 70;
@@ -87,10 +138,54 @@ pub fn print_banner(host: &str, port: u16, config: &AppConfig, config_dir: &Path
     );
     println!("{}", row("", &format!("MCP         {mcp}")));
     println!("{}", row("  Rust · Personal AI", ""));
-    println!(
-        "{}",
-        row(&format!("  {dir_display}"), "Press Ctrl+C to stop")
-    );
+    println!("{}", row("", &format!("Config      {config_display}")));
+    println!("{}", row("", &format!("CWD         {cwd_display}")));
+    println!("{}", row("", "Press Ctrl+C to stop"));
     println!("{}", row("", ""));
     println!("{bottom}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn shorten_path_no_op_for_short_paths() {
+        let p = PathBuf::from("/tmp/x");
+        let s = shorten_path(&p);
+        assert_eq!(s, "/tmp/x");
+    }
+
+    #[test]
+    fn shorten_path_collapses_home() {
+        let home = dirs::home_dir().expect("test env should have a home dir");
+        let inside = home.join("garraia");
+        let s = shorten_path(&inside);
+        assert!(
+            s.starts_with('~'),
+            "expected leading '~', got `{s}` (home was `{}`)",
+            home.display()
+        );
+        assert!(s.ends_with("garraia"), "expected trailing leaf, got `{s}`");
+    }
+
+    #[test]
+    fn shorten_path_truncates_long_paths_with_ellipsis() {
+        // Path that's definitely longer than MAX_PATH_DISPLAY_WIDTH = 32 chars
+        // and does not start with the user's home (so the home-collapse branch
+        // does not trigger).
+        let p =
+            PathBuf::from("/var/lib/some/deeply/nested/garraia-config-directory-that-is-very-long");
+        let s = shorten_path(&p);
+        assert!(
+            s.chars().count() <= MAX_PATH_DISPLAY_WIDTH,
+            "shortened path too long: `{s}` ({} chars)",
+            s.chars().count()
+        );
+        assert!(
+            s.contains('…'),
+            "expected ellipsis in shortened path, got `{s}`"
+        );
+    }
 }

--- a/crates/garraia-config/src/check.rs
+++ b/crates/garraia-config/src/check.rs
@@ -692,11 +692,72 @@ fn validate_storage(
     }
 }
 
+/// Pure validation of the config directory path. Separated from the
+/// loader/env read so it can be unit-tested without touching process state.
+///
+/// `env_explicitly_set` is `true` when the user set `GARRAIA_CONFIG_DIR`
+/// (or whichever env var produced this path) directly — in that case a
+/// missing directory is suspicious. When `false`, we assume the loader
+/// fell back to a default location and skip the missing-dir warning to
+/// avoid spooking fresh installs that haven't run anything yet.
+///
+/// Findings:
+/// - `CONFIG_DIR_PLACEHOLDER`: matches a known placeholder leaked from
+///   `.env.example` (`/custom/config/path`) or generic templating
+///   patterns (`/path/to/`, `your-`, `change-me`). Always warn.
+/// - `CONFIG_DIR_MISSING`: gated on `env_explicitly_set`. Warns when the
+///   resolved path does not exist on disk.
+fn validate_config_dir_inner(dir: &std::path::Path, env_explicitly_set: bool) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    let display = dir.to_string_lossy();
+
+    // CONFIG_DIR_PLACEHOLDER: substring lookup — we deliberately avoid
+    // pulling `regex` for four substrings.
+    const PLACEHOLDER_NEEDLES: &[&str] =
+        &["/custom/config/path", "/path/to/", "/your-", "change-me"];
+    if PLACEHOLDER_NEEDLES
+        .iter()
+        .any(|needle| display.contains(needle))
+    {
+        findings.push(Finding {
+            severity: Severity::Warning,
+            field: "config_dir".to_owned(),
+            message: format!(
+                "config directory `{}` looks like a placeholder copied from `.env.example`. \
+                 Unset `GARRAIA_CONFIG_DIR` or point it at a real path before starting the gateway.",
+                display
+            ),
+        });
+    }
+
+    if env_explicitly_set && !dir.exists() {
+        findings.push(Finding {
+            severity: Severity::Warning,
+            field: "config_dir".to_owned(),
+            message: format!(
+                "config directory `{}` was set via GARRAIA_CONFIG_DIR but does not exist on disk",
+                display
+            ),
+        });
+    }
+
+    findings
+}
+
+/// Thin wrapper that reads the process env to drive
+/// [`validate_config_dir_inner`].
+fn validate_config_dir(loader: &ConfigLoader) -> Vec<Finding> {
+    let env_set = std::env::var_os("GARRAIA_CONFIG_DIR").is_some();
+    validate_config_dir_inner(loader.config_dir(), env_set)
+}
+
 /// Run the full validation + reporting pipeline.
 pub fn run_check(loader: &ConfigLoader, config: &AppConfig) -> ConfigCheck {
+    let mut findings = validate(config);
+    findings.extend(validate_config_dir(loader));
     ConfigCheck {
         source: source_report(loader),
-        findings: validate(config),
+        findings,
         summary: summarise(config),
     }
 }
@@ -1318,6 +1379,69 @@ mod tests {
         assert!(
             findings.iter().all(|f| f.field != "channels.telegram"),
             "disabled channel should not warn about missing token: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn validate_config_dir_flags_posix_placeholder() {
+        // The literal value shipped in `.env.example` line 59.
+        let path = PathBuf::from("/custom/config/path");
+        let findings = validate_config_dir_inner(&path, true);
+        assert!(
+            findings.iter().any(|f| f.severity == Severity::Warning
+                && f.field == "config_dir"
+                && f.message.contains("placeholder")),
+            "findings = {findings:?}"
+        );
+    }
+
+    #[test]
+    fn validate_config_dir_flags_generic_path_to_pattern() {
+        let path = PathBuf::from("/path/to/garraia");
+        let findings = validate_config_dir_inner(&path, false);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.severity == Severity::Warning && f.message.contains("placeholder")),
+            "findings = {findings:?}"
+        );
+    }
+
+    #[test]
+    fn validate_config_dir_flags_missing_only_when_env_set() {
+        // A real-looking, definitely-not-existing path.
+        let path = PathBuf::from("/nonexistent/garraia-test-path-zzz-12345");
+
+        // env_explicitly_set = true => MISSING warning fires.
+        let with_env = validate_config_dir_inner(&path, true);
+        assert!(
+            with_env
+                .iter()
+                .any(|f| f.severity == Severity::Warning && f.message.contains("does not exist")),
+            "with_env should fire MISSING warning: {with_env:?}"
+        );
+
+        // env_explicitly_set = false => MISSING warning does NOT fire.
+        let without_env = validate_config_dir_inner(&path, false);
+        assert!(
+            !without_env
+                .iter()
+                .any(|f| f.message.contains("does not exist")),
+            "without_env should NOT fire MISSING warning: {without_env:?}"
+        );
+    }
+
+    #[test]
+    fn validate_config_dir_quiet_for_real_existing_path() {
+        // Use a directory we know exists: the OS temp dir.
+        let path = std::env::temp_dir();
+        assert!(path.exists(), "precondition: temp_dir must exist");
+        let findings = validate_config_dir_inner(&path, true);
+        // No placeholder warning (the temp dir path doesn't match any needle),
+        // no missing warning (path exists). Should be empty.
+        assert!(
+            findings.is_empty(),
+            "real existing path should produce no findings: {findings:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Two related Windows-on-Garra UX fixes that came out of `.\target\release\garra start` printing `/custom/config/path` as the config dir on Windows.

- `garra config check` now produces two new Warnings on the resolved config dir:
  - **`CONFIG_DIR_PLACEHOLDER`** — substring match against `/custom/config/path`, `/path/to/`, `your-`, `change-me`. Fires whenever the dir looks like leaked templating (e.g., a real `.env` that copied the example value verbatim).
  - **`CONFIG_DIR_MISSING`** — fires *only* when `GARRAIA_CONFIG_DIR` was set **explicitly** and the path does not exist. The env-set gate keeps fresh installs without `~/.garraia` quiet.
  - Both → exit `0` by default, exit `2` under `--strict` (existing `compute_exit_code` in `garraia-cli`).
  - Logic split into `validate_config_dir_inner(dir, env_explicitly_set)` so the env read is isolated and the rule is unit-testable.

- Banner shows `Config` and `CWD` on separate lines, both via a new pure `shorten_path()` helper:
  - Home collapse uses `dirs::home_dir()` so `~` works on **Windows (USERPROFILE)** and Unix. The old code only honoured POSIX `$HOME`, which is exactly how `/custom/config/path` was getting printed raw on Windows.
  - Middle-ellipsis truncation at 32 chars keeps the right-hand column readable.

`.env.example` is **not** touched — line 59 is already commented; the active leak this fixes is users' local `.env`, plus the missing diagnostic affordance.

## Test plan

- [x] `cargo clippy -p garraia-config --all-targets -- -D warnings` clean
- [x] `cargo test -p garraia-config check::` → 38/38, including 4 new tests:
  - `validate_config_dir_flags_posix_placeholder`
  - `validate_config_dir_flags_generic_path_to_pattern`
  - `validate_config_dir_flags_missing_only_when_env_set`
  - `validate_config_dir_quiet_for_real_existing_path`
- [ ] CI: `cargo test -p garraia banner::` (pure unit tests of `shorten_path`; blocked locally by `utoipa-swagger-ui` Windows TLS chain issue — environmental, not code)
- [ ] Manual: `.\target\release\garra start` shows `Config: <real>` and `CWD: G:\Projetos\GarraRUST` on Windows
- [ ] Manual: `GARRAIA_CONFIG_DIR=/custom/config/path garra config check --strict` → exit 2 + placeholder warning

## Context

Part of plan `rustling-nibbling-frost` (Agent Mode wiring + tool registration + config-path UX). This is **PR 1 of 3**:
- **PR 1 (this)**: Config path UX.
- PR 2: Agent Mode end-to-end via WebSocket (the actual mode behavior fix).
- PR 3: Register 4 read-only tools in the gateway bootstrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)