### PR TITLE
feat(gateway): GAR-595 — GET /v1/messages/{id} + GET /v1/messages/{id}/threads

### DIFF
--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -368,6 +368,15 @@ name = "rest_v1_messages_edit_delete"
 path = "tests/rest_v1_messages_edit_delete.rs"
 required-features = ["test-helpers"]
 
+# Plan 0109 (GAR-595) — GET /v1/messages/{id} + GET /v1/messages/{id}/threads.
+# 10 bundled scenarios (MG1-MG5 single-message + MT1-MT5 thread listing).
+# Requires test-helpers so `cargo clippy --all-targets` without
+# `--features test-helpers` skips compilation cleanly.
+[[test]]
+name = "rest_v1_messages_get_threads"
+path = "tests/rest_v1_messages_get_threads.rs"
+required-features = ["test-helpers"]
+
 [dev-dependencies]
 # Plan 0024 T4 (GAR-412): metrics_exporter tests and the
 # metrics_auth_integration binary build a `PrometheusRecorder` directly

--- a/crates/garraia-gateway/src/rest_v1/messages.rs
+++ b/crates/garraia-gateway/src/rest_v1/messages.rs
@@ -944,6 +944,338 @@ pub async fn delete_message(
     Ok(StatusCode::NO_CONTENT)
 }
 
+// ─── GET /v1/messages/{id} ────────────────────────────────────────────────────────────────────
+
+/// Response body for `GET /v1/messages/{message_id}/threads`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ThreadMessagesResponse {
+    /// The thread anchored on this message, or `null` if no thread exists.
+    pub thread: Option<ThreadResponse>,
+    /// Replies in this thread, oldest-first (`created_at ASC`).
+    pub messages: Vec<MessageSummary>,
+    /// Cursor for the next page. `null` when all replies have been returned.
+    pub next_cursor: Option<Uuid>,
+}
+
+/// `GET /v1/messages/{message_id}` — fetch a single message by ID.
+///
+/// Returns the full `MessageResponse` for the message if it belongs to the
+/// caller's group and has not been soft-deleted. Returns 404 in all other
+/// cases to avoid leaking the existence of messages in other tenants.
+#[utoipa::path(
+    get,
+    path = "/v1/messages/{message_id}",
+    params(
+        ("message_id" = Uuid, Path, description = "Message UUID."),
+    ),
+    responses(
+        (status = 200, description = "Message found.", body = MessageResponse),
+        (status = 400, description = "Missing X-Group-Id header.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member of the group.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Message not found, deleted, or not in caller's group.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn get_message(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(message_id): Path<Uuid>,
+) -> Result<Json<MessageResponse>, RestError> {
+    // 1. X-Group-Id header required.
+    let group_id = match principal.group_id {
+        Some(hdr) => hdr,
+        None => {
+            return Err(RestError::BadRequest(
+                "X-Group-Id header is required".into(),
+            ));
+        }
+    };
+
+    // 2. Capability gate.
+    if !can(&principal, Action::ChatsRead) {
+        return Err(RestError::Forbidden);
+    }
+
+    // 3. Open transaction with RLS context.
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(principal.user_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_group_id', $1, true)")
+        .bind(group_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    // 4. Fetch message. group_id check is defense-in-depth (RLS already
+    //    filters by current_group_id). 0 rows → 404 to avoid existence leaks.
+    type MsgRow = (
+        Uuid,
+        Uuid,
+        Uuid,
+        Uuid,
+        String,
+        String,
+        Option<Uuid>,
+        DateTime<Utc>,
+    );
+    let row: Option<MsgRow> = sqlx::query_as(
+        "SELECT id, chat_id, group_id, sender_user_id, sender_label, body, reply_to_id, created_at \
+         FROM messages \
+         WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+    )
+    .bind(message_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    match row {
+        None => Err(RestError::NotFound),
+        Some((
+            id,
+            chat_id,
+            grp_id,
+            sender_user_id,
+            sender_label,
+            body,
+            reply_to_id,
+            created_at,
+        )) => Ok(Json(MessageResponse {
+            id,
+            chat_id,
+            group_id: grp_id,
+            sender_user_id,
+            sender_label,
+            body,
+            reply_to_id,
+            created_at,
+        })),
+    }
+}
+
+// ─── GET /v1/messages/{id}/threads ─────────────────────────────────────────────────────────────────────────
+
+/// Query parameters for `GET /v1/messages/{message_id}/threads`.
+#[derive(Debug, Deserialize)]
+pub struct ListThreadMessagesQuery {
+    /// Keyset cursor — UUID of the last reply received. Returns replies
+    /// newer than this one (exclusive). Omit for the first page.
+    pub after: Option<Uuid>,
+    /// Page size. Default 50, max 100. Values < 1 are rejected with 400.
+    pub limit: Option<i64>,
+}
+
+/// `GET /v1/messages/{message_id}/threads` — list replies in the thread.
+///
+/// Returns the thread metadata (or `null` if no thread exists) together with
+/// the replies in oldest-first (`created_at ASC`) order. The root message
+/// itself is NOT included in the `messages` array — only replies whose
+/// `thread_id` matches the thread id.
+///
+/// If the root message exists but has no thread, returns
+/// `{ thread: null, messages: [], next_cursor: null }` (not 404).
+#[utoipa::path(
+    get,
+    path = "/v1/messages/{message_id}/threads",
+    params(
+        ("message_id" = Uuid, Path, description = "Root message UUID."),
+        ("after" = Option<Uuid>, Query, description = "Cursor for pagination."),
+        ("limit" = Option<i64>, Query, description = "Page size (default 50, max 100)."),
+    ),
+    responses(
+        (status = 200, description = "Thread info and replies.", body = ThreadMessagesResponse),
+        (status = 400, description = "Missing X-Group-Id header or bad limit.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member of the group.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Root message not found, deleted, or not in caller's group.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn list_thread_messages(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(message_id): Path<Uuid>,
+    Query(params): Query<ListThreadMessagesQuery>,
+) -> Result<Json<ThreadMessagesResponse>, RestError> {
+    // 1. X-Group-Id header required.
+    let group_id = match principal.group_id {
+        Some(hdr) => hdr,
+        None => {
+            return Err(RestError::BadRequest(
+                "X-Group-Id header is required".into(),
+            ));
+        }
+    };
+
+    // 2. Capability gate.
+    if !can(&principal, Action::ChatsRead) {
+        return Err(RestError::Forbidden);
+    }
+
+    // 3. Parse + clamp limit.
+    let limit: i64 = match params.limit {
+        None => 50,
+        Some(n) if n < 1 => {
+            return Err(RestError::BadRequest("limit must be at least 1".into()));
+        }
+        Some(n) => n.min(100),
+    };
+
+    // 4. Open transaction with RLS context.
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(principal.user_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_group_id', $1, true)")
+        .bind(group_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    // 5. Verify root message exists and belongs to caller's group.
+    //    0 rows → 404 to avoid existence leaks across tenants.
+    let root_exists: Option<(Uuid,)> = sqlx::query_as(
+        "SELECT id FROM messages WHERE id = $1 AND group_id = $2 AND deleted_at IS NULL",
+    )
+    .bind(message_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if root_exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    // 6. Look up thread anchored at this message (may not exist).
+    type ThreadRow = (Uuid, Uuid, Uuid, Option<String>, Uuid, DateTime<Utc>);
+    let thread_row: Option<ThreadRow> = sqlx::query_as(
+        "SELECT id, chat_id, root_message_id, title, created_by, created_at \
+         FROM message_threads \
+         WHERE root_message_id = $1",
+    )
+    .bind(message_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let thread = thread_row.map(
+        |(id, chat_id, root_message_id, title, created_by, created_at)| ThreadResponse {
+            id,
+            chat_id,
+            root_message_id,
+            title,
+            created_by,
+            created_at,
+        },
+    );
+
+    // 7. If there is a thread, fetch its replies (cursor-paginated, ASC).
+    let messages: Vec<MessageSummary> = if let Some(ref t) = thread {
+        let thread_id = t.id;
+
+        type ReplyRow = (
+            Uuid,
+            Uuid,
+            Uuid,
+            String,
+            String,
+            Option<Uuid>,
+            DateTime<Utc>,
+        );
+        let rows: Vec<ReplyRow> = if let Some(after_id) = params.after {
+            sqlx::query_as(
+                "SELECT id, chat_id, sender_user_id, sender_label, body, reply_to_id, created_at \
+                 FROM messages \
+                 WHERE thread_id = $1 \
+                   AND deleted_at IS NULL \
+                   AND (created_at, id) > ( \
+                       SELECT created_at, id FROM messages \
+                       WHERE id = $2 AND thread_id = $1 AND deleted_at IS NULL \
+                   ) \
+                 ORDER BY created_at ASC, id ASC \
+                 LIMIT $3",
+            )
+            .bind(thread_id)
+            .bind(after_id)
+            .bind(limit)
+            .fetch_all(&mut *tx)
+            .await
+            .map_err(|e| RestError::Internal(e.into()))?
+        } else {
+            sqlx::query_as(
+                "SELECT id, chat_id, sender_user_id, sender_label, body, reply_to_id, created_at \
+                 FROM messages \
+                 WHERE thread_id = $1 \
+                   AND deleted_at IS NULL \
+                 ORDER BY created_at ASC, id ASC \
+                 LIMIT $2",
+            )
+            .bind(thread_id)
+            .bind(limit)
+            .fetch_all(&mut *tx)
+            .await
+            .map_err(|e| RestError::Internal(e.into()))?
+        };
+
+        rows.into_iter()
+            .map(
+                |(id, chat_id, sender_user_id, sender_label, body, reply_to_id, created_at)| {
+                    MessageSummary {
+                        id,
+                        chat_id,
+                        sender_user_id,
+                        sender_label,
+                        body,
+                        reply_to_id,
+                        created_at,
+                    }
+                },
+            )
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    let next_cursor = if messages.len() as i64 == limit {
+        messages.last().map(|m| m.id)
+    } else {
+        None
+    };
+
+    Ok(Json(ThreadMessagesResponse {
+        thread,
+        messages,
+        next_cursor,
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -304,14 +304,18 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     post(messages::send_message).get(messages::list_messages),
                 )
                 // Plan 0057 (GAR-509) — threads slice 3.
+                // Plan 0109 (GAR-595) — messages slice 6: GET thread messages.
                 .route(
                     "/v1/messages/{message_id}/threads",
-                    post(messages::create_thread),
+                    post(messages::create_thread).get(messages::list_thread_messages),
                 )
                 // Plan 0107 (GAR-592) — messages slice 5: edit + soft-delete.
+                // Plan 0109 (GAR-595) — messages slice 6: GET single message.
                 .route(
                     "/v1/messages/{message_id}",
-                    patch(messages::patch_message).delete(messages::delete_message),
+                    get(messages::get_message)
+                        .patch(messages::patch_message)
+                        .delete(messages::delete_message),
                 )
                 // Plan 0062 (GAR-514) — memory API slice 1.
                 .route(
@@ -514,14 +518,18 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     post(unconfigured_handler).get(unconfigured_handler),
                 )
                 // Plan 0057 (GAR-509) — threads slice 3, fail-soft 503.
+                // Plan 0109 (GAR-595) — messages slice 6, fail-soft 503.
                 .route(
                     "/v1/messages/{message_id}/threads",
-                    post(unconfigured_handler),
+                    post(unconfigured_handler).get(unconfigured_handler),
                 )
                 // Plan 0107 (GAR-592) — messages slice 5, fail-soft 503.
+                // Plan 0109 (GAR-595) — messages slice 6, fail-soft 503.
                 .route(
                     "/v1/messages/{message_id}",
-                    patch(unconfigured_handler).delete(unconfigured_handler),
+                    get(unconfigured_handler)
+                        .patch(unconfigured_handler)
+                        .delete(unconfigured_handler),
                 )
                 // Plan 0062 (GAR-514) — memory API slice 1, fail-soft 503.
                 .route(
@@ -698,14 +706,18 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     post(unconfigured_handler).get(unconfigured_handler),
                 )
                 // Plan 0057 (GAR-509) — threads slice 3, no-auth stub.
+                // Plan 0109 (GAR-595) — messages slice 6, no-auth stub.
                 .route(
                     "/v1/messages/{message_id}/threads",
-                    post(unconfigured_handler),
+                    post(unconfigured_handler).get(unconfigured_handler),
                 )
                 // Plan 0107 (GAR-592) — messages slice 5, no-auth stub.
+                // Plan 0109 (GAR-595) — messages slice 6, no-auth stub.
                 .route(
                     "/v1/messages/{message_id}",
-                    patch(unconfigured_handler).delete(unconfigured_handler),
+                    get(unconfigured_handler)
+                        .patch(unconfigured_handler)
+                        .delete(unconfigured_handler),
                 )
                 // Plan 0062 (GAR-514) — memory API slice 1, no-auth stub.
                 .route(

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -31,7 +31,7 @@ use super::memory::{
 };
 use super::messages::{
     CreateThreadRequest, MessageListResponse, MessageResponse, MessageSummary, SendMessageRequest,
-    ThreadResponse,
+    ThreadMessagesResponse, ThreadResponse,
 };
 use super::problem::ProblemDetails;
 use super::search::{SearchResponse, SearchResult, SearchResultType};
@@ -106,6 +106,8 @@ impl Modify for SecurityAddon {
         super::messages::send_message,
         super::messages::list_messages,
         super::messages::create_thread,
+        super::messages::get_message,
+        super::messages::list_thread_messages,
         super::memory::list_memory,
         super::memory::create_memory,
         super::memory::delete_memory,
@@ -178,6 +180,7 @@ impl Modify for SecurityAddon {
         MessageListResponse,
         CreateThreadRequest,
         ThreadResponse,
+        ThreadMessagesResponse,
         CreateMemoryRequest,
         PatchMemoryRequest,
         MemoryItemResponse,

--- a/crates/garraia-gateway/tests/rest_v1_messages_get_threads.rs
+++ b/crates/garraia-gateway/tests/rest_v1_messages_get_threads.rs
@@ -1,0 +1,463 @@
+//! Integration tests for `GET /v1/messages/{id}` and
+//! `GET /v1/messages/{id}/threads` (plan 0109, GAR-595).
+//!
+//! All scenarios are bundled into ONE `#[tokio::test]` function to
+//! avoid the sqlx runtime-teardown race documented in plan 0016 M3.
+//!
+//! GET single message scenarios (5):
+//!   MG1. 200 — fetch own group's message; fields correct.
+//!   MG2. 404 — random UUID not in DB.
+//!   MG3. 404 — message is soft-deleted.
+//!   MG4. 404 — cross-group: message belongs to group B, caller in group A.
+//!   MG5. 400 — missing X-Group-Id header.
+//!
+//! GET thread messages scenarios (5):
+//!   MT1. 200 — root message exists, no thread created → thread=null, messages=[].
+//!   MT2. 200 — thread created, no replies yet → thread metadata, messages=[].
+//!   MT3. 200 — thread with 2 replies → replies in created_at ASC order.
+//!   MT4. 404 — root message_id is random UUID.
+//!   MT5. 404 — cross-group: root message in group B, caller in group A.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use common::Harness;
+use common::fixtures::seed_user_with_group;
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("failed to collect response body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("response body is not JSON")
+}
+
+fn get_request(
+    method: &str,
+    path: &str,
+    token: Option<&str>,
+    x_group_id: Option<&str>,
+) -> Request<Body> {
+    let mut req = Request::builder()
+        .method(method)
+        .uri(path)
+        .body(Body::empty())
+        .expect("request builder");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    if let Some(t) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {t}")).unwrap(),
+        );
+    }
+    if let Some(g) = x_group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    req
+}
+
+/// Create a chat via POST /v1/groups/{group_id}/chats, return chat_id.
+async fn create_chat(h: &Harness, token: &str, group_id: &str, name: &str) -> String {
+    let resp = h
+        .router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/groups/{group_id}/chats"))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {token}"))
+                .header("x-group-id", group_id)
+                .extension(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+                    "127.0.0.1:1".parse().unwrap(),
+                ))
+                .body(Body::from(
+                    json!({"name": name, "type": "channel"}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .expect("create_chat");
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    body_json(resp).await["id"].as_str().unwrap().to_string()
+}
+
+/// Send a message to a chat, return message_id.
+async fn send_message(
+    h: &Harness,
+    token: &str,
+    chat_id: &str,
+    group_id: &str,
+    text: &str,
+) -> String {
+    let resp = h
+        .router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/chats/{chat_id}/messages"))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {token}"))
+                .header("x-group-id", group_id)
+                .extension(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+                    "127.0.0.1:1".parse().unwrap(),
+                ))
+                .body(Body::from(json!({"body": text}).to_string()))
+                .unwrap(),
+        )
+        .await
+        .expect("send_message");
+    assert_eq!(
+        resp.status(),
+        StatusCode::CREATED,
+        "seed message should 201"
+    );
+    body_json(resp).await["id"].as_str().unwrap().to_string()
+}
+
+/// Create a thread on a message, return thread_id.
+async fn create_thread(h: &Harness, token: &str, message_id: &str, group_id: &str) -> String {
+    let resp = h
+        .router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/v1/messages/{message_id}/threads"))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {token}"))
+                .header("x-group-id", group_id)
+                .extension(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+                    "127.0.0.1:1".parse().unwrap(),
+                ))
+                .body(Body::from(json!({}).to_string()))
+                .unwrap(),
+        )
+        .await
+        .expect("create_thread");
+    assert_eq!(resp.status(), StatusCode::CREATED, "thread should 201");
+    body_json(resp).await["id"].as_str().unwrap().to_string()
+}
+
+/// Soft-delete a message via the admin pool (bypasses RLS) for test setup.
+async fn admin_soft_delete_message(h: &Harness, message_id: &str) {
+    sqlx::query("UPDATE messages SET deleted_at = now() WHERE id = $1")
+        .bind(Uuid::parse_str(message_id).unwrap())
+        .execute(&h.admin_pool)
+        .await
+        .expect("admin_soft_delete_message");
+}
+
+/// Insert a thread reply directly via admin pool (bypasses RLS for test seeding).
+/// Returns the inserted message id.
+async fn admin_seed_thread_reply(
+    h: &Harness,
+    chat_id: &str,
+    group_id: &str,
+    sender_user_id: &str,
+    thread_id: &str,
+    body: &str,
+) -> String {
+    let row: (Uuid,) = sqlx::query_as(
+        "INSERT INTO messages (chat_id, group_id, sender_user_id, sender_label, body, thread_id) \
+         VALUES ($1, $2, $3, 'test-user', $4, $5) RETURNING id",
+    )
+    .bind(Uuid::parse_str(chat_id).unwrap())
+    .bind(Uuid::parse_str(group_id).unwrap())
+    .bind(Uuid::parse_str(sender_user_id).unwrap())
+    .bind(body)
+    .bind(Uuid::parse_str(thread_id).unwrap())
+    .fetch_one(&h.admin_pool)
+    .await
+    .expect("admin_seed_thread_reply");
+    row.0.to_string()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rest_v1_messages_get_threads_scenarios() {
+    let h = Harness::get().await;
+
+    // ── Setup: two groups ─────────────────────────────────────────────────────────────────────────────
+    let (owner_a_id, group_a_id, token_a) =
+        seed_user_with_group(&h, "owner@msg-get-threads-a.test")
+            .await
+            .expect("seed group A");
+    let group_a = group_a_id.to_string();
+    let owner_a = owner_a_id.to_string();
+
+    let (_owner_b_id, group_b_id, token_b) =
+        seed_user_with_group(&h, "owner@msg-get-threads-b.test")
+            .await
+            .expect("seed group B");
+    let group_b = group_b_id.to_string();
+
+    let _ = token_b; // only used for seeding
+
+    let chat_a = create_chat(&h, &token_a, &group_a, "get-threads-chat-a").await;
+    let chat_b = create_chat(&h, &token_b, &group_b, "get-threads-chat-b").await;
+
+    // Seed a message in group A
+    let msg_a = send_message(&h, &token_a, &chat_a, &group_a, "hello from A").await;
+
+    // Seed a message in group B (for cross-group tests)
+    let msg_b = send_message(&h, &token_b, &chat_b, &group_b, "hello from B").await;
+
+    // ──────────────────────────────────────────────────────────────────────────────────
+    // MG1. GET 200 — fetch own group's message; verify fields
+    // ──────────────────────────────────────────────────────────────────────────────────
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_request(
+                "GET",
+                &format!("/v1/messages/{msg_a}"),
+                Some(&token_a),
+                Some(&group_a),
+            ))
+            .await
+            .expect("MG1");
+        assert_eq!(resp.status(), StatusCode::OK, "MG1 status");
+        let body = body_json(resp).await;
+        assert_eq!(body["id"].as_str().unwrap(), msg_a, "MG1 id");
+        assert_eq!(body["group_id"].as_str().unwrap(), group_a, "MG1 group_id");
+        assert!(body["body"].as_str().is_some(), "MG1 has body");
+        assert!(body["sender_user_id"].as_str().is_some(), "MG1 has sender");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────────
+    // MG2. GET 404 — random UUID not in DB
+    // ──────────────────────────────────────────────────────────────────────────────────
+    {
+        let random_id = Uuid::new_v4().to_string();
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_request(
+                "GET",
+                &format!("/v1/messages/{random_id}"),
+                Some(&token_a),
+                Some(&group_a),
+            ))
+            .await
+            .expect("MG2");
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND, "MG2 status");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────────
+    // MG3. GET 404 — soft-deleted message
+    // ──────────────────────────────────────────────────────────────────────────────────
+    {
+        let msg_del = send_message(&h, &token_a, &chat_a, &group_a, "will be deleted").await;
+        admin_soft_delete_message(&h, &msg_del).await;
+
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_request(
+                "GET",
+                &format!("/v1/messages/{msg_del}"),
+                Some(&token_a),
+                Some(&group_a),
+            ))
+            .await
+            .expect("MG3");
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND, "MG3 status");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────────
+    // MG4. GET 404 — cross-group: message in group B, caller in group A
+    // ──────────────────────────────────────────────────────────────────────────────────
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_request(
+                "GET",
+                &format!("/v1/messages/{msg_b}"),
+                Some(&token_a),
+                Some(&group_a),
+            ))
+            .await
+            .expect("MG4");
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND, "MG4 status");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────────
+    // MG5. GET 400 — missing X-Group-Id header
+    // ──────────────────────────────────────────────────────────────────────────────────
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_request(
+                "GET",
+                &format!("/v1/messages/{msg_a}"),
+                Some(&token_a),
+                None,
+            ))
+            .await
+            .expect("MG5");
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "MG5 status");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────────
+    // MT1. GET /threads 200 — root message exists, no thread → thread=null
+    // ──────────────────────────────────────────────────────────────────────────────────
+    {
+        let msg_no_thread = send_message(&h, &token_a, &chat_a, &group_a, "no thread yet").await;
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_request(
+                "GET",
+                &format!("/v1/messages/{msg_no_thread}/threads"),
+                Some(&token_a),
+                Some(&group_a),
+            ))
+            .await
+            .expect("MT1");
+        assert_eq!(resp.status(), StatusCode::OK, "MT1 status");
+        let body = body_json(resp).await;
+        assert!(body["thread"].is_null(), "MT1 thread should be null");
+        assert_eq!(
+            body["messages"].as_array().unwrap().len(),
+            0,
+            "MT1 messages empty"
+        );
+        assert!(body["next_cursor"].is_null(), "MT1 next_cursor null");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────────
+    // MT2. GET /threads 200 — thread exists, no replies → thread metadata present
+    // ──────────────────────────────────────────────────────────────────────────────────
+    {
+        let msg_root = send_message(&h, &token_a, &chat_a, &group_a, "thread root").await;
+        let thread_id = create_thread(&h, &token_a, &msg_root, &group_a).await;
+
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_request(
+                "GET",
+                &format!("/v1/messages/{msg_root}/threads"),
+                Some(&token_a),
+                Some(&group_a),
+            ))
+            .await
+            .expect("MT2");
+        assert_eq!(resp.status(), StatusCode::OK, "MT2 status");
+        let body = body_json(resp).await;
+        let thread = &body["thread"];
+        assert!(!thread.is_null(), "MT2 thread should not be null");
+        assert_eq!(thread["id"].as_str().unwrap(), thread_id, "MT2 thread id");
+        assert_eq!(
+            thread["root_message_id"].as_str().unwrap(),
+            msg_root,
+            "MT2 root_message_id"
+        );
+        assert_eq!(
+            body["messages"].as_array().unwrap().len(),
+            0,
+            "MT2 no replies yet"
+        );
+        assert!(body["next_cursor"].is_null(), "MT2 next_cursor null");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────────
+    // MT3. GET /threads 200 — thread with 2 replies in ASC order
+    // ──────────────────────────────────────────────────────────────────────────────────
+    {
+        let msg_root2 = send_message(&h, &token_a, &chat_a, &group_a, "thread root 2").await;
+        let thread_id2 = create_thread(&h, &token_a, &msg_root2, &group_a).await;
+
+        // Seed 2 replies directly via admin pool (send_message doesn't expose thread_id yet)
+        let reply1 =
+            admin_seed_thread_reply(&h, &chat_a, &group_a, &owner_a, &thread_id2, "first reply")
+                .await;
+        let reply2 =
+            admin_seed_thread_reply(&h, &chat_a, &group_a, &owner_a, &thread_id2, "second reply")
+                .await;
+
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_request(
+                "GET",
+                &format!("/v1/messages/{msg_root2}/threads"),
+                Some(&token_a),
+                Some(&group_a),
+            ))
+            .await
+            .expect("MT3");
+        assert_eq!(resp.status(), StatusCode::OK, "MT3 status");
+        let body = body_json(resp).await;
+        assert!(!body["thread"].is_null(), "MT3 thread present");
+        let messages = body["messages"].as_array().expect("MT3 messages array");
+        assert_eq!(messages.len(), 2, "MT3 two replies");
+        // Replies should be in ASC order (oldest first)
+        assert_eq!(
+            messages[0]["id"].as_str().unwrap(),
+            reply1,
+            "MT3 first reply first"
+        );
+        assert_eq!(
+            messages[1]["id"].as_str().unwrap(),
+            reply2,
+            "MT3 second reply second"
+        );
+        assert!(body["next_cursor"].is_null(), "MT3 no more pages");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────────
+    // MT4. GET /threads 404 — root message_id is random UUID
+    // ──────────────────────────────────────────────────────────────────────────────────
+    {
+        let random_id = Uuid::new_v4().to_string();
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_request(
+                "GET",
+                &format!("/v1/messages/{random_id}/threads"),
+                Some(&token_a),
+                Some(&group_a),
+            ))
+            .await
+            .expect("MT4");
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND, "MT4 status");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────────
+    // MT5. GET /threads 404 — cross-group: root message in group B, caller in A
+    // ──────────────────────────────────────────────────────────────────────────────────
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_request(
+                "GET",
+                &format!("/v1/messages/{msg_b}/threads"),
+                Some(&token_a),
+                Some(&group_a),
+            ))
+            .await
+            .expect("MT5");
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND, "MT5 status");
+    }
+}

--- a/plans/0109-gar-595-messages-get-single-threads.md
+++ b/plans/0109-gar-595-messages-get-single-threads.md
@@ -1,0 +1,178 @@
+# Plan 0109 — GAR-595: messages slice 6 — GET /v1/messages/{id} + GET /v1/messages/{id}/threads
+
+## Goal
+
+Add two read endpoints to the `/v1` messages surface:
+
+* `GET /v1/messages/{message_id}` — fetch a single message by ID.
+* `GET /v1/messages/{message_id}/threads` — list replies posted in the thread
+  rooted at this message (plus the `ThreadResponse` metadata if a thread exists).
+
+Together these complete the messages verb set and make thread replies readable
+via the API. `POST /v1/messages/{id}/threads` (plan 0058 / GAR-509) can
+already create threads, but without a GET there is no way to read the replies.
+
+No schema migration required — all columns (`messages`, `message_threads`)
+already exist in migration 004.
+
+---
+
+## Architecture
+
+```
+garraia-gateway/src/rest_v1/messages.rs   ← two new handlers + new response types
+garraia-gateway/src/rest_v1/mod.rs        ← two new routes
+crates/garraia-gateway/tests/rest_v1_messages_get_threads.rs  [NEW]
+```
+
+### Endpoint matrix
+
+| Method | Path                                      | Auth                | Happy status |
+|--------|-------------------------------------------|---------------------|--------------|
+| `GET`  | `/v1/messages/{message_id}`               | Bearer + X-Group-Id | 200 OK       |
+| `GET`  | `/v1/messages/{message_id}/threads`       | Bearer + X-Group-Id | 200 OK       |
+
+---
+
+## Tech stack
+
+- Rust / Axum 0.8 — same as rest of `garraia-gateway`
+- `sqlx::query` (Postgres, `garraia_app` pool) — all queries parameterised
+- `garraia-auth`: `Principal` extractor, `can()`, `Action::ChatsRead`
+- `utoipa` for OpenAPI annotations
+
+---
+
+## Design invariants
+
+1. **FORCE RLS** — every handler opens a `pool.begin()` transaction and runs
+   `SELECT set_config('app.current_user_id', $1, true)` and
+   `SELECT set_config('app.current_group_id', $1, true)` before any SELECT.
+2. **Cross-group → 404** — `messages.group_id = X-Group-Id` checked in
+   WHERE clause; 0 rows returns 404, never 403, to avoid existence leaks.
+3. **Soft-deleted → 404** — `deleted_at IS NULL` required on every message
+   fetch. A deleted root message also hides its thread.
+4. **No-thread → 200, not 404** — `GET …/threads` with no thread returns
+   `{ thread: null, messages: [], next_cursor: null }`. The root message's
+   existence is already verified.
+5. **`X-Group-Id` required** — same guard as every other message handler.
+6. **No audit** — read-only endpoints; no `audit_events` row emitted.
+7. **Cursor order** — thread replies paginated `created_at ASC, id ASC`
+   (oldest-first, consistent with chat history scroll direction for threads).
+
+---
+
+## Validações pré-plano
+
+- [x] Migration 004 has `messages(thread_id uuid)` and `message_threads` table.
+- [x] FORCE RLS on both tables active (migration 007).
+- [x] `ThreadResponse` already defined in `messages.rs` (from plan 0058).
+- [x] `MessageResponse` already defined in `messages.rs`.
+- [x] `Action::ChatsRead` exists (see `can.rs`).
+- [x] No `GET /v1/messages/{id}` or `GET /v1/messages/{id}/threads` routes in `mod.rs`.
+
+---
+
+## Out of scope
+
+- Marking a thread as resolved (`PATCH message_threads`)
+- Message reactions
+- WebSocket push
+- `DELETE /v1/messages/{id}/threads` (un-thread)
+
+---
+
+## Rollback
+
+Pure handler addition. Remove the two routes from `mod.rs` and the new
+handlers + types from `messages.rs`. No migration to revert.
+
+---
+
+## §12 Open questions
+
+None — schema and authz foundation fully in place.
+
+---
+
+## File structure
+
+```
+plans/0109-gar-595-messages-get-single-threads.md       [this file]
+crates/garraia-gateway/src/rest_v1/messages.rs          [+2 handlers, +2 types]
+crates/garraia-gateway/src/rest_v1/mod.rs               [+2 routes]
+crates/garraia-gateway/tests/rest_v1_messages_get_threads.rs  [NEW, 10 scenarios]
+```
+
+---
+
+## M1 tasks
+
+### T1 — test scaffold (failing)
+
+- [ ] Create `tests/rest_v1_messages_get_threads.rs` with 10 scenarios (MG1–MG5,
+      MT1–MT5) that compile but fail (handlers not yet wired).
+- [ ] Commit: `test(messages): T1 — failing test scaffold for GAR-595`
+
+### T2 — `get_message` handler
+
+- [ ] Add `GetMessageResponse` type alias (reuse `MessageResponse`) and
+      `get_message` handler in `messages.rs`.
+- [ ] Wire `GET /v1/messages/{message_id}` in `mod.rs` (both `Full` and
+      `NoAuth` layers).
+- [ ] Commit: `feat(messages): T2 — GET /v1/messages/{id} handler (GAR-595)`
+
+### T3 — `list_thread_messages` handler
+
+- [ ] Add `ThreadMessagesResponse` struct and `list_thread_messages` handler
+      in `messages.rs`.
+- [ ] Wire `GET /v1/messages/{message_id}/threads` in `mod.rs`.
+- [ ] Commit: `feat(messages): T3 — GET /v1/messages/{id}/threads handler (GAR-595)`
+
+### T4 — green tests
+
+- [ ] Run `cargo test -p garraia-gateway` locally (or verify in CI).
+- [ ] Clippy strict: `cargo clippy ... --no-deps -- -D warnings`.
+- [ ] Commit if any style fixes needed.
+
+### T5 — ROADMAP + bookkeeping
+
+- [ ] Update ROADMAP.md §3.4 Chats checklist: add `[x]` rows for both endpoints.
+- [ ] Update plans/README.md row 0109: `🔄 In Progress` → `✅ Merged …`.
+- [ ] Commit: `docs(plans): T5 bookkeeping — mark plan 0109 merged (GAR-595)`
+
+---
+
+## Risk register
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|-----------|
+| thread_id circular-FK design means replies filtered by thread_id only, no group_id | Low | Medium | Defend-in-depth: explicit `AND group_id = $gid` on messages query |
+| Cursor inversion (list_messages is DESC, threads list is ASC) | Low | Low | Explicit `ORDER BY created_at ASC, id ASC` in query |
+
+---
+
+## Acceptance criteria
+
+- `GET /v1/messages/{id}` → 200 + `MessageResponse` for own-group message.
+- `GET /v1/messages/{id}` → 404 for wrong-group message.
+- `GET /v1/messages/{id}` → 404 for soft-deleted message.
+- `GET /v1/messages/{id}/threads` with no thread → 200 + `{ thread: null, messages: [], next_cursor: null }`.
+- `GET /v1/messages/{id}/threads` with thread + 2 replies → 200 with replies in ASC order.
+- Cross-group message → 404.
+- CI 18/18 green.
+
+---
+
+## Cross-references
+
+- Plan 0055 (GAR-507) — messages slice 2: POST + GET /v1/chats/{id}/messages
+- Plan 0058 (GAR-509) — messages slice 3: POST /v1/messages/{id}/threads
+- Plan 0107 (GAR-592) — messages slice 5: PATCH + DELETE /v1/messages/{id}
+- ROADMAP §3.4 "Chats" checklist
+
+---
+
+## Estimativa
+
+Low: ~250 LOC + ~200 LOC tests = ~450 LOC total. 2–3 hours.

--- a/plans/README.md
+++ b/plans/README.md
@@ -115,6 +115,7 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0106 | [GAR-589 — FORCE RLS on groups + group\_members tables](0106-gar-589-rls-groups-and-members.md) | [GAR-589](https://linear.app/chatgpt25/issue/GAR-589) | ✅ Merged 2026-05-12 via PR #294 (`36b2b72`) |
 | 0107 | [GAR-592 — messages slice 5: PATCH + DELETE /v1/messages/{id}](0107-gar-592-messages-edit-delete.md) | [GAR-592](https://linear.app/chatgpt25/issue/GAR-592) | ✅ Merged 2026-05-12 via PR #300 (`3c843e4`) |
 | 0108 | [GAR-593 — drop stale RUSTSEC-2026-0002 (lru) after lru 0.16.4](0108-gar-593-lru-advisory-cleanup.md) | [GAR-593](https://linear.app/chatgpt25/issue/GAR-593) | ✅ Merged 2026-05-12 via PR #299 (`7996dc4`) |
+| 0109 | [GAR-595 — messages slice 6: GET /v1/messages/{id} + GET /v1/messages/{id}/threads](0109-gar-595-messages-get-single-threads.md) | [GAR-595](https://linear.app/chatgpt25/issue/GAR-595) | 🔄 In Progress |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

- Adds `GET /v1/messages/{message_id}` — fetch a single message (200/404 soft-delete/404 cross-group/400 missing header)
- Adds `GET /v1/messages/{message_id}/threads` — list thread replies cursor-paginated ASC; no-thread → `{ thread: null, messages: [], next_cursor: null }`
- Both handlers open a transaction, set both RLS configs (`app.current_user_id` + `app.current_group_id`), query with `group_id = $2` guard, cross-group → 404 (not 403)
- Routes wired in all 3 router modes (Full / Unconfigured / NoAuth)
- `ThreadMessagesResponse` + `ListThreadMessagesQuery` added to OpenAPI spec
- 10-scenario integration test: MG1–MG5 (GET single) + MT1–MT5 (GET threads)

Closes [GAR-595](https://linear.app/chatgpt25/issue/GAR-595) — plan 0109

Replaces #302 (conflict on plans/README.md — clean branch from main `0b067c8`)

## Test plan

- [ ] CI green (18 checks): fmt, clippy, test (including `rest_v1_messages_get_threads`), audit, deny, playwright
- [ ] MG1 200 own-group message fields correct
- [ ] MG4 cross-group → 404 (not 403)
- [ ] MT1 no-thread → `thread: null, messages: []`
- [ ] MT3 thread with 2 replies → ASC order

---
_Generated by [Claude Code](https://claude.ai/code/session_01V8fCvt6D43Yi6WwJ9TLKwN)_