### PR TITLE
feat(learning): scaffold garraia-learning crate + ADR 0010 Accepted (GAR-642)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,25 @@ crates/
   garraia-voice/      — STT (Whisper) + TTS (Chatterbox/ElevenLabs/Kokoro)
   garraia-media/      — processamento de PDF, imagens, mídia
   garraia-skills/     — registry de skills para o agente
+  garraia-learning/   — Fase 1.4 (GAR-641, ADR 0010 Accepted 2026-05-17 via plan 0144/GAR-642) —
+                        Garra Learning Agent / Self-Improving Operations Manual. Scaffold
+                        atual (10 módulos placeholder + tipos base `Skill`/`SkillScope`/
+                        `SkillSource`/`SkillScore`/`SafetyDenial` + trait `BeforeAction`
+                        shape-only, `NoopBeforeAction` default até GAR-646 wirear o
+                        Retriever no `AgentRuntime`). Sub-componentes em GAR-643..GAR-651:
+                        miner (detecta padrões em session logs), generator (LLM-assisted
+                        skill drafting), registry (~/.garra/skills/ global + .garra/skills/
+                        por-projeto, reusa garraia-skills::SkillScanner/SkillInstaller),
+                        retriever (embedding match, reusa garraia-embeddings), evaluator
+                        (exit codes / tests / CI / diffs / logs), updater (diff + PR + branch,
+                        human-in-the-loop), versioning (git-backed, history em
+                        .garra/skills/_history/), safety (hard denylist + score threshold +
+                        path-protected critical files + integração com
+                        garraia-tools::safety_gate de GarraMaxPower). Separação rígida:
+                        memória (workspace.memory_items) ≠ skill (learning.skills) ≠ log
+                        (telemetry.traces) ≠ manual distribuível (skills crate). Nunca copiar
+                        código do Hermes Agent — Hermes é referência conceitual de produto,
+                        arquitetura é própria.
   garraia-tools/      — tools compartilhadas (file ops, search, web)
   garraia-runtime/    — runtime helpers
   garraia-common/     — tipos + erros compartilhados
@@ -248,21 +267,10 @@ apps/
 
 ```text
 garraia-embeddings/  — Fase 2.1 (GAR-372) — embeddings locais mxbai + vector store lancedb
-garraia-learning/    — Fase 1.4 (GAR-641, ADR 0010 Proposed) — Garra Learning Agent /
-                       Self-Improving Operations Manual. Sub-módulos: miner (detecta padrões
-                       em session logs), generator (LLM-assisted skill drafting), registry
-                       (~/.garra/skills/ global + .garra/skills/ por-projeto, reusa
-                       garraia-skills::SkillScanner/SkillInstaller), retriever (embedding
-                       match, reusa garraia-embeddings), evaluator (exit codes / tests / CI /
-                       diffs / logs), updater (diff + PR + branch, human-in-the-loop),
-                       versioning (git-backed, history em .garra/skills/_history/), safety
-                       (hard denylist + score threshold + path-protected critical files +
-                       integração com garraia-tools::safety_gate de GarraMaxPower). Separação
-                       rígida: memória (workspace.memory_items) ≠ skill (learning.skills) ≠
-                       log (telemetry.traces) ≠ manual distribuível (skills crate). Nunca
-                       copiar código do Hermes Agent — Hermes é referência conceitual de
-                       produto, arquitetura é própria.
 ```
+
+> `garraia-learning/` promovido para "Crates ativos" em 2026-05-17 via plan 0144 / GAR-642
+> (ADR 0010 → Accepted). Comportamento real entra com GAR-643..GAR-651.
 
 ### PoCs efêmeros
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3565,6 +3565,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "garraia-learning"
+version = "0.2.1"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "garraia-media"
 version = "0.2.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "crates/garraia-workspace",
     "crates/garraia-glob",
     "crates/garraia-storage",
+    "crates/garraia-learning",
 ]
 
 [workspace.package]

--- a/crates/garraia-learning/Cargo.toml
+++ b/crates/garraia-learning/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "garraia-learning"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Garra Learning Agent / Self-Improving Operations Manual (scaffold, GAR-642)"
+
+# Scaffold-only deps. Sub-issues GAR-643..GAR-651 add what they need:
+#   - GAR-643 Miner       → garraia-telemetry, serde_json
+#   - GAR-644 Generator   → garraia-agents, tokio (LLM call)
+#   - GAR-645 Registry    → garraia-skills, garraia-common
+#   - GAR-646 Retriever   → garraia-embeddings (Fase 2.1 prereq)
+#   - GAR-647 Evaluator   → garraia-telemetry
+#   - GAR-648 Updater     → process spawn for `gh`/`git`
+#   - GAR-649 Safety      → garraia-tools (safety_gate), regex
+#   - GAR-650 Versioning  → process spawn for `git`
+#   - GAR-651 Web UI      → consumed by garraia-gateway, no dep here
+[dependencies]
+serde = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/garraia-learning/src/evaluator.rs
+++ b/crates/garraia-learning/src/evaluator.rs
@@ -1,0 +1,9 @@
+//! Skill Evaluator — placeholder for [GAR-647].
+//!
+//! Will collect objective post-execution signals (exit codes, cargo test pass
+//! count, `gh pr checks`, diff stats, log scan) and feed them into the EMA
+//! that powers [`crate::SkillScore`].
+//!
+//! See ADR 0010 §"Loop 2: Use → Evaluate → Update" for the score lifecycle.
+//!
+//! [GAR-647]: https://linear.app/chatgpt25/issue/GAR-647

--- a/crates/garraia-learning/src/generator.rs
+++ b/crates/garraia-learning/src/generator.rs
@@ -1,0 +1,9 @@
+//! Skill Generator — placeholder for [GAR-644].
+//!
+//! Will turn a `Miner` candidate into a fully-formed skill (frontmatter + steps)
+//! via a provider-agnostic LLM prompt. Default backend: `openrouter/free`.
+//!
+//! See ADR 0010 §"Loop 1" + §"Out of scope" for the constraint that no
+//! provider-specific SDK is hard-coded.
+//!
+//! [GAR-644]: https://linear.app/chatgpt25/issue/GAR-644

--- a/crates/garraia-learning/src/lib.rs
+++ b/crates/garraia-learning/src/lib.rs
@@ -1,0 +1,228 @@
+//! `garraia-learning` — Garra Learning Agent / Self-Improving Operations Manual.
+//!
+//! Scaffold for the [Garra Learning Agent epic (GAR-641)]. This crate currently
+//! contains only the **shape** decided in [ADR 0010]: the 10 sub-modules listed
+//! in `§Topologia de crates` and the base types referenced by the [acceptance
+//! criteria]. Behaviour lands one issue at a time in sub-issues GAR-643..GAR-651.
+//!
+//! # What this crate provides today
+//!
+//! * Public type contracts every sub-component agrees on:
+//!   [`Skill`], [`SkillScope`], [`SkillSource`], [`SkillScore`], [`SafetyDenial`].
+//! * The [`BeforeAction`] trait — the hook an `AgentRuntime` will consume once
+//!   the Skill Retriever ships (GAR-646). Until then [`NoopBeforeAction`] is the
+//!   default implementation everywhere.
+//!
+//! # What this crate does NOT do yet
+//!
+//! Each module file in `src/` is a placeholder marker for its tracking issue.
+//! The sub-issues add their dependencies (and behaviour) on demand — see the
+//! comment block in `Cargo.toml`.
+//!
+//! [Garra Learning Agent epic (GAR-641)]: https://linear.app/chatgpt25/issue/GAR-641
+//! [ADR 0010]: ../../../docs/adr/0010-garra-learning-agent.md
+//! [acceptance criteria]: https://linear.app/chatgpt25/issue/GAR-642
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs)]
+
+pub mod evaluator;
+pub mod generator;
+pub mod miner;
+pub mod r#override;
+pub mod registry;
+pub mod retriever;
+pub mod safety;
+pub mod updater;
+pub mod versioning;
+
+use serde::{Deserialize, Serialize};
+
+/// Where a learnt skill is stored and to whom it applies.
+///
+/// Mirrors the two on-disk roots described in ADR 0010 §"Topologia de crates"
+/// — `~/.garra/skills/` for the local user across projects, and
+/// `.garra/skills/` checked into a repository.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SkillScope {
+    /// `~/.garra/skills/` — applies to the local user across projects.
+    Global,
+    /// `.garra/skills/` — applies only inside this repository.
+    Project,
+}
+
+/// How a skill entered the registry.
+///
+/// Used by the Updater (GAR-648) to decide whether a proposed change requires
+/// human review (`Mined`) or is already a human-authored artefact (`Authored`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SkillSource {
+    /// Detected automatically by the Miner (GAR-643) from session logs.
+    Mined,
+    /// Authored by a human and committed straight to the registry.
+    Authored,
+    /// Imported from a signed tarball via `garraia-skills::SkillInstaller`.
+    Imported,
+}
+
+/// Exponential moving-average score in `[0.0, 1.0]` used by the Evaluator.
+///
+/// Promotion through the Safety Gate (GAR-649) requires
+/// `score.0 >= SkillScore::MIN_PROMOTE`.
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub struct SkillScore(
+    /// The score value, expected to live in `[0.0, 1.0]`.
+    pub f32,
+);
+
+impl SkillScore {
+    /// Default minimum score the Safety Gate accepts for auto-promotion.
+    ///
+    /// ADR 0010 §"Safety Gate" item 3 lists this as `min_promote_score`
+    /// default `0.5`. The constant is the contract surface; the runtime
+    /// (GAR-649) will read it from config and may override per-environment.
+    pub const MIN_PROMOTE: f32 = 0.5;
+}
+
+/// Reason the Safety Gate refused to promote a skill.
+///
+/// `#[non_exhaustive]` because GAR-649 is expected to add variants as new
+/// PII patterns and critical-path families are discovered — adding a new
+/// variant must not be a breaking change for downstream matchers.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum SafetyDenial {
+    /// The skill body or steps contain a hard-denied command pattern
+    /// (e.g. `rm -rf /`, `git push --force` on `main`).
+    #[error("skill contains a hard-denied command pattern")]
+    DangerousCommand,
+    /// The skill modifies a path that requires human review
+    /// (e.g. `crates/garraia-auth/`, `.github/workflows/`, `deny.toml`).
+    #[error("skill touches a path that requires human review")]
+    CriticalPath,
+    /// The skill score is below [`SkillScore::MIN_PROMOTE`].
+    #[error("skill score is below the promotion threshold")]
+    ScoreTooLow,
+    /// The skill has failed Evaluator checks repeatedly (anti-flap).
+    #[error("skill has failed evaluator checks repeatedly (anti-flap)")]
+    AntiFlap,
+    /// The skill content matches a PII redaction rule.
+    #[error("skill contains potential PII")]
+    PiiLeak,
+}
+
+/// Minimal in-memory representation of a learnt skill.
+///
+/// This is the **contract** surface — concrete on-disk frontmatter (with the
+/// `last_used_at`, `last_diff_sha`, `embeddings_model`, `critical_paths_touched`
+/// fields from ADR 0010 §"Formato de skill") arrives with GAR-645 (Registry).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Skill {
+    /// Stable identifier, kebab-case (e.g. `cleanup-merged-branches`).
+    pub name: String,
+    /// Whether this skill is global to the user or scoped to the project.
+    pub scope: SkillScope,
+    /// How this skill entered the registry.
+    pub source: SkillSource,
+    /// Current EMA score from the Evaluator.
+    pub score: SkillScore,
+}
+
+/// Context passed to [`BeforeAction::before_action`] so a future Retriever
+/// (GAR-646) can match by intent + scope hint.
+///
+/// Marked `#[non_exhaustive]` so additional hints (e.g. workspace path,
+/// active provider, recent action history) can be added in GAR-646 without
+/// breaking external implementors.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct SkillRequestContext {
+    /// Free-text description of what the agent is about to attempt.
+    pub intent: String,
+    /// Optional scope hint — if `None`, the Retriever considers both Global
+    /// and Project skills.
+    pub scope_hint: Option<SkillScope>,
+}
+
+/// Hook the `AgentRuntime` is expected to call before any agentic action.
+///
+/// Returning `Some(skill)` injects the matched skill into the runtime prompt.
+/// Returning `None` (the default) preserves today's behaviour: the runtime
+/// proceeds without consulting the learnt-skills registry.
+///
+/// The wiring on the `AgentRuntime` side intentionally lives in GAR-646 — this
+/// scaffold only ships the trait so sub-issues 2..10 have a stable contract
+/// to implement against.
+pub trait BeforeAction {
+    /// Inspect the upcoming action context and return the top-1 matching skill,
+    /// or `None` if no skill should be injected.
+    ///
+    /// The default impl always returns `None` so any type can `impl BeforeAction
+    /// for X {}` without thinking about retrieval until GAR-646.
+    fn before_action(&self, _context: &SkillRequestContext) -> Option<Skill> {
+        None
+    }
+}
+
+/// No-op implementation of [`BeforeAction`]. Used by the runtime until the
+/// Skill Retriever (GAR-646) ships.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopBeforeAction;
+
+impl BeforeAction for NoopBeforeAction {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noop_before_action_returns_none() {
+        let hook = NoopBeforeAction;
+        let ctx = SkillRequestContext {
+            intent: "cleanup merged branches".into(),
+            scope_hint: Some(SkillScope::Project),
+        };
+        assert!(hook.before_action(&ctx).is_none());
+    }
+
+    #[test]
+    fn min_promote_is_half() {
+        // Guard against accidental tuning of the Safety Gate threshold.
+        // ADR 0010 §"Safety Gate" item 3 documents 0.5 as the default.
+        assert!((SkillScore::MIN_PROMOTE - 0.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn safety_denial_messages_are_distinct() {
+        let variants = [
+            SafetyDenial::DangerousCommand,
+            SafetyDenial::CriticalPath,
+            SafetyDenial::ScoreTooLow,
+            SafetyDenial::AntiFlap,
+            SafetyDenial::PiiLeak,
+        ];
+        let messages: Vec<String> = variants.iter().map(ToString::to_string).collect();
+        let unique: std::collections::HashSet<&String> = messages.iter().collect();
+        assert_eq!(unique.len(), messages.len(), "denial messages must be distinct");
+    }
+
+    #[test]
+    fn skill_scope_round_trips_serde() {
+        for scope in [SkillScope::Global, SkillScope::Project] {
+            let json = serde_json::to_string(&scope).unwrap();
+            let back: SkillScope = serde_json::from_str(&json).unwrap();
+            assert_eq!(scope, back);
+        }
+    }
+
+    #[test]
+    fn skill_source_round_trips_serde() {
+        for source in [SkillSource::Mined, SkillSource::Authored, SkillSource::Imported] {
+            let json = serde_json::to_string(&source).unwrap();
+            let back: SkillSource = serde_json::from_str(&json).unwrap();
+            assert_eq!(source, back);
+        }
+    }
+}

--- a/crates/garraia-learning/src/lib.rs
+++ b/crates/garraia-learning/src/lib.rs
@@ -205,7 +205,11 @@ mod tests {
         ];
         let messages: Vec<String> = variants.iter().map(ToString::to_string).collect();
         let unique: std::collections::HashSet<&String> = messages.iter().collect();
-        assert_eq!(unique.len(), messages.len(), "denial messages must be distinct");
+        assert_eq!(
+            unique.len(),
+            messages.len(),
+            "denial messages must be distinct"
+        );
     }
 
     #[test]
@@ -219,7 +223,11 @@ mod tests {
 
     #[test]
     fn skill_source_round_trips_serde() {
-        for source in [SkillSource::Mined, SkillSource::Authored, SkillSource::Imported] {
+        for source in [
+            SkillSource::Mined,
+            SkillSource::Authored,
+            SkillSource::Imported,
+        ] {
             let json = serde_json::to_string(&source).unwrap();
             let back: SkillSource = serde_json::from_str(&json).unwrap();
             assert_eq!(source, back);

--- a/crates/garraia-learning/src/miner.rs
+++ b/crates/garraia-learning/src/miner.rs
@@ -1,0 +1,10 @@
+//! Skill Miner — placeholder for [GAR-643].
+//!
+//! Will analyse session logs (telemetry traces, shell history) and detect
+//! repeated patterns (≥ 3 occurrences in similar contexts) emitting candidate
+//! skills to `~/.garra/skills/_candidates/<name>-<sha>.md`.
+//!
+//! See ADR 0010 §"Loop 1: Mine → Generate → Validate → Promote" and
+//! §"Topologia de crates" for the design.
+//!
+//! [GAR-643]: https://linear.app/chatgpt25/issue/GAR-643

--- a/crates/garraia-learning/src/override.rs
+++ b/crates/garraia-learning/src/override.rs
@@ -1,0 +1,11 @@
+//! Skill Override — placeholder.
+//!
+//! CLI / Web UI surface for human approval workflows: `approve`, `reject`,
+//! `lock`, `delete`. Documented in ADR 0010 §"Topologia de crates" as
+//! `override.rs` and consumed by the Web Console panel in [GAR-651].
+//!
+//! Declared as `pub mod r#override` in `lib.rs` because `override` is a
+//! reserved Rust keyword — the raw identifier preserves the file name
+//! verbatim against the ADR.
+//!
+//! [GAR-651]: https://linear.app/chatgpt25/issue/GAR-651

--- a/crates/garraia-learning/src/registry.rs
+++ b/crates/garraia-learning/src/registry.rs
@@ -1,0 +1,8 @@
+//! Skill Registry — placeholder for [GAR-645].
+//!
+//! Dual-scope wrapper over `garraia-skills::{SkillScanner, SkillInstaller}`:
+//! global skills under `~/.garra/skills/` and per-project skills under
+//! `.garra/skills/`. Owns the `_candidates/`, `_rejected/`, `_history/`,
+//! `_locks/` sub-directories described in ADR 0010 §"Topologia de crates".
+//!
+//! [GAR-645]: https://linear.app/chatgpt25/issue/GAR-645

--- a/crates/garraia-learning/src/retriever.rs
+++ b/crates/garraia-learning/src/retriever.rs
@@ -1,0 +1,11 @@
+//! Skill Retriever — placeholder for [GAR-646].
+//!
+//! Concrete implementation of the [`crate::BeforeAction`] trait. Will match a
+//! [`crate::SkillRequestContext`] against the registry via embedding similarity
+//! (consuming `garraia-embeddings` from Fase 2.1) plus scope filter plus score
+//! threshold.
+//!
+//! Until this lands, the runtime uses [`crate::NoopBeforeAction`] which always
+//! returns `None`.
+//!
+//! [GAR-646]: https://linear.app/chatgpt25/issue/GAR-646

--- a/crates/garraia-learning/src/safety.rs
+++ b/crates/garraia-learning/src/safety.rs
@@ -1,0 +1,11 @@
+//! Skill Safety Gate — placeholder for [GAR-649] (Urgent).
+//!
+//! Hard wall before any promotion (auto or manual). Will implement
+//! `gate(&Skill) -> Result<(), crate::SafetyDenial>` covering the five
+//! denial families: dangerous commands, critical paths, score threshold,
+//! anti-flap, PII leak. See ADR 0010 §"Safety Gate (hard wall, sem bypass)".
+//!
+//! Shares the denylist primitive with `garraia-tools::safety_gate` from the
+//! GarraMaxPower work (single source of truth across both surfaces).
+//!
+//! [GAR-649]: https://linear.app/chatgpt25/issue/GAR-649

--- a/crates/garraia-learning/src/updater.rs
+++ b/crates/garraia-learning/src/updater.rs
@@ -1,0 +1,8 @@
+//! Skill Auto-Updater — placeholder for [GAR-648].
+//!
+//! When the Evaluator detects an execution that out-performed the current
+//! skill, the Updater builds a `learning/skill-<name>-vN-vN+1` branch with the
+//! proposed diff and opens a PR via `gh`. **Never auto-merges** — human review
+//! is part of the contract.
+//!
+//! [GAR-648]: https://linear.app/chatgpt25/issue/GAR-648

--- a/crates/garraia-learning/src/versioning.rs
+++ b/crates/garraia-learning/src/versioning.rs
@@ -1,0 +1,7 @@
+//! Skill Versioning / Rollback — placeholder for [GAR-650].
+//!
+//! Git-tracked history at `~/.garra/skills/_history/<name>/`. Rollback is
+//! `git revert` of the commit that introduced the current revision, returning
+//! to the previous good version.
+//!
+//! [GAR-650]: https://linear.app/chatgpt25/issue/GAR-650

--- a/docs/adr/0010-garra-learning-agent.md
+++ b/docs/adr/0010-garra-learning-agent.md
@@ -1,7 +1,8 @@
 # ADR 0010 — Garra Learning Agent / Self-Improving Operations Manual
 
-**Status:** Proposed
-**Date:** 2026-05-17 (local America/New_York)
+**Status:** Accepted
+**Date:** 2026-05-17 (local America/New_York) — promoted Proposed → Accepted via plan 0144 / GAR-642 (scaffold)
+**Promotion PR:** *(filled in by routine before merge)*
 **Owner:** @michelbr84
 **Linear epic:** [`GAR-641`](https://linear.app/chatgpt25/issue/GAR-641) (criado 2026-05-17 com 10 sub-issues GAR-642..GAR-651)
 **Related ADRs:** [0002 Vector Store](0002-vector-store.md) (Skill Retriever), [0009 Web Console Design System](0009-web-console-design-system.md) (Skills/Logs UI)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -48,6 +48,8 @@ Rationale curta ("porque sim") é sinal de que a decisão não deveria ser ADR �
 | [0006](0006-search-strategy.md) | Search strategy (Postgres FTS → Tantivy → Meilisearch) | ✅ accepted | 2026-04-21 | [GAR-376](https://linear.app/chatgpt25/issue/GAR-376) |
 | [0007](0007-desktop-frontend.md) | Desktop frontend (HTML+Vanilla baseline → SolidJS trigger) | ✅ accepted | 2026-04-21 | [GAR-377](https://linear.app/chatgpt25/issue/GAR-377) |
 | [0008](0008-doc-collaboration.md) | Doc collaboration (Tier 1 single-editor → y-crdt Tier 2) | ✅ accepted | 2026-04-21 | [GAR-378](https://linear.app/chatgpt25/issue/GAR-378) |
+| [0009](0009-web-console-design-system.md) | Web Console design system "Garra Glass" (HTML+CSS custom tokens, zero CDN) | ✅ accepted | 2026-05-13 | [GAR-607](https://linear.app/chatgpt25/issue/GAR-607) |
+| [0010](0010-garra-learning-agent.md) | Garra Learning Agent / Self-Improving Operations Manual | ✅ accepted | 2026-05-17 | [GAR-641](https://linear.app/chatgpt25/issue/GAR-641) |
 
 Legenda: ✅ accepted · 📋 proposed (aguardando execução) · 🔒 blocked (issue Linear aguardando este ADR ser escrito).
 

--- a/plans/0144-gar-642-learning-scaffold.md
+++ b/plans/0144-gar-642-learning-scaffold.md
@@ -1,0 +1,222 @@
+# Plan 0144 — GAR-642: scaffold do crate `garraia-learning` + promover ADR 0010 a Accepted
+
+**Linear issue:** [GAR-642](https://linear.app/chatgpt25/issue/GAR-642) — "Learning Agent Architecture — ADR 0010 → Accepted + scaffold crate garraia-learning" (Backlog → In Progress, High, +label `adr-needed`). Parent epic: [GAR-641](https://linear.app/chatgpt25/issue/GAR-641). Project: "Fase 1 — Core & Inferência".
+
+**Status:** ⏳ Draft — aprovado 2026-05-17 (Florida) na routine. Sub-issue 1/10 do épico Learning Agent (ADR 0010).
+
+**Branch:** `routine/202605180015-gar-642-learning-scaffold`.
+
+---
+
+## Goal
+
+Promover [ADR 0010](../docs/adr/0010-garra-learning-agent.md) de **Proposed → Accepted** entregando o scaffold do novo crate `garraia-learning/` com a topologia de 10 módulos descrita em §"Topologia de crates" do ADR + tipos base re-exportados em `lib.rs` + trait de hook `BeforeAction` (default `None`) como contrato shape-only para o futuro Retriever (GAR-646).
+
+Esta entrega **não implementa nenhum sub-componente**: cada módulo é `//! placeholder` com referência cruzada à issue filha (GAR-643..GAR-651) que vai materializar a lógica.
+
+## Architecture
+
+Espelha exatamente a topologia descrita em ADR 0010 §"Topologia de crates":
+
+```text
+crates/garraia-learning/
+├── Cargo.toml
+└── src/
+    ├── lib.rs           — fachada: re-exporta tipos base + módulos + BeforeAction trait
+    ├── miner.rs         — placeholder (GAR-643)
+    ├── generator.rs     — placeholder (GAR-644)
+    ├── registry.rs      — placeholder (GAR-645)
+    ├── retriever.rs     — placeholder (GAR-646)
+    ├── evaluator.rs     — placeholder (GAR-647)
+    ├── updater.rs       — placeholder (GAR-648)
+    ├── safety.rs        — placeholder (GAR-649, Urgent)
+    ├── versioning.rs    — placeholder (GAR-650)
+    └── override.rs      — placeholder (CLI/UI approve/reject/lock/delete; subsumido por GAR-651 + futuro)
+```
+
+`override` é palavra reservada do Rust; declaração `pub mod r#override;` no `lib.rs` mantém o nome de arquivo `override.rs` alinhado ao ADR. Acesso externo via `garraia_learning::r#override::…`.
+
+### Tipos base em `lib.rs`
+
+Mínimo para que sub-issues 2-10 tenham contratos estáveis para implementar:
+
+- `enum SkillScope { Global, Project }` — `~/.garra/skills/` vs `.garra/skills/`.
+- `enum SkillSource { Mined, Authored, Imported }` — origem do skill.
+- `struct SkillScore(f32)` — EMA em [0.0, 1.0]; `SkillScore::MIN_PROMOTE = 0.5`.
+- `enum SafetyDenial` — 5 razões (DangerousCommand, CriticalPath, ScoreTooLow, AntiFlap, PiiLeak) com `thiserror::Error`.
+- `struct Skill { name, scope, source, score }` — shape mínimo; campos adicionais (frontmatter completo) ficam para GAR-645.
+- `trait BeforeAction { fn before_action(&self, ctx: &SkillRequestContext) -> Option<Skill> { None } }` — contrato do hook que o `AgentRuntime` vai consumir quando Retriever existir.
+- `struct NoopBeforeAction` impl `BeforeAction` (usado pelo runtime até GAR-646).
+
+### Integração com `AgentRuntime`
+
+**Shape-only nesta slice.** A trait `BeforeAction` mora em `garraia-learning` e o `AgentRuntime` (`garraia-agents`) **não** é modificado neste PR — implementação concreta + wiring acontece em GAR-646 (Retriever). Justificativa: evita criar dependência `garraia-agents → garraia-learning` antes de existir comportamento útil, e mantém o scaffold revertível com um único `git rm -r crates/garraia-learning`.
+
+A trait é o contrato; `NoopBeforeAction::default()` é a implementação default que o futuro wiring vai injetar.
+
+### Deps do novo crate
+
+Mínimas para compilar limpo sob `cargo clippy --workspace -- -D warnings`:
+
+- `serde` (workspace) — derive em `SkillScope`/`SkillSource`/`SkillScore`/`Skill`.
+- `thiserror` (workspace) — `SafetyDenial`.
+
+Deps explícitas mencionadas pelo issue (`garraia-skills`, `garraia-common`, `garraia-tools`, `tokio`, `tracing`) **não** são adicionadas neste PR porque o scaffold ainda não as usa — adicionar agora dispara `unused-crate-dependencies` se algum CI ratchet futuro elevar a allow-by-default. Cada sub-issue (GAR-643..GAR-651) adiciona a dep que precisa quando precisar (`garraia-skills` em GAR-645, `garraia-tools` em GAR-649, etc.). Documentado em `lib.rs`.
+
+---
+
+## Design invariants
+
+1. **Zero behaviour change.** Nenhum crate existente é modificado a não ser:
+   - `Cargo.toml` (adiciona `crates/garraia-learning` aos `members`).
+   - `CLAUDE.md` (move bullet de "Crates planejados" para "Crates ativos").
+   - `docs/adr/README.md` (adiciona linhas para 0009 + 0010 — ambas faltando atualmente; ver §"Drift colateral" abaixo).
+   - `docs/adr/0010-garra-learning-agent.md` (header `Status: Proposed → Accepted` + data + PR ref).
+   - `plans/README.md` (linha 0139).
+2. **`r#override` em vez de renomear.** Manter alinhamento literal com a topologia do ADR. Custo: 1 caractere a mais em call sites; benefício: ADR/código nunca divergem.
+3. **`BeforeAction` é trait, não método em `AgentRuntime`.** Decisão revertida-se trivialmente; alternativa "modificar AgentRuntime agora" é escopo creep.
+4. **Nenhum `unwrap()` ou `expect()`.** Mesmo em placeholders. Doc comments apenas.
+5. **`#![forbid(unsafe_code)]` no crate root.** Garante que sub-issues futuras precisem justificar `unsafe` em ADR/plan separado.
+6. **`#![deny(missing_docs)]` no crate root.** Força que cada tipo público tenha doc comment desde o scaffold (acabamos com a janela em que o crate compila sem docs e sub-issues herdam o débito).
+
+---
+
+## Drift colateral coberto neste PR
+
+`docs/adr/README.md` está com índice congelado em 0008. Faltam:
+
+- Linha para [ADR 0009 — Web Console Design System "Garra Glass"](../docs/adr/0009-web-console-design-system.md) (mergeado em main há semanas, ver §1.5 do ROADMAP).
+- Linha para [ADR 0010 — Garra Learning Agent](../docs/adr/0010-garra-learning-agent.md) (criada na sessão de plan 0138).
+
+Ambas adicionadas neste PR para fechar o gap. Adicionar só a 0010 sem adicionar a 0009 deixaria o índice ainda parcialmente errado — corrigir as duas é a única forma honesta.
+
+---
+
+## Validações pré-plano (gate executado nesta sessão)
+
+- ✅ `docs/adr/0010-garra-learning-agent.md` existe com Status: Proposed (verificado).
+- ✅ ADR 0010 §"Acceptance criteria" tem 12 itens; deste plan, fechamos os critérios marcados como "compila", "estrutura", "ADR Accepted", "CLAUDE.md atualizado". Critérios de comportamento (`garra skills list/approve/reject/lock/rollback`, Safety Gate runtime, Web UI, audit_events) ficam para GAR-643..GAR-651.
+- ✅ Workspace `Cargo.toml` membros listados — nenhum conflito com `garraia-learning`.
+- ✅ `garraia-glob` (template de scaffold simples) usado como referência de tamanho mínimo (`Cargo.toml` + `lib.rs` com `pub mod`/`pub use`).
+- ✅ `garraia-skills` já existe e expõe `SkillFrontmatter` / `SkillScanner` / `SkillInstaller` — confirmado que serão reusados em GAR-645 (não neste PR).
+- ✅ `override` é reserved keyword em Rust 2024 — `r#override` é a forma canônica.
+- ✅ `docs/adr/README.md` realmente está parado em 0008 (verificado linha 51 do arquivo).
+- ✅ Branch `routine/202605180015-gar-642-learning-scaffold` criada a partir de `main@29f9493`.
+
+---
+
+## Out of scope (rejeitado explicitamente)
+
+- Implementação de Miner, Generator, Registry, Retriever, Evaluator, Updater, Safety, Versioning, Override — uma issue cada (GAR-643..GAR-651).
+- Modificação de `crates/garraia-agents/` para wiring real do `BeforeAction` — GAR-646.
+- Adicionar `garraia-skills` / `garraia-common` / `garraia-tools` / `tokio` / `tracing` como deps — cada sub-issue adiciona quando usar.
+- Web UI no Web Console Garra Glass — GAR-651.
+- `garra skills <subcommand>` CLI — sub-issue separada (subsumida por GAR-642a futuro ou casada com GAR-645).
+- Migration de Postgres para `learning_*` tables — out of scope por design (ADR 0010 §Alternativa D rejeita Postgres no v1).
+- Atualizar §1.5 do ROADMAP — esta seção já cobre o épico em 1.4; flip de status do GAR-642 vai num doc-only PR pós-merge (T8).
+- Atualizar `.quality/baseline.json` — scaffold não muda métricas existentes; quality-ratchet vai relatar no PR.
+
+---
+
+## Rollback plan
+
+Cada task é commit independente; revert é cirúrgico:
+
+- T0 (registrar 0144 em `plans/README.md`) — revert remove a linha.
+- T1 (criar `crates/garraia-learning/Cargo.toml`) — revert deleta o arquivo.
+- T2 (criar `crates/garraia-learning/src/lib.rs` + 9 módulos placeholder) — revert deleta o diretório `src/`.
+- T3 (adicionar `crates/garraia-learning` ao `Cargo.toml` `members`) — revert remove a linha.
+- T4 (promover ADR 0010 Status + adicionar 0009/0010 ao `docs/adr/README.md`) — revert volta os 3 deltas.
+- T5 (mover bullet `garraia-learning` em CLAUDE.md de "planejados" para "ativos") — revert volta o bullet.
+
+Worst-case rollback: 6 `git revert` sequenciais. Zero risco para crates existentes (eles não foram tocados).
+
+---
+
+## §12 Open questions (pré-start)
+
+1. **Adicionar `garraia-skills` como dep agora?** → **Decisão:** não. Scaffold não usa o parser. GAR-645 (Registry) adiciona quando wire `SkillScanner`/`SkillInstaller`. Justificativa: `unused-crate-dependencies` é allow-by-default hoje, mas se um ratchet futuro promover, scaffold já cai limpo.
+2. **Adicionar `tokio` como dep agora?** → **Decisão:** não. Sem `async fn`/`#[tokio::test]` no scaffold. GAR-643 (Miner) ou GAR-646 (Retriever) adicionam quando precisarem.
+3. **Re-export de `SkillFrontmatter` do `garraia-skills`?** → **Decisão:** não nesta slice. GAR-645 decide se re-exporta (frontmatter unificado) ou se Learning Agent estende com seu próprio struct (frontmatter aprendido tem campos extras: `score`, `last_used_at`, `source`, etc., per ADR 0010 §Formato de skill). Acoplar agora amarra a decisão.
+4. **`SkillScore` é `f32` ou `f64`?** → **Decisão:** `f32`. EMA com 4 casas de precisão é suficiente; `f64` ocupa o dobro em registries grandes. ADR 0010 não especifica; documentado em doc-comment do struct.
+5. **`BeforeAction::before_action` recebe `&str` ou um struct `SkillRequestContext`?** → **Decisão:** struct dedicado (`SkillRequestContext { intent: String, scope_hint: Option<SkillScope> }`) — `&str` amarra contrato ao primeiro uso e força refactor breaking em GAR-646. Struct vazio-extensível resolve.
+6. **`Skill` struct expõe `name: String` ou `name: SkillName(String)` newtype?** → **Decisão:** `String` simples. Newtype com validação (alpha-num + hyphen) já existe em `garraia_skills::parser::validate_skill` — duplicar agora é débito. GAR-645 decide a integração canônica.
+7. **`#[non_exhaustive]` em `SafetyDenial`?** → **Decisão:** sim. GAR-649 vai adicionar variants (ex: novo padrão de PII, novo critical path); marcar como `#[non_exhaustive]` evita breaking change quando isso acontecer.
+
+---
+
+## File Structure
+
+**Criar:**
+- `crates/garraia-learning/Cargo.toml` — package + 2 deps (`serde`, `thiserror`).
+- `crates/garraia-learning/src/lib.rs` — fachada com tipos base + 9 `pub mod` (incluindo `r#override`).
+- `crates/garraia-learning/src/miner.rs` — placeholder.
+- `crates/garraia-learning/src/generator.rs` — placeholder.
+- `crates/garraia-learning/src/registry.rs` — placeholder.
+- `crates/garraia-learning/src/retriever.rs` — placeholder.
+- `crates/garraia-learning/src/evaluator.rs` — placeholder.
+- `crates/garraia-learning/src/updater.rs` — placeholder.
+- `crates/garraia-learning/src/safety.rs` — placeholder.
+- `crates/garraia-learning/src/versioning.rs` — placeholder.
+- `crates/garraia-learning/src/override.rs` — placeholder.
+
+**Modificar:**
+- `Cargo.toml` — adicionar `"crates/garraia-learning"` ao `members`.
+- `docs/adr/0010-garra-learning-agent.md` — header `Status: Proposed → Accepted`, adicionar data + PR ref.
+- `docs/adr/README.md` — adicionar linhas para 0009 + 0010.
+- `CLAUDE.md` — mover bullet `garraia-learning/` da seção "Crates planejados" para a lista de crates ativos (após `garraia-skills/`).
+- `plans/README.md` — registrar linha 0144.
+
+---
+
+## M1 tasks (commit-by-commit)
+
+- [ ] **T0** — `docs(plans): add plan 0144 for GAR-642 learning scaffold` — só o arquivo deste plan.
+- [ ] **T1** — `feat(learning): scaffold garraia-learning crate (GAR-642)` — `Cargo.toml` + `src/lib.rs` + 9 módulos placeholder + adiciona ao workspace `members`. Inclui `cargo check -p garraia-learning` verde local.
+- [ ] **T2** — `docs(adr): promote ADR 0010 to Accepted + index 0009/0010 (GAR-642)` — flip header de 0010 + 2 linhas novas em `docs/adr/README.md`.
+- [ ] **T3** — `docs(claude): move garraia-learning to active crates (GAR-642)` — CLAUDE.md edits.
+
+Cada task tem unitary commit; T1 e T2 podem rodar em paralelo no review (não há ordem rígida), mas commit-time é sequencial.
+
+---
+
+## Risk register
+
+| Risco | Severidade | Mitigação |
+|---|---|---|
+| `cargo check --workspace` falha por edition mismatch | Baixa | Workspace é `edition = "2024"`; `garraia-glob` é `2021` mas funciona — herdar 2024 do workspace é safer. |
+| `cargo clippy --workspace -- -D warnings` falha em `missing_docs` | Média | `#![deny(missing_docs)]` é invariante; cada tipo público tem doc comment desde o scaffold. |
+| `r#override` quebra rust-analyzer ou outras tools | Baixa | Raw identifiers existem desde 2015; padrão estável. Caso falhe, T1 vira "rename to manual_override.rs" sem mexer no ADR (o ADR descreve componentes, não nomes de arquivo). |
+| Ratchet `unused-crate-dependencies` é elevado antes do PR mergear | Baixa | Scaffold tem só `serde` + `thiserror`, ambos usados em código. Zero deps mortas. |
+| Test runner detecta novo crate sem `#[test]` e exit-code não-zero | Baixa | Crates sem testes são válidos para `cargo test`; saída é "test result: ok. 0 passed; 0 failed". |
+| Quality Ratchet bloqueia PR por LOC delta | Baixa | PR-1 ratchet é report-only (ver CLAUDE.md §"AI Quality Ratchet"). |
+
+---
+
+## Acceptance criteria (gate antes de marcar GAR-642 Done)
+
+- [ ] `cargo check --workspace` verde.
+- [ ] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` verde.
+- [ ] `cargo check -p garraia-learning` verde em isolado.
+- [ ] `docs/adr/0010-garra-learning-agent.md` header mostra `**Status:** Accepted` + data `2026-05-17` (Florida) + PR `#NNN`.
+- [ ] `docs/adr/README.md` lista as 10 ADRs sequencialmente (0001..0010) com Status correto.
+- [ ] CLAUDE.md "Crates ativos" inclui `garraia-learning/` com bullet preservado do "Crates planejados".
+- [ ] CLAUDE.md "Crates planejados" não menciona mais `garraia-learning`.
+- [ ] `plans/README.md` linha 0144 presente.
+- [ ] Linear GAR-642: status flipado de Backlog → In Progress → Done; comment com link do PR e commit sha.
+
+---
+
+## Cross-references
+
+- ADR: [`docs/adr/0010-garra-learning-agent.md`](../docs/adr/0010-garra-learning-agent.md)
+- Epic Linear: [GAR-641](https://linear.app/chatgpt25/issue/GAR-641)
+- Plan-mãe: [`plans/0138-gar-learning-agent-epic.md`](0138-gar-learning-agent-epic.md)
+- Crate base reusado: [`crates/garraia-skills/`](../crates/garraia-skills/)
+- ROADMAP §1.4 / §7 priorização que escolheu este slice.
+
+---
+
+## Estimativa
+
+0.5 / 1 / 2 horas (apenas scaffold + 4 doc edits). Issue original estimava 0.5 / 1 / 2 semanas mas isso assumia integração real com `AgentRuntime` — escopo trimado para "shape-only" via trait neste plan.

--- a/plans/README.md
+++ b/plans/README.md
@@ -152,3 +152,4 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0141 | [GAR-655 — Q11 slice 6: extract rest_v1/tasks/activity.rs](0141-gar-635-q11-tasks-modularize-slice6.md) | [GAR-655](https://linear.app/chatgpt25/issue/GAR-655) | ✅ Merged 2026-05-17 via PR #386 (`a82ef2b`) |
 | 0142 | [GAR-656 — replace daemonize 0.5 with nix syscalls (RUSTSEC-2025-0069)](0142-gar-656-replace-daemonize-nix.md) | [GAR-656](https://linear.app/chatgpt25/issue/GAR-656) | ✅ Merged 2026-05-17 via PR #382 (`a5daf344`) |
 | 0143 | [GAR-658 — Q11 slice 7: extract rest_v1/tasks/attachments.rs](0143-gar-658-q11-tasks-modularize-slice7.md) | [GAR-658](https://linear.app/chatgpt25/issue/GAR-658) | ✅ Merged 2026-05-17 via PR #388 (`e04fc2c`) |
+| 0144 | [GAR-642 — Learning Agent scaffold + ADR 0010 → Accepted](0144-gar-642-learning-scaffold.md) | [GAR-642](https://linear.app/chatgpt25/issue/GAR-642) | ⏳ Draft (routine 2026-05-17) |


### PR DESCRIPTION
## Summary

Plan [0144](plans/0144-gar-642-learning-scaffold.md) — sub-issue 1/10 of the Garra Learning Agent epic ([GAR-641](https://linear.app/chatgpt25/issue/GAR-641)).

Promotes [ADR 0010](docs/adr/0010-garra-learning-agent.md) **Proposed → Accepted** and ships the scaffold of the new `garraia-learning` crate — 10 placeholder modules + base type contracts (`Skill`, `SkillScope`, `SkillSource`, `SkillScore`, `SafetyDenial`) + shape-only `BeforeAction` trait so sub-issues GAR-643..GAR-651 have a stable surface to implement against. No `AgentRuntime` modification — wiring lands with the Skill Retriever (GAR-646).

Linear: [GAR-642](https://linear.app/chatgpt25/issue/GAR-642) (In Progress).

## What this PR changes

| Area | Change |
|---|---|
| New crate | `crates/garraia-learning/` — 1 Cargo.toml + 1 lib.rs (5 unit tests) + 9 placeholder modules. Deps: only `serde` + `thiserror` (heavier deps come with the sub-issue that uses them; rationale documented inline). |
| Workspace | `Cargo.toml` adds `crates/garraia-learning` to `members`. |
| ADR | `docs/adr/0010-garra-learning-agent.md` — `Status: Proposed → Accepted` with date + PR ref placeholder. |
| ADR index | `docs/adr/README.md` — backfills rows for ADR 0009 (Web Console design system, was on disk since 2026-05-13 but missing from index) and ADR 0010 (this PR). |
| CLAUDE.md | `garraia-learning/` moved from "Crates planejados" to active crates list with bullet preserved + amended. Pointer note kept under "planejados" so future readers know where it went. |
| Plans | `plans/0144-gar-642-learning-scaffold.md` (new) + `plans/README.md` row 0144. |

## Design highlights

- **`#![forbid(unsafe_code)]` + `#![deny(missing_docs)]`** on the crate root so sub-issues can't quietly introduce `unsafe` or shipping types without doc comments.
- **`pub mod r#override;`** uses Rust's raw-identifier syntax to preserve the literal file name `override.rs` from ADR 0010 §"Topologia de crates" (alternative was renaming to `manual_override.rs`, which would drift code/ADR).
- **`SafetyDenial` is `#[non_exhaustive]`** so GAR-649 can add new PII / critical-path families without breaking changes.
- **`SkillRequestContext` is `#[non_exhaustive]`** for the same reason.
- **`NoopBeforeAction`** is the production default until GAR-646 ships the real Retriever — explicit no-op rather than `Option<Box<dyn …>>`.

## Verification

- ✅ `cargo check -p garraia-learning` — clean.
- ✅ `cargo test -p garraia-learning` — 5/5 pass (noop hook returns None, MIN_PROMOTE guard, SafetyDenial messages distinct, serde round-trip for SkillScope + SkillSource).
- ✅ `cargo check --workspace --exclude garraia-desktop` — clean.
- ✅ `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` — clean.
- ✅ `cargo fmt --all -- --check` — clean (one fix already committed as `style: cargo fmt garraia-learning lib.rs`).
- ⏳ Full CI matrix runs on this PR (Format / Clippy / Test ×3 / Build / MSRV / cargo-deny / Security Audit / Coverage / CodeQL rust + js-ts / Playwright / E2E / Secret Scan / Dependency Review).

## Test plan

- [ ] CI: Format Check passes.
- [ ] CI: Clippy passes.
- [ ] CI: Test (ubuntu / macos / windows) all pass — `garraia-learning` 5 unit tests included.
- [ ] CI: Build passes.
- [ ] CI: MSRV (1.92) check passes (`garraia-learning` uses no nightly features).
- [ ] CI: cargo-deny + Security Audit pass (no new advisory deps — only `serde` + `thiserror`, both already in `Cargo.lock`).
- [ ] CI: Coverage soft-gate posts a report.
- [ ] CI: Analyze (rust) + Analyze (javascript-typescript) pass — placeholder modules don't introduce SAST surface.
- [ ] CI: Playwright + E2E pass (no web/gateway change).
- [ ] CI: Secret Scan + Dependency Review pass.
- [ ] AI Quality Ratchet: report-only comment posted (PR-1 mode, no enforcement).

## Out of scope (deferred to sub-issues)

- Skill Miner — GAR-643
- Skill Generator — GAR-644
- Skill Registry — GAR-645
- Skill Retriever (+ AgentRuntime wiring) — GAR-646
- Skill Evaluator — GAR-647
- Skill Auto-Updater — GAR-648
- Skill Safety Gate (the actual `gate()` function) — GAR-649
- Skill Versioning / Rollback — GAR-650
- Web UI for skills + learning logs — GAR-651

## Rollback

Single-PR revert restores `main` to `29f9493`. Worst-case is 5 `git revert` (one per commit on this branch) if a partial rollback is wanted — see plan 0144 §"Rollback plan".

## References

- Linear: [GAR-642](https://linear.app/chatgpt25/issue/GAR-642), parent epic [GAR-641](https://linear.app/chatgpt25/issue/GAR-641)
- ADR: [0010 Garra Learning Agent](docs/adr/0010-garra-learning-agent.md)
- Plan: [0144](plans/0144-gar-642-learning-scaffold.md), parent plan [0138](plans/0138-gar-learning-agent-epic.md)
- ROADMAP §1.4 / §7