### PR TITLE
fix(desktop): align build-installer.ps1 sidecar with garra CLI rename

### DIFF
--- a/scripts/build-installer.ps1
+++ b/scripts/build-installer.ps1
@@ -23,8 +23,10 @@ Write-Host "==> [2/3] Copiando sidecar para binaries/..." -ForegroundColor Cyan
 $arch = "x86_64-pc-windows-msvc"
 $binDir = "crates\garraia-desktop\src-tauri\binaries"
 New-Item -ItemType Directory -Force -Path $binDir | Out-Null
-Copy-Item "target\release\garraia.exe" "$binDir\garraia-$arch.exe" -Force
-Write-Host "    Copiado: $binDir\garraia-$arch.exe"
+# Tauri externalBin = "binaries/garra" expects "binaries/garra-<triple>.exe".
+# Binary name set by `name = "garra"` in crates/garraia-cli/Cargo.toml (rename a1c56e8).
+Copy-Item "target\release\garra.exe" "$binDir\garra-$arch.exe" -Force
+Write-Host "    Copiado: $binDir\garra-$arch.exe"
 
 Write-Host "==> [3/3] Gerando MSI com cargo tauri build..." -ForegroundColor Cyan
 Push-Location "crates\garraia-desktop\src-tauri"


### PR DESCRIPTION
## Summary

- `scripts/build-installer.ps1` was missed in commit [`a1c56e8`](https://github.com/michelbr84/GarraRUST/commit/a1c56e8) (CLI binary rename `garraia` → `garra`).
- Script still copied `target/release/garraia.exe` → `binaries/garraia-<triple>.exe`, but `tauri.conf.json` declares `externalBin = "binaries/garra"`, which expects `binaries/garra-<triple>.exe`.
- Effect: `cargo tauri build` failed at sidecar lookup since 2026-03-07. **No MSI shipped between v0.1.0-beta.1 (2026-03-07) and this PR.**

## Fix

One-line change: copy from the real binary name (`garra.exe`) into the path the existing conf already expects. Conf is unchanged — drift was entirely in the script.

```diff
-Copy-Item "target\release\garraia.exe" "$binDir\garraia-$arch.exe" -Force
+# Tauri externalBin = "binaries/garra" expects "binaries/garra-<triple>.exe".
+# Binary name set by `name = "garra"` in crates/garraia-cli/Cargo.toml (rename a1c56e8).
+Copy-Item "target\release\garra.exe" "$binDir\garra-$arch.exe" -Force
```

## Validation (end-to-end)

| Step | Command | Result |
|------|---------|--------|
| 1 | `cargo build -p garraia --release` | `target/release/garra.exe` (43 MB) ✓ |
| 2 | Copy sidecar (via the patched script logic) | `binaries/garra-x86_64-pc-windows-msvc.exe` ✓ |
| 3 | `cargo tauri build` in `src-tauri/` | `bundle/msi/garraia-desktop_0.2.1_x64_pt-BR.msi` (20.7 MB) ✓ |
| 4 | `sha256sum -c` against generated `.sha256` | OK ✓ |
| 5 | `gh release upload v0.2.1 …` | MSI + `.sha256` + updated `SHA256SUMS` ✓ |
| 6 | Download MSI from release, re-verify | OK ✓ |

## Test plan

- [x] cargo build -p garraia --release succeeds on Windows MSVC
- [x] cargo tauri build produces MSI + NSIS bundle
- [x] sha256sum -c verifies the MSI matches its `.sha256`
- [x] MSI uploaded to v0.2.1 GitHub release alongside CLI binaries
- [x] Re-downloaded MSI verifies against published checksum
- [ ] (manual) Smoke-install the MSI on a clean Windows VM, confirm `garra.exe` sidecar starts the local gateway

## Out of scope (deliberate)

- NSIS `.exe` bundle was also produced locally (`garraia-desktop_0.2.1_x64-setup.exe`, 13.4 MB) but **not uploaded** — user's goal was MSI specifically. Available if wanted; one `gh release upload` command away.
- Adding MSI to the official `release.yml` workflow is a separate job (would need a `windows-latest` runner with WiX + cargo-tauri-cli). Tracked separately.
- Code signing the MSI — installer ships unsigned today (SmartScreen warning expected); signing is a non-trivial cert-management task.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — `/max-power` workflow