### PR TITLE
feat(embeddings): scaffold garraia-embeddings (GAR-372)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,20 @@ crates/
                         testids são contrato de teste. Remove `continue-on-error: true`
                         do step `Run Playwright tests` (`ci.yml:425`); CoE count
                         cai 2→1 (só RUSTSEC remanescente).
+  garraia-embeddings/ — Fase 2.1 (GAR-372, ADR 0002 Accepted 2026-04-21, plan
+                        0145 scaffold branch `feat/garraia-embeddings-scaffold`).
+                        Public surface only: traits `EmbeddingProvider` (async,
+                        `embed`/`embed_batch`/`model_id`) + `VectorStore`
+                        (async, `insert`/`search`/`delete`, scoped by `Scope` +
+                        `Option<Uuid> group_id`); strong types
+                        `Scope`/`EmbeddingVector(768)`/`Document`/`Chunk`/
+                        `SearchHit`; `HybridQuery` typed builder (rejects
+                        cross-tenant via build-time scope ↔ group_id check);
+                        `DeterministicProvider` (sha2-backed, default-on via
+                        feature `testing-provider`) para unit tests downstream.
+                        Sem `PgVectorStore` real, sem `MxbaiProvider`, sem
+                        wiring em learning/agents — esses são slices futuros.
+                        23 unit tests verdes.
   garraia-storage/    — Fase 3.5 (GAR-394 slice 1 plan 0037 + slice 2 plan 0038) —
                         trait ObjectStore + LocalFs baseline + path_sanitize. Slice 2
                         adiciona `S3Compatible` (aws-sdk-s3) atrás da feature
@@ -263,9 +277,13 @@ apps/
 ### Crates planejados (ROADMAP AAA Fases 2-3)
 
 ```text
-garraia-embeddings/  — Fase 2.1 (GAR-372) — embeddings locais mxbai + vector store lancedb
+(nenhum no momento — garraia-embeddings foi promovido em 2026-05-18 via plan 0145)
 ```
 
+> `garraia-embeddings/` promovido de "planejado" para "ativo" em 2026-05-18 (scaffold per
+> ADR 0002 + plan 0145; `PgVectorStore` real + `MxbaiProvider` ainda Backlog em
+> GAR-372 sub-issues a criar).
+>
 > `garraia-learning/` promovido para "Crates ativos" em 2026-05-17 (ADR 0010 → Accepted,
 > via PR #393 + plan 0144). Sub-componentes restantes (GAR-643..GAR-651) materializam
 > miner / generator / registry full / retriever / evaluator / auto-updater / versioning /

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3480,6 +3480,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "garraia-embeddings"
+version = "0.2.1"
+dependencies = [
+ "async-trait",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "garraia-gateway"
 version = "0.2.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "crates/garraia-workspace",
     "crates/garraia-glob",
     "crates/garraia-storage",
+    "crates/garraia-embeddings",
 ]
 
 [workspace.package]
@@ -136,6 +137,7 @@ garraia-tools = { path = "crates/garraia-tools" }
 garraia-runtime = { path = "crates/garraia-runtime" }
 garraia-voice = { path = "crates/garraia-voice" }
 garraia-glob = { path = "crates/garraia-glob" }
+garraia-embeddings = { path = "crates/garraia-embeddings" }
 
 [profile.release]
 lto = true

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Roadmap unificado do ecossistema GarraIA (CLI, Gateway, Desktop, Mobile, Agents, Channels, Voice) rumo ao padrão **AAA**. Funde o plano de inferência local + workflows agenticos com a nova direção de produto **Group Workspace** (família/equipe multi-tenant) derivada de `deep-research-report.md`.
 >
-> **Última atualização:** 2026-05-18 (local America/New_York) — ADR 0010 promovido Proposed → **Accepted** + crate `garraia-learning` scaffoldado (GAR-642, plan 0144, PR #392). 17 Safety Gate tests verdes. Anterior (2026-05-17): Q11 modularization COMPLETA (GAR-635), RUSTSEC-2025-0134 + RUSTSEC-2025-0069 fechados, GAR-410 CredentialVault Done.
+> **Última atualização:** 2026-05-18 (local America/New_York) — Crate `garraia-embeddings` scaffoldado per ADR 0002 (GAR-372, plan 0145, branch `feat/garraia-embeddings-scaffold`): traits `EmbeddingProvider` + `VectorStore`, strong types (`Scope`/`EmbeddingVector`/`Document`/`Chunk`/`SearchHit`), `HybridQuery` typed builder, `DeterministicProvider` para testes downstream. 23 unit tests verdes; sem wiring DB/learning ainda — `PgVectorStore` real é o próximo slice. Anterior (2026-05-18): ADR 0010 promovido Proposed → **Accepted** + crate `garraia-learning` scaffoldado (GAR-642, plan 0144, PR #392). 17 Safety Gate tests verdes. (2026-05-17): Q11 modularization COMPLETA (GAR-635), RUSTSEC-2025-0134 + RUSTSEC-2025-0069 fechados, GAR-410 CredentialVault Done.
 > **Owner:** @michelbr84
 > **Equipe Linear:** GAR
 > **Branch base:** `main`

--- a/crates/garraia-embeddings/Cargo.toml
+++ b/crates/garraia-embeddings/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "garraia-embeddings"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Embeddings and vector search — traits, strong types, deterministic test provider. ADR 0002."
+
+[features]
+# Enables the DeterministicProvider (sha2-backed pseudo-embedding generator)
+# for unit tests and dev fixtures. Default-on because the crate's test surface
+# depends on it and the workspace CI runs `cargo test --workspace` without
+# `--all-features`. Production builds that explicitly opt out via
+# `default-features = false` still get the trait surface — they just lose the
+# test-only DeterministicProvider implementation.
+testing-provider = ["dep:sha2"]
+default = ["testing-provider"]
+
+[dependencies]
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+uuid = { workspace = true, features = ["serde"] }
+sha2 = { version = "0.10", optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/garraia-embeddings/README.md
+++ b/crates/garraia-embeddings/README.md
@@ -1,0 +1,103 @@
+# garraia-embeddings
+
+Embeddings & vector-search surface for GarraIA.
+
+This crate ships the **trait surface** + **strong types** that the rest of the
+workspace programs against. Concrete database wiring (`PgVectorStore` over
+`sqlx` against migration 005) and real embedding model loaders
+(`MxbaiProvider` via `candle`) land in follow-up slices — see
+[plan 0145](../../plans/0145-gar-372-embeddings-scaffold.md) and
+[ADR 0002](../../docs/adr/0002-vector-store.md) for the full plan.
+
+## What this crate ships today
+
+| Module | Status | Purpose |
+|---|---|---|
+| `types` | ✅ stable | `Scope`, `EmbeddingVector`, `Document`, `Chunk`, `SearchHit` |
+| `error` | ✅ stable | typed `EmbeddingError` with PII-safe `Display` |
+| `provider` | ✅ trait + 1 test impl | `EmbeddingProvider` async trait; `DeterministicProvider` for unit tests |
+| `store` | ✅ trait only | `VectorStore` async trait, `SearchOptions` |
+| `hybrid` | ✅ stable | `HybridQuery` typed builder for FTS+ANN+filter retrieval |
+
+## What this crate **does not** ship (yet)
+
+- No `PgVectorStore` — the real Postgres + pgvector implementation is a
+  separate slice that requires the testcontainers harness already used by
+  `garraia-workspace`.
+- No `MxbaiProvider` / `OllamaProvider` / `CandleProvider` — real model loaders
+  consume ADR 0001 backends and land per-provider.
+- No wiring into `garraia-learning::retriever` or `garraia-agents` — the trait
+  is published; consumers connect it in their own PRs.
+
+## Quick start (downstream crate)
+
+```rust,ignore
+use std::sync::Arc;
+
+use garraia_embeddings::{EmbeddingProvider, EmbeddingVector, HybridQuery, Scope};
+
+async fn build_query<P>(provider: Arc<P>, text: &str) -> Result<HybridQuery, garraia_embeddings::EmbeddingError>
+where
+    P: EmbeddingProvider + 'static,
+{
+    let vector: EmbeddingVector = provider.embed(text).await?;
+    HybridQuery::builder()
+        .scope(Scope::User)
+        .model_id(provider.model_id())
+        .vector(vector)
+        .text("monthly invoice")
+        .limit(5)
+        .build()
+}
+```
+
+### Unit tests without a real model
+
+`DeterministicProvider` (default-on via the `testing-provider` feature) is
+suitable for unit tests in downstream crates:
+
+```rust,ignore
+use garraia_embeddings::{DeterministicProvider, EmbeddingProvider};
+
+#[tokio::test]
+async fn my_handler_calls_the_provider() {
+    let provider = DeterministicProvider::new();
+    let v = provider.embed("hello").await.unwrap();
+    assert_eq!(v.as_slice().len(), 768);
+    // The vector has no semantic meaning, but it IS deterministic and
+    // dimensioned correctly — enough to test that your handler hands the
+    // vector to the right caller.
+}
+```
+
+## Invariants worth knowing
+
+1. **Dimension is fixed at 768** (`EMBEDDING_DIM`). Matches `vector(768)` in
+   migration 005 and `mxbai-embed-large-v1`. A different-dim model is a
+   schema migration, not a runtime switch.
+2. **Every query is tenant-scoped.** `VectorStore` methods take `Scope` +
+   `Option<Uuid> group_id`. The trait shape makes "search everything"
+   queries unrepresentable.
+3. **`Scope::User` ↔ `group_id = None`** is enforced at `HybridQuery::build`
+   time. Personal memories are not group-scoped (migration 005 has
+   `memory_items.group_id` nullable specifically for this).
+4. **`include_secret` defaults to `false`.** Mirrors the
+   `sensitivity = 'secret'` invariant on `memory_items`. Opt-in is explicit
+   per call.
+5. **Errors never echo input.** `EmbeddingError::Display` uses static strings
+   only — same PII safety contract as `garraia-telemetry::redact`.
+
+## Feature flags
+
+| Feature | Default | What it gates |
+|---|---|---|
+| `testing-provider` | ✅ on | `DeterministicProvider` + `sha2` dep |
+
+Production builds may opt out (`default-features = false`) to drop the
+test-only provider; the trait surface remains intact.
+
+## Next concrete PR
+
+`PgVectorStore` over `sqlx` against `memory_embeddings` (migration 005, HNSW
+cosine). See [plan 0145](../../plans/0145-gar-372-embeddings-scaffold.md)
+§"Next concrete PR" for the sequencing.

--- a/crates/garraia-embeddings/src/error.rs
+++ b/crates/garraia-embeddings/src/error.rs
@@ -1,0 +1,92 @@
+//! Typed errors for embedding and vector-search operations.
+//!
+//! `Display` impls in this module deliberately **omit** the embedding inputs
+//! (text, chunk content, IDs). The same redaction discipline applies as for
+//! `memory_items.content` (see migration 005 comments) — PII never leaks via
+//! error strings.
+
+use thiserror::Error;
+
+/// All errors surfaced by this crate.
+#[derive(Debug, Error)]
+pub enum EmbeddingError {
+    /// The embedding vector did not have the expected dimension.
+    ///
+    /// The actual dimension is reported; the offending vector is not.
+    #[error("embedding vector dimension mismatch: expected {expected}, got {actual}")]
+    DimensionMismatch {
+        /// The dimension required by the [`crate::types::EmbeddingVector`] type
+        /// (currently 768).
+        expected: usize,
+        /// The dimension observed at construction time.
+        actual: usize,
+    },
+
+    /// A required field on a builder (e.g. [`crate::HybridQuery`]) was not set.
+    ///
+    /// The field name is included; user input is not.
+    #[error("required field `{field}` missing")]
+    MissingField {
+        /// Name of the missing field.
+        field: &'static str,
+    },
+
+    /// A required scope-bound parameter was missing or inconsistent.
+    ///
+    /// This is the catch-all for "you passed `Scope::Group` but no
+    /// `group_id`" — the trait API tries to make these unrepresentable,
+    /// but builder paths must still validate.
+    #[error("invalid scope: {reason}")]
+    InvalidScope {
+        /// Static description of the violation; never user input.
+        reason: &'static str,
+    },
+
+    /// The provider rejected an input (size, encoding, language, etc.).
+    ///
+    /// The reason is a static string — `Display` does not echo user content.
+    #[error("embedding provider rejected input: {reason}")]
+    ProviderRejected {
+        /// Static description.
+        reason: &'static str,
+    },
+
+    /// The provider failed transiently (network, model load, etc.).
+    ///
+    /// The underlying error is preserved for logs but not for `Display`.
+    #[error("embedding provider failure")]
+    ProviderFailure(#[source] Box<dyn std::error::Error + Send + Sync>),
+
+    /// The vector store failed transiently (db down, timeout, etc.).
+    #[error("vector store failure")]
+    StoreFailure(#[source] Box<dyn std::error::Error + Send + Sync>),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_does_not_leak_inputs() {
+        // The Display string for ProviderRejected uses the static reason field
+        // only — there is no path to embed user content in it.
+        let err = EmbeddingError::ProviderRejected {
+            reason: "input too long",
+        };
+        let s = format!("{err}");
+        assert!(s.contains("input too long"));
+        // Smoke: it does NOT contain anything we might have leaked.
+        assert!(!s.contains("secret-token"));
+    }
+
+    #[test]
+    fn dimension_mismatch_carries_numbers_not_content() {
+        let err = EmbeddingError::DimensionMismatch {
+            expected: 768,
+            actual: 384,
+        };
+        let s = format!("{err}");
+        assert!(s.contains("768"));
+        assert!(s.contains("384"));
+    }
+}

--- a/crates/garraia-embeddings/src/hybrid.rs
+++ b/crates/garraia-embeddings/src/hybrid.rs
@@ -104,7 +104,9 @@ impl HybridQueryBuilder {
 
     /// Validate the builder and produce a [`HybridQuery`] value.
     pub fn build(self) -> Result<HybridQuery, EmbeddingError> {
-        let scope = self.scope.ok_or(EmbeddingError::MissingField { field: "scope" })?;
+        let scope = self
+            .scope
+            .ok_or(EmbeddingError::MissingField { field: "scope" })?;
         let model_id = self
             .model_id
             .ok_or(EmbeddingError::MissingField { field: "model_id" })?;

--- a/crates/garraia-embeddings/src/hybrid.rs
+++ b/crates/garraia-embeddings/src/hybrid.rs
@@ -1,0 +1,305 @@
+//! [`HybridQuery`] — typed builder for hybrid retrieval queries.
+//!
+//! "Hybrid" here means combining:
+//!
+//! - Full-text search (Postgres `tsvector @@ tsquery`)
+//! - Approximate nearest neighbor (`pgvector` HNSW cosine)
+//! - Structural filters (`scope_type`, `group_id`, `sensitivity`, `kind`)
+//!
+//! ADR 0002 §Decisões item 4 specifies this is expressed as a single Postgres
+//! CTE; this builder is the language-level surface that produces the typed
+//! query value executed by the concrete `VectorStore` impl.
+//!
+//! The actual SQL string is **not** materialized in this crate. Producing it
+//! is a concern of `PgVectorStore` (future PR) which has the connection
+//! handle, the parameter binder, and the right place to run `EXPLAIN`.
+
+use uuid::Uuid;
+
+use crate::error::EmbeddingError;
+use crate::types::{EmbeddingVector, Scope};
+
+/// Typed builder for a hybrid retrieval query.
+///
+/// Required fields (the builder errors out at [`HybridQuery::build`] if any
+/// are missing):
+///
+/// - `scope`
+/// - `model_id`
+/// - `vector`
+///
+/// `group_id` is **required when scope ≠ User** and **forbidden when scope =
+/// User** (per migration 005's `memory_items.group_id` contract).
+#[derive(Debug, Default, Clone)]
+pub struct HybridQueryBuilder {
+    scope: Option<Scope>,
+    group_id: Option<Uuid>,
+    model_id: Option<String>,
+    vector: Option<EmbeddingVector>,
+    text_query: Option<String>,
+    kind: Option<String>,
+    include_secret: bool,
+    limit: u32,
+}
+
+impl HybridQueryBuilder {
+    /// Start a new builder.
+    pub fn new() -> Self {
+        Self {
+            limit: 5,
+            ..Default::default()
+        }
+    }
+
+    /// Set the retrieval scope (required).
+    pub fn scope(mut self, scope: Scope) -> Self {
+        self.scope = Some(scope);
+        self
+    }
+
+    /// Bind the query to a `group_id`. Required for `Scope::Group` and
+    /// `Scope::Chat`; forbidden for `Scope::User`.
+    pub fn group_id(mut self, group_id: Uuid) -> Self {
+        self.group_id = Some(group_id);
+        self
+    }
+
+    /// Set the embedding model partition (required).
+    pub fn model_id(mut self, model_id: impl Into<String>) -> Self {
+        self.model_id = Some(model_id.into());
+        self
+    }
+
+    /// Set the dense query vector (required).
+    pub fn vector(mut self, vector: EmbeddingVector) -> Self {
+        self.vector = Some(vector);
+        self
+    }
+
+    /// Optional FTS clause. When `None`, the query is pure ANN.
+    pub fn text(mut self, query: impl Into<String>) -> Self {
+        self.text_query = Some(query.into());
+        self
+    }
+
+    /// Optional `memory_items.kind` filter (`"fact"`, `"profile"`, etc.).
+    pub fn kind(mut self, kind: impl Into<String>) -> Self {
+        self.kind = Some(kind.into());
+        self
+    }
+
+    /// Opt in to including `sensitivity = 'secret'` rows in the result set.
+    /// Defaults to **false** to enforce the retrieval invariant documented
+    /// on the `memory_items.sensitivity` column.
+    pub fn include_secret(mut self, include: bool) -> Self {
+        self.include_secret = include;
+        self
+    }
+
+    /// Top-k limit. Defaults to 5.
+    pub fn limit(mut self, limit: u32) -> Self {
+        self.limit = limit;
+        self
+    }
+
+    /// Validate the builder and produce a [`HybridQuery`] value.
+    pub fn build(self) -> Result<HybridQuery, EmbeddingError> {
+        let scope = self.scope.ok_or(EmbeddingError::MissingField { field: "scope" })?;
+        let model_id = self
+            .model_id
+            .ok_or(EmbeddingError::MissingField { field: "model_id" })?;
+        let vector = self
+            .vector
+            .ok_or(EmbeddingError::MissingField { field: "vector" })?;
+
+        match (scope, self.group_id) {
+            (Scope::User, Some(_)) => {
+                return Err(EmbeddingError::InvalidScope {
+                    reason: "group_id must be None for Scope::User",
+                });
+            }
+            (Scope::User, None) => { /* ok */ }
+            (Scope::Group | Scope::Chat, None) => {
+                return Err(EmbeddingError::InvalidScope {
+                    reason: "group_id required for Scope::Group / Scope::Chat",
+                });
+            }
+            (Scope::Group | Scope::Chat, Some(_)) => { /* ok */ }
+        }
+
+        if self.limit == 0 {
+            return Err(EmbeddingError::InvalidScope {
+                reason: "limit must be >= 1",
+            });
+        }
+
+        Ok(HybridQuery {
+            scope,
+            group_id: self.group_id,
+            model_id,
+            vector,
+            text_query: self.text_query,
+            kind: self.kind,
+            include_secret: self.include_secret,
+            limit: self.limit,
+        })
+    }
+}
+
+/// A fully-validated hybrid query, ready to be executed by a `VectorStore`
+/// implementation.
+#[derive(Debug, Clone)]
+pub struct HybridQuery {
+    /// Retrieval scope.
+    pub scope: Scope,
+    /// Group binding (`None` only when [`scope`](Self::scope) is
+    /// [`Scope::User`]).
+    pub group_id: Option<Uuid>,
+    /// Embedding model partition.
+    pub model_id: String,
+    /// Dense query vector.
+    pub vector: EmbeddingVector,
+    /// Optional FTS clause.
+    pub text_query: Option<String>,
+    /// Optional `memory_items.kind` filter.
+    pub kind: Option<String>,
+    /// Whether to include `sensitivity = 'secret'` rows.
+    pub include_secret: bool,
+    /// Top-k limit.
+    pub limit: u32,
+}
+
+impl HybridQuery {
+    /// Convenience constructor returning a fresh [`HybridQueryBuilder`].
+    pub fn builder() -> HybridQueryBuilder {
+        HybridQueryBuilder::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::EMBEDDING_DIM;
+
+    fn fake_vector() -> EmbeddingVector {
+        EmbeddingVector::try_from_vec(vec![0.0; EMBEDDING_DIM]).unwrap()
+    }
+
+    #[test]
+    fn build_succeeds_with_minimum_fields_user_scope() {
+        let q = HybridQuery::builder()
+            .scope(Scope::User)
+            .model_id("deterministic-sha256-768")
+            .vector(fake_vector())
+            .build()
+            .unwrap();
+        assert!(matches!(q.scope, Scope::User));
+        assert_eq!(q.limit, 5);
+        assert!(!q.include_secret);
+    }
+
+    #[test]
+    fn build_requires_group_id_for_group_scope() {
+        let err = HybridQuery::builder()
+            .scope(Scope::Group)
+            .model_id("m")
+            .vector(fake_vector())
+            .build()
+            .unwrap_err();
+        assert!(matches!(err, EmbeddingError::InvalidScope { .. }));
+    }
+
+    #[test]
+    fn build_requires_group_id_for_chat_scope() {
+        let err = HybridQuery::builder()
+            .scope(Scope::Chat)
+            .model_id("m")
+            .vector(fake_vector())
+            .build()
+            .unwrap_err();
+        assert!(matches!(err, EmbeddingError::InvalidScope { .. }));
+    }
+
+    #[test]
+    fn build_rejects_group_id_on_user_scope() {
+        let err = HybridQuery::builder()
+            .scope(Scope::User)
+            .group_id(Uuid::nil())
+            .model_id("m")
+            .vector(fake_vector())
+            .build()
+            .unwrap_err();
+        assert!(matches!(err, EmbeddingError::InvalidScope { .. }));
+    }
+
+    #[test]
+    fn build_accepts_group_scope_with_group_id() {
+        let q = HybridQuery::builder()
+            .scope(Scope::Group)
+            .group_id(Uuid::nil())
+            .model_id("m")
+            .vector(fake_vector())
+            .build()
+            .unwrap();
+        assert_eq!(q.group_id, Some(Uuid::nil()));
+    }
+
+    #[test]
+    fn build_rejects_missing_required_fields() {
+        // Missing scope.
+        let err = HybridQuery::builder()
+            .model_id("m")
+            .vector(fake_vector())
+            .build()
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            EmbeddingError::MissingField { field: "scope" }
+        ));
+
+        // Missing model_id.
+        let err = HybridQuery::builder()
+            .scope(Scope::User)
+            .vector(fake_vector())
+            .build()
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            EmbeddingError::MissingField { field: "model_id" }
+        ));
+
+        // Missing vector.
+        let err = HybridQuery::builder()
+            .scope(Scope::User)
+            .model_id("m")
+            .build()
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            EmbeddingError::MissingField { field: "vector" }
+        ));
+    }
+
+    #[test]
+    fn build_rejects_zero_limit() {
+        let err = HybridQuery::builder()
+            .scope(Scope::User)
+            .model_id("m")
+            .vector(fake_vector())
+            .limit(0)
+            .build()
+            .unwrap_err();
+        assert!(matches!(err, EmbeddingError::InvalidScope { .. }));
+    }
+
+    #[test]
+    fn include_secret_defaults_off() {
+        let q = HybridQuery::builder()
+            .scope(Scope::User)
+            .model_id("m")
+            .vector(fake_vector())
+            .build()
+            .unwrap();
+        assert!(!q.include_secret);
+    }
+}

--- a/crates/garraia-embeddings/src/lib.rs
+++ b/crates/garraia-embeddings/src/lib.rs
@@ -1,0 +1,48 @@
+//! GarraIA — Embeddings & vector search.
+//!
+//! This crate ships the public surface (traits + strong types) that the rest of
+//! the GarraIA workspace programs against for embedding-based retrieval. It
+//! intentionally contains **no** concrete database wiring — the
+//! [`VectorStore`] trait is a definition; a real `PgVectorStore` over `sqlx`
+//! lives in a follow-up slice.
+//!
+//! Design is fixed by [ADR 0002][adr-0002] (Accepted 2026-04-21). Briefly:
+//!
+//! - `pgvector` is the primary vector store.
+//! - Embedding dimension is 768 (mxbai-embed-large-v1).
+//! - Every retrieval is **scoped** by [`Scope`] + `group_id` — the trait
+//!   shape makes cross-tenant queries impossible to express.
+//!
+//! ## Modules
+//!
+//! - [`types`] — [`Scope`], [`EmbeddingVector`], [`Document`], [`Chunk`],
+//!   [`SearchHit`].
+//! - [`error`] — typed [`EmbeddingError`].
+//! - [`provider`] — [`EmbeddingProvider`] trait and (under
+//!   `testing-provider` feature) [`DeterministicProvider`] for tests.
+//! - [`store`] — [`VectorStore`] trait.
+//! - [`hybrid`] — [`HybridQuery`] builder for FTS+ANN+filter Postgres CTE
+//!   queries (ADR 0002 §Decisões item 4).
+//!
+//! [adr-0002]: https://github.com/michelbr84/GarraRUST/blob/main/docs/adr/0002-vector-store.md
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+pub mod error;
+pub mod hybrid;
+pub mod provider;
+pub mod store;
+pub mod types;
+
+pub use error::EmbeddingError;
+pub use hybrid::HybridQuery;
+pub use provider::EmbeddingProvider;
+pub use store::{SearchOptions, VectorStore};
+pub use types::{Chunk, Document, EmbeddingVector, Scope, SearchHit, EMBEDDING_DIM};
+
+#[cfg(feature = "testing-provider")]
+pub use provider::DeterministicProvider;
+
+/// Convenience [`Result`] alias.
+pub type Result<T> = core::result::Result<T, EmbeddingError>;

--- a/crates/garraia-embeddings/src/lib.rs
+++ b/crates/garraia-embeddings/src/lib.rs
@@ -39,7 +39,7 @@ pub use error::EmbeddingError;
 pub use hybrid::HybridQuery;
 pub use provider::EmbeddingProvider;
 pub use store::{SearchOptions, VectorStore};
-pub use types::{Chunk, Document, EmbeddingVector, Scope, SearchHit, EMBEDDING_DIM};
+pub use types::{Chunk, Document, EMBEDDING_DIM, EmbeddingVector, Scope, SearchHit};
 
 #[cfg(feature = "testing-provider")]
 pub use provider::DeterministicProvider;

--- a/crates/garraia-embeddings/src/provider.rs
+++ b/crates/garraia-embeddings/src/provider.rs
@@ -1,0 +1,197 @@
+//! [`EmbeddingProvider`] trait — the abstraction over an embedding model.
+//!
+//! Implementations live in their own crates / slices:
+//!
+//! - `MxbaiProvider` via `candle` (ADR 0001) — future PR.
+//! - `OllamaProvider` for self-hosted Ollama endpoints — future PR.
+//! - [`DeterministicProvider`] (this module, gated by `testing-provider`
+//!   feature) — used by `[dev-dependencies]` consumers to write unit tests
+//!   that don't need a real model.
+
+use async_trait::async_trait;
+
+use crate::error::EmbeddingError;
+use crate::types::EmbeddingVector;
+
+/// An embedding model — produces a fixed-dimension vector from input text.
+///
+/// Implementations must be `Send + Sync` so they can be stored as
+/// `Arc<dyn EmbeddingProvider>` in shared application state.
+///
+/// `embed_batch` is on the trait by design: single-shot embeds are an
+/// anti-pattern for RAG latency budgets. Callers MUST batch; providers MAY
+/// fan out internally.
+#[async_trait]
+pub trait EmbeddingProvider: Send + Sync {
+    /// A short, stable identifier for the model — goes into
+    /// `memory_embeddings.model`. Examples: `"mxbai-embed-large-v1"`,
+    /// `"deterministic-sha256-768"`.
+    fn model_id(&self) -> &str;
+
+    /// Embed a single piece of text. Default implementation defers to
+    /// [`embed_batch`](EmbeddingProvider::embed_batch) with a single-item
+    /// slice — most providers will want to override this for the trivial
+    /// path.
+    async fn embed(&self, text: &str) -> Result<EmbeddingVector, EmbeddingError> {
+        let mut out = self.embed_batch(&[text]).await?;
+        out.pop().ok_or(EmbeddingError::ProviderRejected {
+            reason: "batch returned empty result",
+        })
+    }
+
+    /// Embed a batch of texts in one round-trip / model invocation.
+    ///
+    /// The output `Vec<EmbeddingVector>` MUST have the same length as the
+    /// input slice and be in the same order.
+    async fn embed_batch(&self, texts: &[&str]) -> Result<Vec<EmbeddingVector>, EmbeddingError>;
+}
+
+// =========================================================================
+// DeterministicProvider — testing only.
+// =========================================================================
+
+#[cfg(feature = "testing-provider")]
+mod deterministic {
+    use super::*;
+    use crate::types::EMBEDDING_DIM;
+    use sha2::{Digest, Sha256};
+
+    /// A pseudo-random, **deterministic** [`EmbeddingProvider`] for tests.
+    ///
+    /// Same input → same output, byte-for-byte. Different inputs → different
+    /// outputs (collisions are theoretically possible at the SHA-256 level
+    /// but cosmically unlikely; we don't depend on this cryptographically).
+    ///
+    /// **NOT for production.** Vectors produced here have no semantic
+    /// meaning — nearest-neighbor results are gibberish. The provider exists
+    /// so downstream crates can unit-test their consumption of the
+    /// [`EmbeddingProvider`] trait without bringing up a real model.
+    ///
+    /// The vector is built by repeatedly hashing `seed_index || text`, mapping
+    /// each 4-byte SHA-256 window into a float in `[-1.0, 1.0]`. After
+    /// `EMBEDDING_DIM` floats are produced the vector is L2-normalized.
+    #[derive(Debug, Default, Clone)]
+    pub struct DeterministicProvider;
+
+    impl DeterministicProvider {
+        /// Construct.
+        pub fn new() -> Self {
+            Self
+        }
+
+        fn embed_one(text: &str) -> EmbeddingVector {
+            let mut out: Vec<f32> = Vec::with_capacity(EMBEDDING_DIM);
+            // We need EMBEDDING_DIM floats; each SHA-256 hash gives 8 floats
+            // (8 × 4 bytes = 32 bytes). 768 / 8 = 96 rounds.
+            let rounds = EMBEDDING_DIM.div_ceil(8);
+            for seed in 0..rounds {
+                let mut hasher = Sha256::new();
+                hasher.update(seed.to_le_bytes());
+                hasher.update(text.as_bytes());
+                let digest = hasher.finalize();
+                for chunk in digest.chunks_exact(4) {
+                    if out.len() == EMBEDDING_DIM {
+                        break;
+                    }
+                    let bytes: [u8; 4] = chunk.try_into().expect("chunks_exact(4) yields [u8;4]");
+                    // Map u32 to (-1.0, 1.0).
+                    let n = u32::from_le_bytes(bytes);
+                    let f = (n as f64 / u32::MAX as f64) * 2.0 - 1.0;
+                    out.push(f as f32);
+                }
+            }
+            // L2-normalize so the vectors live on the unit sphere — closer to
+            // what a real embedding model produces.
+            let norm = out.iter().map(|x| (*x as f64).powi(2)).sum::<f64>().sqrt();
+            if norm > 0.0 {
+                for v in out.iter_mut() {
+                    *v = ((*v as f64) / norm) as f32;
+                }
+            }
+            EmbeddingVector::try_from_vec(out).expect("constructed with EMBEDDING_DIM elements")
+        }
+    }
+
+    #[async_trait]
+    impl EmbeddingProvider for DeterministicProvider {
+        fn model_id(&self) -> &str {
+            "deterministic-sha256-768"
+        }
+
+        async fn embed_batch(
+            &self,
+            texts: &[&str],
+        ) -> Result<Vec<EmbeddingVector>, EmbeddingError> {
+            Ok(texts.iter().map(|t| Self::embed_one(t)).collect())
+        }
+    }
+}
+
+#[cfg(feature = "testing-provider")]
+pub use deterministic::DeterministicProvider;
+
+#[cfg(all(test, feature = "testing-provider"))]
+mod tests {
+    use super::*;
+    use crate::types::EMBEDDING_DIM;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn deterministic_provider_is_deterministic() {
+        let p = DeterministicProvider::new();
+        let a = p.embed("hello world").await.unwrap();
+        let b = p.embed("hello world").await.unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn different_inputs_yield_different_outputs() {
+        let p = DeterministicProvider::new();
+        let a = p.embed("alpha").await.unwrap();
+        let b = p.embed("beta").await.unwrap();
+        assert_ne!(a, b);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn batch_preserves_order_and_length() {
+        let p = DeterministicProvider::new();
+        let inputs = ["one", "two", "three"];
+        let out = p.embed_batch(&inputs).await.unwrap();
+        assert_eq!(out.len(), inputs.len());
+
+        // Verify positional correspondence by recomputing index 1 via embed().
+        let solo = p.embed("two").await.unwrap();
+        assert_eq!(out[1], solo);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn output_dimension_is_fixed() {
+        let p = DeterministicProvider::new();
+        let v = p.embed("anything").await.unwrap();
+        assert_eq!(v.as_slice().len(), EMBEDDING_DIM);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn model_id_is_stable() {
+        // Real consumers will write this to memory_embeddings.model, so we
+        // pin it down by a test.
+        let p = DeterministicProvider::new();
+        assert_eq!(p.model_id(), "deterministic-sha256-768");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn vectors_are_approximately_unit_norm() {
+        let p = DeterministicProvider::new();
+        let v = p.embed("a longer string that pushes more entropy through").await.unwrap();
+        let norm: f64 = v
+            .as_slice()
+            .iter()
+            .map(|x| (*x as f64).powi(2))
+            .sum::<f64>()
+            .sqrt();
+        // f32 round-trip + multi-round hashing — give it a 1e-3 tolerance.
+        assert!(
+            (norm - 1.0).abs() < 1e-3,
+            "expected unit norm, got {norm}"
+        );
+    }
+}

--- a/crates/garraia-embeddings/src/provider.rs
+++ b/crates/garraia-embeddings/src/provider.rs
@@ -181,7 +181,10 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn vectors_are_approximately_unit_norm() {
         let p = DeterministicProvider::new();
-        let v = p.embed("a longer string that pushes more entropy through").await.unwrap();
+        let v = p
+            .embed("a longer string that pushes more entropy through")
+            .await
+            .unwrap();
         let norm: f64 = v
             .as_slice()
             .iter()
@@ -189,9 +192,6 @@ mod tests {
             .sum::<f64>()
             .sqrt();
         // f32 round-trip + multi-round hashing — give it a 1e-3 tolerance.
-        assert!(
-            (norm - 1.0).abs() < 1e-3,
-            "expected unit norm, got {norm}"
-        );
+        assert!((norm - 1.0).abs() < 1e-3, "expected unit norm, got {norm}");
     }
 }

--- a/crates/garraia-embeddings/src/store.rs
+++ b/crates/garraia-embeddings/src/store.rs
@@ -1,0 +1,81 @@
+//! [`VectorStore`] trait — the abstraction over the vector storage backend.
+//!
+//! ADR 0002 fixes Postgres + pgvector as the primary store. The concrete
+//! `PgVectorStore` implementation lives in a follow-up slice and is gated on a
+//! DB integration test harness. This module ships only the trait so the rest
+//! of the codebase can program against it today.
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::error::EmbeddingError;
+use crate::types::{EmbeddingVector, Scope, SearchHit};
+
+/// Optional tuning knobs for [`VectorStore::search`].
+///
+/// Defaults are the right answer for the common case (top-5 within a single
+/// `group_id`). Power-user knobs land here as the surface matures — keep
+/// additions backwards-compatible (new fields default to `None`).
+#[derive(Debug, Clone, Default)]
+pub struct SearchOptions {
+    /// HNSW `ef_search` — increase for higher recall at the cost of latency.
+    /// `None` defaults to the pgvector default (40 in pgvector 0.7).
+    pub ef_search: Option<u32>,
+
+    /// Hard cap on cosine distance. Hits with distance > this value are not
+    /// returned. `None` returns all top-k regardless of distance.
+    pub max_distance: Option<f32>,
+}
+
+/// The persistence + retrieval surface for embedding vectors.
+///
+/// Every method takes a [`Scope`] + `group_id` pair. The combination mirrors
+/// the RLS policy on `memory_items` from migration 007 (FORCE RLS on
+/// `group_id`, with `scope_type` filtering enforced by the policy USING
+/// clause). The trait shape makes cross-tenant queries impossible to
+/// express — there is no `search_all_tenants` method.
+///
+/// Implementations MUST:
+///
+/// 1. Use the embedding's `model_id` (from [`crate::EmbeddingProvider::model_id`])
+///    as the persistence partition. Different models live in different rows
+///    of `memory_embeddings`.
+/// 2. Refuse to return hits from rows whose `sensitivity = 'secret'` unless
+///    the caller passes an explicit opt-in (a future `SearchOptions` field).
+/// 3. Apply `ttl_expires_at` filtering: rows past their TTL are excluded
+///    even before the cleanup worker has hard-deleted them.
+#[async_trait]
+pub trait VectorStore: Send + Sync {
+    /// Insert (or upsert) the embedding for a single `memory_items` row.
+    ///
+    /// `group_id` is required when `scope` is [`Scope::Group`] or
+    /// [`Scope::Chat`]; for [`Scope::User`] it MUST be `None` (per migration
+    /// 005 `memory_items.group_id` is NULL for personal memories).
+    async fn insert(
+        &self,
+        memory_item_id: Uuid,
+        scope: Scope,
+        group_id: Option<Uuid>,
+        model_id: &str,
+        embedding: &EmbeddingVector,
+    ) -> Result<(), EmbeddingError>;
+
+    /// Top-k nearest neighbor search scoped to a single tenant + scope.
+    ///
+    /// Returns up to `limit` hits, sorted by ascending cosine distance.
+    async fn search(
+        &self,
+        scope: Scope,
+        group_id: Option<Uuid>,
+        model_id: &str,
+        query: &EmbeddingVector,
+        limit: u32,
+        options: SearchOptions,
+    ) -> Result<Vec<SearchHit>, EmbeddingError>;
+
+    /// Delete embeddings for a `memory_items` row.
+    ///
+    /// Typically driven by `memory_items.deleted_at` becoming non-NULL or
+    /// by a TTL sweep. Idempotent — deleting twice is not an error.
+    async fn delete(&self, memory_item_id: Uuid, model_id: &str) -> Result<(), EmbeddingError>;
+}

--- a/crates/garraia-embeddings/src/types.rs
+++ b/crates/garraia-embeddings/src/types.rs
@@ -1,0 +1,209 @@
+//! Strong types shared by [`crate::EmbeddingProvider`] and
+//! [`crate::VectorStore`].
+//!
+//! Three invariants are enforced at the type level:
+//!
+//! 1. **Dimension.** [`EmbeddingVector`] only ever holds `EMBEDDING_DIM`
+//!    floats (currently 768). Construction validates this.
+//! 2. **Scope.** Every retrieval call carries a [`Scope`] enum and a
+//!    `group_id`. The combination mirrors the `memory_items` row contract from
+//!    migration 005 and the RLS policy from migration 007.
+//! 3. **Document → chunks → embeddings** is the pipeline shape — callers can't
+//!    persist an embedding without an originating chunk and document id.
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::error::EmbeddingError;
+
+/// Embedding vector dimension. Matches `vector(768)` in migration 005 and
+/// `mxbai-embed-large-v1`.
+pub const EMBEDDING_DIM: usize = 768;
+
+/// Retrieval scope. Mirrors `memory_items.scope_type` from migration 005.
+///
+/// The semantic precedence (Chat > Group > User when multiple scopes
+/// intersect) is enforced by the **caller**, not by this enum — this type
+/// just identifies which scope a single request runs against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Scope {
+    /// Personal memory — visible only to the creator.
+    User,
+    /// Shared within a group.
+    Group,
+    /// Bound to a specific chat / channel.
+    Chat,
+}
+
+impl Scope {
+    /// String representation as stored in the `memory_items.scope_type` column.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Scope::User => "user",
+            Scope::Group => "group",
+            Scope::Chat => "chat",
+        }
+    }
+}
+
+/// Fixed-dimension embedding vector.
+///
+/// Constructed via [`EmbeddingVector::try_from_vec`] which validates the
+/// dimension. Equality is bitwise on `f32` — callers that want
+/// distance-based equality should use cosine similarity at the application
+/// layer.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EmbeddingVector(Vec<f32>);
+
+impl EmbeddingVector {
+    /// Build from a `Vec<f32>`, returning [`EmbeddingError::DimensionMismatch`]
+    /// when the length is not [`EMBEDDING_DIM`].
+    pub fn try_from_vec(v: Vec<f32>) -> Result<Self, EmbeddingError> {
+        if v.len() != EMBEDDING_DIM {
+            return Err(EmbeddingError::DimensionMismatch {
+                expected: EMBEDDING_DIM,
+                actual: v.len(),
+            });
+        }
+        Ok(Self(v))
+    }
+
+    /// Borrowed slice — useful for serialization into pgvector's text format
+    /// or for cosine-similarity helpers.
+    pub fn as_slice(&self) -> &[f32] {
+        &self.0
+    }
+
+    /// Consume the vector and return the inner `Vec<f32>`.
+    pub fn into_inner(self) -> Vec<f32> {
+        self.0
+    }
+}
+
+/// A document submitted for embedding — the unit of provenance.
+///
+/// A document is split into [`Chunk`]s by the caller (chunking strategy is
+/// out of scope for this crate; the agents/learning layer owns it).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Document {
+    /// Stable identifier — typically the originating `memory_items.id` or
+    /// `messages.id`.
+    pub id: Uuid,
+    /// Document text. Embedded content; never logged via tracing fields
+    /// without a redaction layer (see [`crate::error`] for the same rule).
+    pub text: String,
+    /// Soft tag — `"memory"`, `"message"`, `"skill"`, etc. Free-form so
+    /// callers can categorize without bumping the crate.
+    pub kind: String,
+}
+
+/// A fragment of a [`Document`] suitable for embedding in a single forward
+/// pass of the model.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Chunk {
+    /// Foreign key to the originating [`Document::id`].
+    pub document_id: Uuid,
+    /// Sequential chunk index within the document, starting at 0.
+    pub index: u32,
+    /// Chunk text. Same redaction rules as [`Document::text`].
+    pub text: String,
+}
+
+/// A search result from [`crate::VectorStore::search`].
+///
+/// `distance` is in cosine-distance units (0.0 = identical, up to 2.0 =
+/// opposite). Callers comparing thresholds across providers must agree on
+/// the distance metric beforehand.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchHit {
+    /// The `memory_items.id` (or equivalent) of the matched row.
+    pub item_id: Uuid,
+    /// Cosine distance.
+    pub distance: f32,
+    /// Whichever scope this row belongs to. Useful when the caller queried
+    /// `Scope::Group` but the row's resolved scope is `Chat` (allowed when
+    /// `chat.group_id` matches and the chat is included).
+    pub scope: Scope,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scope_serializes_lowercase() {
+        let s = serde_json::to_string(&Scope::User).unwrap();
+        assert_eq!(s, "\"user\"");
+        let s = serde_json::to_string(&Scope::Group).unwrap();
+        assert_eq!(s, "\"group\"");
+        let s = serde_json::to_string(&Scope::Chat).unwrap();
+        assert_eq!(s, "\"chat\"");
+    }
+
+    #[test]
+    fn scope_round_trip() {
+        for sc in [Scope::User, Scope::Group, Scope::Chat] {
+            let s = serde_json::to_string(&sc).unwrap();
+            let back: Scope = serde_json::from_str(&s).unwrap();
+            assert_eq!(sc, back);
+        }
+    }
+
+    #[test]
+    fn scope_rejects_invalid_string() {
+        let err = serde_json::from_str::<Scope>("\"admin\"").unwrap_err();
+        // Make sure deserialization actually rejected it (rather than silently
+        // defaulting). Any error here is acceptable.
+        assert!(err.is_data() || err.is_syntax());
+    }
+
+    #[test]
+    fn scope_as_str_matches_migration_005() {
+        // These three literals appear verbatim in migration 005's CHECK
+        // constraint. If we change them, that migration must also change.
+        assert_eq!(Scope::User.as_str(), "user");
+        assert_eq!(Scope::Group.as_str(), "group");
+        assert_eq!(Scope::Chat.as_str(), "chat");
+    }
+
+    #[test]
+    fn embedding_vector_requires_exact_dimension() {
+        let v = vec![0.0; EMBEDDING_DIM];
+        let ev = EmbeddingVector::try_from_vec(v).unwrap();
+        assert_eq!(ev.as_slice().len(), EMBEDDING_DIM);
+
+        let v = vec![0.0; EMBEDDING_DIM - 1];
+        let err = EmbeddingVector::try_from_vec(v).unwrap_err();
+        assert!(matches!(
+            err,
+            EmbeddingError::DimensionMismatch {
+                expected: EMBEDDING_DIM,
+                actual,
+            } if actual == EMBEDDING_DIM - 1
+        ));
+
+        let v = vec![0.0; EMBEDDING_DIM + 1];
+        let err = EmbeddingVector::try_from_vec(v).unwrap_err();
+        assert!(matches!(err, EmbeddingError::DimensionMismatch { .. }));
+    }
+
+    #[test]
+    fn embedding_vector_equality_is_bitwise() {
+        let a = EmbeddingVector::try_from_vec(vec![1.0; EMBEDDING_DIM]).unwrap();
+        let b = EmbeddingVector::try_from_vec(vec![1.0; EMBEDDING_DIM]).unwrap();
+        assert_eq!(a, b);
+        let mut c_vec = vec![1.0; EMBEDDING_DIM];
+        c_vec[0] = 1.0000001;
+        let c = EmbeddingVector::try_from_vec(c_vec).unwrap();
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn embedding_dim_matches_migration_005() {
+        // Migration 005 declares `embedding vector(768)`. If this changes we
+        // have a multi-step DB migration to plan (see ADR 0002 supersession
+        // path).
+        assert_eq!(EMBEDDING_DIM, 768);
+    }
+}

--- a/plans/0145-gar-372-embeddings-scaffold.md
+++ b/plans/0145-gar-372-embeddings-scaffold.md
@@ -1,0 +1,155 @@
+# Plan 0145 — GAR-372: Embeddings & Vector Search — Scaffold `garraia-embeddings`
+
+**Status:** 🚧 In Progress (2026-05-18)
+**Issue:** [GAR-372](https://linear.app/chatgpt25/issue/GAR-372)
+**Branch:** `feat/garraia-embeddings-scaffold`
+**Epic parent:** Fase 2.1 — RAG & Embeddings
+**ADR reference:** [`0002-vector-store.md`](../docs/adr/0002-vector-store.md) (Accepted 2026-04-21)
+
+---
+
+## Goal
+
+Deliver the **architecture slice** of Fase 2.1:
+
+1. Create crate `crates/garraia-embeddings/` and add it to the workspace.
+2. Define the public surface: traits + strong types that the rest of the codebase
+   will program against — no concrete database wiring yet.
+3. Provide a **deterministic, dependency-free** `EmbeddingProvider` implementation
+   for unit tests downstream (so callers can be tested without running an
+   embedding model).
+4. Document limits and the next concrete PR (real `PgVectorStore` over `sqlx`).
+5. `cargo check --workspace --all-targets` and `cargo clippy --workspace
+   --all-targets -- -D warnings` stay green.
+
+**Out of scope for this PR** (deferred to future sub-issues):
+
+- `PgVectorStore` real `sqlx` implementation against `memory_embeddings`
+  (migration 005). Requires DB integration tests harness — separate slice.
+- Real `mxbai-embed-large-v1` provider via `candle` or `mistralrs`. The model
+  loader lives in a separate crate (ADR 0001) and will plug into the trait.
+- `LanceDbStore` future opt-in (ADR 0002 §Decisões specifies trigger-driven).
+- Wiring into `garraia-learning::retriever` or `garraia-agents`. The retriever
+  consumes this crate's trait but its construction site lives in their own
+  PRs.
+
+---
+
+## Architecture
+
+```text
+crates/garraia-embeddings/
+├── Cargo.toml
+├── README.md
+└── src/
+    ├── lib.rs       — public facade + re-exports
+    ├── types.rs     — Scope, EmbeddingVector, Document, Chunk, SearchHit
+    ├── error.rs     — typed EmbeddingError
+    ├── provider.rs  — EmbeddingProvider trait + DeterministicProvider (test/dev)
+    ├── store.rs     — VectorStore trait (definition only — no impl in this PR)
+    └── hybrid.rs    — HybridQuery builder type
+```
+
+`Scope` mirrors the `memory_items.scope_type` column from migration 005
+(`user` / `group` / `chat`). `EmbeddingVector` is a fixed-size 768-dim wrapper
+(matches the `vector(768)` column from migration 005 and mxbai-embed-large-v1).
+
+---
+
+## Tech stack
+
+- Rust edition 2024 (workspace default).
+- `async-trait = "0.1"` — `EmbeddingProvider` and `VectorStore` are object-safe
+  via `dyn Trait`; AFIT + `dyn` doesn't work on stable yet (same constraint as
+  `garraia-storage::ObjectStore`, documented in plan 0037).
+- `serde` + `serde_json` for type derives (transport over the wire when the
+  trait is used across process boundaries — admin API + future MCP).
+- `sha2 = "0.10"` (already transitive via `ring` ecosystem) — drives the
+  deterministic test provider.
+- `thiserror = "2"` (workspace) for `EmbeddingError`.
+- `tracing = "0.1"` (workspace) for instrumentation hooks.
+- **No** `sqlx`, **no** `tokio-postgres`, **no** `candle` — those land in
+  follow-up slices when the concrete stores/providers are written.
+
+---
+
+## Design invariants
+
+- `EmbeddingVector` is `[f32; 768]` (mxbai dimension per ADR 0002 §Decisões
+  específicas item 2). Different-dim models require a new vector type or a
+  generic over `const N: usize` — deferred (YAGNI until a second model lands).
+- `VectorStore` operations are always scoped: every call carries `Scope` +
+  `group_id`. App-layer code that talks to this trait CANNOT issue a query that
+  spans tenants. This mirrors the RLS contract in migration 007.
+- `EmbeddingProvider::embed_batch` is **not** optional. Callers ought to batch
+  by default — single embeds are O(n) network round-trips that ruin RAG latency
+  budgets. Providers may implement `embed_batch` as a fan-out over `embed` but
+  the trait signature forces the call site to be batch-aware.
+- `DeterministicProvider` is suitable **only for tests and dev fixtures**. It
+  is `Cargo.toml`-gated behind a feature flag (`testing-provider`) that
+  downstream crates enable in their `[dev-dependencies]`. Production builds
+  that depend on this crate without enabling the feature will **not** compile
+  in a deterministic embedding — a forcing function.
+
+---
+
+## Test plan (this PR)
+
+Unit tests live in-tree (`#[cfg(test)] mod tests {}`):
+
+- `Scope`: serialization round-trip (`user` / `group` / `chat`); rejection of
+  invalid variants.
+- `EmbeddingVector`: builder rejects non-768 vectors; equality is bitwise.
+- `EmbeddingError`: `Display` does not leak content (PII safety, mirrors the
+  redaction invariant on `memory_items.content`).
+- `DeterministicProvider`: same input → same output, different inputs → different
+  outputs (collision probability is statistically negligible but we don't depend
+  on it cryptographically — the provider is for tests).
+- `HybridQuery` builder: setting filter / scope / limit produces a fully-typed
+  query value; missing required fields yield a typed error before reaching SQL.
+
+No DB integration tests in this PR (no DB code).
+
+---
+
+## Validation gates
+
+Before commit:
+
+- [x] `cargo fmt --all --check`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo check --workspace --all-targets`
+- [ ] `cargo test -p garraia-embeddings`
+- [ ] `cargo test --workspace` (no regressions in other crates)
+
+Before PR:
+
+- [ ] All of the above + manual diff review
+- [ ] ROADMAP §1.5 amended to reflect the scaffold delivery + next PR pointer
+
+---
+
+## Next concrete PR (recommended sequencing)
+
+1. **PR 2 — `PgVectorStore` over sqlx**: real implementation of
+   `VectorStore` for Postgres + pgvector against `memory_embeddings`.
+   Requires DB integration test harness (testcontainers) — follow the pattern
+   from `garraia-workspace` RLS matrix tests.
+2. **PR 3 — `MxbaiProvider`** via candle (consumes ADR 0001 backend choice).
+3. **PR 4 — Wire `garraia-learning::retriever`** to `EmbeddingProvider` +
+   `VectorStore` (real, behind feature flag with `DeterministicProvider`
+   fallback in dev).
+
+Each step lands independently with its own test surface.
+
+---
+
+## Risks
+
+- **Trait drift**: if PR 2/3 discovers `VectorStore::search` needs additional
+  params (e.g., `ef_search` HNSW tuning), the trait signature changes and
+  consumers must update. Mitigation: keep the trait surface minimal in this PR,
+  add `SearchOptions` struct as the only extension vector.
+- **Feature flag confusion**: `testing-provider` must be off in production
+  builds of `garraia-gateway`. The CI matrix already enforces this for
+  `garraia-storage`'s `storage-s3` flag — reuse the same pattern.


### PR DESCRIPTION
## Summary

- Scaffold do crate `garraia-embeddings` per ADR 0002 (Accepted 2026-04-21).
- Public surface only: traits (`EmbeddingProvider`, `VectorStore`), strong types (`Scope` / `EmbeddingVector(768)` / `Document` / `Chunk` / `SearchHit`), `HybridQuery` typed builder com validação build-time da consistência scope ↔ group_id, e `DeterministicProvider` (sha2-backed, default-on via feature `testing-provider`) para downstream unit tests.
- **Out of scope (slices futuros):** `PgVectorStore` real sobre sqlx, `MxbaiProvider` via candle, e wiring em `garraia-learning::retriever` ou `garraia-agents`.

Promove `garraia-embeddings/` da seção "Crates planejados" para a seção "Crates ativos" do `CLAUDE.md`, mirror do padrão usado em GAR-642 / `garraia-learning`.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings`
- [x] `cargo test -p garraia-embeddings` — **23/23 unit tests verdes**
- [x] `cargo test --workspace --exclude garraia-desktop --no-run` (compila toda matriz de teste)
- [ ] CI Linux runner: `cargo test --workspace --exclude garraia-desktop` (Docker-dependente — não validável local em Windows)

## Invariants enforced by types

1. **Dimensão fixa 768** (`EMBEDDING_DIM`) — alinhada com `vector(768)` em migration 005 e mxbai-embed-large-v1.
2. **Multi-tenant by construction** — toda call de `VectorStore` exige `Scope` + `Option<Uuid> group_id`; "search everything" não é representável.
3. **`Scope::User` ↔ `group_id = None`** — validado em `HybridQuery::build()` (matriz no test `build_rejects_group_id_on_user_scope`).
4. **`include_secret` defaults to `false`** — forcing function para o invariante `sensitivity = 'secret'` documentado em migration 005.
5. **`EmbeddingError::Display` sem PII** — apenas strings estáticas; mesmo contrato de `garraia-telemetry::redact`.

## Commits

1. `docs(plans): GAR-372 plan 0145 — garraia-embeddings scaffold`
2. `feat(embeddings): scaffold garraia-embeddings crate`
3. `feat(embeddings): strong types + typed error`
4. `feat(embeddings): EmbeddingProvider trait + DeterministicProvider`
5. `feat(embeddings): VectorStore trait + HybridQuery builder`
6. `docs(embeddings): README + ROADMAP §1.5 + CLAUDE.md crates index`
7. `style(embeddings): apply cargo fmt --all`

## Next concrete PR (recommended sequencing)

1. **PR 2 — `PgVectorStore` over sqlx** contra `memory_embeddings` (migration 005, HNSW cosine). Requer harness de testcontainers — seguir padrão do `garraia-workspace` RLS matrix.
2. **PR 3 — `MxbaiProvider`** via candle (consome ADR 0001 backend).
3. **PR 4 — Wire `garraia-learning::retriever`** ao trait com `DeterministicProvider` fallback em dev.

## Risks

- **Trait drift** se PR 2/3 descobrir que `VectorStore::search` precisa de params adicionais (ex.: `ef_search`). Mitigação: `SearchOptions` é o vetor de extensão único — campos `Option` aditivos.
- **Feature flag**: `testing-provider` é default-on para que `cargo test --workspace` (sem `--all-features`) consiga rodar a in-tree test suite. Produção pode opt-out via `default-features = false`. Mesmo padrão do `storage-s3` em `garraia-storage`.

Refs: [ADR 0002](docs/adr/0002-vector-store.md), [plan 0145](plans/0145-gar-372-embeddings-scaffold.md), [GAR-372](https://linear.app/chatgpt25/issue/GAR-372).

🤖 Generated with [Claude Code](https://claude.com/claude-code)