### PR TITLE
docs(bookkeeping): plan 0125 — PR #341 self-ref fix + plans/README rows 0118-0123 (GAR-623)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,8 +63,8 @@ crates/
                         #338 (Channels + Sessions + `/api/channels`),
                         #339 (Settings Registry + `/api/settings/{schema,effective}` +
                         `PATCH /api/settings` dry-run),
-                        #340 (Diagnostics + Logs + `/api/diagnostics`), PR final (E2E +
-                        ROADMAP/README/CLAUDE). **Nunca** importar Bootstrap/AdminLTE/
+                        #340 (Diagnostics + Logs + `/api/diagnostics`),
+                        #341 (E2E + ROADMAP/README/CLAUDE). **Nunca** importar Bootstrap/AdminLTE/
                         Animate.css de CDN — ports inline (ADR 0009 §3). Endpoints
                         novos do Web Console (todos auth-free em `/api/*`, secret-free):
                         `/api/health` (Dashboard schema com `version`, `gateway_url`,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -779,7 +779,7 @@ Módulo dentro de `garraia-workspace`. Schema entregue via migration 006 com **R
 - [ ] **Sample data**: grupo "Playground" com mensagens, arquivos e memória de exemplo.
 - [ ] **Onboarding tour** com `shepherd.js` ou equivalente no Desktop.
 - [ ] **Empty states** ilustrados em toda a UI.
-- [x] **Web Console redesign "Garra Glass"** (plan 0116 + 0117-0122) ✅ entregue 2026-05-14.
+- [x] **Web Console redesign "Garra Glass"** (plan 0116 + 0117-0123) ✅ entregue 2026-05-14.
       Stack: HTML + CSS (custom properties `--garra-*`) + JS vanilla, sem novas deps runtime
       (zero CDN para Bootstrap/AdminLTE/Animate.css — todos os ícones SVG inline). 9 páginas
       multi-page roteadas por hash: Dashboard, Chat, Providers & Models, Channels, Sessions,
@@ -788,7 +788,7 @@ Módulo dentro de `garraia-workspace`. Schema entregue via migration 006 com **R
       (extended Dashboard schema), `/api/capabilities`, `/api/channels`, `/api/providers/test`,
       `/api/providers/default`, `/api/settings/{schema,effective}`, `PATCH /api/settings`
       (dry-run, audit), `/api/diagnostics`. ADR: `docs/adr/0009-web-console-design-system.md`.
-      Plans: 0116a/0116b/0117-0123. PRs: #330, #331, #332, #333, #334, #335, #337, #338, #339, #340.
+      Plans: 0116a/0116b/0117-0123. PRs: #330, #331, #332, #333, #334, #335, #337, #338, #339, #340, #341.
 
 **Estimativa fase 5:** 6 / 8 / 12 semanas (paralelo).
 **Épicos Linear sugeridos:** `GAR-SEC-HARDEN`, `GAR-TEST-COV`, `GAR-COMPLIANCE`, `GAR-UX-FTUE`.

--- a/plans/0125-gar-623-bookkeeping-plan0123-pr341-self-ref.md
+++ b/plans/0125-gar-623-bookkeeping-plan0123-pr341-self-ref.md
@@ -1,0 +1,66 @@
+# Plan 0125 — GAR-623: docs(bookkeeping) — plan 0123 / PR #341 self-ref fix
+
+**Linear issue:** [GAR-623](https://linear.app/chatgpt25/issue/GAR-623) — "docs(bookkeeping): plan 0123 / PR #341 self-ref fix — CLAUDE.md + ROADMAP + plans/README" (In Progress, Low). Team: GarraIA-RUST.
+
+**Status:** ✅ Approved 2026-05-14 (Florida).
+
+**Goal:** PR #341 (`e570631`) could not write its own PR number into `CLAUDE.md` — a classic self-referential bootstrapping gap. This plan fixes the three dangling references left by that PR and adds the missing `plans/README.md` rows for the web console delivery series (plans 0118–0123).
+
+---
+
+## Root cause
+
+`e570631` (PR #341, plan 0123) added the full 10-PR delivery log to `CLAUDE.md` but had to leave the last entry as `PR final (E2E + ROADMAP/README/CLAUDE)` because the PR number was unknown at write time. Same omission affected:
+
+- `ROADMAP.md` line 782: plan range listed as `0117-0122` (0123 missing).
+- `ROADMAP.md` line 791: PR list ends at `#340` (missing `#341`).
+- `plans/README.md`: no rows for plans 0118–0123 (web console PRs 5–10).
+
+---
+
+## Scope
+
+| File | Change |
+|------|--------|
+| `CLAUDE.md` | `PR final (E2E + ROADMAP/README/CLAUDE)` → `#341 (E2E + ROADMAP/README/CLAUDE)` |
+| `ROADMAP.md` | `0117-0122` → `0117-0123`; add `, #341` to PR list |
+| `plans/README.md` | Add rows for 0118–0123 |
+
+Administrative: close **GAR-486** in Linear (all sub-issues Done; umbrella stale).
+
+---
+
+## Out of scope
+
+- No Rust code changes.
+- No new Playwright tests (already added in PR #341).
+- No ROADMAP structural changes (§7 priority order will be updated in a future session when the next Fase 3.4 slice ships).
+
+---
+
+## Tasks
+
+- [x] T1 — Create plan file (this document) and Linear issue GAR-623.
+- [x] T2 — Fix `CLAUDE.md`: replace `PR final (...)` with `#341 (...)`.
+- [x] T3 — Fix `ROADMAP.md`: add `0123` to plan range; add `#341` to PR list.
+- [x] T4 — Fix `plans/README.md`: add rows 0118–0123.
+- [ ] T5 — Commit, push, open PR.
+- [ ] T6 — CI green → squash-merge.
+- [ ] T7 — Close GAR-486 in Linear; mark GAR-623 Done.
+- [ ] T8 — Update `plans/README.md` with this plan's PR number + commit sha.
+
+---
+
+## Acceptance criteria
+
+- `grep "PR final" CLAUDE.md` returns empty.
+- `grep "#341" CLAUDE.md` matches the PR list entry.
+- `grep "0117-0123" ROADMAP.md` returns a match.
+- `grep "#341" ROADMAP.md` returns a match in the PR list.
+- `plans/README.md` contains rows for 0118, 0119, 0120, 0121, 0122, 0123.
+
+---
+
+## Estimativa
+
+≪10 min implementation, ~20 min CI.

--- a/plans/README.md
+++ b/plans/README.md
@@ -126,4 +126,10 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0116a | [Web Console redesign "Garra Glass" — Chat slice](0116a-web-console-redesign-garra-glass.md) | [GAR-607](https://linear.app/chatgpt25/issue/GAR-607) | ✅ Merged 2026-05-14 via PRs #330 (foundation), #331 (chat), #332 (right panel) |
 | 0116b | [Web Console multi-page vision](0116b-transformar-a-tela-atual-do-GarraIA.md) | [GAR-607](https://linear.app/chatgpt25/issue/GAR-607) | ✅ Merged 2026-05-14 via PRs #333, #335, #337, #338, #339, #340 + plan 0123 finalization |
 | 0117 | [GAR-618 — Web Console PR-4: Dashboard page + GET /api/stats](0117-gar-618-web-console-pr4-dashboard.md) | [GAR-618](https://linear.app/chatgpt25/issue/GAR-618) | ✅ Merged 2026-05-14 via PR #334 (`9e9deab`) |
+| 0118 | GAR-612 — Web Console PR-5: `/api/health` + `/api/capabilities` | [GAR-612](https://linear.app/chatgpt25/issue/GAR-612) | ✅ Merged 2026-05-14 via PR #335 |
+| 0119 | GAR-613 — Web Console PR-6: Providers page + `/api/providers/{test,default}` | [GAR-613](https://linear.app/chatgpt25/issue/GAR-613) | ✅ Merged 2026-05-14 via PR #337 |
+| 0120 | GAR-614 — Web Console PR-7: Channels + Sessions pages + `/api/channels` | [GAR-614](https://linear.app/chatgpt25/issue/GAR-614) | ✅ Merged 2026-05-14 via PR #338 |
+| 0121 | GAR-615 — Web Console PR-8: Settings Registry + `/api/settings/{schema,effective}` + `PATCH /api/settings` | [GAR-615](https://linear.app/chatgpt25/issue/GAR-615) | ✅ Merged 2026-05-14 via PR #339 |
+| 0122 | GAR-616 — Web Console PR-9: Diagnostics + Logs pages + `/api/diagnostics` | [GAR-616](https://linear.app/chatgpt25/issue/GAR-616) | ✅ Merged 2026-05-14 via PR #340 |
+| 0123 | GAR-617 — Web Console PR-10: E2E Playwright matrix + ROADMAP/README/CLAUDE finalization | [GAR-617](https://linear.app/chatgpt25/issue/GAR-617) | ✅ Merged 2026-05-14 via PR #341 (`e570631`) |
 | 0124 | [GAR-620 — bump `metrics 0.24.5` (yanked) → `0.24.6` (health routine 2026-05-14)](0124-gar-620-metrics-yanked-0246.md) | [GAR-620](https://linear.app/chatgpt25/issue/GAR-620) | ✅ Merged 2026-05-14 via PR #336 (`adbe00af`) |


### PR DESCRIPTION
## Summary

PR #341 (`e570631`, plan 0123) could not write its own PR number into `CLAUDE.md` — a classic self-referential bootstrapping gap. This PR closes that gap.

- **CLAUDE.md**: replace `PR final (E2E + ROADMAP/README/CLAUDE)` → `#341 (E2E + ROADMAP/README/CLAUDE)`
- **ROADMAP.md**: plan range `0117-0122` → `0117-0123`; PR list gains `, #341`
- **plans/README.md**: add rows 0118–0123 (web console PRs 5–10, delivered inline without individual plan files)
- **plans/0125-gar-623-…**: new plan file documenting this bookkeeping PR

No Rust code, no schema, no test changes. All CI checks should pass (doc-only).

Linear: [GAR-623](https://linear.app/chatgpt25/issue/GAR-623)

## Test plan

- [ ] `grep "PR final" CLAUDE.md` returns empty
- [ ] `grep "#341" CLAUDE.md` returns the PR list entry
- [ ] `grep "0117-0123" ROADMAP.md` returns a match
- [ ] `grep "#341" ROADMAP.md` matches the PR list
- [ ] `plans/README.md` contains rows for 0118, 0119, 0120, 0121, 0122, 0123
- [ ] CI green (Format + Clippy + Test + Build + all other checks)

https://claude.ai/code/session_018rUHN3BDEFJEhMZhFHzdWJ

---
_Generated by [Claude Code](https://claude.ai/code/session_018rUHN3BDEFJEhMZhFHzdWJ)_