### PR TITLE
fix(docker): bump runtime base to trixie-slim to match builder glibc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,18 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 # ---------------------------------------------------------------------------
 # Stage 5: Runtime — minimal production image
 # ---------------------------------------------------------------------------
-FROM debian:bookworm-slim AS runtime
+# Must match the builder's glibc. `rust:1.92-slim` (chef base, line 9) is
+# debian:trixie with glibc 2.39, so the `garra` binary is linked against
+# 2.39. Using bookworm here (glibc 2.36) made the binary fail at startup
+# with `GLIBC_2.39 not found` — discovered during the GAR-603 Runpod local
+# smoke test on 2026-05-13 (first runtime exercise of the image after the
+# rust:1.86 → 1.92 bump in PR #314, commit c1483e6). Same root cause as
+# the Runpod LB "timed out waiting for worker" symptom on endpoint
+# k3d2h9xumk2r4o: the worker container exited(1) before binding the port.
+#
+# Trixie's newer glibc is backward-compatible, so the Node 22 binary copied
+# from the bookworm-based node-installer stage continues to work here.
+FROM debian:trixie-slim AS runtime
 
 LABEL org.opencontainers.image.title="GarraIA Gateway" \
       org.opencontainers.image.description="Multi-channel, multi-provider LLM orchestration gateway" \


### PR DESCRIPTION
## Summary

The runtime container exits immediately with `GLIBC_2.39 not found` on every `docker run`. PR [#314](https://github.com/michelbr84/GarraRUST/pull/314) (commit [`c1483e6`](https://github.com/michelbr84/GarraRUST/commit/c1483e68e9f216660d4d2773deee8807dfb84357)) bumped the builder from `rust:1.86` to `rust:1.92`, which moved the builder base from `debian:bookworm` (glibc 2.36) to `debian:trixie` (glibc 2.39). The runtime stage was not bumped. The build still **succeeded** (no glibc check at build time), but the produced image is **not runnable**.

This is the same root cause as the [GAR-603](https://linear.app/chatgpt25/issue/GAR-603) Runpod LB symptom on endpoint `k3d2h9xumk2r4o` (`timed out waiting for worker`): the worker container exits before binding the port, so Runpod's `/ping` probe times out. GAR-603's `/ping` route, `PORT`/`HOST` env handling, and Dockerfile HEALTHCHECK all work — they're just unreachable until the image actually starts.

## Reproduction (before fix)

```bash
docker build -t garraia:repro .   # → succeeds
docker run --rm garraia:repro
# garra: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by garra)
# exit 1
```

Caught during the GAR-603 acceptance smoke test on 2026-05-14 (image `garraia:gar603` built from `main` at `cdebe9a`).

## The fix (1 line)

```diff
-FROM debian:bookworm-slim AS runtime
+FROM debian:trixie-slim AS runtime
```

Plus an inline comment block documenting the glibc constraint and the PR #314 context, so a future Rust bump doesn't re-introduce the same drift.

## Why trixie (not pin builder back to bookworm)

- Trixie is the current Debian stable as of 2025; bookworm is the prior stable.
- Trixie's glibc 2.39 is backward-compatible with binaries linked against 2.36 — so the Node 22 binary copied from the bookworm-based `node-installer` stage continues to work.
- The reverse (downgrade builder) would mean tracking down `rust:1.92-slim-bookworm` (variant existence not guaranteed) and re-introduces the drift risk on the next Rust bump.

## Local verification

```bash
docker build -t garraia:fix-glibc .          # → success
docker run -d -p 3888:3888 --name t garraia:fix-glibc
curl -i http://localhost:3888/ping           # → HTTP 200, body: pong
curl -i http://localhost:3888/health         # → HTTP 200, body: ok
docker logs t | grep listening
# 2026-05-14T04:05:09Z INFO garraia_gateway::server: GarraIA gateway listening on http://0.0.0.0:3888
```

All three of: container starts cleanly, `/ping` returns 200, `/health` returns 200.

## Scope

- One-line Dockerfile change + comment block.
- No code touched. No tests touched. Existing CI exercises the build, not the runtime — that's what let this slip in. (A "container starts and responds to /ping" smoke test in CI would prevent this whole class of bug; out of scope here, but worth a separate issue.)

## Related

- Unblocks: GAR-603 — Runpod LB Serverless compatibility (only acceptance item remaining is the public Runpod `/ping` smoke).
- Caused by: PR #314 / commit `c1483e6` (`fix(docker): unblock build (rust 1.92 + scope chef cook)`).

## Test plan

- [x] Local `docker build` → success.
- [x] Local `docker run` → container stays up, gateway binds to `0.0.0.0:3888`.
- [x] Local `curl /ping` → 200 `pong`.
- [x] Local `curl /health` → 200 `ok`.
- [ ] CI green on this PR.
- [ ] Post-merge: re-trigger `deploy.yml` on `main` to push fixed image to GHCR.
- [ ] Post-merge: redeploy Runpod endpoint `k3d2h9xumk2r4o`, then `curl https://k3d2h9xumk2r4o.api.runpod.ai/ping` → expected 200 `pong`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)