### PR TITLE
feat(web-console): plan 0116-PR-B — Garra Glass app-header + chat redesign

### DIFF
--- a/crates/garraia-gateway/src/webchat.html
+++ b/crates/garraia-gateway/src/webchat.html
@@ -535,6 +535,333 @@ nav.sidebar#sidebar .session-item-time { color: var(--garra-muted-2); }
 .sidebar-chip.warning { background: rgba(255, 176, 32, 0.16); color: var(--garra-warning); }
 .sidebar-chip.danger  { background: rgba(255, 92, 122, 0.16); color: var(--garra-danger); }
 
+/* ========================================================================
+   GARRA GLASS — APP HEADER (plan 0116 T3). 58px translucent header above
+   the 3-pane app-shell. Hosts hamburger + nav stub + status pills + theme
+   toggle. The body switches to flex-column to accommodate it.
+   ======================================================================== */
+body { display: flex; flex-direction: column; }
+.app-header {
+  height: 58px;
+  flex-shrink: 0;
+  background: rgba(3, 17, 38, 0.74);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.09);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+  gap: 16px;
+  position: relative;
+  z-index: 5;
+}
+@supports not (backdrop-filter: blur(1px)) {
+  .app-header { background: var(--garra-sidebar); }
+}
+.app-header .header-brand {
+  display: inline-flex; align-items: center; gap: 10px;
+  font-weight: 800; font-size: 15px;
+  color: #fff;
+}
+.app-header .header-brand .garra-logo {
+  width: 30px; height: 30px;
+  border-radius: 9px;
+  display: grid; place-items: center;
+  background: linear-gradient(135deg, var(--garra-primary), #fff3a0);
+  color: #05142c;
+  font-weight: 900;
+  font-size: 14px;
+  letter-spacing: -0.03em;
+  box-shadow: 0 8px 18px rgba(var(--garra-primary-rgb), 0.32);
+}
+.app-header nav.header-nav {
+  display: flex; gap: 4px;
+  margin-left: 4px;
+}
+.app-header nav.header-nav a, .app-header nav.header-nav button {
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--garra-muted);
+  font-family: var(--garra-font);
+  font-weight: 600;
+  font-size: 13px;
+  padding: 6px 12px;
+  border-radius: 10px;
+  cursor: pointer;
+  text-decoration: none;
+}
+.app-header nav.header-nav a:hover, .app-header nav.header-nav button:hover {
+  background: rgba(255, 255, 255, 0.06); color: #fff;
+}
+.app-header nav.header-nav a.active, .app-header nav.header-nav button.active {
+  background: rgba(var(--garra-accent-rgb), 0.18);
+  border-color: rgba(var(--garra-accent-rgb), 0.32);
+  color: #fff;
+}
+.app-header .header-right { margin-left: auto; display: flex; align-items: center; gap: 8px; flex-wrap: nowrap; }
+.app-header button.hamburger-btn,
+.app-header .header-icon-btn {
+  width: 36px; height: 36px;
+  border-radius: 10px;
+  border: 1px solid var(--garra-border);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--garra-text);
+  cursor: pointer;
+  display: grid; place-items: center;
+  font-size: 14px;
+  transition: background 120ms ease, transform 120ms ease;
+}
+.app-header button.hamburger-btn { display: grid; }
+.app-header .header-icon-btn:hover { background: rgba(255, 255, 255, 0.10); }
+.app-header .header-icon-btn[aria-disabled="true"] { opacity: 0.55; cursor: not-allowed; }
+.app-header .header-icon-btn .icon-svg { width: 16px; height: 16px; fill: currentColor; }
+
+/* Pill system (plan 0116 T3.4) — used by header + future right-panel */
+.pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: var(--garra-panel);
+  border: 1px solid var(--garra-border);
+  font-size: 12px; font-weight: 700;
+  color: var(--garra-text);
+  white-space: nowrap;
+}
+.pill .icon-svg { width: 14px; height: 14px; fill: currentColor; }
+.pill.success { background: rgba(32, 232, 135, 0.14); border-color: rgba(32, 232, 135, 0.3); color: var(--garra-success); }
+.pill.warning { background: rgba(255, 176, 32, 0.14); border-color: rgba(255, 176, 32, 0.3); color: var(--garra-warning); }
+.pill.danger  { background: rgba(255, 92, 122, 0.14); border-color: rgba(255, 92, 122, 0.3); color: var(--garra-danger); }
+[data-theme="light"] .pill,
+[data-bs-theme="light"] .pill { color: #06142b; }
+[data-theme="light"] .pill.success, [data-bs-theme="light"] .pill.success { color: #066a3a; background: rgba(32, 232, 135, 0.22); border-color: rgba(20, 150, 90, 0.45); }
+[data-theme="light"] .pill.warning, [data-bs-theme="light"] .pill.warning { color: #7a4500; background: rgba(255, 176, 32, 0.24); border-color: rgba(190, 120, 12, 0.45); }
+[data-theme="light"] .pill.danger,  [data-bs-theme="light"] .pill.danger  { color: #7a1a2d; background: rgba(255, 92, 122, 0.22); border-color: rgba(180, 40, 60, 0.45); }
+
+.status-dot {
+  width: 8px; height: 8px; border-radius: 999px;
+  background: var(--garra-success);
+  box-shadow: 0 0 0 4px rgba(32, 232, 135, 0.18);
+  flex-shrink: 0;
+}
+.status-dot.warning { background: var(--garra-warning); box-shadow: 0 0 0 4px rgba(255, 176, 32, 0.18); }
+.status-dot.danger  { background: var(--garra-danger);  box-shadow: 0 0 0 4px rgba(255, 92, 122, 0.18); }
+.status-dot.offline { background: var(--garra-muted-2); box-shadow: 0 0 0 4px rgba(113, 134, 174, 0.20); }
+
+/* App-shell adjustments for header coexistence (plan 0116 T3.3) */
+.app-shell { flex: 1; min-height: 0; height: auto !important; }
+@media (max-width: 768px) {
+  .app-header { padding: 0 10px; gap: 8px; }
+  .app-header nav.header-nav { display: none; }
+  .app-header .header-right .url-pill,
+  .app-header .header-right .status-pill-text { display: none; }
+}
+
+/* ========================================================================
+   GARRA GLASS — CHAT REDESIGN (plan 0116 T4). Wraps the chat in a
+   translucent glass-panel, redesigns bubbles with avatars (cyan/purple AI,
+   gold user), warning-box variant, and a gold send button.
+   ======================================================================== */
+.glass-panel {
+  background: var(--garra-panel);
+  border: 1px solid var(--garra-border);
+  border-radius: var(--garra-radius);
+  box-shadow: var(--garra-shadow);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+@supports not (backdrop-filter: blur(1px)) {
+  .glass-panel { background: var(--garra-panel-2); }
+}
+main.chat-area {
+  background: transparent;
+  padding: 16px;
+  min-width: 0;
+}
+.chat-console {
+  flex: 1;
+  display: flex; flex-direction: column;
+  min-height: 0;
+}
+main.chat-area > .glass-panel.chat-console {
+  flex: 1;
+  display: flex; flex-direction: column;
+  overflow: hidden;
+}
+
+/* Panel header — used by chat + future right panel */
+.panel-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--garra-border);
+  gap: 10px;
+}
+.panel-title {
+  display: inline-flex; align-items: center; gap: 10px;
+  margin: 0;
+  font-family: var(--garra-font);
+  font-weight: 800;
+  font-size: 15px;
+  color: var(--garra-text);
+}
+.icon-box {
+  width: 32px; height: 32px;
+  border-radius: 10px;
+  display: grid; place-items: center;
+  background: rgba(var(--garra-accent-rgb), 0.18);
+  color: var(--garra-accent);
+}
+.icon-box .icon-svg { width: 16px; height: 16px; fill: currentColor; }
+
+/* Chat header (replacement for legacy .chat-header — same element, new look) */
+main.chat-area > .glass-panel.chat-console > .panel-header { background: transparent; min-height: 56px; flex-shrink: 0; }
+main.chat-area > .glass-panel.chat-console > .panel-header .chat-title {
+  font-weight: 800; font-size: 15px; letter-spacing: -0.01em; color: var(--garra-text);
+}
+main.chat-area > .glass-panel.chat-console > .panel-header .chat-header-left,
+main.chat-area > .glass-panel.chat-console > .panel-header .chat-header-right { display: flex; align-items: center; gap: 10px; }
+
+/* Messages scroller */
+main.chat-area > .glass-panel.chat-console > .chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 22px 20px;
+  background: transparent;
+  display: flex; flex-direction: column;
+  gap: 4px;
+}
+
+/* Message groups + bubbles (Garra Glass) */
+main.chat-area .message-group {
+  animation: fadeInUp var(--garra-anim-duration) ease both;
+  padding: 12px 0;
+  gap: 12px;
+}
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+main.chat-area .message-group .msg-avatar {
+  width: 36px; height: 36px;
+  border-radius: 12px;
+  display: grid; place-items: center;
+  font-weight: 800;
+  font-size: 14px;
+  flex-shrink: 0;
+  background: linear-gradient(135deg, var(--garra-accent), var(--garra-purple));
+  color: #fff;
+  margin-top: 2px;
+  box-shadow: 0 8px 22px rgba(22, 217, 255, 0.22);
+}
+main.chat-area .message-group.user-group .msg-avatar {
+  background: linear-gradient(135deg, var(--garra-primary), #fff3a0);
+  color: #05142c;
+  box-shadow: 0 8px 22px rgba(var(--garra-primary-rgb), 0.32);
+}
+main.chat-area .message-group .msg-body {
+  background: var(--garra-panel-2);
+  border: 1px solid var(--garra-border);
+  border-radius: 18px;
+  padding: 12px 16px;
+  color: var(--garra-text);
+  max-width: 78ch;
+  line-height: 1.55;
+}
+main.chat-area .message-group.user-group .msg-body {
+  background: linear-gradient(135deg, rgba(var(--garra-accent-rgb), 0.42), rgba(var(--garra-accent-rgb), 0.22));
+  color: var(--garra-text);
+  border-color: rgba(var(--garra-accent-rgb), 0.4);
+  border-bottom-right-radius: 6px;
+}
+main.chat-area .message-group.ai-group .msg-body {
+  border-bottom-left-radius: 6px;
+}
+main.chat-area .message-group.system-group {
+  justify-content: center;
+}
+main.chat-area .message-group.system-group .msg-body {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px dashed var(--garra-border);
+  color: var(--garra-muted);
+  font-size: 12px;
+  text-align: center;
+}
+[data-theme="light"] main.chat-area .message-group .msg-body,
+[data-bs-theme="light"] main.chat-area .message-group .msg-body { color: #06142b; }
+[data-theme="light"] main.chat-area .message-group.system-group .msg-body,
+[data-bs-theme="light"] main.chat-area .message-group.system-group .msg-body { color: #466080; }
+[data-theme="light"] main.chat-area .message-group.user-group .msg-body,
+[data-bs-theme="light"] main.chat-area .message-group.user-group .msg-body { color: #06142b; }
+
+/* Warning-box — replaces "Not connected" banner */
+.warning-box {
+  display: flex; gap: 12px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: rgba(255, 92, 122, 0.10);
+  border: 1px solid rgba(255, 92, 122, 0.32);
+  color: var(--garra-danger);
+  font-size: 13px;
+  align-items: flex-start;
+}
+.warning-box .icon-svg { width: 18px; height: 18px; flex-shrink: 0; fill: currentColor; margin-top: 2px; }
+.warning-box.amber {
+  background: rgba(255, 176, 32, 0.10);
+  border-color: rgba(255, 176, 32, 0.32);
+  color: var(--garra-warning);
+}
+
+/* Chat input bar — gold send + glass strip */
+main.chat-area > .glass-panel.chat-console > .chat-input-area {
+  background: transparent;
+  border-top: 1px solid var(--garra-border);
+  padding: 12px 16px 16px;
+  flex-shrink: 0;
+}
+main.chat-area > .glass-panel.chat-console > .chat-input-area .input-wrapper {
+  background: var(--garra-panel-2);
+  border: 1px solid var(--garra-border-strong);
+  border-radius: 18px;
+  padding: 8px 10px;
+  max-width: 900px;
+  margin: 0 auto;
+  align-items: center;
+}
+main.chat-area > .glass-panel.chat-console > .chat-input-area .input-wrapper:focus-within {
+  border-color: rgba(var(--garra-accent-rgb), 0.55);
+  box-shadow: 0 0 0 4px rgba(var(--garra-accent-rgb), 0.18);
+}
+main.chat-area > .glass-panel.chat-console > .chat-input-area #chat-input {
+  color: var(--garra-text);
+  font-family: var(--garra-font);
+}
+main.chat-area > .glass-panel.chat-console > .chat-input-area #chat-input::placeholder { color: var(--garra-muted-2); }
+main.chat-area > .glass-panel.chat-console > .chat-input-area .input-btn {
+  color: var(--garra-muted);
+  border-radius: 10px;
+}
+main.chat-area > .glass-panel.chat-console > .chat-input-area .input-btn:hover { background: rgba(255, 255, 255, 0.06); color: var(--garra-text); }
+main.chat-area > .glass-panel.chat-console > .chat-input-area .input-btn .icon-svg { width: 16px; height: 16px; fill: currentColor; }
+main.chat-area > .glass-panel.chat-console > .chat-input-area .send-btn {
+  width: 40px; height: 40px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, var(--garra-primary), #fff3a0);
+  color: #05142c;
+  box-shadow: 0 12px 26px rgba(var(--garra-primary-rgb), 0.32);
+  transition: transform 120ms ease, box-shadow 120ms ease;
+  display: grid; place-items: center;
+}
+main.chat-area > .glass-panel.chat-console > .chat-input-area .send-btn:hover {
+  transform: translateY(-1px);
+  background: linear-gradient(135deg, var(--garra-primary), #fff3a0);
+  box-shadow: 0 16px 32px rgba(var(--garra-primary-rgb), 0.45);
+}
+main.chat-area > .glass-panel.chat-console > .chat-input-area .send-btn .icon-svg { width: 16px; height: 16px; fill: currentColor; }
+[data-theme="light"] main.chat-area > .glass-panel.chat-console > .chat-input-area #chat-input,
+[data-bs-theme="light"] main.chat-area > .glass-panel.chat-console > .chat-input-area #chat-input { color: #06142b; }
+[data-theme="light"] main.chat-area > .glass-panel.chat-console > .chat-input-area .input-btn,
+[data-bs-theme="light"] main.chat-area > .glass-panel.chat-console > .chat-input-area .input-btn { color: var(--garra-muted-2); }
+
 nav.sidebar#sidebar .sidebar-footer-btn {
   color: var(--garra-muted);
   border-radius: 12px;
@@ -1348,6 +1675,39 @@ nav.sidebar#sidebar .sidebar-footer-btn .icon-svg rect {
 </style>
 </head>
 <body>
+<!-- APP HEADER (plan 0116 T3) -->
+<header class="app-header" data-testid="garra-app-header" role="banner">
+  <button class="hamburger-btn" id="hamburger-btn" title="Toggle sidebar" aria-label="Toggle sidebar">
+    <svg class="icon-svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z"/></svg>
+  </button>
+  <span class="header-brand">
+    <span class="garra-logo" title="🦀 Powered by Rust">G</span>
+    GarraIA
+  </span>
+  <nav class="header-nav" aria-label="Console pages">
+    <button class="active" type="button" data-page="chat">Chat</button>
+    <!-- TODO plan 0117: Dashboard / Providers / Channels / Sessions / Settings / Diagnostics / Logs / Skins -->
+  </nav>
+  <div class="header-right">
+    <span class="pill success status-pill-text" title="Gateway status">
+      <span class="status-dot"></span>
+      Gateway running
+    </span>
+    <span class="pill url-pill" id="gateway-url-pill" title="Gateway URL">
+      <svg class="icon-svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M4.5 11.5A.5.5 0 0 1 5 11h6a.5.5 0 0 1 0 1H5a.5.5 0 0 1-.5-.5zm-2-1A.5.5 0 0 1 3 10h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-7A.5.5 0 0 1 3 3h10a.5.5 0 0 1 .5.5v5a.5.5 0 0 1-.5.5H3a.5.5 0 0 1-.5-.5v-5zM3 4v4h10V4H3z"/></svg>
+      <span id="gateway-url-text">http://127.0.0.1:3888</span>
+    </span>
+    <button class="header-icon-btn" type="button" id="header-bell-btn" title="Notifications (em breve)" aria-disabled="true">
+      <svg class="icon-svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 16a2 2 0 0 0 2-2H6a2 2 0 0 0 2 2zM8 1.918l-.797.161A4.002 4.002 0 0 0 4 6c0 .628-.134 2.197-.459 3.742-.16.767-.376 1.566-.663 2.258h10.244c-.287-.692-.502-1.49-.663-2.258C12.134 8.197 12 6.628 12 6a4.002 4.002 0 0 0-3.203-3.92L8 1.917zM14.22 12c.223.447.481.801.78 1H1c.299-.199.557-.553.78-1C2.68 10.2 3 6.88 3 6c0-2.42 1.72-4.44 4.005-4.901a1 1 0 1 1 1.99 0A5.002 5.002 0 0 1 13 6c0 .88.32 4.2 1.22 6z"/></svg>
+    </button>
+    <button class="header-icon-btn" type="button" id="header-theme-toggle" title="Toggle theme (light/dark)">
+      <svg class="icon-svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M6 .278a.77.77 0 0 1 .08.858 7.2 7.2 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277.527 0 1.04-.055 1.533-.16a.79.79 0 0 1 .81.316.73.73 0 0 1-.031.893A8.349 8.349 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.75.75 0 0 1 6 .278z"/></svg>
+    </button>
+    <button class="header-icon-btn" type="button" id="right-panel-toggle" title="Toggle context panel">
+      <svg class="icon-svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M10 4.5a.5.5 0 0 1 .5-.5h2a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1-.5-.5v-7zM2 4.5a.5.5 0 0 1 .5-.5h6a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-.5.5h-6a.5.5 0 0 1-.5-.5v-7z"/></svg>
+    </button>
+  </div>
+</header>
 <div class="app-shell">
   <!-- LEFT SIDEBAR -->
   <nav class="sidebar" id="sidebar">
@@ -1388,19 +1748,21 @@ nav.sidebar#sidebar .sidebar-footer-btn .icon-svg rect {
 
   <!-- CENTER — Chat -->
   <main class="chat-area">
-    <header class="chat-header">
-      <div class="chat-header-left">
-        <button class="hamburger-btn" id="hamburger-btn" title="Toggle sidebar">&#9776;</button>
+    <div class="glass-panel chat-console" data-testid="garra-chat-panel">
+    <div class="panel-header chat-header">
+      <h3 class="panel-title">
+        <span class="icon-box">
+          <svg class="icon-svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M2.678 11.894a1 1 0 0 1 .287.801 10.97 10.97 0 0 1-.398 2c1.395-.323 2.247-.697 2.634-.893a1 1 0 0 1 .71-.074A8.06 8.06 0 0 0 8 14c3.996 0 7-2.807 7-6 0-3.192-3.004-6-7-6S1 4.808 1 8c0 1.468.617 2.83 1.678 3.894zm-.493 3.905a21.682 21.682 0 0 1-.713.129c-.2.032-.352-.176-.273-.362a9.68 9.68 0 0 0 .244-.637l.003-.01c.248-.72.45-1.548.524-2.319C.743 11.37 0 9.76 0 8c0-3.866 3.582-7 8-7s8 3.134 8 7-3.582 7-8 7a9.06 9.06 0 0 1-2.347-.306c-.52.263-1.639.742-3.468 1.105z"/></svg>
+        </span>
         <span class="chat-title" id="chat-title">New Conversation</span>
-      </div>
+      </h3>
       <div class="chat-header-right">
-        <span class="header-badge" id="conn-badge">
-          <span class="dot dot-offline" id="conn-dot"></span>
+        <span class="pill success" id="conn-badge" data-testid="garra-conn-badge">
+          <span class="status-dot offline" id="conn-dot"></span>
           <span id="conn-status">Disconnected</span>
         </span>
-        <button class="input-btn" id="right-panel-toggle" title="Toggle info panel">&#9776;</button>
       </div>
-    </header>
+    </div>
 
     <div class="chat-messages" id="chat-messages">
       <div class="message-group system-group">
@@ -1483,11 +1845,16 @@ nav.sidebar#sidebar .sidebar-footer-btn .icon-svg rect {
               </div>
             </div>
           </div>
-          <button class="input-btn" id="mic-btn" title="Voice input (hold or click to record)">&#127908;</button>
-          <button class="send-btn" id="send-btn" title="Send message">&#10148;</button>
+          <button class="input-btn" id="mic-btn" title="Voice input (hold or click to record)">
+            <svg class="icon-svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M5 3a3 3 0 0 1 6 0v5a3 3 0 0 1-6 0V3z"/><path d="M3.5 6.5A.5.5 0 0 1 4 7v1a4 4 0 0 0 8 0V7a.5.5 0 0 1 1 0v1a5 5 0 0 1-4.5 4.975V15h3a.5.5 0 0 1 0 1h-7a.5.5 0 0 1 0-1h3v-2.025A5 5 0 0 1 3 8V7a.5.5 0 0 1 .5-.5z"/></svg>
+          </button>
+          <button class="send-btn" id="send-btn" title="Send message" aria-label="Send">
+            <svg class="icon-svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M15.964.686a.5.5 0 0 0-.65-.65L.767 5.855H.766l-.452.18a.5.5 0 0 0-.082.887l.41.26.001.002 4.995 3.178 3.178 4.995.002.002.26.41a.5.5 0 0 0 .886-.083l6-15zm-1.833 1.89L6.637 10.07l-.215-.338a.5.5 0 0 0-.154-.154l-.338-.215 7.494-7.494 1.178-.471-.47 1.178z"/></svg>
+          </button>
         </div>
       </div>
     </div>
+    </div><!-- /.glass-panel.chat-console -->
   </main>
 
   <!-- RIGHT PANEL -->
@@ -1702,6 +2069,10 @@ chatMessages.addEventListener('click', function(e) {
 // ─── Theme System ─────────────────────────────────────────────────────
 function applyTheme(theme) {
   document.documentElement.setAttribute('data-theme', theme);
+  // Plan 0116 / ADR 0009: dual attribute parity for Garra Glass design system.
+  // Only `light` vs everything-else is meaningful for `data-bs-theme` (the
+  // AdminLTE-derived stylesheets only branch on those two states).
+  document.documentElement.setAttribute('data-bs-theme', theme === 'light' ? 'light' : 'dark');
   localStorage.setItem('garraia.ui.theme', theme);
   State.currentTheme = theme;
   // Update hljs theme. The SRI on the static <link> in <head> only covers
@@ -2898,6 +3269,20 @@ async function boot() {
   refreshStatus();
   loadExtensions();
   loadSessions();
+
+  // Plan 0116 T3: header-bound chrome. Bind header theme toggle + sync the
+  // gateway-URL pill against the live origin (works for 127.0.0.1, Runpod
+  // proxy domains, https endpoints, all the same code path).
+  try {
+    const urlText = document.getElementById('gateway-url-text');
+    if (urlText) urlText.textContent = window.location.origin || urlText.textContent;
+  } catch (e) { /* non-fatal */ }
+  const headerThemeBtn = document.getElementById('header-theme-toggle');
+  if (headerThemeBtn) {
+    headerThemeBtn.addEventListener('click', () => {
+      applyTheme(State.currentTheme === 'light' ? 'dark' : 'light');
+    });
+  }
 
   try {
     const r = await fetch('/api/auth-check');


### PR DESCRIPTION
## Summary

Second slice of the Garra Glass web-console redesign (plan `0116a` §T3+T4). Builds directly on top of PR #330 which landed the design tokens and sidebar redesign.

- **T3 (app-header, 58px):** new translucent header above `.app-shell` (body flips to flex-column). Hosts the hamburger (moved from chat-header), brand badge, single \"Chat\" nav button, Gateway-running pill, live origin URL pill, disabled bell, theme toggle, and the right-panel toggle (also moved out of chat-header). `@supports not (backdrop-filter)` fallback keeps it legible on older browsers.
- **T3.4 (pill primitive):** `.pill` (+ `.success` / `.warning` / `.danger`) and `.status-dot` (+ same variants) — reused by header AND right-panel (PR-C). Explicit light-theme overrides so pills stay AA-readable on the pastel background.
- **T4 (chat redesign):** chat wrapped in `.glass-panel.chat-console`. New `.panel-header` (with `.icon-box` + `.panel-title`). Conn-badge becomes a pill with `.status-dot`. Message bubbles: fadeInUp 720ms, AI avatar = cyan→purple gradient, user avatar + bubble = gold→cream. Welcome message renders as a dashed glass pill. `.warning-box` primitive ready for \"Not connected\" banner. Input bar = glass strip with cyan focus halo + gold send button (translateY hover) + inline SVG mic / send icons.

### JS wiring (additive — zero ID renames)

- `applyTheme()` now mirrors the chosen theme into BOTH `data-theme` AND `data-bs-theme` (Garra Glass dual-attribute parity, ADR 0009 §4).
- `boot()` syncs `#gateway-url-text` against `window.location.origin` (works for 127.0.0.1, Runpod proxy, https — same code path) and binds `#header-theme-toggle` → `applyTheme()` flip.

All ID contracts from PR-A preserved (`hamburger-btn`, `chat-title`, `conn-badge`, `conn-dot`, `conn-status`, `right-panel-toggle`, `chat-messages`, `chat-input`, `mic-btn`, `send-btn`).

## Test plan

- [x] `cargo check -p garraia-gateway` (green, 4.43s)
- [ ] CI: fmt / clippy / test / audit / deny / coverage / Playwright (admin) / Quality Ratchet
- [ ] Manual smoke: `cargo build --bin garraia --release && ./target/release/garraia start --port 3888` → visit http://127.0.0.1:3888, verify the 58px gold-G app-header, chat glass-panel, gold send button, conn-badge pill, theme toggle works
- [ ] Visual diff: PR description should include 4 screenshots (dark/light × desktop/mobile)

## Follow-ups

- **PR-C (plan 0116a §T5-T10):** right panel tabs + remaining SVG icons + animations + light parity + mobile + Playwright smoke spec.
- **PR-4..PR-10:** multi-page console (Dashboard / Providers / Channels / Sessions / Settings / Diagnostics / Logs / Skins) + Rust endpoints.

Closes part of GAR-609.

🤖 Generated with [Claude Code](https://claude.com/claude-code)