### PR TITLE
chore(bookkeeping): flip in-file Status headers for plans 0127 + 0128

### DIFF
--- a/plans/0127-curl-sh-auto-bootstrap-prb-installer.md
+++ b/plans/0127-curl-sh-auto-bootstrap-prb-installer.md
@@ -1,6 +1,6 @@
 # Plan 0127 — `curl | sh` auto-bootstrap **PR-B**: `install.sh` wiring
 
-> **Status:** ⏳ **Draft — in flight 2026-05-14 (Florida).** PR-A merged 2026-05-14 via PR #348 (`6a2279e`), unblocking this slice. §M1 below is now the authoritative implementation checklist.
+> **Status:** ✅ **Merged 2026-05-14 (Florida) via PR #350 (`bfddf78`).** PR-A merged earlier the same day via PR #348 (`6a2279e`), which unblocked this slice. §M1 below was the authoritative implementation checklist during execution.
 
 **Linear issue:** TBD — to be created when PR-A merges.
 

--- a/plans/0128-gar-470-admin-providers-refactor.md
+++ b/plans/0128-gar-470-admin-providers-refactor.md
@@ -4,7 +4,7 @@
 **Parent:** GAR-439 (Q9 Refactor admin/handlers.rs)
 **Issue:** [GAR-470](https://linear.app/chatgpt25/issue/GAR-470)
 **Branch:** `routine/202505150020-admin-providers-extract`
-**Status:** In Progress
+**Status:** ✅ Merged 2026-05-14 (Florida) via PR #349 (`eacbf9b`)
 
 ---
 


### PR DESCRIPTION
## Summary

Closes the leftover from PR #353 (a3bd92c) — that PR updated the `plans/README.md` index rows for plans 0127 and 0128 to `✅ Merged`, but did NOT touch the in-file `**Status:**` headers inside the plan documents themselves. This PR fixes that gap.

- `plans/0127-curl-sh-auto-bootstrap-prb-installer.md` → flip header from `⏳ Draft — in flight` to `✅ Merged 2026-05-14 (Florida) via PR #350 (bfddf78)`.
- `plans/0128-gar-470-admin-providers-refactor.md` → flip metadata line from `Status: In Progress` to `Status: ✅ Merged 2026-05-14 (Florida) via PR #349 (eacbf9b)`.

**Pure docs delta — 2 lines in 2 files. Zero behavior change.**

## Why now

Without these, anyone running `/garra-routine`, `grep -r "In Progress" plans/`, or reading the plans directly will be misled into thinking 0127 / 0128 are still active work. The `plans/README.md` index already says they're merged — keeping the in-file headers in sync prevents drift between the index and the documents.

## Test plan

- [x] `git diff --stat` → 2 files, 2 insertions, 2 deletions
- [ ] CI green on all 4 required (Format Check, Clippy, Test ubuntu, Test windows) — none should be affected by markdown-only changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)