### PR TITLE
fix(mobile): clear Flutter analyzer + real mobile README

### DIFF
--- a/apps/garraia-mobile/README.md
+++ b/apps/garraia-mobile/README.md
@@ -1,17 +1,81 @@
-# garraia_mobile
+# garraia_mobile — Garra Cloud Alpha
 
-A new Flutter project.
+Cliente Flutter (Android / iOS / web preview) do gateway [GarraIA](../../README.md).
+Conversa com o agente local ou remoto via JWT + Dio sobre as rotas
+`/auth/*` e `/chat/*` expostas por `garraia-gateway`.
 
-## Getting Started
+## Stack
 
-This project is a starting point for a Flutter application.
+- **Flutter** 3.41+ (Dart 3.11+)
+- **Riverpod 2** + code generation para state management
+- **go_router** com redirect baseado em JWT
+- **Dio** + `_AuthInterceptor` (Bearer)
+- **flutter_secure_storage** para persistir o token (`garraia_jwt`)
+- **rive** para o mascote animado (placeholder até `assets/garra_mascot.riv`)
 
-A few resources to get you started if this is your first Flutter project:
+## Início rápido
 
-- [Learn Flutter](https://docs.flutter.dev/get-started/learn-flutter)
-- [Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Flutter learning resources](https://docs.flutter.dev/reference/learning-resources)
+```bash
+cd apps/garraia-mobile
+flutter pub get
+dart run build_runner build --delete-conflicting-outputs
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+# Emulador Android → backend local na porta 3888 (10.0.2.2 = host)
+flutter run
+
+# Apontar para o gateway na nuvem
+flutter run --dart-define=API_BASE_URL=https://api.garraia.org
+```
+
+Setup completo (pré-requisitos, build de APK, mascote Rive, variáveis de
+ambiente do backend): ver [`SETUP.md`](SETUP.md).
+
+## Endpoints consumidos
+
+| Endpoint           | Origem                         |
+|--------------------|--------------------------------|
+| `POST /auth/register` | `garraia-gateway` mobile auth (GAR-335) |
+| `POST /auth/login`    | idem                                   |
+| `GET  /me`            | idem                                   |
+| `POST /chat`          | `garraia-gateway` mobile chat (GAR-339) |
+| `GET  /chat/history`  | idem                                   |
+
+A base URL default é `http://10.0.2.2:3888` (loopback do emulador
+Android). Override via `--dart-define=API_BASE_URL=...`.
+
+## Estrutura
+
+```text
+lib/
+├── main.dart              # MaterialApp.router + ProviderScope
+├── router/app_router.dart # GoRouter + auth redirect
+├── services/api_service.dart
+├── providers/             # AuthState, ChatMessages, MascotState
+├── screens/               # splash, login, register, chat, settings
+└── widgets/               # MascotWidget (4 estados), ChatBubble
+assets/                    # ativos empacotados (Rive, ícones, fontes)
+test/                      # widget tests (Riverpod overrides)
+```
+
+## Testes
+
+```bash
+flutter analyze
+flutter test
+```
+
+Os widget tests injetam um stub de `ApiService` via
+`apiServiceProvider.overrideWithValue(...)`, mantendo a árvore offline
+e determinística.
+
+## Convenções
+
+- Riverpod com code generation (`*.g.dart` gerado, não commitado).
+- Nunca usar `withOpacity()` — usar `withValues(alpha:)` (CLAUDE.md raiz).
+- JWT armazenado em `flutter_secure_storage`, chave `garraia_jwt`.
+
+## Referências
+
+- Projeto raiz e arquitetura: [`README.md`](../../README.md)
+- Setup detalhado: [`SETUP.md`](SETUP.md)
+- ROADMAP e Linear: [`ROADMAP.md`](../../ROADMAP.md)

--- a/apps/garraia-mobile/assets/.gitkeep
+++ b/apps/garraia-mobile/assets/.gitkeep
@@ -1,0 +1,7 @@
+# Placeholder for the Flutter `assets/` directory declared in pubspec.yaml.
+#
+# Drop UI assets (mascot Rive files, icons, fonts, JSON, etc.) into this
+# directory. The pubspec.yaml entry `- assets/` already picks everything
+# up recursively at build time.
+#
+# Planned first asset: `garra_mascot.riv` — see lib/widgets/mascot_widget.dart.

--- a/apps/garraia-mobile/test/settings_screen_test.dart
+++ b/apps/garraia-mobile/test/settings_screen_test.dart
@@ -14,6 +14,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:garraia_mobile/screens/settings_screen.dart';
 import 'package:garraia_mobile/services/api_service.dart';
+import 'package:go_router/go_router.dart';
 
 class _StubApiService implements ApiService {
   final MeResult _me;
@@ -64,10 +65,28 @@ ProviderContainer _container(_StubApiService api) {
 }
 
 Widget _wrap(ProviderContainer container, Widget child) {
+  // SettingsScreen calls `context.go('/login')` on logout, so the widget
+  // tree needs a real GoRouter ancestor. Wiring the real `appRouterProvider`
+  // would drag in the app's auth-redirect logic and `flutter_secure_storage`
+  // — overkill for a UI test. A minimal local router with `/` and `/login`
+  // gives the screen exactly what `context.go` needs without coupling to
+  // production navigation behaviour.
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(path: '/', builder: (_, __) => child),
+      GoRoute(
+        path: '/login',
+        builder: (_, __) => const Scaffold(
+          body: Center(child: Text('login-stub')),
+        ),
+      ),
+    ],
+  );
   return UncontrolledProviderScope(
     container: container,
-    child: MaterialApp(
-      home: child,
+    child: MaterialApp.router(
+      routerConfig: router,
       theme: ThemeData(useMaterial3: true, brightness: Brightness.dark),
     ),
   );
@@ -143,7 +162,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(api.logoutCalled, isTrue,
-          'logout() must be called after dialog confirm');
+          reason: 'logout() must be called after dialog confirm');
     });
   });
 }


### PR DESCRIPTION
## Summary

Closes three diagnostics surfaced in `apps/garraia-mobile/`:

- **`test/settings_screen_test.dart:146`** — `expect(actual, matcher, 'reason')` rejected as 3 positional args; convert to named `reason:`. The compile error was hiding a latent bug: the test wrapper used plain `MaterialApp`, but `SettingsScreen` calls `context.go('/login')` on logout. Switch the wrapper to `MaterialApp.router` with a minimal local `GoRouter` so the logout test actually executes end-to-end.
- **`pubspec.yaml:72`** — `- assets/` declared, directory missing. Materialise `apps/garraia-mobile/assets/` with a `.gitkeep` (reserves the slot for the planned `garra_mascot.riv` referenced in `widgets/mascot_widget.dart`).
- **`apps/garraia-mobile/README.md`** — was the default `flutter create` scaffold. Rewritten as a real Garra Cloud Alpha overview (stack, quick start, endpoints, structure, conventions, links to `SETUP.md` + project root).

No changes outside `apps/garraia-mobile/`.

## Verification

- `flutter analyze` from `apps/garraia-mobile/` → `No issues found! (ran in 5.6s)`
- `flutter test test/settings_screen_test.dart` → `+2: All tests passed!`

### Pre-existing, out-of-scope

- `test/widget_test.dart` still fails with `databaseFactory not initialized` (sqflite needs `sqflite_common_ffi` + `databaseFactory = databaseFactoryFfi` in test bootstrap). Unrelated to the diagnostics reported here; touching neither `main.dart` nor `services/offline_queue.dart`.

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test test/settings_screen_test.dart` green (2/2)
- [ ] CI pipeline green on this branch