### PR TITLE
chore(bookkeeping): mark plan 0127 / PR #350 merged

### DIFF
--- a/plans/0127-curl-sh-auto-bootstrap-prb-installer.md
+++ b/plans/0127-curl-sh-auto-bootstrap-prb-installer.md
@@ -1,6 +1,6 @@
 # Plan 0127 — `curl | sh` auto-bootstrap **PR-B**: `install.sh` wiring
 
-> **Status:** ⏳ **Draft — in flight 2026-05-14 (Florida).** PR-A merged 2026-05-14 via PR #348 (`6a2279e`), unblocking this slice. §M1 below is now the authoritative implementation checklist.
+> **Status:** ✅ **Merged 2026-05-14 (Florida) via PR #350 (`bfddf78`).** PR-A merged earlier the same day via PR #348 (`6a2279e`), which unblocked this slice. §M1 below was the authoritative implementation checklist during execution.
 
 **Linear issue:** TBD — to be created when PR-A merges.
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -135,5 +135,5 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0124 | [GAR-620 — bump `metrics 0.24.5` (yanked) → `0.24.6` (health routine 2026-05-14)](0124-gar-620-metrics-yanked-0246.md) | [GAR-620](https://linear.app/chatgpt25/issue/GAR-620) | ✅ Merged 2026-05-14 via PR #336 (`adbe00af`) |
 | 0125 | [GAR-623 — docs(bookkeeping): plan 0123 / PR #341 self-ref fix — CLAUDE.md + ROADMAP + plans/README](0125-gar-623-bookkeeping-plan0123-pr341-self-ref.md) | [GAR-623](https://linear.app/chatgpt25/issue/GAR-623) | ✅ Merged 2026-05-14 via PR #346 (`079b2c6`) |
 | 0126 | [`curl \| sh` auto-bootstrap PR-A: `garraia init` foundation](0126-curl-sh-auto-bootstrap-pra-wizard.md) | TBD | ✅ Merged 2026-05-14 via PR #348 (`6a2279e`) |
-| 0127 | [`curl \| sh` auto-bootstrap PR-B: `install.sh` wiring](0127-curl-sh-auto-bootstrap-prb-installer.md) | TBD | ⏳ Draft 2026-05-14 |
+| 0127 | [`curl \| sh` auto-bootstrap PR-B: `install.sh` wiring](0127-curl-sh-auto-bootstrap-prb-installer.md) | TBD | ✅ Merged 2026-05-14 via PR #350 (`bfddf78`) |
 | 0128 | [GAR-470 — Q9.b: extract admin/providers.rs from admin/handlers.rs (3240 → 2900 LOC)](0128-gar-470-admin-providers-refactor.md) | [GAR-470](https://linear.app/chatgpt25/issue/GAR-470) | ⏳ In Progress |


### PR DESCRIPTION
Superseded by PR #353 which covered both plan 0127 AND plan 0128 bookkeeping and was merged as `a3bd92c`. Closing this narrower PR as redundant.