### PR TITLE
chore(release): v0.2.1 — fix garraia update 404 (GAR-619)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,12 @@ GARRAIA_VAULT_PASSPHRASE=change-me-generate-with-openssl-rand-hex-32
 # --- Gateway port override ---
 # GARRAIA_PORT=3888
 
+# --- Auto-update (`garra update`, crates/garraia-cli/src/update.rs) ---
+# Set to any non-empty value to disable the background "update available"
+# check that runs at daemon start. The blocking `garra update` command is
+# unaffected — it always hits GitHub directly.
+# GARRAIA_NO_UPDATE_CHECK=1
+
 # --- OpenClaw Bridge (optional — multi-channel AI assistant) ---
 # Install: npm install -g openclaw@latest
 # OPENCLAW_ENABLED=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,14 +72,14 @@ jobs:
       - name: Package binary
         run: |
           mkdir -p release
-          cp target/aarch64-unknown-linux-gnu/release/garra release/garraia-linux-arm64
-          chmod +x release/garraia-linux-arm64
+          cp target/aarch64-unknown-linux-gnu/release/garra release/garraia-linux-aarch64
+          chmod +x release/garraia-linux-aarch64
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
-          name: garraia-linux-arm64
-          path: release/garraia-linux-arm64
+          name: garraia-linux-aarch64
+          path: release/garraia-linux-aarch64
 
   # Build for Windows x86_64
   build-windows-x86_64:
@@ -156,14 +156,14 @@ jobs:
       - name: Package binary
         run: |
           mkdir -p release
-          cp target/release/garra release/garraia-macos-arm64
-          chmod +x release/garraia-macos-arm64
+          cp target/release/garra release/garraia-macos-aarch64
+          chmod +x release/garraia-macos-aarch64
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
-          name: garraia-macos-arm64
-          path: release/garraia-macos-arm64
+          name: garraia-macos-aarch64
+          path: release/garraia-macos-aarch64
 
   # Create release
   release:
@@ -211,19 +211,19 @@ jobs:
           cp artifacts/garraia-windows-x86_64/garraia-windows-x86_64.exe release/
           cp artifacts/garraia-macos-x86_64/garraia-macos-x86_64 release/
 
-          # Optional (ARM64) — included only if their build job succeeded and
+          # Optional (aarch64) — included only if their build job succeeded and
           # uploaded an artifact. softprops/action-gh-release defaults
           # fail_on_unmatched_files to false, so missing entries in the `files:`
           # list below are silently skipped.
-          if [ -f artifacts/garraia-linux-arm64/garraia-linux-arm64 ]; then
-            cp artifacts/garraia-linux-arm64/garraia-linux-arm64 release/
+          if [ -f artifacts/garraia-linux-aarch64/garraia-linux-aarch64 ]; then
+            cp artifacts/garraia-linux-aarch64/garraia-linux-aarch64 release/
           else
-            echo "::warning ::Linux ARM64 binary not built; release will ship without it."
+            echo "::warning ::Linux aarch64 binary not built; release will ship without it."
           fi
-          if [ -f artifacts/garraia-macos-arm64/garraia-macos-arm64 ]; then
-            cp artifacts/garraia-macos-arm64/garraia-macos-arm64 release/
+          if [ -f artifacts/garraia-macos-aarch64/garraia-macos-aarch64 ]; then
+            cp artifacts/garraia-macos-aarch64/garraia-macos-aarch64 release/
           else
-            echo "::warning ::macOS ARM64 binary not built; release will ship without it."
+            echo "::warning ::macOS aarch64 binary not built; release will ship without it."
           fi
 
       - name: Get version
@@ -238,24 +238,47 @@ jobs:
           echo "VERSION: $VERSION"
 
       - name: Generate checksums
+        # Produces BOTH the aggregate SHA256SUMS (for human verification +
+        # install.sh single-fetch) AND per-asset `<name>.sha256` files
+        # consumed by `garraia update` (see crates/garraia-cli/src/update.rs:127
+        # — it expects `<asset>.sha256` siblings). Without per-asset files the
+        # auto-updater aborts with "release is missing checksum file".
         run: |
+          set -euo pipefail
           cd release
-          sha256sum * > SHA256SUMS
+          : > SHA256SUMS
+          for f in *; do
+            # Skip the SHA256SUMS file itself and any pre-existing .sha256 files
+            # so a re-run never recursively hashes its own output.
+            case "$f" in
+              SHA256SUMS|*.sha256) continue ;;
+            esac
+            sha256sum "$f" | tee -a SHA256SUMS > "${f}.sha256"
+          done
+          echo "--- SHA256SUMS ---"
           cat SHA256SUMS
+          echo "--- per-asset .sha256 files ---"
+          ls -1 *.sha256
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
           name: Release ${{ steps.version.outputs.VERSION }}
           draft: false
-          prerelease: ${{ contains(steps.version.outputs.VERSION, 'alpha') || contains(steps.version.outputs.VERSION, 'beta') }}
+          prerelease: ${{ contains(steps.version.outputs.VERSION, 'alpha') || contains(steps.version.outputs.VERSION, 'beta') || contains(steps.version.outputs.VERSION, 'rc') }}
           generate_release_notes: true
+          # `softprops/action-gh-release` uses glob expansion on this list, so
+          # `*.sha256` covers every per-asset checksum (5 expected; missing
+          # aarch64 builds simply contribute fewer matches). `fail_on_unmatched_files`
+          # defaults to false, so a missing optional binary still ships the
+          # release with what we have.
           files: |
             release/garraia-linux-x86_64
-            release/garraia-linux-arm64
+            release/garraia-linux-aarch64
             release/garraia-windows-x86_64.exe
             release/garraia-macos-x86_64
-            release/garraia-macos-arm64
+            release/garraia-macos-aarch64
             release/SHA256SUMS
+            release/*.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-05-14
+
+### Auto-update pipeline — fixes 404 on `garraia update`
+
+#### Fixed
+- **`/releases/latest` 404** — Every prior tag (`v0.1.0-beta`, `v0.1.0-beta.1`, `v0.2.0-beta`) shipped as a prerelease, so the GitHub endpoint that `garraia update` calls (`GET /repos/{owner}/{repo}/releases/latest`) returned 404. `v0.2.1` is the first **non-prerelease** tag — the workflow auto-flips `prerelease: true` only when the tag contains `alpha`/`beta`/`rc`. From now on, installed `0.2.0` binaries find an updatable release.
+- **Asset-name mismatch (`arm64` ↔ `aarch64`)** — `crates/garraia-cli/src/update.rs:43-50` selects assets by Rust's `std::env::consts::ARCH`, which on Apple Silicon and Linux ARMv8 is `aarch64`. The release workflow named those binaries `garraia-linux-arm64` / `garraia-macos-arm64`, so even if a non-prerelease existed the updater would have bailed with "release has no asset for this platform". Renamed to `garraia-linux-aarch64` / `garraia-macos-aarch64`.
+- **Missing per-asset `.sha256` files** — `update.rs:127` reads `<asset>.sha256` siblings for tamper-detection. The previous workflow only emitted a single aggregate `SHA256SUMS`. The "Generate checksums" step now emits both: aggregate `SHA256SUMS` (kept for `install.sh` + human verification) **and** one `<asset>.sha256` per binary, gathered into the release via `release/*.sha256` glob.
+
+#### Changed
+- Workspace `version = "0.2.1"` (Cargo.toml, `crates/garraia-desktop/src-tauri/Cargo.toml`, `tauri.conf.json`).
+- Prerelease gate widened to also detect `rc` in the tag string (was `alpha|beta`).
+
 ## [0.1.12] - 2026-02-27
 
 ### Fase 5: Delivery and Ecosystem

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3297,7 +3297,7 @@ dependencies = [
 
 [[package]]
 name = "garraia"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-agents"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -3366,7 +3366,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-auth"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-channels"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -3422,7 +3422,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-common"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3436,7 +3436,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-config"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dirs 6.0.0",
  "garraia-common",
@@ -3454,7 +3454,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-db"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3474,7 +3474,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-desktop"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -3490,7 +3490,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-gateway"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3575,7 +3575,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-media"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3593,7 +3593,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-plugins"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3625,7 +3625,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-security"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64 0.22.1",
  "garraia-common",
@@ -3641,7 +3641,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-skills"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "garraia-common",
  "reqwest 0.12.28",
@@ -3653,7 +3653,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-storage"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3680,7 +3680,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-telemetry"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -3717,7 +3717,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-voice"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3731,7 +3731,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-workspace"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/michelbr84/GarraRUST"

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ cargo build --release -p garraia-desktop
 </details>
 
 <details>
-<summary>Instalar via script (Linux, macOS) — requer binários publicados no release</summary>
+<summary>Instalar via script (Linux, macOS) — usa binários publicados no release</summary>
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/michelbr84/GarraRUST/main/install.sh | sh
@@ -99,7 +99,25 @@ garraia init
 garraia start
 ```
 
-> **Nota:** o script de instalação requer que binários CLI pré-compilados estejam publicados nas [Versões do GitHub](https://github.com/michelbr84/GarraRUST/releases). Enquanto isso, compile a partir do código-fonte conforme acima.
+> A partir de `v0.2.1` (2026-05-14) — primeira release **não-prerelease** do repo — o script consome `GET /repos/michelbr84/GarraRUST/releases/latest` e verifica cada binário contra seu `<asset>.sha256` correspondente.
+> Em ARM, certifique-se de que `uname -m` reporta `aarch64`/`arm64` — os assets `garraia-linux-aarch64` e `garraia-macos-aarch64` são best-effort enquanto o cross-compile de `openssl` para ARM64 estabiliza ([release.yml](.github/workflows/release.yml)).
+
+</details>
+
+<details>
+<summary>Atualizar uma instalação existente — <code>garra update</code></summary>
+
+```bash
+# Verifica a release mais recente, baixa o binário da sua plataforma,
+# confere SHA-256 contra <asset>.sha256 e troca o executável atomicamente.
+garra update          # interativo
+garra update --yes    # não interativo (CI)
+
+# Volta para o binário anterior se algo der errado:
+garra rollback
+```
+
+> `garra update` falava com **404** em todas as versões anteriores a `v0.2.1` porque toda release publicada era marcada como prerelease (e o endpoint `releases/latest` ignora prereleases). Documentado no commit que introduziu este parágrafo + em [`CHANGELOG.md`](CHANGELOG.md#021---2026-05-14).
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -105,19 +105,19 @@ garraia start
 </details>
 
 <details>
-<summary>Atualizar uma instalação existente — <code>garra update</code></summary>
+<summary>Atualizar uma instalação existente — <code>garraia update</code></summary>
 
 ```bash
 # Verifica a release mais recente, baixa o binário da sua plataforma,
 # confere SHA-256 contra <asset>.sha256 e troca o executável atomicamente.
-garra update          # interativo
-garra update --yes    # não interativo (CI)
+garraia update          # interativo
+garraia update --yes    # não interativo (CI)
 
 # Volta para o binário anterior se algo der errado:
-garra rollback
+garraia rollback
 ```
 
-> `garra update` falava com **404** em todas as versões anteriores a `v0.2.1` porque toda release publicada era marcada como prerelease (e o endpoint `releases/latest` ignora prereleases). Documentado no commit que introduziu este parágrafo + em [`CHANGELOG.md`](CHANGELOG.md#021---2026-05-14).
+> `garraia update` falava com **404** em todas as versões anteriores a `v0.2.1` porque toda release publicada era marcada como prerelease (e o endpoint `releases/latest` ignora prereleases). Detalhamento em [`CHANGELOG.md`](CHANGELOG.md#021---2026-05-14).
 
 </details>
 
@@ -507,7 +507,7 @@ Consulte a [documentação completa de integração com Continue](docs/continue-
 
 - **Recarregamento de config a quente** - edite `config.yml`, as alterações são aplicadas sem reiniciar
 - **Daemonização** - `garra start --daemon` com gerenciamento de PID
-- **Auto-atualização** - `garra update` baixa a versão mais recente com verificação SHA-256, `garra rollback` para reverter
+- **Auto-atualização** - `garraia update` baixa a versão mais recente com verificação SHA-256, `garraia rollback` para reverter
 - **Reinicialização** - `garra restart` para graciosamente parar e iniciar o daemon
 - **Troca de provedor em runtime** - adicione ou troque provedores de LLM via interface webchat ou API REST sem reiniciar
 - **Fallback automático de providers** - em caso de erro 429/5xx, tenta automaticamente o próximo provider configurado em `fallback_providers` com backoff exponencial e circuit breaker

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -122,6 +122,26 @@ Sub-issues 4 e 5 de GAR-486 estão em execução agora:
 
 ✅ **Done** (2026-05-04). Fechado após [GAR-490](https://linear.app/chatgpt25/issue/GAR-490) (PR [#112](https://github.com/michelbr84/GarraRUST/pull/112), 2026-05-04) e [GAR-491](https://linear.app/chatgpt25/issue/GAR-491) (PR [#109](https://github.com/michelbr84/GarraRUST/pull/109), 2026-05-01) mergearem.
 
+### Auto-update pipeline (`garraia update`) — entrega `v0.2.1` (2026-05-14)
+
+`garraia update` retornava `404 Not Found` em todas as instalações desde
+o lançamento do comando porque o repo só tinha **prereleases** (`v0.1.0-beta`,
+`v0.1.0-beta.1`, `v0.2.0-beta`), e `GET /repos/{owner}/{repo}/releases/latest`
+ignora prereleases por design ([GitHub REST docs](https://docs.github.com/rest/releases/releases)).
+A nota original do triagem está versionada em [`release.md`](release.md).
+
+Três mismatches estruturais entre [`release.yml`](.github/workflows/release.yml)
+e [`crates/garraia-cli/src/update.rs`](crates/garraia-cli/src/update.rs)
+foram corrigidos no mesmo PR:
+
+| # | Mismatch | Antes | Depois |
+|---|---------|-------|--------|
+| 1 | Todas as releases marcadas `prerelease: true` | `v0.2.0-beta` (prerelease) | Tag `v0.2.1` produz release **não-prerelease** automaticamente (gate `contains(alpha|beta|rc)`) |
+| 2 | Sufixo ARM64 errado | `garraia-{linux,macos}-arm64` | `garraia-{linux,macos}-aarch64` (alinha com `std::env::consts::ARCH` que `update.rs:43-50` consome) |
+| 3 | Só `SHA256SUMS` agregado | Falhava no `release is missing checksum file` | `SHA256SUMS` **mais** `<asset>.sha256` per-asset (loop sha256sum + glob `release/*.sha256` no `files:` da action) |
+
+Workspace version bumped `0.2.0 → 0.2.1` em `Cargo.toml`, `crates/garraia-desktop/src-tauri/Cargo.toml` e `tauri.conf.json` para fechar o gap de versão sem reuso de tag. Linear: [GAR-619](https://linear.app/chatgpt25/issue/GAR-619) (criada nesta sessão).
+
 ---
 
 ## 2. Estrutura do roadmap

--- a/crates/garraia-desktop/src-tauri/Cargo.toml
+++ b/crates/garraia-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "garraia-desktop"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "Garra Desktop — Clippy-style AI assistant overlay"
 license = "MIT"

--- a/crates/garraia-desktop/src-tauri/tauri.conf.json
+++ b/crates/garraia-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "garraia-desktop",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "org.garraia.desktop",
   "build": {
     "frontendDist": "../ui",

--- a/crates/garraia-gateway/src/health.rs
+++ b/crates/garraia-gateway/src/health.rs
@@ -389,7 +389,7 @@ fn extras_from_state(state: &SharedState) -> (Vec<String>, Option<String>, Optio
 /// ```json
 /// {
 ///   "status": "degraded",
-///   "version": "0.2.0",
+///   "version": "0.2.1",
 ///   "gateway_url": "http://127.0.0.1:3888",
 ///   "uptime_secs": 1234,
 ///   "active_sessions": 2,

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -141,10 +141,14 @@ Download from [GitHub Releases](https://github.com/michelbr84/GarraRUST/releases
 | Platform | Architecture | Filename |
 |----------|--------------|----------|
 | Linux | x86_64 | garraia-linux-x86_64 |
-| Linux | ARM64 | garraia-linux-arm64 |
+| Linux | aarch64 (ARM64) | garraia-linux-aarch64 |
 | macOS | x86_64 | garraia-macos-x86_64 |
-| macOS | ARM64 | garraia-macos-arm64 |
+| macOS | aarch64 (Apple Silicon) | garraia-macos-aarch64 |
 | Windows | x86_64 | garraia-windows-x86_64.exe |
+
+> From `v0.2.1` (2026-05-14) aarch64 binaries match Rust's `std::env::consts::ARCH`,
+> so `garraia update` selects the right asset automatically. Each binary ships with
+> a sibling `<name>.sha256` for verification.
 
 ## Verification
 

--- a/install.sh
+++ b/install.sh
@@ -42,14 +42,11 @@ detect_platform() {
         *)             error "Unsupported architecture: ${ARCH}" ;;
     esac
 
-    # Release workflow names the arm64 binary "arm64", not "aarch64".
-    case "${ARCH_NAME}" in
-        aarch64) ASSET_ARCH="arm64" ;;
-        *)       ASSET_ARCH="${ARCH_NAME}" ;;
-    esac
-
-    ARTIFACT="${BINARY}-${OS_NAME}-${ASSET_ARCH}"
-    echo "Detected platform: ${OS_NAME}-${ASSET_ARCH}"
+    # release.yml emits `garraia-{linux,macos}-aarch64` from v0.2.1 onwards
+    # (aligned with `std::env::consts::ARCH` consumed by garraia-cli's
+    # update command). No remapping needed.
+    ARTIFACT="${BINARY}-${OS_NAME}-${ARCH_NAME}"
+    echo "Detected platform: ${OS_NAME}-${ARCH_NAME}"
 }
 
 resolve_version() {

--- a/release.md
+++ b/release.md
@@ -1,0 +1,96 @@
+O comando garraia update (root@e3d968dec9ba:/# garraia update update failed: GitHub API returned 404 Not Found: {"message":"Not Found","documentation\_url":"https://docs.github.com/rest/releases/releases#get-the-latest-release","status":"404"}) parece nao funcionar — esse erro faz sentido.
+
+
+
+O `garraia update` provavelmente tenta chamar este endpoint do GitHub:
+
+
+
+`GET /repos/{owner}/{repo}/releases/latest`
+
+
+
+Esse endpoint \*\*não busca tags\*\*. Ele busca apenas a última \*\*GitHub Release publicada\*\*, que não seja draft e não seja prerelease. A própria documentação do GitHub diz que “latest release” é a release publicada mais recente, excluindo prereleases/drafts, e que pode retornar `404 Resource not found`. (\[GitHub Docs]\[1])
+
+
+
+No GarraRUST, parece que o README já deixa uma pista forte: a instalação via script “requer binários CLI pré-compilados publicados no release” e, enquanto isso, recomenda compilar a partir do código-fonte. (\[GitHub]\[2]) Também aparece que o repo tem \*\*3 tags\*\*, mas isso não garante que exista uma \*\*Release\*\* publicada com assets. (\[GitHub]\[2])
+
+
+
+Então, meu diagnóstico mais provável é:
+
+
+
+\*\*o comando `garraia update` foi implementado esperando que já exista uma GitHub Release oficial com binários publicados, mas hoje o repo provavelmente ainda só tem tags / código-fonte / documentação, ou não tem uma release “latest” válida.\*\*
+
+
+
+Outras possibilidades, em ordem de chance:
+
+
+
+1\. \*\*Não existe release publicada\*\*
+
+&#x20;  Tag `v0.2.0` ou similar não basta. Precisa criar uma Release no GitHub.
+
+
+
+2\. \*\*Só existe prerelease ou draft\*\*
+
+&#x20;  O endpoint `/latest` ignora prerelease e draft.
+
+
+
+3\. \*\*O updater está apontando para o repo errado\*\*
+
+&#x20;  Por exemplo, hardcoded para outro owner/repo antigo.
+
+
+
+4\. \*\*Repo privado ou token sem permissão\*\*
+
+&#x20;  GitHub às vezes retorna `404` em vez de `403` quando o recurso existe, mas a autenticação não tem acesso. (\[GitHub Docs]\[3]) Porém, como o GarraRUST parece público, eu colocaria essa hipótese abaixo das outras.
+
+
+
+5\. \*\*Existe release, mas sem asset compatível\*\*
+
+&#x20;  Nesse caso eu esperaria um erro diferente depois do `/latest`, não exatamente esse `404`.
+
+
+
+Na prática, eu trataria isso como \*\*funcionalidade documentada/planejada, mas ainda não operacional\*\*. O comando está lá, o README até promete “Auto-atualização Sim (`garraia update`)”, mas a infraestrutura de release parece ainda não estar fechada. (\[GitHub]\[2])
+
+
+
+Para ficar correto, o Garra precisa de uma pipeline de release que publique, por exemplo:
+
+
+
+`garraia-linux-x86\_64.tar.gz`
+
+`garraia-linux-aarch64.tar.gz`
+
+`garraia-windows-x86\_64.zip`
+
+`garraia-macos-aarch64.tar.gz`
+
+checksums/SHA256
+
+e uma GitHub Release marcada como release normal, não draft/prerelease.
+
+
+
+Resumo bem direto: \*\*não parece ser problema do RunPod. Parece ser falta de uma release oficial compatível para o auto-update consumir.\*\*
+
+
+
+\[1]: https://docs.github.com/rest/releases/releases "REST API endpoints for releases - GitHub Docs"
+
+\[2]: https://github.com/michelbr84/GarraRUST "GitHub - michelbr84/GarraRUST: O framework seguro e leve de código aberto para agentes de IA desenvolvido 100% em português. · GitHub"
+
+\[3]: https://docs.github.com/en/rest/using-the-rest-api/troubleshooting-the-rest-api "Troubleshooting the REST API - GitHub Docs"
+
+
+


### PR DESCRIPTION
## Summary

Closes [GAR-619](https://linear.app/chatgpt25/issue/GAR-619). Source memo: [`release.md`](release.md) (versioned in this PR).

`garraia update` answered `404 Not Found` on every install. Root cause is structural — not RunPod, not the binary, not the user environment:

- Every prior tag (`v0.1.0-beta`, `v0.1.0-beta.1`, `v0.2.0-beta`) shipped as a **prerelease**, and [GitHub REST](https://docs.github.com/rest/releases/releases#get-the-latest-release) excludes prereleases from `/releases/latest`. So the endpoint really did return 404 — there was no eligible release.
- The release workflow named ARM binaries `garraia-{linux,macos}-arm64`, but [`update.rs:43-50`](crates/garraia-cli/src/update.rs#L43) selects assets by `std::env::consts::ARCH`, which is `aarch64`. Even with a non-prerelease, the updater would have bailed on `aarch64` machines.
- [`update.rs:127`](crates/garraia-cli/src/update.rs#L127) reads `<asset>.sha256` siblings to verify each download. The workflow only emitted a single aggregate `SHA256SUMS`. The updater would have aborted with `release is missing checksum file`.

## What changed

### `.github/workflows/release.yml`
- ARM artifact names: `arm64` → `aarch64` (Linux + macOS) — both the build steps and the `release/*` copy lines.
- "Generate checksums" step now emits **both** `SHA256SUMS` (one file, all lines) **and** `<asset>.sha256` (one file per binary). Glob `release/*.sha256` is added to the action's `files:` list. Skip-self guard handles re-runs.
- Prerelease gate widened: `contains(VERSION, 'alpha') || contains(VERSION, 'beta') || contains(VERSION, 'rc')`. Tag `v0.2.1` → public release.

### Workspace version `0.2.0 → 0.2.1`
- `Cargo.toml` (`[workspace.package].version`)
- `crates/garraia-desktop/src-tauri/Cargo.toml` (`[package].version`)
- `crates/garraia-desktop/src-tauri/tauri.conf.json` (`version`)
- `crates/garraia-gateway/src/health.rs` (docstring JSON example)
- `Cargo.lock` (lockfile follow-up)

### Docs
- `CHANGELOG.md` — new `[0.2.1] - 2026-05-14` section with the full diagnostic.
- `README.md` — installer note rephrased (binaries now ARE published from 0.2.1 onward) + new `garra update` collapse-card with caveats.
- `ROADMAP.md` §1.5 — entry "Auto-update pipeline (`garraia update`) — entrega `v0.2.1`".
- `.env.example` — documents `GARRAIA_NO_UPDATE_CHECK`.
- `release.md` — committed as the source triage memo.

## Test plan

- [ ] CI green on this PR (fmt, clippy, test, audit, deny, quality-ratchet report-only).
- [ ] After merge: push tag `v0.2.1` from `main`. `release.yml` fires.
- [ ] `gh release view v0.2.1 --json prerelease,assets` reports `prerelease: false` plus, at minimum: `garraia-linux-x86_64`, `garraia-windows-x86_64.exe`, `garraia-macos-x86_64` (the x86_64 triad is hard-required by the `release` job's `if:`), each with a sibling `.sha256`, plus the aggregate `SHA256SUMS`.
- [ ] `curl -fsSL https://api.github.com/repos/michelbr84/GarraRUST/releases/latest | jq -r .tag_name` returns `v0.2.1` (no 404).
- [ ] A pre-existing `0.2.0` install runs `garraia update` and successfully upgrades to `v0.2.1` (verify SHA-256 against `<asset>.sha256`).

## Non-goals

- ARM64 cross-compile of OpenSSL is still best-effort (`if:` gates the release job only on the x86_64 triad). Tracked separately in [GAR-370](https://linear.app/chatgpt25/issue/GAR-370).
- No backwards-compat fallback in `update.rs` for old releases that ship `SHA256SUMS` without per-asset siblings — the previous releases were all prereleases anyway and won't be returned by `/releases/latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)