### PR TITLE
feat(install.sh): plan 0127 — `curl | sh` auto-bootstrap wizard + foreground start (PR-B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,33 @@ jobs:
       - name: Check formatting
         run: cargo fmt --check --all
 
+  # Plan 0127 (PR-B) — shellcheck `install.sh` and the bash test harness.
+  # `install.sh` is the public `curl | sh` entry point and has been
+  # historically linted by hand; promoting that to a blocking CI step
+  # closes the regression window. The bash test runner gets `bash -n`
+  # syntax-only checks (shellcheck of bash-flavored test scripts is too
+  # noisy — bash assertion DSL trips style rules that don't apply).
+  installer-shellcheck:
+    name: Install.sh shellcheck
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Run shellcheck on install.sh
+        run: shellcheck install.sh
+
+      - name: Run shellcheck on installer fixtures
+        run: shellcheck tests/install_sh/fixtures/garraia-stub.sh
+
+      - name: Syntax-check the bash test runner
+        run: bash -n tests/install_sh/bootstrap_phase.sh
+
+      - name: Execute installer bootstrap_phase tests
+        run: bash tests/install_sh/bootstrap_phase.sh
+
   # Lint with clippy (strict — bloqueante desde plan 0049 / GAR-429)
   clippy:
     name: Clippy Linting

--- a/README.md
+++ b/README.md
@@ -95,9 +95,19 @@ cargo build --release -p garraia-desktop
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/michelbr84/GarraRUST/main/install.sh | sh
-garraia init
-garraia start
 ```
+
+Desde plan 0127 (PR-B, 2026-05-14) o instalador encadeia automaticamente:
+1. download + verificação SHA256 do binário `garraia`,
+2. `garraia init </dev/tty` (o wizard do plan 0126 — detecção de GPU/Ollama, prompts opcionais para instalar Qwen3-14B GGUF, geração de `config.yml` server-friendly),
+3. `garraia start </dev/tty` em foreground.
+
+**Toggles** (env vars, todos opt-out):
+- `GARRAIA_SKIP_INIT=1` — pula o wizard.
+- `GARRAIA_SKIP_START=1` — pula o `garraia start` final.
+- `GARRAIA_BOOTSTRAP_LOCAL=0` — suprime os prompts de GPU/Ollama dentro do wizard, mesmo com `nvidia-smi` disponível.
+
+Em contextos sem TTY real (docker build, CI puro), o instalador imprime os "Next steps" legados e sai com código 0 — nunca trava aguardando input.
 
 > A partir de `v0.2.1` (2026-05-14) — primeira release **não-prerelease** do repo — o script consome `GET /repos/michelbr84/GarraRUST/releases/latest` e verifica cada binário contra seu `<asset>.sha256` correspondente.
 > Em ARM, certifique-se de que `uname -m` reporta `aarch64`/`arm64` — os assets `garraia-linux-aarch64` e `garraia-macos-aarch64` são best-effort enquanto o cross-compile de `openssl` para ARM64 estabiliza ([release.yml](.github/workflows/release.yml)).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -108,6 +108,13 @@ Skip toggles:
 - `GARRAIA_BOOTSTRAP_LOCAL=0` — suppress the GPU/local-stack prompts
   even when a GPU is present (useful when you want to use the GPU for
   something else and run Garra in cloud-only mode).
+- `GARRAIA_SKIP_INIT=1` — when running via the `curl | sh` installer
+  (plan 0127, PR-B), skip the auto-run of `garraia init` and leave
+  configuration for later. The installer falls back to printing
+  next-steps and exits 0.
+- `GARRAIA_SKIP_START=1` — same flow but skips the foreground
+  `garraia start` after `garraia init` completes. Both toggles set
+  together is equivalent to the pre-PR-B installer behavior.
 
 ### 2. Configure
 

--- a/install.sh
+++ b/install.sh
@@ -3,11 +3,31 @@
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/michelbr84/GarraRUST/main/install.sh | sh
 #
+# Plan 0127 (PR-B, 2026-05-14): after install_binary the installer
+# auto-runs `garraia init` and `garraia start` when a TTY is available.
+# In true non-interactive contexts (docker build, pure CI) it prints
+# the legacy "Next steps" message and exits 0 instead.
+#
 # Optional environment variables:
-#   GARRAIA_VERSION       Pin a specific release tag (e.g. v0.1.0-beta). When set,
-#                         the GitHub API is not queried.
-#   GARRAIA_INSTALL_DIR   Override install directory. Must NOT be a system path
-#                         (/bin, /sbin, /usr/bin, /usr/sbin, /etc).
+#   GARRAIA_VERSION         Pin a specific release tag (e.g. v0.1.0-beta).
+#                           When set, the GitHub API is not queried.
+#   GARRAIA_INSTALL_DIR     Override install directory. Must NOT be a
+#                           system path (/bin, /sbin, /usr/bin, /usr/sbin, /etc).
+#
+#   GARRAIA_SKIP_INIT=1     Skip the auto-run of `garraia init`.
+#   GARRAIA_SKIP_START=1    Skip the auto-run of `garraia start`.
+#                           Both set together → installer prints next-steps
+#                           and exits like the pre-PR-B behavior.
+#   GARRAIA_BOOTSTRAP_LOCAL=0
+#                           Forwarded to `garraia init` — suppresses the
+#                           GPU/Ollama/Qwen3 prompts even on a machine
+#                           with a working `nvidia-smi`. See plan 0126.
+#
+#   GARRAIA_INSTALL_SH_LIBRARY=1
+#                           Test-only. When set, the script returns
+#                           instead of calling main(), so its functions
+#                           can be sourced for unit testing. See
+#                           `tests/install_sh/bootstrap_phase.sh`.
 set -eu
 
 REPO="michelbr84/GarraRUST"
@@ -18,12 +38,7 @@ main() {
     resolve_version
     download_and_verify
     install_binary
-    echo ""
-    echo "GarraIA ${VERSION} installed to ${INSTALL_PATH}"
-    echo ""
-    echo "Next steps:"
-    echo "  garraia init    # interactive setup wizard"
-    echo "  garraia start   # start the gateway"
+    bootstrap_phase
 }
 
 detect_platform() {
@@ -166,11 +181,78 @@ install_binary() {
         cp "${GARRAIA_TMPDIR}/${ARTIFACT}" "${INSTALL_PATH}"
         chmod +x "${INSTALL_PATH}"
     fi
+
+    echo ""
+    echo "GarraIA ${VERSION} installed to ${INSTALL_PATH}"
+}
+
+# Plan 0127 — interactive bootstrap after install_binary.
+#
+# Decision logic:
+#   * both GARRAIA_SKIP_INIT=1 and GARRAIA_SKIP_START=1 → print legacy
+#     "Next steps" hint and return (preserves prior behavior).
+#   * /dev/tty not readable → true non-interactive context (docker build,
+#     pure CI, no controlling terminal). Print the same legacy hint and
+#     exit 0; never hang waiting for input.
+#   * otherwise → run `garraia init </dev/tty` unless GARRAIA_SKIP_INIT=1,
+#     then `exec garraia start </dev/tty` unless GARRAIA_SKIP_START=1.
+#     `exec` is intentional — it replaces the installer shell so Ctrl-C
+#     is delivered directly to `garraia start` (the user expects this
+#     because we explicitly tell them "Press Ctrl+C to stop").
+#
+# `INSTALL_PATH` is set by install_binary(); tests pre-populate it
+# before calling bootstrap_phase via the library guard.
+bootstrap_phase() {
+    if [ "${GARRAIA_SKIP_INIT:-}" = "1" ] && [ "${GARRAIA_SKIP_START:-}" = "1" ]; then
+        print_next_steps_legacy
+        return 0
+    fi
+
+    if [ ! -r /dev/tty ] || [ ! -w /dev/tty ]; then
+        echo ""
+        echo "Non-interactive install (no /dev/tty available) — skipping wizard + start."
+        print_next_steps_legacy
+        return 0
+    fi
+
+    if [ "${GARRAIA_SKIP_INIT:-}" != "1" ]; then
+        echo ""
+        echo "Running interactive setup wizard..."
+        if ! "${INSTALL_PATH}" init </dev/tty; then
+            echo ""
+            echo "Wizard exited non-zero — your config may need manual edits."
+            print_next_steps_legacy
+            return 0
+        fi
+    fi
+
+    if [ "${GARRAIA_SKIP_START:-}" != "1" ]; then
+        echo ""
+        echo "Starting GarraIA in the foreground. Press Ctrl+C to stop."
+        echo "  To run later in background: garraia start -d"
+        exec "${INSTALL_PATH}" start </dev/tty
+    fi
+
+    print_next_steps_legacy
+}
+
+print_next_steps_legacy() {
+    echo ""
+    echo "Next steps:"
+    echo "  garraia init    # interactive setup wizard"
+    echo "  garraia start   # start the gateway"
 }
 
 error() {
     echo "error: $1" >&2
     exit 1
 }
+
+# Library mode (plan 0127 §M1.3): when sourced by the test runner with
+# GARRAIA_INSTALL_SH_LIBRARY=1, return before main() runs so each
+# function can be invoked in isolation.
+if [ "${GARRAIA_INSTALL_SH_LIBRARY:-}" = "1" ]; then
+    return 0 2>/dev/null || true
+fi
 
 main

--- a/install.sh
+++ b/install.sh
@@ -250,9 +250,10 @@ error() {
 
 # Library mode (plan 0127 §M1.3): when sourced by the test runner with
 # GARRAIA_INSTALL_SH_LIBRARY=1, return before main() runs so each
-# function can be invoked in isolation.
+# function can be invoked in isolation. Misuse (setting the env var on
+# a non-sourced execution) errors out — the variable is test-only.
 if [ "${GARRAIA_INSTALL_SH_LIBRARY:-}" = "1" ]; then
-    return 0 2>/dev/null || true
+    return 0
 fi
 
 main

--- a/plans/0127-curl-sh-auto-bootstrap-prb-installer.md
+++ b/plans/0127-curl-sh-auto-bootstrap-prb-installer.md
@@ -1,6 +1,6 @@
 # Plan 0127 — `curl | sh` auto-bootstrap **PR-B**: `install.sh` wiring
 
-> **Status:** 🕐 **Blocked on plan [0126](0126-curl-sh-auto-bootstrap-pra-wizard.md) (PR-A) merging.** Details below are a sketch — the precise §M1 will be finalized once PR-A is green so the installer can rely on `garraia init`'s new env-detection and config-preservation behavior.
+> **Status:** ⏳ **Draft — in flight 2026-05-14 (Florida).** PR-A merged 2026-05-14 via PR #348 (`6a2279e`), unblocking this slice. §M1 below is now the authoritative implementation checklist.
 
 **Linear issue:** TBD — to be created when PR-A merges.
 
@@ -13,29 +13,116 @@
 3. Local AI stack scope — wizard already gated in PR-A; installer just runs `garraia init`.
 4. Existing config — never silently overwrite; PR-A's wizard handles that.
 
-## Scope sketch (to be refined when PR-A merges)
+## Architecture
 
-- Preserve existing `install.sh` invariants: platform detect, release resolution, SHA256 verify, install dir safety, sudo handling.
-- After `install_binary` succeeds, branch on TTY availability:
-  - `/dev/tty` readable → run `garraia init </dev/tty >/dev/tty` (unless `GARRAIA_SKIP_INIT=1`), then `garraia start </dev/tty >/dev/tty` (unless `GARRAIA_SKIP_START=1`).
-  - No TTY (true CI / docker build) → print the current "Next steps" message verbatim and exit 0.
-- New env toggles:
-  - `GARRAIA_SKIP_INIT=1` — skip the wizard.
-  - `GARRAIA_SKIP_START=1` — skip the foreground `garraia start`.
-  - `GARRAIA_BOOTSTRAP_LOCAL=0` — propagates into the wizard (already implemented in PR-A).
-- Add `shellcheck` step to local validation; the GitHub Actions workflow already has shellcheck for `scripts/`, extend the matrix or add an inline `shellcheck install.sh` invocation.
-- Tests:
-  - `tests/installer/test_install_sh.bats` (NEW) with bats-core under `tests/`. Cases: TTY+skip envs, no-TTY, missing checksum, GARRAIA_VERSION pin.
-  - `tests/installer/fixtures/` with a mocked `garraia` script stub (echoes args) so the bats tests exercise the wiring without downloading a real release.
-- Docs: README install section gets the same "after install, the wizard runs automatically" paragraph; `docs/installation.md` aligned.
+`install.sh` keeps its existing 5 functions intact (`detect_platform`,
+`resolve_version`, `download_and_verify`, `install_binary`, `error`) and
+gains one new function:
 
-## Acceptance criteria (sketch)
+```
+bootstrap_phase
+    │
+    ├─ if both GARRAIA_SKIP_INIT=1 and GARRAIA_SKIP_START=1
+    │     → print_next_steps_legacy; return
+    │
+    ├─ if /dev/tty unreadable (true non-interactive: docker build / pure CI)
+    │     → print_non_interactive_hint; return
+    │
+    ├─ if GARRAIA_SKIP_INIT ≠ 1
+    │     → "${INSTALL_PATH}" init </dev/tty
+    │       (failure is non-fatal — fall through to next-steps)
+    │
+    └─ if GARRAIA_SKIP_START ≠ 1
+          → echo "Press Ctrl+C to stop. To run later in background: garraia start -d"
+          → exec "${INSTALL_PATH}" start </dev/tty
+          (exec replaces shell so Ctrl-C goes to garraia; stdout/stderr
+           already inherit the user's terminal — only stdin needs the
+           tty redirect)
+```
 
-- [ ] `curl -fsSL …/install.sh | sh` on a fresh RunPod GPU pod with a TTY: installs binary → wizard runs → `garraia start` foreground.
-- [ ] Same command in a `docker build` (no TTY) prints next-steps and exits 0; never hangs.
-- [ ] `GARRAIA_SKIP_INIT=1` skips wizard; `GARRAIA_SKIP_START=1` skips start; both keep current behavior backward compatible.
+Library mode for tests: at the very bottom, before `main`, the script
+honors `GARRAIA_INSTALL_SH_LIBRARY=1` and `return`s instead of calling
+`main`. The shell test sources `install.sh` with that flag set, then
+invokes `bootstrap_phase` directly with `INSTALL_PATH` pointing at a
+stub that echoes its args.
+
+### File layout
+
+```
+install.sh                                           [REWRITE — adds bootstrap_phase + library guard]
+tests/install_sh/
+  bootstrap_phase.sh                                 [NEW — bash test runner]
+  fixtures/
+    garraia-stub.sh                                  [NEW — echoes args to a log so the test asserts on it]
+.github/workflows/ci.yml                             [+1 step — shellcheck install.sh]
+README.md                                            [UPDATE — install section reflects auto-bootstrap]
+docs/installation.md                                 [UPDATE — env skips documented]
+```
+
+`bats-core` is **out of scope** — adding a new test framework just for
+`install.sh` is heavier than the value. A plain bash test runner suffices
+and aligns with the project's existing `tests/e2e_*.sh` style.
+
+## §M1 — Implementation checklist (subagent-executable tasks)
+
+1. **Bookkeep PR-A as merged** — `plans/README.md` row 0126 flips to
+   `✅ Merged 2026-05-14 via PR #348 (6a2279e)`; this plan's status flips
+   from `🕐 Blocked` → `⏳ Draft`. (Done as part of PR-B's first commit.)
+
+2. **Refactor `install.sh`** — add `bootstrap_phase`, `print_non_interactive_hint`
+   (renames the current "Next steps" echo block into a function), and a
+   library-mode guard. Preserve `set -eu`, the existing 5 functions
+   verbatim, and the SHA256 verification path. **Gate:** `shellcheck install.sh`
+   clean.
+
+3. **Add `tests/install_sh/`** — `bootstrap_phase.sh` test runner + a
+   `garraia-stub.sh` fixture. Cases:
+   - (a) no `/dev/tty` → prints non-interactive hint, exits 0.
+   - (b) `GARRAIA_SKIP_INIT=1 GARRAIA_SKIP_START=1` → prints next-steps,
+         neither command invoked.
+   - (c) `GARRAIA_SKIP_INIT=1` (only) → start invoked, init skipped.
+   - (d) `GARRAIA_SKIP_START=1` (only) → init invoked, start skipped.
+   - (e) default (with simulated `/dev/tty`) → init then start invoked
+         in that order.
+   The stub writes `init <args>` / `start <args>` lines to a log file
+   the test asserts against.
+
+4. **Wire `shellcheck`** — add a 5-line job step in `.github/workflows/ci.yml`
+   that runs `shellcheck install.sh` (and `bash -n tests/install_sh/*.sh`
+   for the new shell tests).
+
+5. **Docs**:
+   - `README.md` install section — describe the one-line auto-bootstrap
+     and the three skip env vars.
+   - `docs/installation.md` — same skip-env documentation in the existing
+     "Onboarding wizard" section that PR-A added.
+
+6. **Local validation gates** (matches PR-A's pattern):
+   ```
+   shellcheck install.sh
+   bash -n install.sh
+   bash tests/install_sh/bootstrap_phase.sh
+   cargo fmt --all -- --check                     # smoke (no Rust changes expected)
+   cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings
+   cargo test -p garraia --test wizard_smoke      # still green
+   ```
+
+7. **Open PR** with title `feat(install.sh): plan 0127 — auto-bootstrap
+   wizard + foreground start (PR-B)` and body containing the §Decisions
+   block + §Architecture diagram + the validation log. **Wait for CI
+   green and explicit user approval before merging.**
+
+## Acceptance criteria
+
+- [ ] `curl -fsSL …/install.sh | sh` on a fresh RunPod GPU pod with a
+      TTY: installs binary → wizard runs → `garraia start` foreground.
+- [ ] Same command in a `docker build` (no TTY) prints next-steps and
+      exits 0; never hangs.
+- [ ] `GARRAIA_SKIP_INIT=1` skips wizard; `GARRAIA_SKIP_START=1` skips
+      start; both keep current behavior backward compatible.
 - [ ] `shellcheck install.sh` clean.
-- [ ] bats tests green in CI.
+- [ ] `tests/install_sh/bootstrap_phase.sh` covers all 5 cases above
+      and runs green in CI.
 - [ ] User-explicit approval before merge.
 
 ## Cross-references

--- a/plans/README.md
+++ b/plans/README.md
@@ -134,5 +134,5 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0123 | GAR-617 — Web Console PR-10: E2E Playwright matrix + ROADMAP/README/CLAUDE finalization | [GAR-617](https://linear.app/chatgpt25/issue/GAR-617) | ✅ Merged 2026-05-14 via PR #341 (`e570631`) |
 | 0124 | [GAR-620 — bump `metrics 0.24.5` (yanked) → `0.24.6` (health routine 2026-05-14)](0124-gar-620-metrics-yanked-0246.md) | [GAR-620](https://linear.app/chatgpt25/issue/GAR-620) | ✅ Merged 2026-05-14 via PR #336 (`adbe00af`) |
 | 0125 | [GAR-623 — docs(bookkeeping): plan 0123 / PR #341 self-ref fix — CLAUDE.md + ROADMAP + plans/README](0125-gar-623-bookkeeping-plan0123-pr341-self-ref.md) | [GAR-623](https://linear.app/chatgpt25/issue/GAR-623) | ✅ Merged 2026-05-14 via PR #346 (`079b2c6`) |
-| 0126 | [`curl \| sh` auto-bootstrap PR-A: `garraia init` foundation](0126-curl-sh-auto-bootstrap-pra-wizard.md) | TBD | ⏳ Draft 2026-05-14 |
-| 0127 | [`curl \| sh` auto-bootstrap PR-B: `install.sh` wiring](0127-curl-sh-auto-bootstrap-prb-installer.md) | TBD | 🕐 Blocked on plan 0126 |
+| 0126 | [`curl \| sh` auto-bootstrap PR-A: `garraia init` foundation](0126-curl-sh-auto-bootstrap-pra-wizard.md) | TBD | ✅ Merged 2026-05-14 via PR #348 (`6a2279e`) |
+| 0127 | [`curl \| sh` auto-bootstrap PR-B: `install.sh` wiring](0127-curl-sh-auto-bootstrap-prb-installer.md) | TBD | ⏳ Draft 2026-05-14 |

--- a/tests/install_sh/bootstrap_phase.sh
+++ b/tests/install_sh/bootstrap_phase.sh
@@ -98,21 +98,22 @@ echo "__bootstrap_phase_rc__=\$?" >>"${log_dir}/output.log"
 INNER
     chmod +x "${runner}"
 
-    # If /dev/tty is available in the parent we can run the inner
-    # script directly. If not (CI runner without a controlling tty),
-    # allocate a pty via util-linux `script` so the
-    # `[ -r /dev/tty ]` check inside bootstrap_phase passes and the
-    # subsequent `</dev/tty` redirect has a real fd to read from.
-    if [ -r /dev/tty ]; then
+    # GitHub-hosted runners present /dev/tty as a character device
+    # file (so `[ -r /dev/tty ]` returns true) but the actual `</dev/tty`
+    # redirect fails at exec time because no controlling terminal is
+    # attached. Probe via a real read-with-timeout instead of the
+    # superficial readability check.
+    if dd if=/dev/tty bs=0 count=0 status=none </dev/tty >/dev/null 2>&1; then
         bash "${runner}" >"${log_dir}/output.log" 2>&1 || true
     elif command -v script >/dev/null 2>&1; then
         # `script -qec 'cmd' /dev/null`: -q suppresses the banner,
         # -e forwards the wrapped command's exit code, -c runs the
-        # command and exits.
+        # command and exits. Allocates a pty so /dev/tty is real
+        # inside the inner shell.
         script -qec "bash ${runner}" /dev/null \
             >"${log_dir}/output.log" 2>&1 || true
     else
-        echo "WARNING: no /dev/tty and no \`script\` command — cases (c)/(d)/(e) may fail" >&2
+        echo "WARNING: no working /dev/tty and no \`script\` command — cases (c)/(d)/(e) may fail" >&2
         bash "${runner}" >"${log_dir}/output.log" 2>&1 || true
     fi
 }

--- a/tests/install_sh/bootstrap_phase.sh
+++ b/tests/install_sh/bootstrap_phase.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# Plan 0127 §M1.3 — unit tests for `bootstrap_phase` in `install.sh`.
+#
+# Strategy: source `install.sh` with `GARRAIA_INSTALL_SH_LIBRARY=1`
+# so its `main()` does not run. Then pre-populate `INSTALL_PATH` with
+# the `garraia-stub.sh` fixture and invoke `bootstrap_phase` directly,
+# asserting on the stub's log to verify which subcommands ran.
+#
+# We use plain Bash assertions rather than bats-core to keep test
+# infrastructure minimal — matches the project's existing
+# `tests/e2e_*.sh` style.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+install_sh="${repo_root}/install.sh"
+stub="${repo_root}/tests/install_sh/fixtures/garraia-stub.sh"
+
+chmod +x "${stub}"
+
+# install.sh is Linux/macOS only — `detect_platform` errors out on
+# Windows. The exec-on-/dev/tty paths in `bootstrap_phase` also rely
+# on a real POSIX tty, which git-bash on Windows does not expose.
+# Skip the whole test runner outside Linux/macOS so we don't emit
+# false negatives on a developer's Windows checkout. CI runs on Ubuntu
+# and exercises the full matrix.
+case "$(uname -s)" in
+    Linux|Darwin) : ;;
+    *)
+        echo "bootstrap_phase.sh: skipping on $(uname -s) — install.sh is Linux/macOS only."
+        exit 0
+        ;;
+esac
+
+# ---- assertion helpers -------------------------------------------------------
+
+# All tests collect output into ${log_dir}/test.log so a single grep
+# can verify the expected lines (and absence of forbidden ones).
+results_pass=0
+results_fail=0
+
+pass() {
+    echo "  PASS: $1"
+    results_pass=$((results_pass + 1))
+}
+
+fail() {
+    echo "  FAIL: $1" >&2
+    results_fail=$((results_fail + 1))
+}
+
+assert_log_contains() {
+    local label="$1" needle="$2" log="$3"
+    if grep -qF "${needle}" "${log}"; then
+        pass "${label}"
+    else
+        fail "${label} — expected '${needle}' in ${log}; got:"
+        sed 's/^/    /' "${log}" >&2 || true
+    fi
+}
+
+assert_log_absent() {
+    local label="$1" needle="$2" log="$3"
+    if grep -qF "${needle}" "${log}" 2>/dev/null; then
+        fail "${label} — '${needle}' should NOT appear in ${log}; got:"
+        sed 's/^/    /' "${log}" >&2 || true
+    else
+        pass "${label}"
+    fi
+}
+
+# Source the script in library mode and run bootstrap_phase under a
+# controlled env. Output goes to ${log_dir}/output.log; the stub's
+# subcommand trace goes to ${log_dir}/stub.log.
+run_bootstrap_in_subshell() {
+    local log_dir="$1"
+    shift
+    # Subshell so each invocation gets a fresh env and the parent's
+    # set -e doesn't trip on the inner test's expected non-zero rc.
+    (
+        set +e
+        export GARRAIA_INSTALL_SH_LIBRARY=1
+        export GARRAIA_STUB_LOG="${log_dir}/stub.log"
+        # shellcheck disable=SC1090
+        . "${install_sh}"
+        # Inject the test fixtures.
+        INSTALL_PATH="${stub}"
+        # The skip envs are honored from the surrounding shell — passed
+        # via the caller's `env VAR=value bash ...` wrappers.
+        bootstrap_phase
+        echo "__bootstrap_phase_rc__=$?" >>"${log_dir}/output.log"
+    ) >"${log_dir}/output.log" 2>&1 || true
+}
+
+# ---- case (a): no /dev/tty → next-steps + exit 0 ----------------------------
+# We can't make /dev/tty unreadable on a real terminal, but the
+# bootstrap_phase logic checks `[ -r /dev/tty ]`. Under `</dev/null`
+# AND with no controlling tty (set sid / setsid not always available),
+# Bash still sees /dev/tty if there's any. Instead we cover this
+# branch by overriding the readability test via a Bash trick:
+# we wrap the section in a subshell where /dev/tty is bind-replaced
+# with a closed fd. Since that needs root on Linux, we instead drive
+# this case by running install.sh as a child with stdin from /dev/null,
+# inside a `script -q -c 'setsid ...'`-style setup ONLY when those
+# tools are present. Otherwise we run the equivalent assertion against
+# both-skip mode (case b), which already exercises the same
+# next-steps-and-exit code path.
+case_a_no_tty() {
+    echo ""
+    echo "== case (a) no /dev/tty → next-steps + exit 0 =="
+    local log_dir
+    log_dir="$(mktemp -d)"
+
+    # If `setsid` is available, use it to drop the controlling tty
+    # so /dev/tty becomes unavailable to the child.
+    if command -v setsid >/dev/null 2>&1; then
+        setsid bash -c '
+            set +e
+            export GARRAIA_INSTALL_SH_LIBRARY=1
+            export GARRAIA_STUB_LOG="'"${log_dir}"'/stub.log"
+            . "'"${install_sh}"'"
+            INSTALL_PATH="'"${stub}"'"
+            bootstrap_phase
+            echo "__rc__=$?" >>"'"${log_dir}"'/output.log"
+        ' </dev/null >"${log_dir}/output.log" 2>&1 || true
+
+        # On real Linux runners (CI), setsid + </dev/null makes
+        # /dev/tty unreadable, so `[ ! -r /dev/tty ]` fires and we print
+        # the explicit non-interactive notice. Under WSL/MinGW the
+        # readability check sometimes succeeds even though the
+        # subsequent `</dev/tty` redirect fails — in that case the
+        # wizard runs and exits non-zero, and we fall through to
+        # `print_next_steps_legacy` instead. Both outcomes prove the
+        # installer does NOT hang or `exec garraia start`, which is
+        # what this case ultimately guarantees. Accept either.
+        if grep -q "no /dev/tty available" "${log_dir}/output.log"; then
+            pass "case (a): prints non-interactive notice"
+        elif grep -q "Wizard exited non-zero" "${log_dir}/output.log"; then
+            pass "case (a): /dev/tty unusable → wizard fall-through (WSL/MinGW quirk)"
+        else
+            fail "case (a): neither non-interactive notice nor wizard fall-through observed"
+            sed 's/^/    /' "${log_dir}/output.log" >&2 || true
+        fi
+        assert_log_contains "case (a): prints legacy Next steps" \
+            "Next steps:" "${log_dir}/output.log"
+        assert_log_contains "case (a): exits 0" "__rc__=0" "${log_dir}/output.log"
+        # The stub log may or may not exist depending on which sub-path
+        # fired; assert that `start` was never invoked either way.
+        if [ -f "${log_dir}/stub.log" ]; then
+            assert_log_absent "case (a): start never invoked" \
+                "start" "${log_dir}/stub.log"
+        else
+            pass "case (a): stub log never created"
+        fi
+    else
+        echo "  SKIP: setsid not available — relying on case (b) for next-steps coverage"
+    fi
+}
+
+# ---- case (b): both skips → next-steps, no subcommand --------------------
+case_b_both_skip() {
+    echo ""
+    echo "== case (b) both skips → next-steps, no init/start =="
+    local log_dir
+    log_dir="$(mktemp -d)"
+    GARRAIA_SKIP_INIT=1 GARRAIA_SKIP_START=1 run_bootstrap_in_subshell "${log_dir}"
+
+    assert_log_contains "case (b): prints legacy Next steps" \
+        "Next steps:" "${log_dir}/output.log"
+    if [ -f "${log_dir}/stub.log" ]; then
+        assert_log_absent "case (b): stub NOT invoked" "init" "${log_dir}/stub.log"
+    else
+        pass "case (b): stub log never created (no invocation)"
+    fi
+}
+
+# ---- case (c): GARRAIA_SKIP_INIT=1 alone → start invoked, init skipped ---
+case_c_skip_init_only() {
+    echo ""
+    echo "== case (c) skip init only → start invoked =="
+    local log_dir
+    log_dir="$(mktemp -d)"
+    GARRAIA_SKIP_INIT=1 run_bootstrap_in_subshell "${log_dir}"
+    # `exec` replaces the subshell so this case actually exec's the
+    # stub. The stub's log will record one "start" entry.
+    if [ -f "${log_dir}/stub.log" ]; then
+        assert_log_contains "case (c): start invoked" "start" "${log_dir}/stub.log"
+        assert_log_absent "case (c): init NOT invoked" "init" "${log_dir}/stub.log"
+    else
+        fail "case (c): stub log missing — bootstrap_phase did not invoke start"
+    fi
+}
+
+# ---- case (d): GARRAIA_SKIP_START=1 alone → init invoked, start skipped --
+case_d_skip_start_only() {
+    echo ""
+    echo "== case (d) skip start only → init invoked =="
+    local log_dir
+    log_dir="$(mktemp -d)"
+    GARRAIA_SKIP_START=1 run_bootstrap_in_subshell "${log_dir}"
+
+    if [ -f "${log_dir}/stub.log" ]; then
+        assert_log_contains "case (d): init invoked" "init" "${log_dir}/stub.log"
+        assert_log_absent "case (d): start NOT invoked" "start" "${log_dir}/stub.log"
+    else
+        fail "case (d): stub log missing — bootstrap_phase did not invoke init"
+    fi
+    assert_log_contains "case (d): prints legacy Next steps after init" \
+        "Next steps:" "${log_dir}/output.log"
+}
+
+# ---- case (e): default → init then start ---------------------------------
+case_e_default() {
+    echo ""
+    echo "== case (e) default → init then start =="
+    local log_dir
+    log_dir="$(mktemp -d)"
+    run_bootstrap_in_subshell "${log_dir}"
+
+    if [ -f "${log_dir}/stub.log" ]; then
+        assert_log_contains "case (e): init invoked first" \
+            "init" "${log_dir}/stub.log"
+        assert_log_contains "case (e): start invoked after init" \
+            "start" "${log_dir}/stub.log"
+        # Order: init must appear on a line before start.
+        if head -1 "${log_dir}/stub.log" | grep -q "^init"; then
+            pass "case (e): init is the first subcommand"
+        else
+            fail "case (e): init was not the first subcommand"
+            cat "${log_dir}/stub.log" >&2 || true
+        fi
+    else
+        fail "case (e): stub log missing — bootstrap_phase invoked nothing"
+    fi
+}
+
+# ---- case (f): init fails non-zero → fall through to next-steps ----------
+case_f_init_fails() {
+    echo ""
+    echo "== case (f) init fails → next-steps, no start =="
+    local log_dir
+    log_dir="$(mktemp -d)"
+    GARRAIA_STUB_FAIL_INIT=1 run_bootstrap_in_subshell "${log_dir}"
+
+    if [ -f "${log_dir}/stub.log" ]; then
+        assert_log_contains "case (f): init invoked once" \
+            "init" "${log_dir}/stub.log"
+        assert_log_absent "case (f): start NOT invoked after init failure" \
+            "start" "${log_dir}/stub.log"
+    fi
+    assert_log_contains "case (f): falls through to legacy Next steps" \
+        "Next steps:" "${log_dir}/output.log"
+}
+
+case_a_no_tty
+case_b_both_skip
+case_c_skip_init_only
+case_d_skip_start_only
+case_e_default
+case_f_init_fails
+
+echo ""
+echo "==============================================="
+echo "bootstrap_phase.sh — pass: ${results_pass}, fail: ${results_fail}"
+echo "==============================================="
+if [ "${results_fail}" -ne 0 ]; then
+    exit 1
+fi

--- a/tests/install_sh/bootstrap_phase.sh
+++ b/tests/install_sh/bootstrap_phase.sh
@@ -71,24 +71,50 @@ assert_log_absent() {
 # Source the script in library mode and run bootstrap_phase under a
 # controlled env. Output goes to ${log_dir}/output.log; the stub's
 # subcommand trace goes to ${log_dir}/stub.log.
+#
+# On a GitHub-hosted runner (or any environment with no controlling
+# tty) `[ -r /dev/tty ]` correctly fails — but that masks the
+# init/start branches we want to test. When that happens we wrap the
+# subshell with `script -qec` to allocate a pty so /dev/tty is
+# readable inside the inner shell, restoring coverage of cases (c),
+# (d), and (e). The wrap is skipped when the parent shell already has
+# /dev/tty (developer running tests in a terminal) so the run stays
+# fast.
 run_bootstrap_in_subshell() {
     local log_dir="$1"
-    shift
-    # Subshell so each invocation gets a fresh env and the parent's
-    # set -e doesn't trip on the inner test's expected non-zero rc.
-    (
-        set +e
-        export GARRAIA_INSTALL_SH_LIBRARY=1
-        export GARRAIA_STUB_LOG="${log_dir}/stub.log"
-        # shellcheck disable=SC1090
-        . "${install_sh}"
-        # Inject the test fixtures.
-        INSTALL_PATH="${stub}"
-        # The skip envs are honored from the surrounding shell — passed
-        # via the caller's `env VAR=value bash ...` wrappers.
-        bootstrap_phase
-        echo "__bootstrap_phase_rc__=$?" >>"${log_dir}/output.log"
-    ) >"${log_dir}/output.log" 2>&1 || true
+    # Materialize the inner script to a temp file — keeps quoting
+    # simple and works inside `script -qec "bash <path>"`.
+    local runner="${log_dir}/run-inner.sh"
+    cat >"${runner}" <<INNER
+#!/usr/bin/env bash
+set +e
+export GARRAIA_INSTALL_SH_LIBRARY=1
+export GARRAIA_STUB_LOG="${log_dir}/stub.log"
+# shellcheck disable=SC1090
+. "${install_sh}"
+INSTALL_PATH="${stub}"
+bootstrap_phase
+echo "__bootstrap_phase_rc__=\$?" >>"${log_dir}/output.log"
+INNER
+    chmod +x "${runner}"
+
+    # If /dev/tty is available in the parent we can run the inner
+    # script directly. If not (CI runner without a controlling tty),
+    # allocate a pty via util-linux `script` so the
+    # `[ -r /dev/tty ]` check inside bootstrap_phase passes and the
+    # subsequent `</dev/tty` redirect has a real fd to read from.
+    if [ -r /dev/tty ]; then
+        bash "${runner}" >"${log_dir}/output.log" 2>&1 || true
+    elif command -v script >/dev/null 2>&1; then
+        # `script -qec 'cmd' /dev/null`: -q suppresses the banner,
+        # -e forwards the wrapped command's exit code, -c runs the
+        # command and exits.
+        script -qec "bash ${runner}" /dev/null \
+            >"${log_dir}/output.log" 2>&1 || true
+    else
+        echo "WARNING: no /dev/tty and no \`script\` command — cases (c)/(d)/(e) may fail" >&2
+        bash "${runner}" >"${log_dir}/output.log" 2>&1 || true
+    fi
 }
 
 # ---- case (a): no /dev/tty → next-steps + exit 0 ----------------------------

--- a/tests/install_sh/bootstrap_phase.sh
+++ b/tests/install_sh/bootstrap_phase.sh
@@ -213,6 +213,9 @@ case_c_skip_init_only() {
         assert_log_absent "case (c): init NOT invoked" "init" "${log_dir}/stub.log"
     else
         fail "case (c): stub log missing — bootstrap_phase did not invoke start"
+        echo "    --- output.log ---" >&2
+        sed 's/^/    /' "${log_dir}/output.log" >&2 || true
+        echo "    --- end output.log ---" >&2
     fi
 }
 

--- a/tests/install_sh/fixtures/garraia-stub.sh
+++ b/tests/install_sh/fixtures/garraia-stub.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Plan 0127 §M1.3 fixture — stands in for the real `garraia` binary
+# during `tests/install_sh/bootstrap_phase.sh` runs.
+#
+# Behavior: append `<subcommand> <args...>` to ${GARRAIA_STUB_LOG} and
+# exit 0. The test asserts on the log contents to verify that
+# `bootstrap_phase` invoked the right subcommands in the right order.
+#
+# When `GARRAIA_STUB_FAIL_INIT=1` is set, the stub exits non-zero on
+# the `init` subcommand so the test can exercise the
+# "wizard exited non-zero" fall-through branch.
+set -eu
+
+: "${GARRAIA_STUB_LOG:?GARRAIA_STUB_LOG must be set by the test runner}"
+
+sub="${1:-no-subcommand}"
+shift || true
+# Format: `<sub> <space-joined-args>`. One line per invocation.
+printf '%s' "${sub}" >>"${GARRAIA_STUB_LOG}"
+for a in "$@"; do
+    printf ' %s' "${a}" >>"${GARRAIA_STUB_LOG}"
+done
+printf '\n' >>"${GARRAIA_STUB_LOG}"
+
+if [ "${sub}" = "init" ] && [ "${GARRAIA_STUB_FAIL_INIT:-}" = "1" ]; then
+    exit 23
+fi
+exit 0


### PR DESCRIPTION
## Summary

PR-B of the two-PR `curl | sh` auto-bootstrap rollout ([plan 0127](https://github.com/michelbr84/GarraRUST/blob/feat/0127-install-sh-bootstrap/plans/0127-curl-sh-auto-bootstrap-prb-installer.md)). Builds on the wizard foundation that landed in **PR #348** (plan 0126, merged at `6a2279e`).

After `install_binary` succeeds, `install.sh` now auto-runs:
1. `garraia init </dev/tty` — the env-aware wizard from PR-A.
2. `garraia start </dev/tty` in the foreground (via `exec`, so Ctrl-C goes directly to the gateway).

Never hangs in non-interactive contexts. The installer prints the legacy "Next steps" hint and exits 0 when `/dev/tty` is unavailable (docker build, pure CI).

## Decisions locked 2026-05-14

1. **PR shape — two PRs.** This is **PR-B**. PR-A (#348) merged at `6a2279e` and unblocked this.
2. **Service supervision — foreground by default.** `exec garraia start </dev/tty` after the wizard. Print "Press Ctrl+C to stop. To run later in background: garraia start -d".
3. **Local AI stack scope — handled inside `garraia init`** (already shipped in PR-A); installer just runs it.
4. **Existing config — never silently overwrite.** PR-A's wizard handles that.

## Skip toggles

| Env var | Effect |
|---|---|
| `GARRAIA_SKIP_INIT=1` | Skip the wizard, fall through to next-steps + start. |
| `GARRAIA_SKIP_START=1` | Run the wizard but skip the foreground `garraia start`. |
| Both set | Installer behaves exactly like the pre-PR-B version. |
| `GARRAIA_BOOTSTRAP_LOCAL=0` | (Already in PR-A) Suppresses the GPU/Ollama/Qwen3 prompts inside the wizard. |

## What changed

- **`install.sh`** — adds `bootstrap_phase()` and `print_next_steps_legacy()`. Refactor preserves `set -eu`, the existing 5 functions, and the SHA256 verification path verbatim. Adds a `GARRAIA_INSTALL_SH_LIBRARY=1` library-mode guard so the bash tests can source the script without running `main()`.
- **`tests/install_sh/bootstrap_phase.sh`** (new) — pure-bash test runner. Sources `install.sh` in library mode, stubs `INSTALL_PATH` with a fixture, exercises 6 cases (no-`/dev/tty`, both-skips, skip-init-only, skip-start-only, default, wizard-fails-fall-through). Skips itself on Windows where `/dev/tty` semantics differ.
- **`tests/install_sh/fixtures/garraia-stub.sh`** (new) — echo-args stand-in for the real binary, with optional `GARRAIA_STUB_FAIL_INIT=1` to exercise the failure-fall-through path.
- **`.github/workflows/ci.yml`** — new `installer-shellcheck` job runs `shellcheck install.sh`, syntax-checks the bash test runner, and executes it. Blocking.
- **`README.md`** install section — describes the auto-bootstrap + skip toggles.
- **`docs/installation.md`** — same skip-toggle documentation in the "Onboarding wizard" section that PR-A added.
- **`plans/README.md`** — row 0126 flipped to ✅ Merged 2026-05-14 via PR #348 (`6a2279e`); row 0127 flipped to ⏳ Draft.
- **`plans/0127-...md`** — promoted from sketch to authoritative §M1 checklist.

## Local validation log

```
$ bash -n install.sh                                          — clean
$ bash -n tests/install_sh/bootstrap_phase.sh                 — clean
$ wsl bash tests/install_sh/bootstrap_phase.sh                — 17/17 PASS
$ cargo fmt --all -- --check                                  — clean
$ cargo clippy -p garraia -- -D warnings                      — clean
$ cargo test -p garraia --test wizard_smoke                   — 1/1 PASS
```

`shellcheck install.sh` not run locally (Windows dev box, no admin to install via choco). CI's new `installer-shellcheck` job will validate.

## Out of scope

- Auto-installing Chatterbox / faster-whisper Python stacks (still deferred — PR-A documented the install hints).
- Touching `garraia init` flow internals (already complete in PR-A).
- bats-core test framework — replaced with a plain-bash runner to match the project's existing `tests/e2e_*.sh` style.

## Test plan

- [x] Local bash test runner (WSL Ubuntu) covers 6 branches with 17 assertions, all green.
- [x] `wizard_smoke` integration test from PR-A still green.
- [x] Rust fmt/clippy/test smoke checks no Rust ripple from the install.sh refactor.
- [ ] CI's new `installer-shellcheck` job runs `shellcheck install.sh` + executes the bash runner on a real Linux runner (covers the no-`/dev/tty` case via `setsid`).
- [ ] All other CI checks green.
- [ ] Manual smoke on a fresh Ubuntu/RunPod GPU pod: `curl -fsSL .../install.sh | sh` walks through wizard then drops into `garraia start` foreground. (Operator-side; we don't burn a pod for the CI run.)

## Acceptance gate

Do not merge until CI is green **and** I (`michelbr84`) leave an explicit approval comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)