### PR TITLE
fix(security): close 17 Medium CodeQL alerts (perms + SRI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,20 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
+# Workflow-level default: read-only GITHUB_TOKEN. The `coverage` and
+# `dependency-review` jobs override with `pull-requests: write` to post their
+# PR comments. Closes CodeQL rule `actions/missing-workflow-permissions`
+# (Medium).
+permissions:
+  contents: read
+
 jobs:
   # Check formatting
   fmt:
     name: Format Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -41,6 +50,8 @@ jobs:
   clippy:
     name: Clippy Linting
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     # Plan 0049 (GAR-429 Lote Q.1, 2026-04-22) limpou os 26 warnings
     # pré-existentes (too_many_arguments, collapsible_if, explicit_auto_deref,
     # assertions_on_constants, new_without_default, items_after_test_module,
@@ -77,6 +88,8 @@ jobs:
   cargo-deny:
     name: cargo-deny
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -93,6 +106,12 @@ jobs:
     name: Dependency Review
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      # `comment-summary-in-pr: on-failure` below posts a PR comment via the
+      # GITHUB_TOKEN — requires pull-requests write. Without this, the comment
+      # silently 403s on first regression and the team loses signal.
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -115,6 +134,8 @@ jobs:
   gitleaks:
     name: Secret Scan (gitleaks)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -132,6 +153,8 @@ jobs:
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -338,6 +361,8 @@ jobs:
   build:
     name: Build Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -364,6 +389,8 @@ jobs:
   msrv:
     name: MSRV check (1.92)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -378,6 +405,8 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     # Plan 0050 Lote 2 (GAR-438, plan happy-finch 2026-04-24):
     # The previous "gateway exits immediately" hypothesis was wrong. Root cause
     # was that `garraia-gateway` is a library crate (no production [[bin]]);
@@ -513,6 +542,8 @@ jobs:
   playwright:
     name: Playwright E2E (MCP UI)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     # Plan 0050 Lote 2 (GAR-438, plan happy-finch 2026-04-24): same root cause
     # as the `e2e` job — the previous workflow ran a binary that never existed
     # (`./target/release/garraia-gateway`, but the real binary is `garra`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,19 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
+# Workflow-level default: read-only GITHUB_TOKEN. The `release` job overrides
+# this with `contents: write` to upload artifacts via softprops/action-gh-release.
+# Closes CodeQL rule `actions/missing-workflow-permissions` (Medium).
+permissions:
+  contents: read
+
 jobs:
   # Build for Linux x86_64
   build-linux-x86_64:
     name: Build Linux x86_64
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -46,6 +54,8 @@ jobs:
   build-linux-arm64:
     name: Build Linux ARM64
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -75,6 +85,8 @@ jobs:
   build-windows-x86_64:
     name: Build Windows x86_64
     runs-on: windows-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -101,6 +113,8 @@ jobs:
   build-macos-x86_64:
     name: Build macOS x86_64
     runs-on: macos-13
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -127,6 +141,8 @@ jobs:
   build-macos-arm64:
     name: Build macOS ARM64
     runs-on: macos-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/crates/garraia-gateway/src/admin.html
+++ b/crates/garraia-gateway/src/admin.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>GarraIA Admin Console</title>
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-9nhczxUqK87bcKHh20fSQcTGD4qq5GhayNYSYWqwBkINBhOfQLg/P5HG5lF1urn4" crossorigin="anonymous"></script>
 <style>
 :root {
   --bg-primary: #0f1117;

--- a/crates/garraia-gateway/src/webchat.html
+++ b/crates/garraia-gateway/src/webchat.html
@@ -4,10 +4,10 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>GarraIA Chat</title>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" id="hljs-theme" />
-<script src="https://cdnjs.cloudflare.com/ajax/libs/marked/12.0.0/marked.min.js"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css" integrity="sha384-wH75j6z1lH97ZOpMOInqhgKzFkAInZPPSPlZpYKYTOqsaizPvhQZmAtLcPKXpLyH" crossorigin="anonymous" id="hljs-theme" />
+<script src="https://cdnjs.cloudflare.com/ajax/libs/marked/12.0.0/marked.min.js" integrity="sha384-NNQgBjjuhtXzPmmy4gurS5X7P4uTt1DThyevz4Ua0IVK5+kazYQI1W27JHjbbxQz" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.1.7/purify.min.js" integrity="sha384-XQqX/4yiUGu+oyr87jvWzRuqBUK/adrY0DunhL+tID9m/9dwSpV8h9Fk/Sg6ifVQ" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" integrity="sha384-F/bZzf7p3Joyp5psL90p/p89AZJsndkSoGwRpXcZhleCWhd8SnRuoYo4d0yirjJp" crossorigin="anonymous"></script>
 <style>
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap");
 
@@ -1495,13 +1495,21 @@ function applyTheme(theme) {
   document.documentElement.setAttribute('data-theme', theme);
   localStorage.setItem('garraia.ui.theme', theme);
   State.currentTheme = theme;
-  // Update hljs theme
+  // Update hljs theme. The SRI on the static <link> in <head> only covers
+  // the initial dark CSS — when we swap `href` at runtime the browser
+  // refetches, so `integrity` + `crossorigin` must be set BEFORE `href` so
+  // the new fetch is verified. Hashes computed against the served files.
   const hljsLink = $('hljs-theme');
   if (hljsLink) {
     const isDark = !['light'].includes(theme);
-    hljsLink.href = isDark
-      ? 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css'
-      : 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css';
+    const next = isDark
+      ? { href: 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css',
+          integrity: 'sha384-wH75j6z1lH97ZOpMOInqhgKzFkAInZPPSPlZpYKYTOqsaizPvhQZmAtLcPKXpLyH' }
+      : { href: 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css',
+          integrity: 'sha384-eFTL69TLRZTkNfYZOLM+G04821K1qZao/4QLJbet1pP4tcF+fdXq/9CdqAbWRl/L' };
+    hljsLink.setAttribute('crossorigin', 'anonymous');
+    hljsLink.setAttribute('integrity', next.integrity);
+    hljsLink.href = next.href;
   }
   // Update preset buttons
   document.querySelectorAll('.skin-preset-btn[data-theme]').forEach(btn => {


### PR DESCRIPTION
## Summary

Closes all **17 open Medium CodeQL alerts** in [Code scanning](https://github.com/michelbr84/GarraRUST/security/code-scanning) with one bundled, surgical change:

| Rule | Count | Fix |
|------|-------|-----|
| `actions/missing-workflow-permissions` | 15 | Top-level `permissions: contents: read` + per-job least-privilege blocks in `ci.yml` and `release.yml` |
| `js/functionality-from-untrusted-source` | 2 | SRI `integrity` (sha384) + `crossorigin="anonymous"` on the 2 flagged cdnjs `<script>` tags in `webchat.html` |

### Workflow permissions (15 alerts)
- **ci.yml**: workflow-level `permissions: contents: read` + explicit per-job blocks on 10 jobs (fmt, clippy, cargo-deny, dependency-review, gitleaks, test, build, msrv, e2e, playwright). `coverage` and `security` already had their blocks (untouched).
- **release.yml**: workflow-level + per-job `contents: read` on 5 build-* matrix jobs. `release` keeps its pre-existing `contents: write` (required by `softprops/action-gh-release`).
- **dependency-review** elevated to `pull-requests: write` because of `comment-summary-in-pr: on-failure`.

### SRI (2 alerts + defense-in-depth)
- Added `integrity` + `crossorigin="anonymous"` to `marked@12.0.0/marked.min.js` and `highlight.js@11.9.0/highlight.min.js` (the 2 flagged tags).
- Also SRI-protected `github-dark.min.css` (same cdnjs origin, same risk profile, not flagged but free to harden).
- **Fixed runtime SRI bypass** flagged by `security-auditor` pre-commit: the theme switcher at `webchat.html:1497-1511` dynamically reassigns `hljsLink.href` to the light theme; the static `<link integrity>` doesn't cover that path. Both light + dark hashes are now set from JS before `href` change, so the browser re-verifies on theme toggle.

All three SHA-384 hashes were computed locally against the served files and verified stable across 3 consecutive fetches. cdnjs versioned URLs are immutable.

### Pre-merge review
- `security-auditor` agent: PASS after the SRI-bypass fix.
- `code-reviewer` agent: PASS in all three files.

## Test plan
- [x] YAML re-parses cleanly (12 jobs in ci.yml, 6 in release.yml, all with explicit `permissions:`).
- [x] All 4 cdnjs tags in webchat.html carry `integrity` + `crossorigin="anonymous"`.
- [x] Hashes verified stable across 3 fetches.
- [ ] CI passes (fmt, clippy, cargo-deny, dependency-review, gitleaks, test×3, coverage, build, msrv, e2e, playwright, security, quality-ratchet).
- [ ] After merge: CodeQL re-scans on main and confirms the 17 Medium alerts move to `fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)