### PR TITLE
feat(gateway): plan 0120 — Channels + Sessions pages + /api/channels endpoint

### DIFF
--- a/crates/garraia-gateway/src/router.rs
+++ b/crates/garraia-gateway/src/router.rs
@@ -137,6 +137,7 @@ pub fn build_router(
         .route("/api/providers", get(list_providers).post(add_provider))
         .route("/api/providers/test", post(test_provider))
         .route("/api/providers/default", patch(set_default_provider))
+        .route("/api/channels", get(list_channels))
         .route("/api/mcp", get(list_mcp_servers))
         .route("/api/mcp/tools", get(list_mcp_runtime_tools))
         .route("/api/mcp/health", get(mcp_health))
@@ -969,6 +970,74 @@ async fn test_provider(
             }),
         ),
     }
+}
+
+// ─── Channels (plan 0120 / PR-7) ───────────────────────────────────────────
+
+/// Known channels — display metadata mirrors `KNOWN_PROVIDERS`. The `id`
+/// column matches `ChannelRegistry` entries; `needs_secret` is purely
+/// informational (the Web Console renders an amber pill when true but the
+/// actual secret value never crosses the API boundary).
+const KNOWN_CHANNELS: &[(&str, &str, bool)] = &[
+    ("web", "Web Chat", false),
+    ("api", "REST API", false),
+    ("telegram", "Telegram", true),
+    ("discord", "Discord", true),
+    ("slack", "Slack", true),
+    ("whatsapp", "WhatsApp", true),
+    ("imessage", "iMessage", false),
+    ("openclaw", "OpenClaw", false),
+    ("mcp", "MCP", false),
+    ("cli", "CLI", false),
+];
+
+#[derive(serde::Serialize)]
+struct ChannelInfo {
+    id: &'static str,
+    display_name: &'static str,
+    /// `"active"` (registered + live), `"configured"` (known but not registered),
+    /// `"offline"` (not registered, secret needed), `"optional"` (no secret needed).
+    status: &'static str,
+    needs_secret: bool,
+    /// Server-side timestamp of process boot — `last_activity` is not tracked
+    /// per channel yet (plan 0122 follow-up). Present as a stable placeholder
+    /// so the Web Console column always has SOMETHING to render.
+    boot_time_secs: u64,
+}
+
+/// GET /api/channels — Web Console Channels page payload. Secret-free.
+async fn list_channels(
+    axum::extract::State(state): axum::extract::State<SharedState>,
+) -> axum::Json<serde_json::Value> {
+    let live: Vec<String> = state
+        .channels
+        .read()
+        .await
+        .list()
+        .into_iter()
+        .map(|s| s.to_string())
+        .collect();
+
+    let mut channels: Vec<ChannelInfo> = Vec::with_capacity(KNOWN_CHANNELS.len());
+    for (id, display, needs_secret) in KNOWN_CHANNELS {
+        let active = live.iter().any(|name| name == *id);
+        let status = if active {
+            "active"
+        } else if *needs_secret {
+            "offline"
+        } else {
+            "optional"
+        };
+        channels.push(ChannelInfo {
+            id,
+            display_name: display,
+            status,
+            needs_secret: *needs_secret,
+            boot_time_secs: state.boot_time.elapsed().as_secs(),
+        });
+    }
+
+    axum::Json(serde_json::json!({ "channels": channels }))
 }
 
 /// PATCH /api/providers/default — switch the default LLM provider.

--- a/crates/garraia-gateway/src/webchat.html
+++ b/crates/garraia-gateway/src/webchat.html
@@ -1404,6 +1404,49 @@ nav.sidebar#sidebar .sidebar-page-btn .page-tag {
 [data-theme="light"] .provider-card .provider-actions button,
 [data-bs-theme="light"] .provider-card .provider-actions button { background: rgba(255, 255, 255, 0.6); color: #06142b; }
 
+/* Sessions table (plan 0120) */
+.garra-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  color: var(--garra-text);
+}
+.garra-table thead th {
+  text-align: left;
+  font-weight: 700;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--garra-muted-2);
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--garra-border);
+}
+.garra-table tbody td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--garra-border);
+  vertical-align: middle;
+}
+.garra-table tbody tr:hover { background: rgba(255, 255, 255, 0.04); }
+.garra-table tbody td code { font-family: var(--garra-mono); font-size: 12px; color: var(--garra-accent); }
+.garra-table .row-actions { display: inline-flex; gap: 6px; flex-wrap: wrap; }
+.garra-table .row-actions button {
+  font-family: var(--garra-font); font-weight: 700; font-size: 11px;
+  padding: 6px 10px; border-radius: 8px;
+  border: 1px solid var(--garra-border);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--garra-text);
+  cursor: pointer;
+}
+.garra-table .row-actions button:hover { background: rgba(255, 255, 255, 0.10); }
+.garra-table .row-actions button.danger { color: var(--garra-danger); border-color: rgba(var(--garra-accent-rgb), 0.0); }
+.garra-table .row-actions button.danger:hover { background: rgba(255, 92, 122, 0.16); }
+[data-theme="light"] .garra-table tbody td code,
+[data-bs-theme="light"] .garra-table tbody td code { color: #0a648a; }
+[data-theme="light"] .garra-table tbody tr:hover,
+[data-bs-theme="light"] .garra-table tbody tr:hover { background: rgba(0, 0, 0, 0.03); }
+[data-theme="light"] .garra-table .row-actions button,
+[data-bs-theme="light"] .garra-table .row-actions button { background: rgba(255, 255, 255, 0.6); color: #06142b; }
+
 /* Generic placeholder for not-yet-implemented pages */
 .page-placeholder {
   display: flex; flex-direction: column;
@@ -2594,33 +2637,40 @@ nav.sidebar#sidebar .sidebar-footer-btn .icon-svg rect {
     </div>
   </section>
 
+  <!-- CHANNELS page (plan 0120) -->
   <section class="page-view" data-page="channels" data-testid="garra-page-channels">
     <div class="glass-panel page-card">
       <div class="panel-header">
         <h3 class="panel-title"><span class="icon-box"><svg class="icon-svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M5.5 9.511c.076.954.83 1.697 2.182 1.785V12h.6v-.709c1.4-.098 2.218-.846 2.218-1.932 0-.987-.626-1.496-1.745-1.76l-.473-.112V5.57c.6.068.982.396 1.074.85h1.052c-.076-.93-.848-1.642-2.126-1.726V4h-.6v.719c-1.195.117-2.01.836-2.01 1.853 0 .9.606 1.472 1.613 1.707l.397.098v2.034c-.615-.093-1.022-.43-1.114-.9H5.5z"/></svg></span> Channels</h3>
-        <span class="pill warning"><span class="status-dot warning"></span> Em breve</span>
+        <button class="icon-btn header-icon-btn" id="channels-refresh-btn" type="button" title="Refresh channels">
+          <svg class="icon-svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M3.17 6.706a5 5 0 0 1 7.103-3.16.5.5 0 1 0 .454-.892A6 6 0 0 0 2.19 6.296a.5.5 0 1 0 .98.21z"/></svg>
+        </button>
       </div>
       <div class="page-body">
-        <div class="page-placeholder">
-          <div class="icon-circle"><svg class="icon-svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/></svg></div>
-          <h2>Channels</h2>
-          <p>Gerenciamento de Web, Telegram, Discord, API e canais futuros. Endpoints Rust em <code>plan 0120 / PR-7</code>.</p>
-        </div>
+        <p style="color: var(--garra-muted); margin-bottom: 16px;">Cada canal mostra seu estado em runtime. Active = registrado e respondendo; Optional = sem segredo necessário e não configurado; Offline = depende de secret ainda ausente.</p>
+        <div id="channels-grid" class="providers-grid"></div>
       </div>
     </div>
   </section>
 
+  <!-- SESSIONS page (plan 0120) -->
   <section class="page-view" data-page="sessions" data-testid="garra-page-sessions">
     <div class="glass-panel page-card">
       <div class="panel-header">
         <h3 class="panel-title"><span class="icon-box"><svg class="icon-svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M14.5 3h-13a.5.5 0 0 0-.5.5v9a.5.5 0 0 0 .5.5h13a.5.5 0 0 0 .5-.5v-9a.5.5 0 0 0-.5-.5z"/></svg></span> Sessions</h3>
-        <span class="pill warning"><span class="status-dot warning"></span> Em breve</span>
+        <button class="icon-btn header-icon-btn" id="sessions-refresh-btn" type="button" title="Refresh sessions">
+          <svg class="icon-svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M3.17 6.706a5 5 0 0 1 7.103-3.16.5.5 0 1 0 .454-.892A6 6 0 0 0 2.19 6.296a.5.5 0 1 0 .98.21z"/></svg>
+        </button>
       </div>
       <div class="page-body">
-        <div class="page-placeholder">
-          <div class="icon-circle"><svg class="icon-svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/></svg></div>
-          <h2>Sessions</h2>
-          <p>Histórico, exportação e auditoria de sessões. Endpoints Rust em <code>plan 0120 / PR-7</code>.</p>
+        <p style="color: var(--garra-muted); margin-bottom: 16px;">Sessões persistidas. <strong>Open</strong> volta ao chat com o session id ativo. <strong>Export</strong> baixa o histórico como JSON (cliente-side). <strong>Delete</strong> remove server-side.</p>
+        <div id="sessions-table-wrap">
+          <table class="garra-table">
+            <thead>
+              <tr><th>ID</th><th>Channel</th><th>Provider</th><th>Updated</th><th>Actions</th></tr>
+            </thead>
+            <tbody id="sessions-table-body"></tbody>
+          </table>
         </div>
       </div>
     </div>
@@ -3013,6 +3063,8 @@ function setPage(name) {
   // Per-page hydration hooks.
   switch (name) {
     case 'providers':   loadProvidersPage && loadProvidersPage(); break;
+    case 'channels':    loadChannelsPage && loadChannelsPage(); break;
+    case 'sessions':    loadSessionsPage && loadSessionsPage(); break;
     case 'dashboard':   hydrateDashboard && hydrateDashboard(); break;
     default: break;
   }
@@ -3137,6 +3189,106 @@ async function setDefaultProvider(id) {
       await loadProvidersPage(); // re-render with new default
     }
   } catch (_e) { /* swallow — UI will surface via reload */ }
+}
+
+// ─── Channels page (plan 0120) ───────────────────────────────────────
+async function loadChannelsPage() {
+  const grid = document.getElementById('channels-grid');
+  if (!grid) return;
+  grid.innerHTML = '<div style="color:var(--garra-muted);font-size:13px;">Carregando channels…</div>';
+  try {
+    const r = await fetch('/api/channels');
+    if (!r.ok) { grid.innerHTML = '<div class="warning-box">Falha ao carregar channels.</div>'; return; }
+    const j = await r.json();
+    const items = Array.isArray(j.channels) ? j.channels : [];
+    grid.innerHTML = items.map((c, i) => renderChannelCard(c, i)).join('');
+  } catch (e) {
+    grid.innerHTML = '<div class="warning-box">Erro: ' + (e && e.message ? e.message : e) + '</div>';
+  }
+}
+function renderChannelCard(c, i) {
+  const pillCls = c.status === 'active' ? 'success' : (c.status === 'offline' ? 'danger' : (c.status === 'optional' ? 'warning' : ''));
+  const pillTxt = c.status === 'active' ? 'Active' : c.status === 'offline' ? 'Offline' : c.status === 'optional' ? 'Optional' : c.status;
+  return `
+    <div class="provider-card" style="--i:${i};" data-channel-id="${escapeHtml(c.id)}">
+      <div class="provider-card-head">
+        <strong>${escapeHtml(c.display_name || c.id)}</strong>
+        <span class="pill ${pillCls}"><span class="status-dot ${c.status === 'active' ? '' : (c.status === 'offline' ? 'offline' : 'warning')}"></span> ${escapeHtml(pillTxt)}</span>
+      </div>
+      <div class="provider-meta">id <code>${escapeHtml(c.id)}</code>${c.needs_secret ? ' • secret required' : ' • no secret'}</div>
+    </div>
+  `;
+}
+
+// ─── Sessions page (plan 0120) ───────────────────────────────────────
+async function loadSessionsPage() {
+  const body = document.getElementById('sessions-table-body');
+  if (!body) return;
+  body.innerHTML = '<tr><td colspan="5" style="color:var(--garra-muted);text-align:center;padding:20px;">Carregando sessions…</td></tr>';
+  try {
+    const r = await fetch('/api/sessions');
+    if (!r.ok) { body.innerHTML = '<tr><td colspan="5" class="warning-box">Falha ao carregar.</td></tr>'; return; }
+    const j = await r.json();
+    const items = Array.isArray(j) ? j : (Array.isArray(j.sessions) ? j.sessions : []);
+    if (!items.length) {
+      body.innerHTML = '<tr><td colspan="5" style="color:var(--garra-muted);text-align:center;padding:24px;">Nenhuma session ainda.</td></tr>';
+      return;
+    }
+    body.innerHTML = items.map(s => renderSessionRow(s)).join('');
+    body.querySelectorAll('[data-session-open]').forEach(el => el.addEventListener('click', () => openSession(el.dataset.sessionOpen)));
+    body.querySelectorAll('[data-session-export]').forEach(el => el.addEventListener('click', () => exportSession(el.dataset.sessionExport)));
+    body.querySelectorAll('[data-session-delete]').forEach(el => el.addEventListener('click', () => deleteSession(el.dataset.sessionDelete)));
+  } catch (e) {
+    body.innerHTML = '<tr><td colspan="5" class="warning-box">Erro: ' + (e && e.message ? e.message : e) + '</td></tr>';
+  }
+}
+function renderSessionRow(s) {
+  const id = s.id || s.session_id || s.sessionId || '';
+  const channel = s.channel || s.source || '—';
+  const provider = s.provider || (s.providers && s.providers[0]) || '—';
+  const updated = s.updated_at || s.last_activity || s.created_at || '—';
+  return `
+    <tr>
+      <td><code>${escapeHtml(id)}</code></td>
+      <td>${escapeHtml(channel)}</td>
+      <td>${escapeHtml(provider)}</td>
+      <td>${escapeHtml(updated)}</td>
+      <td><div class="row-actions">
+        <button data-session-open="${escapeHtml(id)}">Open</button>
+        <button data-session-export="${escapeHtml(id)}">Export</button>
+        <button class="danger" data-session-delete="${escapeHtml(id)}">Delete</button>
+      </div></td>
+    </tr>
+  `;
+}
+function openSession(id) {
+  if (!id) return;
+  location.hash = '#/chat';
+  // The chat page reads existing session list; user can resume via sidebar.
+  // For now we just navigate; deep-link to session ID is a plan 0117a follow-up.
+}
+async function exportSession(id) {
+  if (!id) return;
+  try {
+    const r = await fetch('/api/sessions/' + encodeURIComponent(id) + '/history');
+    if (!r.ok) return;
+    const j = await r.json();
+    const blob = new Blob([JSON.stringify(j, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'garra-session-' + id + '.json';
+    a.click();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  } catch (_e) { /* swallow — non-fatal */ }
+}
+async function deleteSession(id) {
+  if (!id) return;
+  if (!confirm('Delete session ' + id + '?')) return;
+  try {
+    const r = await fetch('/api/sessions/' + encodeURIComponent(id), { method: 'DELETE' });
+    if (r.ok) loadSessionsPage();
+  } catch (_e) { /* swallow */ }
 }
 
 // ─── Dashboard hydration (plan 0118 — uses /api/health + /api/capabilities) ──
@@ -4372,6 +4524,11 @@ async function boot() {
   // lazy-loads via setPage() when first visited.
   const provRefresh = document.getElementById('providers-refresh-btn');
   if (provRefresh) provRefresh.addEventListener('click', () => loadProvidersPage && loadProvidersPage());
+  // Plan 0120: same pattern for channels + sessions refresh.
+  const chRefresh = document.getElementById('channels-refresh-btn');
+  if (chRefresh) chRefresh.addEventListener('click', () => loadChannelsPage && loadChannelsPage());
+  const sessRefresh = document.getElementById('sessions-refresh-btn');
+  if (sessRefresh) sessRefresh.addEventListener('click', () => loadSessionsPage && loadSessionsPage());
 
   try {
     const r = await fetch('/api/auth-check');


### PR DESCRIPTION
## Summary
- **`GET /api/channels`** (new) — `{id, display_name, status: active|offline|optional, needs_secret, boot_time_secs}` for each of the 10 KNOWN_CHANNELS (web/api/telegram/discord/slack/whatsapp/imessage/openclaw/mcp/cli). Auth-free, secret-free.
- **Channels page** — `.providers-grid` reused, one card per channel with success/warning/danger pill matching the runtime status.
- **Sessions page** — `.garra-table` primitive with one row per session, Actions column (Open / Export / Delete). Reuses the existing `/api/sessions`, `/api/sessions/{id}/history`, `DELETE /api/sessions/{id}` endpoints — no new sessions endpoints needed in this PR.
- **Export** is implemented client-side as a blob download of `/api/sessions/{id}/history` JSON — no server endpoint needed.
- **Delete** has a `confirm()` prompt; on success, the row disappears and the table reloads.

## Test plan
- [x] `cargo check -p garraia-gateway` (green, 4.89s)
- [ ] CI matrix
- [ ] Manual: `#/channels` renders 10 cards; `#/sessions` shows rows; Export downloads a JSON file; Delete prompts then removes the row.

## Security
- `/api/channels` never reads any channel token. Status reflects registration, not credential validity. No token value crosses the API boundary.

Closes part of GAR-614. Next PR-8 (plan 0121) — Settings Registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)