### PR TITLE
feat(gateway): GAR-599 — GET /v1/groups/{group_id}/task-lists/{list_id} + PATCH /v1/me

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -395,6 +395,7 @@ Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
 - [x] `GET /v1/groups/{group_id}/members` — plan 0097 / [GAR-574](https://linear.app/chatgpt25/issue/GAR-574), implementado 2026-05-11 (Florida)
 - [x] `GET /v1/groups/{group_id}/invites` — plan 0097 / [GAR-574](https://linear.app/chatgpt25/issue/GAR-574), implementado 2026-05-11 (Florida)
 - [x] `GET /v1/me` — plan 0015 (skeleton Fase 3.4), entregue 2026-04-14
+- [x] `PATCH /v1/me` (display_name self-update) — plan 0110 / [GAR-599](https://linear.app/chatgpt25/issue/GAR-599) ✅
 
 **Chats**
 
@@ -405,6 +406,8 @@ Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
 - [x] `POST /v1/messages/{message_id}/threads` — plan 0058 / [GAR-509](https://linear.app/chatgpt25/issue/GAR-509), implementado 2026-05-05 (Florida)
 - [x] `PATCH /v1/messages/{message_id}` (edit body, sender-only) — plan 0107 / [GAR-592](https://linear.app/chatgpt25/issue/GAR-592), merged 2026-05-12 via PR #300 (`3c843e4`). ✅
 - [x] `DELETE /v1/messages/{message_id}` (soft-delete; admin override) — plan 0107 / [GAR-592](https://linear.app/chatgpt25/issue/GAR-592), merged 2026-05-12 via PR #300 (`3c843e4`). ✅
+- [x] `GET /v1/messages/{message_id}` — plan 0109 / [GAR-595](https://linear.app/chatgpt25/issue/GAR-595), merged 2026-05-13 via PR #305 (`e8cc44d`). ✅
+- [x] `GET /v1/messages/{message_id}/threads` — plan 0109 / [GAR-595](https://linear.app/chatgpt25/issue/GAR-595), merged 2026-05-13 via PR #305 (`e8cc44d`). ✅
 - [ ] WebSocket `/v1/chats/{chat_id}/stream` com backpressure
 
 **Arquivos**
@@ -521,6 +524,7 @@ Módulo dentro de `garraia-workspace`. Schema entregue via migration 006 com **R
 
 - [x] `POST /v1/groups/{group_id}/task-lists` — plan 0066 / GAR-516 ✅
 - [x] `GET /v1/groups/{group_id}/task-lists` — plan 0066 / GAR-516 ✅
+- [x] `GET /v1/groups/{group_id}/task-lists/{list_id}` — plan 0110 / [GAR-599](https://linear.app/chatgpt25/issue/GAR-599) ✅
 - [x] `PATCH /v1/groups/{group_id}/task-lists/{list_id}` — plan 0066 / GAR-516 ✅
 - [x] `DELETE /v1/groups/{group_id}/task-lists/{list_id}` (archive, idempotente) — plan 0066 / GAR-516 ✅
 - [x] `POST /v1/groups/{group_id}/task-lists/{list_id}/tasks` — plan 0066 / GAR-516 ✅

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -297,10 +297,10 @@ required-features = ["test-helpers"]
 
 # Plan 0082 (GAR-544): task move endpoint POST tasks/{id}/move.
 # 8 bundled scenarios (M1-M8). required-features gates the binary so
-# `cargo clippy --all-targets` without `--features test-helpers`
-# (CI's clippy invocation) skips compilation — otherwise the
-# `mod common` import would pull `JwtIssuer::new_for_test` /
-# `build_router_for_test` which only exist behind `test-helpers`.
+# `cargo clippy --all-targets` without `--features test-helpers` (CI's
+# clippy invocation) skips compilation — otherwise the `mod common`
+# import would pull `JwtIssuer::new_for_test` / `build_router_for_test`
+# which only exist behind `test-helpers`.
 [[test]]
 name = "rest_v1_task_move"
 path = "tests/rest_v1_task_move.rs"
@@ -375,6 +375,22 @@ required-features = ["test-helpers"]
 [[test]]
 name = "rest_v1_messages_get_threads"
 path = "tests/rest_v1_messages_get_threads.rs"
+required-features = ["test-helpers"]
+
+# Plan 0110 (GAR-599) — GET /v1/groups/{group_id}/task-lists/{list_id}.
+# Feature-gated so plain `cargo test -p garraia-gateway` (without
+# --features test-helpers) skips compilation cleanly.
+[[test]]
+name = "rest_v1_task_list_get"
+path = "tests/rest_v1_task_list_get.rs"
+required-features = ["test-helpers"]
+
+# Plan 0110 (GAR-599) — PATCH /v1/me.
+# Feature-gated so plain `cargo test -p garraia-gateway` (without
+# --features test-helpers) skips compilation cleanly.
+[[test]]
+name = "rest_v1_me_patch"
+path = "tests/rest_v1_me_patch.rs"
 required-features = ["test-helpers"]
 
 [dev-dependencies]

--- a/crates/garraia-gateway/src/rest_v1/me.rs
+++ b/crates/garraia-gateway/src/rest_v1/me.rs
@@ -1,16 +1,23 @@
-//! `GET /v1/me` — returns the authenticated caller's identity.
+//! `/v1/me` — authenticated caller identity + self-service profile update.
 //!
-//! Read-only. Uses the `garraia_auth::Principal` extractor, which also
-//! handles the optional `X-Group-Id` membership lookup. This handler
-//! issues no SQL of its own.
+//! `GET /v1/me` returns identity info from the `Principal` extractor only —
+//! no SQL. `PATCH /v1/me` updates `display_name` on the `users` table via
+//! the `garraia_app` AppPool. `users` is NOT FORCE-RLS group-scoped, so no
+//! `SET LOCAL` context is needed; isolation is via `WHERE id = $1` with the
+//! JWT-authenticated `principal.user_id`.
 
 use axum::Json;
+use axum::extract::State;
+use chrono::{DateTime, Utc};
 use garraia_auth::Principal;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
+use super::RestV1FullState;
 use super::problem::RestError;
+
+// ─── GET /v1/me ──────────────────────────────────────────────────────────────
 
 /// Response body for `GET /v1/me`.
 #[derive(Debug, Serialize, ToSchema)]
@@ -45,6 +52,113 @@ pub async fn get_me(principal: Principal) -> Result<Json<MeResponse>, RestError>
     }))
 }
 
+// ─── PATCH /v1/me ────────────────────────────────────────────────────────────
+
+/// Request body for `PATCH /v1/me`.
+///
+/// All fields are optional. An empty body `{}` is a valid no-op that returns
+/// the current profile. Unknown fields are rejected with 422 (deny_unknown_fields).
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct PatchMeRequest {
+    /// Updated display name. 1–128 characters when provided.
+    pub display_name: Option<String>,
+}
+
+impl PatchMeRequest {
+    fn validate(&self) -> Result<(), &'static str> {
+        if let Some(dn) = &self.display_name {
+            let len = dn.chars().count();
+            if len == 0 {
+                return Err("display_name must not be empty");
+            }
+            if len > 128 {
+                return Err("display_name exceeds 128 character limit");
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Response body for `PATCH /v1/me`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct PatchMeResponse {
+    /// UUID of the authenticated user.
+    pub user_id: Uuid,
+    /// Current email address (read-only, returned for client sync).
+    pub email: String,
+    /// Current display name after the update.
+    pub display_name: String,
+    /// Account creation timestamp (UTC).
+    pub created_at: DateTime<Utc>,
+    /// Last update timestamp (UTC).
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(sqlx::FromRow)]
+struct UserRow {
+    id: Uuid,
+    email: String,
+    display_name: String,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+#[utoipa::path(
+    patch,
+    path = "/v1/me",
+    request_body = PatchMeRequest,
+    responses(
+        (status = 200, description = "Profile updated.", body = PatchMeResponse),
+        (status = 400, description = "Validation error.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 422, description = "Unknown field or malformed body.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn patch_me(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Json(body): Json<PatchMeRequest>,
+) -> Result<Json<PatchMeResponse>, RestError> {
+    body.validate()
+        .map_err(|msg| RestError::BadRequest(msg.into()))?;
+
+    let pool = state.app_pool.pool_for_handlers();
+
+    let row: UserRow = if body.display_name.is_none() {
+        // No-op path: return current user data without issuing an UPDATE.
+        sqlx::query_as(
+            "SELECT id, email, display_name, created_at, updated_at \
+             FROM users WHERE id = $1",
+        )
+        .bind(principal.user_id)
+        .fetch_one(pool)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?
+    } else {
+        sqlx::query_as(
+            "UPDATE users \
+             SET display_name = COALESCE($2, display_name), updated_at = now() \
+             WHERE id = $1 \
+             RETURNING id, email, display_name, created_at, updated_at",
+        )
+        .bind(principal.user_id)
+        .bind(body.display_name.as_deref())
+        .fetch_one(pool)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?
+    };
+
+    Ok(Json(PatchMeResponse {
+        user_id: row.id,
+        email: row.email,
+        display_name: row.display_name,
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -76,5 +190,34 @@ mod tests {
         let v = serde_json::to_value(&body).unwrap();
         assert_eq!(v["group_id"], "11111111-1111-1111-1111-111111111111");
         assert_eq!(v["role"], "owner");
+    }
+
+    #[test]
+    fn patch_me_request_validates_name_too_long() {
+        let req = PatchMeRequest {
+            display_name: Some("x".repeat(129)),
+        };
+        assert!(req.validate().is_err(), "129-char name must fail validation");
+    }
+
+    #[test]
+    fn patch_me_request_validates_empty_name() {
+        let req = PatchMeRequest {
+            display_name: Some(String::new()),
+        };
+        assert!(req.validate().is_err(), "empty name must fail validation");
+    }
+
+    #[test]
+    fn patch_me_request_allows_none() {
+        let req = PatchMeRequest { display_name: None };
+        assert!(req.validate().is_ok(), "None display_name is valid (no-op)");
+    }
+
+    #[test]
+    fn patch_me_request_rejects_unknown_fields() {
+        let json = r#"{"display_name": "Alice", "status": "deleted"}"#;
+        let result: Result<PatchMeRequest, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "unknown field 'status' must be rejected");
     }
 }

--- a/crates/garraia-gateway/src/rest_v1/me.rs
+++ b/crates/garraia-gateway/src/rest_v1/me.rs
@@ -197,7 +197,10 @@ mod tests {
         let req = PatchMeRequest {
             display_name: Some("x".repeat(129)),
         };
-        assert!(req.validate().is_err(), "129-char name must fail validation");
+        assert!(
+            req.validate().is_err(),
+            "129-char name must fail validation"
+        );
     }
 
     #[test]

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -328,13 +328,16 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 .route("/v1/memory/{id}/pin", post(memory::pin_memory))
                 .route("/v1/memory/{id}/unpin", post(memory::unpin_memory))
                 // Plan 0066/0067 (GAR-516/GAR-518) — tasks API slices 1+2.
+                // Plan 0110 (GAR-599) — GET task-list single item.
                 .route(
                     "/v1/groups/{group_id}/task-lists",
                     post(tasks::create_task_list).get(tasks::list_task_lists),
                 )
                 .route(
                     "/v1/groups/{group_id}/task-lists/{list_id}",
-                    patch(tasks::patch_task_list).delete(tasks::delete_task_list),
+                    get(tasks::get_task_list)
+                        .patch(tasks::patch_task_list)
+                        .delete(tasks::delete_task_list),
                 )
                 .route(
                     "/v1/groups/{group_id}/task-lists/{list_id}/tasks",
@@ -538,13 +541,16 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 .route("/v1/memory/{id}/pin", post(unconfigured_handler))
                 .route("/v1/memory/{id}/unpin", post(unconfigured_handler))
                 // Plan 0066/0067/0069/0077 (GAR-516/GAR-518/GAR-520/GAR-533) — tasks API slices 1+2+3+4, fail-soft 503.
+                // Plan 0110 (GAR-599) — GET task-list, fail-soft 503.
                 .route(
                     "/v1/groups/{group_id}/task-lists",
                     post(unconfigured_handler).get(unconfigured_handler),
                 )
                 .route(
                     "/v1/groups/{group_id}/task-lists/{list_id}",
-                    patch(unconfigured_handler).delete(unconfigured_handler),
+                    get(unconfigured_handler)
+                        .patch(unconfigured_handler)
+                        .delete(unconfigured_handler),
                 )
                 .route(
                     "/v1/groups/{group_id}/task-lists/{list_id}/tasks",
@@ -722,13 +728,16 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 .route("/v1/memory/{id}/pin", post(unconfigured_handler))
                 .route("/v1/memory/{id}/unpin", post(unconfigured_handler))
                 // Plan 0066/0067/0069/0077 (GAR-516/GAR-518/GAR-520/GAR-533) — tasks API slices 1+2+3+4, no-auth stub.
+                // Plan 0110 (GAR-599) — GET task-list, no-auth stub.
                 .route(
                     "/v1/groups/{group_id}/task-lists",
                     post(unconfigured_handler).get(unconfigured_handler),
                 )
                 .route(
                     "/v1/groups/{group_id}/task-lists/{list_id}",
-                    patch(unconfigured_handler).delete(unconfigured_handler),
+                    get(unconfigured_handler)
+                        .patch(unconfigured_handler)
+                        .delete(unconfigured_handler),
                 )
                 .route(
                     "/v1/groups/{group_id}/task-lists/{list_id}/tasks",

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -472,10 +472,7 @@ pub fn router(app_state: Arc<AppState>) -> Router {
             // whether `GARRAIA_APP_DATABASE_URL` is set.
             Router::new()
                 // Plan 0110 (GAR-599) — PATCH /v1/me stub (no AppPool in mode 2).
-                .route(
-                    "/v1/me",
-                    get(me::get_me).patch(unconfigured_handler),
-                )
+                .route("/v1/me", get(me::get_me).patch(unconfigured_handler))
                 .route("/v1/groups", post(unconfigured_handler))
                 .route(
                     "/v1/groups/{id}",

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -262,7 +262,8 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 .layer(axum::middleware::from_fn(uploads::tus_version_header_layer));
 
             Router::new()
-                .route("/v1/me", get(me::get_me))
+                // Plan 0110 (GAR-599) — PATCH /v1/me self-service profile update.
+                .route("/v1/me", get(me::get_me).patch(me::patch_me))
                 // Plan 0105 (GAR-580) — groups slice 3: list user's groups.
                 .route(
                     "/v1/groups",
@@ -470,7 +471,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
             // mode 1 so clients see consistent URLs regardless of
             // whether `GARRAIA_APP_DATABASE_URL` is set.
             Router::new()
-                .route("/v1/me", get(me::get_me))
+                // Plan 0110 (GAR-599) — PATCH /v1/me stub (no AppPool in mode 2).
+                .route(
+                    "/v1/me",
+                    get(me::get_me).patch(unconfigured_handler),
+                )
                 .route("/v1/groups", post(unconfigured_handler))
                 .route(
                     "/v1/groups/{id}",
@@ -657,7 +662,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
             // `OPTIONS /v1/uploads` which has no auth requirements
             // by spec — always return the discovery headers.
             Router::new()
-                .route("/v1/me", get(unconfigured_handler))
+                // Plan 0110 (GAR-599) — PATCH /v1/me stub (no-auth mode).
+                .route(
+                    "/v1/me",
+                    get(unconfigured_handler).patch(unconfigured_handler),
+                )
                 .route("/v1/groups", post(unconfigured_handler))
                 .route(
                     "/v1/groups/{id}",

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -47,7 +47,7 @@ use std::sync::Arc;
 
 use axum::Router;
 use axum::extract::FromRef;
-use axum::routing::{delete, get, head, patch, post};
+use axum::routing::{delete, get, head, post};
 use garraia_auth::{AppPool, JwtIssuer, LoginPool};
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -115,6 +115,7 @@ impl Modify for SecurityAddon {
         super::memory::unpin_memory,
         super::tasks::create_task_list,
         super::tasks::list_task_lists,
+        super::tasks::get_task_list,
         super::tasks::patch_task_list,
         super::tasks::delete_task_list,
         super::tasks::create_task,

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -24,7 +24,7 @@ use super::groups::{
     MemberResponse, SetRoleRequest, UpdateGroupRequest,
 };
 use super::invites::AcceptInviteResponse;
-use super::me::MeResponse;
+use super::me::{MeResponse, PatchMeRequest, PatchMeResponse};
 use super::memory::{
     CreateMemoryRequest, ListMemoryResponse, MemoryItemResponse, MemoryItemSummary,
     PatchMemoryRequest, PinMemoryResponse,
@@ -87,6 +87,7 @@ impl Modify for SecurityAddon {
     ),
     paths(
         super::me::get_me,
+        super::me::patch_me,
         super::groups::create_group,
         super::groups::list_groups,
         super::groups::get_group,
@@ -157,6 +158,8 @@ impl Modify for SecurityAddon {
     ),
     components(schemas(
         MeResponse,
+        PatchMeRequest,
+        PatchMeResponse,
         ProblemDetails,
         CreateGroupRequest,
         UpdateGroupRequest,

--- a/crates/garraia-gateway/src/rest_v1/tasks.rs
+++ b/crates/garraia-gateway/src/rest_v1/tasks.rs
@@ -1397,6 +1397,75 @@ pub async fn get_task(
     }
 }
 
+/// `GET /v1/groups/{group_id}/task-lists/{list_id}` — fetch a single task list.
+///
+/// Returns 404 for archived, cross-tenant, or non-existent lists (no 403 leak).
+/// Authz: `Action::TasksRead`. Path `group_id` must equal `principal.group_id`.
+///
+/// ## Error matrix
+///
+/// | Condition                               | Status |
+/// |-----------------------------------------|--------|
+/// | Missing/invalid JWT                     | 401    |
+/// | Non-member of group                     | 403    |
+/// | Path group_id ≠ principal group_id      | 403    |
+/// | List not found / archived / cross-tenant | 404   |
+/// | Happy path                              | 200    |
+#[utoipa::path(
+    get,
+    path = "/v1/groups/{group_id}/task-lists/{list_id}",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("list_id" = Uuid, Path, description = "Task list UUID."),
+    ),
+    responses(
+        (status = 200, description = "Task list.", body = TaskListResponse),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Task list not found, archived, or cross-tenant.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn get_task_list(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, list_id)): Path<(Uuid, Uuid)>,
+) -> Result<Json<TaskListResponse>, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksRead) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    let row: Option<TaskListRow> = sqlx::query_as(
+        "SELECT id, group_id, name, type AS list_type, description, \
+                created_by, created_by_label, created_at, updated_at, archived_at \
+         FROM task_lists \
+         WHERE id = $1 AND group_id = $2 AND archived_at IS NULL",
+    )
+    .bind(list_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    match row {
+        Some(r) => Ok(Json(TaskListResponse::from(r))),
+        None => Err(RestError::NotFound),
+    }
+}
+
 /// `PATCH /v1/groups/{group_id}/task-lists/{list_id}` — update a task list.
 ///
 /// All fields are optional. `description` supports three-way semantics: omit
@@ -4136,4 +4205,32 @@ pub async fn delete_task_attachment(
         .map_err(|e| RestError::Internal(e.into()))?;
 
     Ok(StatusCode::NO_CONTENT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    #[test]
+    fn task_list_response_from_row_roundtrip() {
+        let now = Utc::now();
+        let row = TaskListRow {
+            id: Uuid::nil(),
+            group_id: Uuid::nil(),
+            name: "Backlog".into(),
+            list_type: "list".into(),
+            description: Some("desc".into()),
+            created_by: None,
+            created_by_label: "Alice".into(),
+            created_at: now,
+            updated_at: now,
+            archived_at: None,
+        };
+        let resp = TaskListResponse::from(row);
+        assert_eq!(resp.name, "Backlog");
+        assert_eq!(resp.list_type, "list");
+        assert_eq!(resp.description, Some("desc".into()));
+        assert!(resp.archived_at.is_none());
+    }
 }

--- a/crates/garraia-gateway/tests/rest_v1_me_patch.rs
+++ b/crates/garraia-gateway/tests/rest_v1_me_patch.rs
@@ -157,10 +157,7 @@ async fn rest_v1_me_patch_scenarios() {
         let resp = h
             .router
             .clone()
-            .oneshot(patch_me_req(
-                None,
-                json!({ "display_name": "No auth" }),
-            ))
+            .oneshot(patch_me_req(None, json!({ "display_name": "No auth" })))
             .await
             .expect("ME-PATCH-5 oneshot");
         assert_eq!(

--- a/crates/garraia-gateway/tests/rest_v1_me_patch.rs
+++ b/crates/garraia-gateway/tests/rest_v1_me_patch.rs
@@ -1,0 +1,172 @@
+//! Integration tests for `PATCH /v1/me` (plan 0110 T8, GAR-599).
+//!
+//! All scenarios bundled into ONE `#[tokio::test]` — same pattern as
+//! `rest_v1_me_authed.rs`. Splitting triggers the sqlx runtime-teardown race.
+//!
+//! Scenarios (5):
+//!   ME-PATCH-1. 200 success — updates display_name, verifies field returned.
+//!   ME-PATCH-2. 200 no-op — empty body `{}`, returns current data without error.
+//!   ME-PATCH-3. 422 display_name too long (129 chars).
+//!   ME-PATCH-4. 422 unknown field in body (deny_unknown_fields).
+//!   ME-PATCH-5. 401 no JWT.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+
+use common::Harness;
+use common::fixtures::seed_user_with_group;
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect response body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("response body is not JSON")
+}
+
+fn patch_me_req(token: Option<&str>, body: serde_json::Value) -> Request<Body> {
+    let mut req = Request::builder()
+        .method("PATCH")
+        .uri("/v1/me")
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .expect("request builder");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    if let Some(t) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {t}")).unwrap(),
+        );
+    }
+    req
+}
+
+#[cfg(feature = "test-helpers")]
+#[tokio::test]
+async fn rest_v1_me_patch_scenarios() {
+    let h = Harness::get().await;
+
+    let (user_id, _group_id, token) = seed_user_with_group(&h, "alice@me-patch.test")
+        .await
+        .expect("seed alice");
+
+    // ── ME-PATCH-1: 200 success — updates display_name ──────────────────────
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(patch_me_req(
+                Some(&token),
+                json!({ "display_name": "Alice Updated" }),
+            ))
+            .await
+            .expect("ME-PATCH-1 oneshot");
+        assert_eq!(resp.status(), StatusCode::OK, "ME-PATCH-1 status");
+        let v = body_json(resp).await;
+        assert_eq!(
+            v["user_id"],
+            user_id.to_string(),
+            "ME-PATCH-1 user_id matches"
+        );
+        assert_eq!(
+            v["display_name"], "Alice Updated",
+            "ME-PATCH-1 display_name updated"
+        );
+        assert!(
+            v.get("email").is_some(),
+            "ME-PATCH-1 email present in response"
+        );
+        assert!(
+            v.get("created_at").is_some(),
+            "ME-PATCH-1 created_at present"
+        );
+        assert!(
+            v.get("updated_at").is_some(),
+            "ME-PATCH-1 updated_at present"
+        );
+    }
+
+    // ── ME-PATCH-2: 200 no-op — empty body `{}` ─────────────────────────────
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(patch_me_req(Some(&token), json!({})))
+            .await
+            .expect("ME-PATCH-2 oneshot");
+        assert_eq!(resp.status(), StatusCode::OK, "ME-PATCH-2 status");
+        let v = body_json(resp).await;
+        // display_name should still be the one set in ME-PATCH-1
+        assert_eq!(
+            v["display_name"], "Alice Updated",
+            "ME-PATCH-2 display_name unchanged"
+        );
+    }
+
+    // ── ME-PATCH-3: 422 display_name too long (129 chars) ───────────────────
+    {
+        let long_name = "x".repeat(129);
+        let resp = h
+            .router
+            .clone()
+            .oneshot(patch_me_req(
+                Some(&token),
+                json!({ "display_name": long_name }),
+            ))
+            .await
+            .expect("ME-PATCH-3 oneshot");
+        // Validation returns 400 from our handler validate() path
+        assert!(
+            resp.status() == StatusCode::BAD_REQUEST
+                || resp.status() == StatusCode::UNPROCESSABLE_ENTITY,
+            "ME-PATCH-3 too-long name must return 400 or 422, got {}",
+            resp.status()
+        );
+    }
+
+    // ── ME-PATCH-4: 422 unknown field ────────────────────────────────────────
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(patch_me_req(
+                Some(&token),
+                json!({ "display_name": "Alice", "status": "deleted" }),
+            ))
+            .await
+            .expect("ME-PATCH-4 oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "ME-PATCH-4 unknown field must return 422"
+        );
+    }
+
+    // ── ME-PATCH-5: 401 no JWT ───────────────────────────────────────────────
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(patch_me_req(
+                None,
+                json!({ "display_name": "No auth" }),
+            ))
+            .await
+            .expect("ME-PATCH-5 oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "ME-PATCH-5 missing JWT must return 401"
+        );
+    }
+}

--- a/crates/garraia-gateway/tests/rest_v1_task_list_get.rs
+++ b/crates/garraia-gateway/tests/rest_v1_task_list_get.rs
@@ -103,10 +103,9 @@ async fn rest_v1_task_list_get_scenarios() {
     let h = Harness::get().await;
 
     // Seed two independent groups for cross-tenant isolation.
-    let (_owner_id, group_id, owner_token) =
-        seed_user_with_group(&h, "alice@task-list-get.test")
-            .await
-            .expect("seed alice+group1");
+    let (_owner_id, group_id, owner_token) = seed_user_with_group(&h, "alice@task-list-get.test")
+        .await
+        .expect("seed alice+group1");
     let (_, group2_id, owner2_token) = seed_user_with_group(&h, "bob@task-list-get.test")
         .await
         .expect("seed bob+group2");
@@ -126,7 +125,11 @@ async fn rest_v1_task_list_get_scenarios() {
         ))
         .await
         .expect("seed: create task list");
-    assert_eq!(resp.status(), StatusCode::CREATED, "seed: task list created");
+    assert_eq!(
+        resp.status(),
+        StatusCode::CREATED,
+        "seed: task list created"
+    );
     let created = body_json(resp).await;
     let list_id = created["id"].as_str().expect("seed: list id").to_string();
 
@@ -150,14 +153,8 @@ async fn rest_v1_task_list_get_scenarios() {
         assert_eq!(v["name"], "Sprint Backlog", "TL-GET-1 name");
         assert_eq!(v["type"], "list", "TL-GET-1 type");
         assert_eq!(v["description"], "Initial backlog", "TL-GET-1 description");
-        assert!(
-            v.get("created_at").is_some(),
-            "TL-GET-1 created_at present"
-        );
-        assert!(
-            v.get("updated_at").is_some(),
-            "TL-GET-1 updated_at present"
-        );
+        assert!(v.get("created_at").is_some(), "TL-GET-1 created_at present");
+        assert!(v.get("updated_at").is_some(), "TL-GET-1 updated_at present");
         assert!(
             v["archived_at"].is_null() || v.get("archived_at").is_none(),
             "TL-GET-1 archived_at null/absent"

--- a/crates/garraia-gateway/tests/rest_v1_task_list_get.rs
+++ b/crates/garraia-gateway/tests/rest_v1_task_list_get.rs
@@ -1,0 +1,267 @@
+//! Integration tests for `GET /v1/groups/{group_id}/task-lists/{list_id}` (plan 0110 T4, GAR-599).
+//!
+//! All scenarios bundled into ONE `#[tokio::test]` — same pattern as
+//! `rest_v1_tasks.rs`. Splitting triggers the sqlx runtime-teardown race.
+//!
+//! Scenarios (5):
+//!   TL-GET-1. Owner 200 — happy path, all response fields present.
+//!   TL-GET-2. Member 200 — second user is a member, also gets 200.
+//!   TL-GET-3. Cross-group 404 — list belongs to another group.
+//!   TL-GET-4. Archived task list 404 — archived_at IS NOT NULL → 404.
+//!   TL-GET-5. Missing X-Group-Id → 400.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{HeaderName, HeaderValue, Request, StatusCode};
+use http_body_util::BodyExt;
+use serde_json::json;
+use tower::ServiceExt;
+
+use common::Harness;
+use common::fixtures::{seed_member_via_admin, seed_user_with_group};
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect response body")
+        .to_bytes();
+    serde_json::from_slice(&bytes).expect("response body is not JSON")
+}
+
+fn auth_req(
+    method: &str,
+    uri: &str,
+    token: Option<&str>,
+    x_group_id: Option<&str>,
+    body: Option<serde_json::Value>,
+) -> Request<Body> {
+    let body_bytes = match body {
+        Some(v) => Body::from(v.to_string()),
+        None => Body::empty(),
+    };
+    let mut req = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(body_bytes)
+        .expect("request builder");
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo::<std::net::SocketAddr>(
+            "127.0.0.1:1".parse().unwrap(),
+        ));
+    if let Some(t) = token {
+        req.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {t}")).unwrap(),
+        );
+    }
+    if let Some(g) = x_group_id {
+        req.headers_mut().insert(
+            HeaderName::from_static("x-group-id"),
+            HeaderValue::from_str(g).unwrap(),
+        );
+    }
+    req
+}
+
+fn post_task_list(
+    token: Option<&str>,
+    x_group_id: Option<&str>,
+    path_group_id: &str,
+    body: serde_json::Value,
+) -> Request<Body> {
+    auth_req(
+        "POST",
+        &format!("/v1/groups/{path_group_id}/task-lists"),
+        token,
+        x_group_id,
+        Some(body),
+    )
+}
+
+fn get_task_list(
+    token: Option<&str>,
+    x_group_id: Option<&str>,
+    path_group_id: &str,
+    list_id: &str,
+) -> Request<Body> {
+    auth_req(
+        "GET",
+        &format!("/v1/groups/{path_group_id}/task-lists/{list_id}"),
+        token,
+        x_group_id,
+        None,
+    )
+}
+
+#[cfg(feature = "test-helpers")]
+#[tokio::test]
+async fn rest_v1_task_list_get_scenarios() {
+    let h = Harness::get().await;
+
+    // Seed two independent groups for cross-tenant isolation.
+    let (_owner_id, group_id, owner_token) =
+        seed_user_with_group(&h, "alice@task-list-get.test")
+            .await
+            .expect("seed alice+group1");
+    let (_, group2_id, owner2_token) = seed_user_with_group(&h, "bob@task-list-get.test")
+        .await
+        .expect("seed bob+group2");
+
+    let gid = group_id.to_string();
+    let g2id = group2_id.to_string();
+
+    // ── Seed: create a task list in group1 ──────────────────────────────────
+    let resp = h
+        .router
+        .clone()
+        .oneshot(post_task_list(
+            Some(&owner_token),
+            Some(&gid),
+            &gid,
+            json!({ "name": "Sprint Backlog", "type": "list", "description": "Initial backlog" }),
+        ))
+        .await
+        .expect("seed: create task list");
+    assert_eq!(resp.status(), StatusCode::CREATED, "seed: task list created");
+    let created = body_json(resp).await;
+    let list_id = created["id"].as_str().expect("seed: list id").to_string();
+
+    // ── TL-GET-1: owner 200 — all fields correct ─────────────────────────────
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_task_list(
+                Some(&owner_token),
+                Some(&gid),
+                &gid,
+                &list_id,
+            ))
+            .await
+            .expect("TL-GET-1 oneshot");
+        assert_eq!(resp.status(), StatusCode::OK, "TL-GET-1 status");
+        let v = body_json(resp).await;
+        assert_eq!(v["id"], list_id, "TL-GET-1 id");
+        assert_eq!(v["group_id"], gid, "TL-GET-1 group_id");
+        assert_eq!(v["name"], "Sprint Backlog", "TL-GET-1 name");
+        assert_eq!(v["type"], "list", "TL-GET-1 type");
+        assert_eq!(v["description"], "Initial backlog", "TL-GET-1 description");
+        assert!(
+            v.get("created_at").is_some(),
+            "TL-GET-1 created_at present"
+        );
+        assert!(
+            v.get("updated_at").is_some(),
+            "TL-GET-1 updated_at present"
+        );
+        assert!(
+            v["archived_at"].is_null() || v.get("archived_at").is_none(),
+            "TL-GET-1 archived_at null/absent"
+        );
+    }
+
+    // ── TL-GET-2: member 200 ─────────────────────────────────────────────────
+    {
+        let (_member_id, member_token) =
+            seed_member_via_admin(&h, group_id, "member@task-list-get.test", "member")
+                .await
+                .expect("TL-GET-2 seed member");
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_task_list(
+                Some(&member_token),
+                Some(&gid),
+                &gid,
+                &list_id,
+            ))
+            .await
+            .expect("TL-GET-2 oneshot");
+        assert_eq!(resp.status(), StatusCode::OK, "TL-GET-2 member gets 200");
+        let v = body_json(resp).await;
+        assert_eq!(v["id"], list_id, "TL-GET-2 id matches");
+    }
+
+    // ── TL-GET-3: cross-group 404 — list_id from group1 requested via group2 ─
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_task_list(
+                Some(&owner2_token),
+                Some(&g2id),
+                &g2id,
+                &list_id,
+            ))
+            .await
+            .expect("TL-GET-3 oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "TL-GET-3 cross-group must return 404"
+        );
+    }
+
+    // ── TL-GET-4: archived task list 404 ────────────────────────────────────
+    {
+        // Archive the list via DELETE (archive endpoint).
+        let del_resp = h
+            .router
+            .clone()
+            .oneshot(auth_req(
+                "DELETE",
+                &format!("/v1/groups/{gid}/task-lists/{list_id}"),
+                Some(&owner_token),
+                Some(&gid),
+                None,
+            ))
+            .await
+            .expect("TL-GET-4 archive list");
+        assert_eq!(
+            del_resp.status(),
+            StatusCode::NO_CONTENT,
+            "TL-GET-4 archive step"
+        );
+
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_task_list(
+                Some(&owner_token),
+                Some(&gid),
+                &gid,
+                &list_id,
+            ))
+            .await
+            .expect("TL-GET-4 oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "TL-GET-4 archived list must return 404"
+        );
+    }
+
+    // ── TL-GET-5: missing X-Group-Id → 400 ───────────────────────────────────
+    {
+        let resp = h
+            .router
+            .clone()
+            .oneshot(get_task_list(
+                Some(&owner_token),
+                None, // no X-Group-Id
+                &gid,
+                &list_id,
+            ))
+            .await
+            .expect("TL-GET-5 oneshot");
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "TL-GET-5 missing X-Group-Id must return 400"
+        );
+    }
+}

--- a/plans/0110-gar-599-task-list-get-patch-me.md
+++ b/plans/0110-gar-599-task-list-get-patch-me.md
@@ -1,0 +1,233 @@
+# Plan 0110 — GAR-599: GET /v1/groups/{group_id}/task-lists/{list_id} + PATCH /v1/me
+
+> **For agentic workers:** implement task-by-task following the TDD pattern (test first → red → impl → green → clippy → commit).
+
+**Linear issue:** [GAR-599](https://linear.app/chatgpt25/issue/GAR-599) — "REST /v1 — GET /v1/groups/{group_id}/task-lists/{list_id} + PATCH /v1/me (profile update)" (In Progress, High). Labels: `epic:ws-api`, `epic:ws-tasks`. Project: "Fase 3 — Group Workspace".
+
+**Status:** ⏳ Draft — 2026-05-13 (Florida). Pré-requisitos validados abaixo.
+
+**Goal:** Fechar dois gaps de CRUD na superfície `/v1`:
+1. `GET /v1/groups/{group_id}/task-lists/{list_id}` — busca uma task list por ID; a rota já tem `PATCH` + `DELETE` mas faltava `GET`.
+2. `PATCH /v1/me` — permite ao usuário autenticado atualizar seu próprio `display_name`. Status (`active/suspended/deleted`) é admin-controlled e permanece fora de escopo.
+
+Zero migration nova, zero ADR novo, zero nova capability. Reutiliza `TaskListRow`/`TaskListResponse` (existentes em `tasks.rs`), `AppPool` (já wired no `AppState`), e `Principal` extractor.
+
+**Architecture:**
+
+### GET /v1/groups/{group_id}/task-lists/{list_id}
+- Handler `get_task_list` em `crates/garraia-gateway/src/rest_v1/tasks.rs` (~80 LOC).
+- Mesmo padrão de `get_task`: `require_group_id` → `check_group_match` → `can(&principal, Action::TasksRead)` → tx → `SET LOCAL` (user_id + group_id via `set_rls_context`) → `SELECT ... FROM task_lists WHERE id = $1 AND group_id = $2 AND archived_at IS NULL` → `COMMIT` → 200/404.
+- Registrado no router (`mod.rs`) como `get(tasks::get_task_list)` na rota `/v1/groups/{group_id}/task-lists/{list_id}` que já tem `.patch(tasks::patch_task_list).delete(tasks::delete_task_list)`.
+- OpenAPI: path `GET /v1/groups/{group_id}/task-lists/{list_id}` + responses 200/400/401/403/404.
+
+### PATCH /v1/me
+- Handler `patch_me` em `crates/garraia-gateway/src/rest_v1/me.rs` (~120 LOC).
+- `State<RestV1FullState>` para acesso ao `app_pool`. `Principal` para `user_id`. JSON body `PatchMeRequest { display_name: Option<String> }` com `deny_unknown_fields`.
+- Validação: `display_name` ≤ 128 chars se presente; body completamente vazio (`{}`) → 200 no-op (idempotente).
+- `UPDATE users SET display_name = COALESCE($2, display_name), updated_at = now() WHERE id = $1 RETURNING id, email, display_name, status, created_at, updated_at`.
+- `users` NÃO está em FORCE RLS group-scoped (é tenant-root, migration 001). `SET LOCAL` NOT needed — apenas o `WHERE id = $1` com `principal.user_id` garante que o usuário só altera o próprio registro.
+- Retorna `PatchMeResponse { user_id, email, display_name, created_at, updated_at }`.
+- Registrado como `patch(me::patch_me)` na rota `/v1/me` (atualmente só tem `get`).
+- Modo 2/3 (AppPool ausente) → `unconfigured_handler` no router.
+
+**Tech stack:** Axum 0.8, `utoipa 5`, `garraia-auth::{Action, Principal, can}`, `sqlx 0.8` (postgres), `serde 1.0`, `chrono 0.4`, `uuid 1.x`. Test harness: `testcontainers` + `pgvector/pgvector:pg16` (existente em `tests/common/`).
+
+---
+
+## Design invariants
+
+1. **`task_lists` está sob FORCE RLS — `app.current_group_id` obrigatório.** Policy `task_lists_group_isolation` usa `group_id = NULLIF(current_setting(...), '')::uuid`. Falhar `SET LOCAL` retorna 0 rows (RLS filtra), que handler trata como 404 — fail-closed correto.
+2. **GET task-list retorna 404 para listas arquivadas.** `archived_at IS NULL` no WHERE é intencional — alinha com PATCH/DELETE que também rejeitam listas arquivadas.
+3. **PATCH /v1/me: somente `display_name` exposto.** `status` (active/suspended/deleted) é responsabilidade do admin — expô-lo via self-service endpoint violaria RBAC. Se um segundo campo for necessário no futuro, requer ADR ou nova issue.
+4. **PATCH /v1/me: `deny_unknown_fields`.** Garante que campos não suportados retornam 422, evitando confusão de API.
+5. **PATCH /v1/me: `UPDATE ... WHERE id = $1` com principal.user_id.** Não precisa de SET LOCAL porque users é tenant-root sem FORCE RLS por grupo. A filtragem é por PK do usuário (JWT-authenticated).
+6. **Sem auditoria no PATCH /v1/me nesta slice.** O `audit_events` table é group-scoped. Profile updates são user-scoped; auditoria por tenant fica para epic GAR-compliance.
+
+---
+
+## Validações pré-plano
+
+- ✅ `TaskListRow`, `TaskListResponse`, `TaskListSummary` já existem em `tasks.rs:109-275`.
+- ✅ `Action::TasksRead` existe em `action.rs:58` com string `"tasks.read"`.
+- ✅ `can(Owner|Admin|Member|Guest|Child, TasksRead)` = true — verificar `can.rs`.
+- ✅ `set_rls_context(&mut tx, user_id, group_id)` helper existe em `tasks.rs` (re-check import path).
+- ✅ `task_lists` tem `archived_at` (migration 006) — `WHERE id = $1 AND group_id = $2 AND archived_at IS NULL` é seguro.
+- ✅ `app_pool.pool_for_handlers()` disponível em `RestV1FullState`. Padrão em todos os handlers que fazem SQL.
+- ✅ `users` schema: `id UUID PK`, `email citext`, `display_name TEXT`, `status TEXT CHECK(active/suspended/deleted)`, `created_at`, `updated_at` (migration 001).
+- ✅ `garraia_app` tem `GRANT UPDATE ON ALL TABLES` (migration 007:70) — `UPDATE users` via AppPool é permitido.
+- ✅ `users` NÃO está em FORCE RLS (migrations 007 lista as 10 tabelas; users não está).
+
+---
+
+## Out of scope
+
+- PATCH /v1/me para `status` — admin-only.
+- GET /v1/groups/{group_id}/task-lists/{list_id} com chats arquivadas — arquivadas retornam 404.
+- Cursor pagination no GET — retorna o objeto único; paginação não se aplica.
+- Audit event para profile update — user-scoped, deferred.
+- `?include_archived=true` na task-list GET — futuro com `Action::TasksAdmin`.
+- WebSocket `/v1/task-lists/{list_id}/stream` — large scope, issue separada.
+- PATCH /v1/me para email — implica re-verificação; fora de escopo.
+
+---
+
+## Rollback plan
+
+Aditivo por task. Cada task é commit independente:
+- Task 0 (plano no README) — revert remove a linha do índice.
+- Task 1 (`get_task_list` handler + utoipa path + testes unitários) — revert remove o handler (arquivo existente, remover apenas a função).
+- Task 2 (router wiring: adiciona `get(tasks::get_task_list)`) — revert volta ao `.patch().delete()` sem `.get()`.
+- Task 3 (OpenAPI registration de GET task-list) — revert remove o path de `openapi.rs`.
+- Task 4 (integration test `rest_v1_task_list_get.rs`) — revert deleta o arquivo de test.
+- Task 5 (`PatchMeRequest` + `PatchMeResponse` + `patch_me` handler + unit tests) — revert remove as structs e a função.
+- Task 6 (router wiring PATCH /v1/me + Mode 2/3 unconfigured_handler) — revert volta `/v1/me` a `get(me::get_me)` only.
+- Task 7 (OpenAPI registration de PATCH /v1/me) — revert remove o path.
+- Task 8 (integration test `rest_v1_me_patch.rs`) — revert deleta o arquivo.
+
+Zero migration, zero novo role, zero ADR. Worst-case: 9 revert commits sequenciais.
+
+---
+
+## §12 Open questions
+
+1. **`display_name` pode ser NULL?** → Schema tem `TEXT NOT NULL` implícito? Verificar migration 001. Se `NOT NULL`, PATCH com `display_name: null` deve retornar 422. Se nullable, `null` limpa o campo.
+2. **PATCH /v1/me deve retornar o objeto completo do usuário (com email)?** → Sim: `PatchMeResponse { user_id, email, display_name, created_at, updated_at }` — facilita sync do cliente sem GET adicional.
+3. **Qual state type para `patch_me`?** → `State<RestV1FullState>` — requer full AppPool. Modes 2/3 ficam com `unconfigured_handler`.
+
+---
+
+## File structure
+
+```
+crates/garraia-gateway/src/rest_v1/
+  tasks.rs          ← adiciona get_task_list handler (~80 LOC)
+  me.rs             ← adiciona PatchMeRequest, PatchMeResponse, patch_me (~120 LOC)
+  mod.rs            ← wiring: get(tasks::get_task_list), patch(me::patch_me)
+  openapi.rs        ← registra 2 novos paths + PatchMeRequest + PatchMeResponse
+tests/
+  rest_v1_task_list_get.rs   ← 5 cenários TL-GET-1..5 (novo arquivo)
+  rest_v1_me_patch.rs        ← 5 cenários ME-PATCH-1..5 (novo arquivo)
+plans/
+  0110-gar-599-task-list-get-patch-me.md   ← este arquivo
+  README.md         ← adiciona linha 0110
+```
+
+---
+
+## M1 Tasks
+
+### T0 — Bookkeeping: registrar plano no README
+- [ ] Adicionar linha `| 0110 | GAR-599 — GET task-list + PATCH /v1/me | GAR-599 | 🔄 In Progress |` ao `plans/README.md`.
+- [ ] Commit: `docs(plans): add plan 0110 for GAR-599 (GET task-list + PATCH me)`.
+
+### T1 — `get_task_list` handler em `tasks.rs`
+- [ ] Adicionar handler `pub async fn get_task_list(...)` seguindo padrão de `get_task`:
+  - `State`, `Principal`, `Path<(Uuid, Uuid)>` (path_group_id, list_id).
+  - `require_group_id` + `check_group_match` + `can(TasksRead)`.
+  - `pool.begin()` → `set_rls_context(user_id, group_id)` → `SELECT ... FROM task_lists WHERE id = $1 AND group_id = $2 AND archived_at IS NULL` → `COMMIT` → 200/404.
+  - Columns: `id, group_id, name, type AS list_type, description, created_by, created_by_label, created_at, updated_at, archived_at`.
+  - `#[utoipa::path(get, path = "/v1/groups/{group_id}/task-lists/{list_id}", ...)]` com responses 200/400/401/403/404.
+- [ ] Unit tests dentro de `mod tests` (inline): `task_list_response_from_row_roundtrip` (verifica conversão `TaskListRow → TaskListResponse`).
+- [ ] Commit: `feat(tasks): add get_task_list handler (plan 0110 T1)`.
+
+### T2 — Router wiring para GET task-list
+- [ ] Em `mod.rs`, alterar rota `/v1/groups/{group_id}/task-lists/{list_id}` de `patch(...).delete(...)` para `get(tasks::get_task_list).patch(tasks::patch_task_list).delete(tasks::delete_task_list)`.
+- [ ] Adicionar a mesma wiring no bloco Mode 2 (`unconfigured_handler` para get).
+- [ ] Commit: `feat(rest-v1): wire GET /v1/groups/{group_id}/task-lists/{list_id} (plan 0110 T2)`.
+
+### T3 — OpenAPI para GET task-list
+- [ ] Em `openapi.rs`, adicionar `get_task_list` em `paths(...)`.
+- [ ] `TaskListResponse` já está registrado em `schemas` — sem duplicata.
+- [ ] Commit: `docs(openapi): register GET task-list path (plan 0110 T3)`.
+
+### T4 — Integration tests para GET task-list
+- [ ] Criar `tests/rest_v1_task_list_get.rs` com função `#[tokio::test] async fn rest_v1_task_list_get()`:
+  - **TL-GET-1**: owner 200 com campos corretos (name, type, description, created_by).
+  - **TL-GET-2**: member 200 (seed segundo user via `seed_member_via_admin`).
+  - **TL-GET-3**: cross-group → 404 (usar list_id de outro grupo).
+  - **TL-GET-4**: archived task list → 404 (`UPDATE task_lists SET archived_at = now()`).
+  - **TL-GET-5**: missing `X-Group-Id` header → 400.
+- [ ] Commit: `test(rest-v1): integration tests for GET task-list (plan 0110 T4)`.
+
+### T5 — `patch_me` handler + DTOs em `me.rs`
+- [ ] Adicionar `PatchMeRequest`:
+  ```rust
+  #[derive(Debug, Deserialize, ToSchema)]
+  #[serde(deny_unknown_fields)]
+  pub struct PatchMeRequest {
+      pub display_name: Option<String>,
+  }
+  ```
+  Com `validate()` → erro se `display_name.as_ref().map(|s| s.chars().count()).unwrap_or(0) > 128`.
+- [ ] Adicionar `PatchMeResponse { user_id: Uuid, email: String, display_name: Option<String>, created_at: DateTime<Utc>, updated_at: DateTime<Utc> }`.
+- [ ] Handler `patch_me`:
+  - `State<RestV1FullState>`, `Principal`, `Json<PatchMeRequest>`.
+  - Validate body.
+  - Se tudo None → retornar 200 com dados atuais do usuário (SELECT sem UPDATE).
+  - Caso contrário: `UPDATE users SET display_name = COALESCE($2, display_name), updated_at = now() WHERE id = $1 RETURNING id, email, display_name, created_at, updated_at`.
+  - Retornar `PatchMeResponse`.
+- [ ] Unit tests inline: `patch_me_request_validates_name_too_long`, `patch_me_request_rejects_unknown_fields`.
+- [ ] `#[utoipa::path(patch, path = "/v1/me", ...)]`.
+- [ ] Commit: `feat(me): add patch_me handler + PatchMeRequest + PatchMeResponse (plan 0110 T5)`.
+
+### T6 — Router wiring para PATCH /v1/me
+- [ ] Em `mod.rs` Mode 1: `.route("/v1/me", get(me::get_me).patch(me::patch_me))`.
+- [ ] Em Mode 2/3: adicionar `patch(unconfigured_handler)` na rota `/v1/me`.
+- [ ] Commit: `feat(rest-v1): wire PATCH /v1/me (plan 0110 T6)`.
+
+### T7 — OpenAPI para PATCH /v1/me
+- [ ] Em `openapi.rs`, adicionar `patch_me` em `paths(...)` + `PatchMeRequest` + `PatchMeResponse` em `schemas(...)`.
+- [ ] Commit: `docs(openapi): register PATCH /v1/me path (plan 0110 T7)`.
+
+### T8 — Integration tests para PATCH /v1/me
+- [ ] Criar `tests/rest_v1_me_patch.rs`:
+  - **ME-PATCH-1**: success 200 — atualiza `display_name`, verifica campo retornado.
+  - **ME-PATCH-2**: no-op 200 — body `{}`, retorna dados atuais sem erro.
+  - **ME-PATCH-3**: `display_name` too long (129 chars) → 422.
+  - **ME-PATCH-4**: unknown field no body → 422 (graças a `deny_unknown_fields`).
+  - **ME-PATCH-5**: sem JWT → 401.
+- [ ] Commit: `test(rest-v1): integration tests for PATCH /v1/me (plan 0110 T8)`.
+
+### T9 — Bookkeeping final + clippy/fmt
+- [ ] `cargo fmt --check` → limpo.
+- [ ] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` → zero warnings.
+- [ ] Atualizar `plans/README.md` linha 0110: status → `✅ Merged` (pós-merge).
+- [ ] Atualizar ROADMAP.md §3.4 com `[x]` para GET task-list + PATCH /v1/me.
+
+---
+
+## Risk register
+
+| Risco | Mitigação |
+|-------|-----------|
+| `users.display_name` pode ser `NOT NULL` no schema — rejeitar `null` no PATCH | Verificar migration 001 linha 28; se `NOT NULL`, documentar no utoipa e retornar 422 para body com `display_name: null` |
+| FORCE RLS em `task_lists` bloqueia silenciosamente com 404 se `SET LOCAL` falhar | Coberto por TL-GET-3 (cross-group) + TL-GET-5 (missing header) |
+| `get_task_list` pode entrar em conflito de nome com `list_task_lists` | Nomes distintos: `get_task_list` (singular, by ID) vs `list_task_lists` (plural, all) — ok |
+
+---
+
+## Acceptance criteria
+
+- [ ] `cargo test -p garraia-gateway --test rest_v1_task_list_get` → 5/5 verde.
+- [ ] `cargo test -p garraia-gateway --test rest_v1_me_patch` → 5/5 verde.
+- [ ] `GET /v1/groups/{group_id}/task-lists/{list_id}` e `PATCH /v1/me` aparecem em `/docs` OpenAPI.
+- [ ] `cargo clippy --workspace -- -D warnings` verde (zero novo warning).
+- [ ] PR CI: todos os 17+ checks passam.
+
+---
+
+## Cross-references
+
+- Plan 0068 (GAR-518): PATCH/DELETE task-list (onde GET ficou faltando).
+- Plan 0015 (GAR-393): scaffold GET /v1/me (base para PATCH).
+- Plan 0066 (GAR-516): tasks slice 1 (full CRUD — mas missing GET task-list).
+- [GAR-599](https://linear.app/chatgpt25/issue/GAR-599): issue Linear deste plan.
+- ROADMAP §3.4 "API REST /v1" — Fase 3.
+
+---
+
+## Estimativa
+
+**LOC:** ~210 (tasks.rs +80, me.rs +130) + routing/openapi ~40 + tests ~200 = ~450 LOC total.
+**Tempo:** 1–2h implementação + CI (~45min). Total: < 3h wall clock.
+**Risco:** Baixo — padrão estabelecido, sem migration, sem nova capability.

--- a/plans/README.md
+++ b/plans/README.md
@@ -115,7 +115,7 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0106 | [GAR-589 — FORCE RLS on groups + group\_members tables](0106-gar-589-rls-groups-and-members.md) | [GAR-589](https://linear.app/chatgpt25/issue/GAR-589) | ✅ Merged 2026-05-12 via PR #294 (`36b2b72`) |
 | 0107 | [GAR-592 — messages slice 5: PATCH + DELETE /v1/messages/{id}](0107-gar-592-messages-edit-delete.md) | [GAR-592](https://linear.app/chatgpt25/issue/GAR-592) | ✅ Merged 2026-05-12 via PR #300 (`3c843e4`) |
 | 0108 | [GAR-593 — drop stale RUSTSEC-2026-0002 (lru) after lru 0.16.4](0108-gar-593-lru-advisory-cleanup.md) | [GAR-593](https://linear.app/chatgpt25/issue/GAR-593) | ✅ Merged 2026-05-12 via PR #299 (`7996dc4`) |
-| 0109 | [GAR-595 — GET /v1/messages/{id} + GET /v1/messages/{id}/threads](0109-gar-595-messages-get.md) | [GAR-595](https://linear.app/chatgpt25/issue/GAR-595) | 🔄 In Progress (PR #305) |
+| 0109 | [GAR-595 — GET /v1/messages/{id} + GET /v1/messages/{id}/threads](0109-gar-595-messages-get.md) | [GAR-595](https://linear.app/chatgpt25/issue/GAR-595) | ✅ Merged 2026-05-13 via PR #305 (`e8cc44d`) |
 | 0110 | [GAR-599 — GET /v1/groups/{group_id}/task-lists/{list_id} + PATCH /v1/me](0110-gar-599-task-list-get-patch-me.md) | [GAR-599](https://linear.app/chatgpt25/issue/GAR-599) | 🔄 In Progress |
 
 ## Arquivos não-versionados

--- a/plans/README.md
+++ b/plans/README.md
@@ -115,6 +115,8 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0106 | [GAR-589 — FORCE RLS on groups + group\_members tables](0106-gar-589-rls-groups-and-members.md) | [GAR-589](https://linear.app/chatgpt25/issue/GAR-589) | ✅ Merged 2026-05-12 via PR #294 (`36b2b72`) |
 | 0107 | [GAR-592 — messages slice 5: PATCH + DELETE /v1/messages/{id}](0107-gar-592-messages-edit-delete.md) | [GAR-592](https://linear.app/chatgpt25/issue/GAR-592) | ✅ Merged 2026-05-12 via PR #300 (`3c843e4`) |
 | 0108 | [GAR-593 — drop stale RUSTSEC-2026-0002 (lru) after lru 0.16.4](0108-gar-593-lru-advisory-cleanup.md) | [GAR-593](https://linear.app/chatgpt25/issue/GAR-593) | ✅ Merged 2026-05-12 via PR #299 (`7996dc4`) |
+| 0109 | [GAR-595 — GET /v1/messages/{id} + GET /v1/messages/{id}/threads](0109-gar-595-messages-get.md) | [GAR-595](https://linear.app/chatgpt25/issue/GAR-595) | 🔄 In Progress (PR #305) |
+| 0110 | [GAR-599 — GET /v1/groups/{group_id}/task-lists/{list_id} + PATCH /v1/me](0110-gar-599-task-list-get-patch-me.md) | [GAR-599](https://linear.app/chatgpt25/issue/GAR-599) | 🔄 In Progress |
 
 ## Arquivos não-versionados
 


### PR DESCRIPTION
## Summary

- **GET /v1/groups/{group_id}/task-lists/{list_id}** — fetches a single task list by ID. Closes the CRUD gap on the task-list route that already had PATCH + DELETE but was missing GET. Returns 404 for archived/cross-tenant/missing lists (RLS fail-closed). Authz: `Action::TasksRead`.
- **PATCH /v1/me** — self-service `display_name` update. `users` is NOT FORCE-RLS group-scoped (tenant-root), so no `SET LOCAL` needed; isolation is via `WHERE id = $1` with `principal.user_id`. `deny_unknown_fields` rejects unknown fields with 422. Empty body `{}` is idempotent (returns current data).

Plan: [0110](https://github.com/michelbr84/GarraRUST/blob/main/plans/0110-gar-599-task-list-get-patch-me.md) | Linear: [GAR-599](https://linear.app/chatgpt25/issue/GAR-599)

## Commits (T0–T9)

- `docs(plans)`: add plan 0110 for GAR-599
- `feat(tasks)`: add `get_task_list` handler (T1)
- `feat(rest-v1)`: wire `GET /v1/groups/{group_id}/task-lists/{list_id}` (T2)
- `docs(openapi)`: register GET task-list path (T3)
- `test(rest-v1)`: integration tests for GET task-list — 5 scenarios TL-GET-1..5 (T4)
- `feat(me)`: add `patch_me` + `PatchMeRequest` + `PatchMeResponse` (T5)
- `feat(rest-v1)`: wire `PATCH /v1/me` — Mode 1 real, Modes 2/3 unconfigured_handler (T6)
- `docs(openapi)`: register PATCH /v1/me path + schemas (T7)
- `test(rest-v1)`: integration tests for PATCH /v1/me — 5 scenarios ME-PATCH-1..5 (T8)
- `style`: cargo fmt + ROADMAP + plans/README bookkeeping (T9)
- `chore`: remove unused `axum::routing::patch` import (post-merge cargo fix)

## Test plan

- [ ] `GET /v1/groups/{group_id}/task-lists/{list_id}` — TL-GET-1 owner 200, TL-GET-2 member 200, TL-GET-3 cross-group 404, TL-GET-4 archived 404, TL-GET-5 missing X-Group-Id 400
- [ ] `PATCH /v1/me` — ME-PATCH-1 display_name updated, ME-PATCH-2 no-op `{}` 200, ME-PATCH-3 too long 400/422, ME-PATCH-4 unknown field 422, ME-PATCH-5 no JWT 401
- [ ] Clippy strict: zero warnings
- [ ] Format Check: clean
- [ ] All 17 actual CI checks green

https://claude.ai/code/session_016BLfrVGzzqwjgPvEJvgv4Z

---
_Generated by [Claude Code](https://claude.ai/code/session_016BLfrVGzzqwjgPvEJvgv4Z)_