### PR TITLE
feat(gateway): plan 0118 — /api/health Dashboard schema + /api/capabilities

### DIFF
--- a/crates/garraia-gateway/src/health.rs
+++ b/crates/garraia-gateway/src/health.rs
@@ -33,10 +33,36 @@ pub struct HealthStatus {
 }
 
 /// Aggregate health response for the `/api/health` endpoint.
+///
+/// Plan 0118 / PR-5 extends the original `{status, checks}` shape with the
+/// fields the web-console Dashboard consumes (`version`, `gateway_url`,
+/// `uptime_secs`, `active_sessions`, `provider`, `model`, `channels`,
+/// `warnings`). `checks` is retained for back-compat with any operator
+/// scripts that already parsed it.
+///
+/// Secret-free by construction: nothing in the response derives from
+/// `state.config.gateway.api_key` or any provider API key.
 #[derive(Debug, Clone, Serialize)]
 pub struct HealthResponse {
     /// Overall status: "healthy", "degraded", or "unhealthy"
     pub status: String,
+    /// Gateway binary version (`CARGO_PKG_VERSION` at build time).
+    pub version: &'static str,
+    /// Effective listener URL (`http(s)://host:port`).
+    pub gateway_url: String,
+    /// Seconds since process boot.
+    pub uptime_secs: u64,
+    /// Number of in-memory sessions (DashMap entry count).
+    pub active_sessions: usize,
+    /// Default LLM provider id, if one is configured.
+    pub provider: Option<String>,
+    /// Configured model on the default provider, if any.
+    pub model: Option<String>,
+    /// Live channel registry list.
+    pub channels: Vec<String>,
+    /// Human-readable warnings derived from failed `checks`.
+    pub warnings: Vec<String>,
+    /// Per-check results (preserved for back-compat).
     pub checks: Vec<HealthStatus>,
 }
 
@@ -328,44 +354,74 @@ pub fn spawn_periodic_checks(state: SharedState, cache: HealthCache) {
 
 // ─── HTTP Endpoint ─────────────────────────────────────────────────────────
 
-/// GET /api/health — returns JSON with all provider health statuses.
+/// Computes the gateway URL from the live config (`scheme://host:port`).
+/// `scheme` is `https` when TLS is configured, otherwise `http`. Used in
+/// `/api/health` and `/api/capabilities`.
+fn gateway_url_from_config(cfg: &garraia_config::AppConfig) -> String {
+    let scheme = if cfg.gateway.tls_cert_path.is_some() {
+        "https"
+    } else {
+        "http"
+    };
+    format!("{}://{}:{}", scheme, cfg.gateway.host, cfg.gateway.port)
+}
+
+/// Builds the Dashboard-friendly fields shared by `/api/health` and the
+/// embedded status preview. Extracts a default-provider id + model and
+/// the live channel list without touching any secret.
+fn extras_from_state(state: &SharedState) -> (Vec<String>, Option<String>, Option<String>) {
+    // Channels — `state.channels.read()` is async, but we delegate to the
+    // caller; this helper only computes provider/model. Channels handled
+    // separately.
+    let provider = state
+        .agents
+        .default_provider_id()
+        .map(|s| s.to_string());
+    let model = provider
+        .as_deref()
+        .and_then(|p| state.agents.get_provider(p))
+        .and_then(|p| p.configured_model().map(|m| m.to_string()));
+    (Vec::new(), provider, model)
+}
+
+/// GET /api/health — Dashboard contract per plan 0116b §6.1 + back-compat
+/// `checks` array. Always 200; degraded/unhealthy is conveyed in the
+/// `status` field, never the HTTP code (the Web Console renders an amber
+/// or red warning-box without losing the rest of the payload).
 ///
 /// ```json
 /// {
 ///   "status": "degraded",
-///   "checks": [
-///     {"name": "openrouter", "ok": true, "latency_ms": 231},
-///     {"name": "ollama", "ok": false, "error": "connection refused"},
-///     {"name": "chatterbox", "ok": true, "latency_ms": 42}
-///   ]
+///   "version": "0.2.0",
+///   "gateway_url": "http://127.0.0.1:3888",
+///   "uptime_secs": 1234,
+///   "active_sessions": 2,
+///   "provider": "openrouter",
+///   "model": "openrouter/auto",
+///   "channels": ["web", "telegram"],
+///   "warnings": ["ollama: connection refused"],
+///   "checks": [ {"name": "openrouter", "ok": true, "latency_ms": 231}, ... ]
 /// }
 /// ```
 pub async fn health_handler(State(state): State<SharedState>) -> Json<HealthResponse> {
-    // Try to read from cache first
-    if let Some(cache) = &state.health_cache {
+    // Provider check results: prefer cache, fall back to a live run.
+    let checks = if let Some(cache) = &state.health_cache {
         let cached = cache.read().await;
         if !cached.is_empty() {
-            let healthy = cached.iter().filter(|r| r.ok).count();
-            let total = cached.len();
-            let status = if healthy == total {
-                "healthy"
-            } else if healthy > 0 {
-                "degraded"
-            } else {
-                "unhealthy"
-            };
-            return Json(HealthResponse {
-                status: status.to_string(),
-                checks: cached.clone(),
-            });
+            cached.clone()
+        } else {
+            run_all_checks(&state).await
         }
-    }
+    } else {
+        run_all_checks(&state).await
+    };
 
-    // No cache available — run checks now
-    let results = run_all_checks(&state).await;
-    let healthy = results.iter().filter(|r| r.ok).count();
-    let total = results.len();
-    let status = if healthy == total {
+    let healthy = checks.iter().filter(|r| r.ok).count();
+    let total = checks.len();
+    let status = if total == 0 {
+        // No registered checks — gateway itself is up; report healthy.
+        "healthy"
+    } else if healthy == total {
         "healthy"
     } else if healthy > 0 {
         "degraded"
@@ -373,8 +429,139 @@ pub async fn health_handler(State(state): State<SharedState>) -> Json<HealthResp
         "unhealthy"
     };
 
+    let warnings: Vec<String> = checks
+        .iter()
+        .filter(|c| !c.ok)
+        .map(|c| match &c.error {
+            Some(e) => format!("{}: {}", c.name, e),
+            None => format!("{}: unhealthy", c.name),
+        })
+        .collect();
+
+    let channels: Vec<String> = state
+        .channels
+        .read()
+        .await
+        .list()
+        .into_iter()
+        .map(|s| s.to_string())
+        .collect();
+
+    let (_unused, provider, model) = extras_from_state(&state);
+
     Json(HealthResponse {
         status: status.to_string(),
-        checks: results,
+        version: env!("CARGO_PKG_VERSION"),
+        gateway_url: gateway_url_from_config(&state.config),
+        uptime_secs: state.boot_time.elapsed().as_secs(),
+        active_sessions: state.sessions.len(),
+        provider,
+        model,
+        channels,
+        warnings,
+        checks,
+    })
+}
+
+// ─── /api/capabilities ─────────────────────────────────────────────────────
+
+/// What the Web Console + future remote clients can rely on. Each list is
+/// computed live from the running gateway (`AgentRuntime`,
+/// `ChannelRegistry`, `CommandRegistry`). Secret-free.
+#[derive(Debug, Clone, Serialize)]
+pub struct CapabilitiesResponse {
+    /// Cargo-feature-flag-shaped capability flags.
+    pub features: Vec<String>,
+    /// Provider IDs currently registered (sorted, deduped).
+    pub providers: Vec<String>,
+    /// Per-provider configured model — emitted as `provider/model`.
+    pub models: Vec<String>,
+    /// Live channel registry list.
+    pub channels: Vec<String>,
+    /// Slash-command registry — names only, no descriptions or aliases that
+    /// might leak admin paths.
+    pub commands: Vec<String>,
+    /// Skin / theme presets the front-end can offer.
+    pub skins: Vec<String>,
+    /// Forward-compat hook for `--experimental-*` flags. Empty for now.
+    pub experimental_flags: Vec<String>,
+    /// Gateway binary version, mirroring `/api/health`.
+    pub version: &'static str,
+}
+
+/// GET /api/capabilities — read-only snapshot of what the gateway can
+/// currently do. Renders the Dashboard "Arquitetura" card + drives the
+/// Skins page enumeration without hardcoded JS lists.
+pub async fn capabilities_handler(
+    State(state): State<SharedState>,
+) -> Json<CapabilitiesResponse> {
+    // Static feature flags driven by Cargo cfg + runtime state shape.
+    let mut features: Vec<String> = Vec::new();
+    features.push("chat".into());
+    features.push("websocket".into());
+    features.push("multi-channel".into());
+    if state.voice_client.is_some() {
+        features.push("tts".into());
+    }
+    if state.stt_client.is_some() {
+        features.push("stt".into());
+    }
+    if state.mcp_manager_arc.is_some() {
+        features.push("mcp".into());
+    }
+    if state.openclaw_client.is_some() {
+        features.push("openclaw".into());
+    }
+    if state.auth_provider.is_some() {
+        features.push("auth-v1".into());
+    }
+
+    let mut providers: Vec<String> = state.agents.provider_ids().to_vec();
+    providers.sort();
+    providers.dedup();
+
+    let models: Vec<String> = providers
+        .iter()
+        .filter_map(|pid| {
+            state
+                .agents
+                .get_provider(pid)
+                .and_then(|p| p.configured_model().map(|m| format!("{}/{}", pid, m)))
+        })
+        .collect();
+
+    let channels: Vec<String> = state
+        .channels
+        .read()
+        .await
+        .list()
+        .into_iter()
+        .map(|s| s.to_string())
+        .collect();
+
+    let commands: Vec<String> = state
+        .command_registry
+        .read()
+        .map(|r| r.list().into_iter().map(|(n, _d)| n.to_string()).collect())
+        .unwrap_or_default();
+
+    // Plan 0117 lists four canonical skins. The Settings Registry (PR-8)
+    // can later persist user-defined skins server-side.
+    let skins: Vec<String> = vec![
+        "garra-blue".into(),
+        "aurora-admin".into(),
+        "editorial".into(),
+        "cyber-garra".into(),
+    ];
+
+    Json(CapabilitiesResponse {
+        features,
+        providers,
+        models,
+        channels,
+        commands,
+        skins,
+        experimental_flags: Vec::new(),
+        version: env!("CARGO_PKG_VERSION"),
     })
 }

--- a/crates/garraia-gateway/src/health.rs
+++ b/crates/garraia-gateway/src/health.rs
@@ -373,10 +373,7 @@ fn extras_from_state(state: &SharedState) -> (Vec<String>, Option<String>, Optio
     // Channels — `state.channels.read()` is async, but we delegate to the
     // caller; this helper only computes provider/model. Channels handled
     // separately.
-    let provider = state
-        .agents
-        .default_provider_id()
-        .map(|s| s.to_string());
+    let provider = state.agents.default_provider_id().map(|s| s.to_string());
     let model = provider
         .as_deref()
         .and_then(|p| state.agents.get_provider(p))
@@ -492,9 +489,7 @@ pub struct CapabilitiesResponse {
 /// GET /api/capabilities — read-only snapshot of what the gateway can
 /// currently do. Renders the Dashboard "Arquitetura" card + drives the
 /// Skins page enumeration without hardcoded JS lists.
-pub async fn capabilities_handler(
-    State(state): State<SharedState>,
-) -> Json<CapabilitiesResponse> {
+pub async fn capabilities_handler(State(state): State<SharedState>) -> Json<CapabilitiesResponse> {
     // Static feature flags driven by Cargo cfg + runtime state shape.
     let mut features: Vec<String> = Vec::new();
     features.push("chat".into());

--- a/crates/garraia-gateway/src/router.rs
+++ b/crates/garraia-gateway/src/router.rs
@@ -98,6 +98,10 @@ pub fn build_router(
         .route("/health", get(health))
         .route("/ping", get(ping))
         .route("/api/health", get(crate::health::health_handler))
+        .route(
+            "/api/capabilities",
+            get(crate::health::capabilities_handler),
+        )
         .route("/ws", get(ws::ws_handler))
         .route("/ws/parrot", get(parrot_ws::parrot_ws_handler))
         // OpenAI-compatible endpoints

--- a/crates/garraia-gateway/src/webchat.html
+++ b/crates/garraia-gateway/src/webchat.html
@@ -2975,23 +2975,40 @@ function initSkinCards() {
   });
 }
 
-// ─── Dashboard hydration (plan 0117 — wire to existing /api/status) ──
+// ─── Dashboard hydration (plan 0118 — uses /api/health + /api/capabilities) ──
 async function hydrateDashboard() {
+  const set = (id, v) => { const el = document.getElementById(id); if (el && v !== undefined && v !== null) el.textContent = String(v); };
   try {
-    const r = await fetch('/api/status');
-    if (!r.ok) return;
-    const j = await r.json();
-    const set = (id, v) => { const el = document.getElementById(id); if (el && v !== undefined && v !== null) el.textContent = String(v); };
-    set('dashboard-version', j.version ? ('GarraIA v' + j.version) : 'GarraIA');
-    set('dashboard-metric-port', (j.gateway && j.gateway.port) || (location.port || '—'));
-    set('dashboard-metric-providers', Array.isArray(j.providers) ? j.providers.length : (j.llm ? Object.keys(j.llm).length : '—'));
-    set('dashboard-metric-channels', Array.isArray(j.channels) ? j.channels.length : '—');
-    set('dashboard-metric-sessions', (j.sessions !== undefined ? j.sessions : (j.active_sessions !== undefined ? j.active_sessions : '—')));
-    set('dashboard-health-server', j.status || 'ok');
-    set('dashboard-health-provider', j.provider || '—');
-    set('dashboard-health-model', j.model || '—');
-    set('dashboard-health-config', j.config_dir || '—');
-  } catch (_e) { /* dashboard renders with placeholders */ }
+    const [healthRes, capsRes] = await Promise.all([
+      fetch('/api/health').catch(() => null),
+      fetch('/api/capabilities').catch(() => null),
+    ]);
+    if (healthRes && healthRes.ok) {
+      const h = await healthRes.json();
+      set('dashboard-version', h.version ? ('GarraIA v' + h.version) : 'GarraIA');
+      set('dashboard-status-label', h.status === 'healthy' ? 'Gateway running' : ('Gateway ' + h.status));
+      if (h.gateway_url) {
+        try {
+          const u = new URL(h.gateway_url);
+          set('dashboard-metric-port', u.port || (u.protocol === 'https:' ? '443' : '80'));
+        } catch (_e) { set('dashboard-metric-port', '—'); }
+      }
+      set('dashboard-metric-sessions', h.active_sessions !== undefined ? h.active_sessions : '—');
+      set('dashboard-metric-channels', Array.isArray(h.channels) ? h.channels.length : '—');
+      set('dashboard-health-server', h.status || 'ok');
+      set('dashboard-health-provider', h.provider || '—');
+      set('dashboard-health-model', h.model || '—');
+    }
+    if (capsRes && capsRes.ok) {
+      const c = await capsRes.json();
+      set('dashboard-metric-providers', Array.isArray(c.providers) ? c.providers.length : '—');
+      // If /api/health didn't fill channels (older binary), fall back here.
+      const channelsEl = document.getElementById('dashboard-metric-channels');
+      if (channelsEl && channelsEl.textContent === '—' && Array.isArray(c.channels)) {
+        set('dashboard-metric-channels', c.channels.length);
+      }
+    }
+  } catch (_e) { /* dashboard renders with placeholders — non-fatal */ }
 }
 
 // Initialize skin editor


### PR DESCRIPTION
## Summary

Two new (effectively new — one extends the existing surface) Rust endpoints feeding the Web Console Dashboard. Both are auth-free (no JWT layer on `/api/*`), secret-free, and 200 always.

### `/api/health` — extended, back-compat preserved
Existing `{status, checks}` shape is kept; new fields added alongside.

Old fields retained: `status`, `checks` (with `name`, `ok`, `latency_ms`, `error`).

New fields:
- `version` — `CARGO_PKG_VERSION`
- `gateway_url` — `scheme://host:port` derived from `AppConfig` (https when TLS cert path is set)
- `uptime_secs` — `boot_time.elapsed()`
- `active_sessions` — DashMap len
- `provider` — `agents.default_provider_id()`
- `model` — `configured_model()` on the default provider
- `channels` — live `ChannelRegistry` list
- `warnings` — failed checks rendered as `\"name: error\"`

200 always; degraded / unhealthy is in the `status` field, not the HTTP code.

### `/api/capabilities` — new
```jsonc
{
  \"features\": [\"chat\", \"websocket\", \"multi-channel\", \"tts\", \"stt\", \"mcp\", \"openclaw\", \"auth-v1\"],
  \"providers\": [\"openrouter\", \"openai\", \"anthropic\", \"ollama\"],
  \"models\": [\"openrouter/auto\", \"anthropic/claude-opus-4-7\"],
  \"channels\": [\"web\", \"telegram\", \"discord\"],
  \"commands\": [\"new\", \"reset\", \"export\", ...],
  \"skins\": [\"garra-blue\", \"aurora-admin\", \"editorial\", \"cyber-garra\"],
  \"experimental_flags\": [],
  \"version\": \"0.2.0\"
}
```
- `features` computed live from `state.*` (only emits `tts`/`stt`/`mcp`/`openclaw`/`auth-v1` when the corresponding subsystem is Some).
- `providers` sorted + deduped.
- `commands` is names only (no descriptions / aliases that could leak admin paths).
- `skins` enumerates the four canonical Garra Glass skins per plan 0117.

### Dashboard hydration
`webchat.html` `hydrateDashboard()` now fires `/api/health` + `/api/capabilities` in parallel and parses `gateway_url` for the port pill. Graceful `—` fallbacks if either endpoint is unreachable.

## Test plan
- [x] `cargo check -p garraia-gateway` (green, 7.07s)
- [x] `cargo test -p garraia-gateway --lib --no-run` (builds clean, 31.38s)
- [ ] CI: fmt / clippy / test / audit / deny / Playwright / Quality Ratchet
- [ ] Manual smoke: `curl http://127.0.0.1:3888/api/health | jq` shape check; `curl http://127.0.0.1:3888/api/capabilities | jq` shape check; visit Dashboard, confirm port + providers + channels + sessions are populated from real data.

## Security
- No secret surface added. `AppConfig.gateway.api_key`, JWT secrets, and provider API keys never enter either response body.
- Both endpoints inherit the existing `/api/*` middleware stack (rate limiter + CORS + tracing) — no new public attack surface.

Closes part of GAR-612. Next PR-6 (plan 0119) wires the Providers page + `/api/providers/test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)