### PR TITLE
chore(ci): add concurrency to cancel superseded PR runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,16 @@ on:
   pull_request:
     branches: [main, develop, master]
 
+# Cancel superseded in-flight runs on the same PR to avoid empilhar FAILUREs
+# em Dependabot rebases e PRs que serão fechados (ex.: #289/#286/#291 hoje
+# 2026-05-13 geraram 33 jobs vermelhos cada um substituindo o anterior).
+# Pushes em main/develop/master NÃO são cancelados — merges + post-merge
+# runs precisam completar. Padrão alinhado a codeql.yml (que comentava
+# "mirrors ci.yml convention" antes deste bloco existir).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1


### PR DESCRIPTION
## Summary
- Adds top-level `concurrency` block to `.github/workflows/ci.yml` (it had none — `codeql.yml` even comments *"mirrors ci.yml convention"* but there was no convention to mirror).
- Cancels superseded in-flight runs on the same PR; **preserves** pushes em `main`/`develop`/`master`.
- Não toca histórico de runs antigas (preserva evidência das incompat técnicas).

## Why now
PRs Dependabot fechados hoje 2026-05-13 04:24-04:25Z geraram ruído visível em "All workflows":

| PR | Bump | Closed by | Reason |
|---|---|---|---|
| #289 | hmac 0.12.1 → 0.13.0 | michelbr84 | digest 0.10/0.11 workspace-wide incompat |
| #286 | sha2 0.10.9 → 0.11.0 | michelbr84 | mesmo motivo |
| #291 | opentelemetry 0.26 → 0.32 | michelbr84 | 6-version jump precisa migration code, não bump passivo |

Cada um gerou ~11 FAILUREs antes do close. Sem concurrency, futuros rebases do Dependabot empilham mais runs. Com este bloco, só a última fica.

## Pattern
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

- Group key usa PR number quando disponível (estável entre rebases) → `github.ref` para pushes diretos.
- `cancel-in-progress` é condicional: `true` só em `pull_request`, `false` em push (preserva main).

## Test plan
- [x] YAML parse OK (`python -m yaml`)
- [x] +10 LOC, sem outras alterações
- [ ] CI green nesta PR
- [ ] Próximo rebase de PR Dependabot cancela run anterior

🤖 Generated with [Claude Code](https://claude.com/claude-code)