### PR TITLE
fix(ci): gate optional Deploy-to-ECS job behind ENABLE_ECS_DEPLOY var

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,7 +84,11 @@ jobs:
     name: Deploy to ECS
     needs: docker
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    # Opt-in: only runs when `ENABLE_ECS_DEPLOY` variable is set to `true`
+    # AND the required AWS secrets/vars are configured. Skips by default so
+    # tag pushes don't create failing production deployments on repos that
+    # only ship via GitHub Releases (the canonical GarraIA distribution path).
+    if: vars.ENABLE_ECS_DEPLOY == 'true' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     environment: production
 
     steps:


### PR DESCRIPTION
## Summary

- Gates the `deploy-ecs` job in `.github/workflows/deploy.yml` behind `vars.ENABLE_ECS_DEPLOY == 'true'`, honoring the existing "Optional: requires AWS secrets" annotation
- Stops every release tag from creating a failing GitHub deployment in the `production` environment (root cause of the red badge at https://github.com/michelbr84/GarraRUST/deployments/production)

## Context

The job uses `aws-actions/configure-aws-credentials@v6`, which **always** fails on this repo because no AWS secrets/vars (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`) and no OIDC role are configured — verified empirically:

- Repo secrets: `gh secret list -R michelbr84/GarraRUST` → empty
- Repo variables: `gh variable list -R michelbr84/GarraRUST` → empty
- Production-environment secrets: `total_count: 0`
- Production-environment variables: `total_count: 0`

GarraIA distributes exclusively via GitHub Releases (binaries + `install.sh` + `garraia update` auto-updater per `reference_release_pipeline_alignment.md`). There is no ECS cluster, no AWS account, and no plan in `ROADMAP.md` to introduce one.

Last failing deployment (`v0.2.1`, run 25862972716, job 76033772068) reported:
```
##[error]Credentials could not be loaded, please check your action inputs: Could not load credentials from any providers
```

The legacy failed deployment (`4691333211`) has been cleared from the environment via API (marked `inactive` then `DELETE`).

## Test plan

- [x] CI green on this branch (no production deployment triggered since not a tag push)
- [x] Verified `production` environment is empty after API cleanup
- [ ] After merge: next `v*` tag push must skip the `deploy-ecs` job cleanly (no deployment record created)
- [ ] Forward-compat: a fork that sets `ENABLE_ECS_DEPLOY=true` + AWS secrets still gets the original behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)