### PR TITLE
chore(deps): remove stale RUSTSEC-2024-0384 (instant) advisory ignore

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,6 +1,6 @@
 # cargo-audit configuration.
 #
-# Last cleanup: 2026-04-26 (plan 0053 PR-6 / GAR-452).
+# Last cleanup: 2026-05-15 (health routine / GAR-627).
 # Originally drafted: 2026-04-22 (plan 0043).
 #
 # Every entry in `ignore` is a REAL advisory against a dep in our
@@ -24,15 +24,16 @@
 #   * `deny.toml` controls advisories flagged by `cargo deny check
 #     advisories` (now invoked in CI via cargo-deny-action default
 #     `command: check`). It mirrors the same vuln/unsound IDs (rsa, glib,
-#     rand) PLUS 22 `unmaintained-only` advisories that `cargo audit`
+#     rand) PLUS 21 `unmaintained-only` advisories that `cargo audit`
 #     auto-classifies as "allowed warnings" and does NOT require
 #     explicit ignore here.
 #   * **Mandatory sync (remaining mirrored IDs): RUSTSEC-2023-0071 (rsa /
 #     GAR-456), RUSTSEC-2024-0429 (glib / GAR-513), RUSTSEC-2026-0097
 #     (rand / GAR-513). Drop any of these atomically from BOTH files when
 #     the upstream fix lands. Closed history: wasmtime ×15 (GAR-454),
-#     webpki ×4 (GAR-455 / PR #295), lru ×1 (GAR-593 / this PR).**
-#   * The 22 unmaintained-only IDs in `deny.toml` (7 directly named +
+#     webpki ×4 (GAR-455 / PR #295), lru ×1 (GAR-593 / this PR),
+#     instant ×1 (GAR-627 / health/202605150000).**
+#   * The 21 unmaintained-only IDs in `deny.toml` (6 directly named +
 #     10 gtk-rs + 5 unic-*) are intentionally NOT mirrored here. Do not
 #     "fix" the asymmetry by mass-mirroring; that would change runtime
 #     behavior of `cargo audit`.

--- a/deny.toml
+++ b/deny.toml
@@ -13,8 +13,8 @@
 #     (rand / GAR-513). Closed: wasmtime ×15 (GAR-454), webpki ×4
 #     (GAR-455 / PR #295), lru ×1 (GAR-593 / health/202605121530). Drop
 #     atomically from BOTH files when an upstream fix lands.**
-#   * The 22 unmaintained-only IDs (7 directly named: daemonize,
-#     derivative, fxhash, instant, proc-macro-error, async-std,
+#   * The 21 unmaintained-only IDs (6 directly named: daemonize,
+#     derivative, fxhash, proc-macro-error, async-std,
 #     rustls-pemfile + 10× gtk-rs + 5× unic-*) are intentionally NOT
 #     mirrored in `audit.toml`. `cargo audit` auto-classifies them as
 #     "allowed warnings" and does NOT require explicit ignore.
@@ -51,7 +51,6 @@ ignore = [
     "RUSTSEC-2025-0069", # daemonize (direct dep, no maintained alternative)
     "RUSTSEC-2024-0388", # derivative (transitive via poise/serenity)
     "RUSTSEC-2025-0057", # fxhash (transitive via wasmtime)
-    "RUSTSEC-2024-0384", # instant (transitive via notify)
     "RUSTSEC-2024-0370", # proc-macro-error (transitive, no maintained alt)
     "RUSTSEC-2025-0052", # async-std (via opentelemetry_sdk 0.26 → garraia-telemetry)
     # Added 2026-04-27 (PR #75 CI surfaced this — local cache was stale):


### PR DESCRIPTION
## Summary

- `instant` crate is no longer present in `Cargo.lock` (`grep instant Cargo.lock` → 0 matches)
- The advisory ignore `RUSTSEC-2024-0384` in `deny.toml` is now stale — `cargo deny` would flag it as `advisory-not-detected`
- Remove the entry and update sync-note counts in both `deny.toml` and `.cargo/audit.toml`

## Changes

| File | Change |
|------|--------|
| `deny.toml` | Remove `RUSTSEC-2024-0384` ignore line; update sync note 22→21 IDs, 7→6 directly named |
| `.cargo/audit.toml` | Mirror sync-note count update 22→21, 7→6; bump Last cleanup date |

## Verification

```
cargo audit --no-fetch
# 21 allowed warnings, exit 0 — unchanged from before
```

## Context

Daily dependency/security routine 2026-05-15. No vulnerabilities detected. This is a hygiene-only commit; `cargo audit` and `cargo deny check advisories` behavior is unchanged since `instant` was never in the active advisory-error category.

**Deferred active items** (no change, all tracked):
- `RUSTSEC-2023-0071` (rsa Marvin Attack) → GAR-456, expires 2026-07-31
- `RUSTSEC-2024-0429` (glib unsound) → GAR-513, expires 2026-07-31
- `RUSTSEC-2026-0097` (rand 0.7.3 unsound) → GAR-513, expires 2026-07-31

https://claude.ai/code/session_015YyYCb6RdMEFApVA6bzLmJ

---
_Generated by [Claude Code](https://claude.ai/code/session_015YyYCb6RdMEFApVA6bzLmJ)_