### PR TITLE
chore(ci): add canonical concurrency to quality-ratchet + deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,10 @@ on:
         default: 'latest'
         type: string
 
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/garraia

--- a/.github/workflows/quality-ratchet.yml
+++ b/.github/workflows/quality-ratchet.yml
@@ -21,6 +21,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
   pull-requests: write   # required for `gh pr comment`


### PR DESCRIPTION
## Summary

PR cirúrgico que aplica o **padrão canônico de `concurrency:`** (estabelecido no PR #311) em dois workflows que ainda não o adotaram:

- **`quality-ratchet.yml`** — `cancel-in-progress` no padrão PR-aware. Como o workflow é report-only (`compare.py --mode report-only`), cancelar em PRs rebasados é seguro e elimina jobs órfãos durante batches Dependabot.
- **`deploy.yml`** — variante conservadora `cancel-in-progress: false` (não-cancela em-vôo). Deploy nunca deve ser cancelado durante push de imagem/ECS update.

### Patches

```yaml
# quality-ratchet.yml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}

# deploy.yml
concurrency:
  group: deploy-${{ github.ref }}
  cancel-in-progress: false
```

Total: **2 arquivos, +8 linhas**, sem código novo nem refactor.

## Contexto da auditoria

Este PR é o quick-fix de uma auditoria mais ampla dos GitHub Actions workflows do repositório. Achados principais:

- **Workflows reais:** 10 (CI, CodeQL custom, Security cargo-audit, Deploy, Garra Routine Trigger, Mutation Testing, Quality Ratchet, Release, Dependabot Updates, Dependency Graph).
- **Entradas na sidebar / `gh workflow list`:** 11 — uma a mais que o esperado.
- **Causa do "CodeQL duplicado":** entrada zumbi `268688350` do GitHub Default Setup desligado (API `code-scanning/default-setup` retorna `state: "not-configured"`). É **cosmético**, não produz runs paralelas, e não interfere no CodeQL custom (`269066117`, `.github/workflows/codeql.yml`).
- **Limpeza da entrada zumbi:** manual, pela UI em Settings → Code security and analysis (não há endpoint REST/CLI para deletar). Fora do escopo deste PR.
- **Ruleset:** `15901595 — Protect main` exige apenas 4 checks (Format Check, Clippy Linting, Test ubuntu-latest, Test windows-latest), todos jobs de `ci.yml`. Snapshot `docs/security/protect-main-ruleset.json` está em sincronismo. **Nenhum check fantasma — antes ou depois deste PR.**
- **Workflows NÃO modificados** (intencional): `ci.yml`, `codeql.yml`, `cargo-audit.yml`, `mutants.yml`, `garra-routine-trigger.yml`, `release.yml`.

## Follow-ups (não neste PR)

- `mutants.yml` está com falhas/timeouts nas últimas 6 runs — investigar separado.
- `release.yml` nunca rodou com sucesso (2 cancelamentos em branches `v*`) — verificar se trigger deve ser tags em vez de branches.
- Decidir se `language: javascript-typescript` ainda faz sentido na matrix do CodeQL custom.

## Test plan

- [x] YAML válido (`python -c "import yaml; yaml.safe_load(...)"`)
- [x] Diff cirúrgico (`git diff` mostra apenas o bloco `concurrency:` em cada arquivo)
- [ ] CI verde (4 required checks: Format Check, Clippy Linting, Test ubuntu-latest, Test windows-latest)
- [ ] `Quality Ratchet` job continua exit 0 (report-only)
- [ ] `gh workflow list` continua mostrando as mesmas 11 entradas
- [ ] Ruleset `15901595` required checks inalterados
- [ ] Merge **apenas com autorização explícita do Michel**

🤖 Generated with [Claude Code](https://claude.com/claude-code)