### PR TITLE
chore(deps): lockfile — webpki-roots 1.0.7, openssl 0.10.80 (health 2026-05-18 run 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4509,7 +4509,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -6108,9 +6108,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
@@ -6139,9 +6139,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -7517,7 +7517,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -11489,9 +11489,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -11502,14 +11502,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]


### PR DESCRIPTION
## Summary

Surgical `Cargo.lock`-only update from the daily security/dependency health routine (2026-05-18 run 2). No source code changes.

- `webpki-roots 1.0.6 → 1.0.7` — root CA certificate refresh
- `webpki-root-certs 1.0.6 → 1.0.7` — root CA certificate refresh
- `openssl 0.10.79 → 0.10.80` — upstream patch release
- `openssl-sys 0.9.115 → 0.9.116` — follows openssl patch

## Security audit result

`cargo audit` loaded **1090 advisories** (fresh fetch) and exited **0**:

```
warning: 19 allowed warnings found
```

All 19 warnings are pre-tracked `unmaintained` advisories already listed in `.cargo/audit.toml` / `deny.toml`. **No new vulnerabilities found.**

## Why not a broad `cargo update`?

`cargo update --dry-run` showed it would **downgrade** `aws-sdk-s3 1.132.0 → 1.119.0` and `lru 0.16.4 → 0.12.5`, which would re-introduce `RUSTSEC-2026-0002` (closed by GAR-593). Targeted `--precise` flags used instead.

## Open tracked advisories (all deferred, expire 2026-07-31)

| ID | Crate | Severity | Owner | Notes |
|----|-------|----------|-------|-------|
| RUSTSEC-2023-0071 | rsa 0.9.10 | High | GAR-456 | Marvin Attack — HS256-only, RSA code path unreachable |
| RUSTSEC-2024-0429 | glib 0.18.5 | Moderate | GAR-513 | Unsound — desktop-only via Tauri |
| RUSTSEC-2026-0097 | rand 0.7.3 | Moderate | GAR-513 | Unsound — build-time only (phf_codegen) |
| 16× unmaintained | gtk-rs ×10, unic-* ×5, derivative/fxhash/proc-macro-error/async-std | Warning | GAR-430 | All desktop-only or no server runtime risk |

## Verification

- `cargo check --workspace --exclude garraia-desktop` ✅ clean (35 s)
- `cargo audit --no-fetch` ✅ exit 0, 19 allowed warnings (unchanged)

## Test plan

- [ ] CI `cargo check` / `clippy` / `test` green
- [ ] CI `cargo audit --deny unsound` green (Security job)
- [ ] CI `cargo deny check` green

https://claude.ai/code/session_01HrJfJXrq2HsZis6iwZT3r8

---
_Generated by [Claude Code](https://claude.ai/code/session_01HrJfJXrq2HsZis6iwZT3r8)_