### PR TITLE
feat(learning): GAR-644 implement Skill Generator — LLM-assisted skill drafting

### DIFF
--- a/crates/garraia-learning/src/generator.rs
+++ b/crates/garraia-learning/src/generator.rs
@@ -190,18 +190,12 @@ fn parse_llm_response(raw: &str, fallback_slug: &str) -> Result<Skill> {
 
     match serde_yaml::from_str::<serde_yaml::Value>(fm_str) {
         Ok(yaml) => {
-            let name_raw = yaml["name"]
-                .as_str()
-                .unwrap_or(fallback_slug)
-                .to_string();
+            let name_raw = yaml["name"].as_str().unwrap_or(fallback_slug).to_string();
             let description = yaml["description"].as_str().unwrap_or("").to_string();
 
             let fm = LearningSkillFrontmatter {
                 name: to_kebab(&name_raw),
-                version: yaml["version"]
-                    .as_str()
-                    .unwrap_or("0.1.0")
-                    .to_string(),
+                version: yaml["version"].as_str().unwrap_or("0.1.0").to_string(),
                 source: SkillSource::Mined,
                 scope: SkillScope::Project,
                 score: yaml["score"].as_f64().unwrap_or(0.5) as f32,
@@ -377,7 +371,10 @@ mod tests {
 
     #[test]
     fn kebab_lowercases_and_replaces_spaces() {
-        assert_eq!(to_kebab("Cleanup Merged Branches"), "cleanup-merged-branches");
+        assert_eq!(
+            to_kebab("Cleanup Merged Branches"),
+            "cleanup-merged-branches"
+        );
     }
 
     #[test]

--- a/crates/garraia-learning/src/generator.rs
+++ b/crates/garraia-learning/src/generator.rs
@@ -1,10 +1,584 @@
 use garraia_common::{Error, Result};
+use std::path::Path;
 
-/// Drafts a skill document from a raw candidate using an LLM provider.
+use crate::{LearningSkillFrontmatter, Skill, SkillScope, SkillSource};
+
+// ──────────────────────────────────────────────
+// Provider trait
+// ──────────────────────────────────────────────
+
+/// Synchronous LLM provider for skill drafting.
 ///
-/// GAR-644 will implement this fully. Default provider: openrouter/free.
-pub fn generate_from_candidate(_candidate_body: &str) -> Result<crate::Skill> {
-    Err(Error::Other(
-        "Skill Generator not yet implemented (GAR-644)".into(),
-    ))
+/// Implementations must be `Send + Sync` so they can be passed across threads.
+/// In async contexts, bridge via `tokio::task::block_in_place`.
+pub trait SkillDraftProvider: Send + Sync {
+    fn draft(&self, prompt: &str) -> Result<String>;
+}
+
+// ──────────────────────────────────────────────
+// Input / output types
+// ──────────────────────────────────────────────
+
+/// In-memory representation of a mined candidate, ready for generation.
+#[derive(Debug, Clone)]
+pub struct Candidate {
+    /// URL-safe kebab slug (e.g. `"merge-delete"`).
+    pub slug: String,
+    /// Normalized commands forming the detected pattern.
+    pub normalized_commands: Vec<String>,
+    /// Number of distinct sessions in which the pattern was seen.
+    pub occurrence_count: usize,
+}
+
+impl Candidate {
+    /// Construct a `Candidate` directly from a [`crate::miner::MinedPattern`].
+    pub fn from_mined_pattern(pattern: &crate::miner::MinedPattern) -> Self {
+        Candidate {
+            slug: pattern.slug.clone(),
+            normalized_commands: pattern.normalized_sequence.clone(),
+            occurrence_count: pattern.occurrence_count,
+        }
+    }
+}
+
+/// Options for the generation step.
+#[derive(Default)]
+pub struct GenerateOptions {
+    /// Skill names already in the active registry.
+    /// Used to detect collisions and append `-v2`, `-v3`, … suffixes.
+    pub existing_skill_names: Vec<String>,
+}
+
+// ──────────────────────────────────────────────
+// Prompt template
+// ──────────────────────────────────────────────
+
+const SKILL_DRAFT_PROMPT: &str = r#"You are a DevOps automation assistant. Generate a reusable skill document in Markdown with YAML frontmatter based on the detected command pattern below.
+
+## Detected pattern
+
+Slug: {SLUG}
+Seen in {COUNT} session(s).
+
+Commands:
+{COMMANDS}
+
+## Required output format
+
+Produce a document that begins with a YAML frontmatter block enclosed in `---` delimiters, followed by Markdown content. Example structure:
+
+---
+name: example-skill-name
+version: "0.1.0"
+description: "A brief one-sentence description."
+source: mined
+score: 0.5
+---
+
+## Overview
+
+Brief explanation of what this skill automates.
+
+## Steps
+
+1. Step one.
+2. Step two.
+
+## Expected outcomes
+
+What happens when the skill runs successfully.
+
+Rules:
+- `name` must be kebab-case and describe the automation.
+- `description` must be one sentence, <= 120 characters.
+- Do NOT include any email addresses, absolute file paths, or API tokens.
+- Output ONLY the document -- no explanation or commentary outside it.
+"#;
+
+// ──────────────────────────────────────────────
+// Public API
+// ──────────────────────────────────────────────
+
+/// Generate a polished skill document from a mined candidate.
+///
+/// 1. Builds a prompt from the candidate.
+/// 2. Calls the provider.
+/// 3. Parses the LLM response into a [`Skill`].
+/// 4. Applies PII redaction to the body.
+/// 5. Deduplicates the skill name against `opts.existing_skill_names`.
+pub fn generate(
+    candidate: &Candidate,
+    provider: &dyn SkillDraftProvider,
+    opts: &GenerateOptions,
+) -> Result<Skill> {
+    let prompt = build_prompt(candidate);
+    let raw = provider.draft(&prompt)?;
+    let mut skill = parse_llm_response(&raw, &candidate.slug)?;
+    skill = apply_pii_redaction(skill);
+    let unique_name = make_unique_name(&skill.frontmatter.name, &opts.existing_skill_names);
+    skill.frontmatter.name = unique_name;
+    Ok(skill)
+}
+
+/// Parse a `mined-<slug>-<hash>.md` file written by the Skill Miner into a `Candidate`.
+pub fn load_candidate_file(path: &Path) -> Result<Candidate> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| Error::Other(format!("read {}: {e}", path.display())))?;
+
+    let (fm_str, _body) = split_frontmatter(&content);
+
+    // Try to extract the slug from the `name` field; fall back to the filename stem.
+    let slug = if !fm_str.is_empty() {
+        if let Ok(fm) = serde_yaml::from_str::<LearningSkillFrontmatter>(fm_str) {
+            to_kebab(&fm.name)
+        } else {
+            stem_slug(path)
+        }
+    } else {
+        stem_slug(path)
+    };
+
+    // Extract the commands list from the Markdown body (```...``` block).
+    let commands = parse_commands_block(&content);
+
+    Ok(Candidate {
+        slug,
+        normalized_commands: commands,
+        occurrence_count: 1, // file-only parse; occurrence_count not recoverable
+    })
+}
+
+// ──────────────────────────────────────────────
+// Internal helpers
+// ──────────────────────────────────────────────
+
+fn stem_slug(path: &Path) -> String {
+    path.file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("mined")
+        .to_string()
+}
+
+fn build_prompt(candidate: &Candidate) -> String {
+    let cmds = candidate
+        .normalized_commands
+        .iter()
+        .map(|c| format!("  {c}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    SKILL_DRAFT_PROMPT
+        .replace("{SLUG}", &candidate.slug)
+        .replace("{COUNT}", &candidate.occurrence_count.to_string())
+        .replace("{COMMANDS}", &cmds)
+}
+
+/// Parse the LLM response into a `Skill`.
+///
+/// If the response contains a valid YAML frontmatter block, parse it.
+/// Otherwise fall back to constructing a minimal `Skill` from the fallback slug.
+fn parse_llm_response(raw: &str, fallback_slug: &str) -> Result<Skill> {
+    let (fm_str, body) = split_frontmatter(raw);
+
+    if fm_str.is_empty() {
+        tracing::warn!(
+            fallback_slug,
+            "LLM response missing frontmatter — using fallback"
+        );
+        return Ok(make_fallback_skill(fallback_slug, raw));
+    }
+
+    match serde_yaml::from_str::<serde_yaml::Value>(fm_str) {
+        Ok(yaml) => {
+            let name_raw = yaml["name"]
+                .as_str()
+                .unwrap_or(fallback_slug)
+                .to_string();
+            let description = yaml["description"].as_str().unwrap_or("").to_string();
+
+            let fm = LearningSkillFrontmatter {
+                name: to_kebab(&name_raw),
+                version: yaml["version"]
+                    .as_str()
+                    .unwrap_or("0.1.0")
+                    .to_string(),
+                source: SkillSource::Mined,
+                scope: SkillScope::Project,
+                score: yaml["score"].as_f64().unwrap_or(0.5) as f32,
+                locked: false,
+                critical_paths_touched: vec![],
+                fail_count: 0,
+            };
+
+            // Embed description in body if not already present.
+            let body_text = if !description.is_empty() && !body.contains(&description) {
+                format!("> {description}\n\n{body}")
+            } else {
+                body.to_string()
+            };
+
+            Ok(Skill {
+                frontmatter: fm,
+                body: body_text.trim().to_string(),
+                source_path: None,
+            })
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to parse LLM frontmatter — using fallback");
+            Ok(make_fallback_skill(fallback_slug, raw))
+        }
+    }
+}
+
+fn make_fallback_skill(slug: &str, raw_body: &str) -> Skill {
+    Skill {
+        frontmatter: LearningSkillFrontmatter {
+            name: to_kebab(slug),
+            version: "0.1.0".to_string(),
+            source: SkillSource::Mined,
+            scope: SkillScope::Project,
+            score: 0.5,
+            locked: false,
+            critical_paths_touched: vec![],
+            fail_count: 0,
+        },
+        body: raw_body.trim().to_string(),
+        source_path: None,
+    }
+}
+
+/// Apply PII redaction to the skill body using [`crate::miner::redact`].
+fn apply_pii_redaction(mut skill: Skill) -> Skill {
+    skill.body = crate::miner::redact(&skill.body);
+    skill
+}
+
+/// Convert an arbitrary string to kebab-case.
+///
+/// Rules: lowercase, whitespace/punctuation → `-`, collapse multiple `-`,
+/// trim trailing `-`. Empty result → `"generated"`.
+pub fn to_kebab(s: &str) -> String {
+    let mut out = String::new();
+    let mut prev_dash = true; // treat start as if preceded by `-` to avoid leading dash
+
+    for ch in s.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+            prev_dash = false;
+        } else if !prev_dash {
+            out.push('-');
+            prev_dash = true;
+        }
+    }
+
+    let out = out.trim_end_matches('-').to_string();
+    if out.is_empty() {
+        "generated".to_string()
+    } else {
+        out
+    }
+}
+
+/// Make a skill name unique by appending `-v2`, `-v3`, … when `base` collides.
+pub fn make_unique_name(base: &str, existing: &[String]) -> String {
+    if !existing.iter().any(|n| n == base) {
+        return base.to_string();
+    }
+    let mut version = 2usize;
+    loop {
+        let candidate = format!("{base}-v{version}");
+        if !existing.iter().any(|n| n == &candidate) {
+            return candidate;
+        }
+        version += 1;
+    }
+}
+
+/// Split a document into `(frontmatter_str, body_str)`.
+///
+/// Looks for the pattern `---\n...\n---`. Returns `("", full_text)` if not found.
+fn split_frontmatter(text: &str) -> (&str, &str) {
+    let text = text.trim_start();
+    if !text.starts_with("---") {
+        return ("", text);
+    }
+    // Skip past the opening `---` line
+    let after_open = match text.find('\n') {
+        Some(pos) => &text[pos + 1..],
+        None => return ("", text),
+    };
+    // Find closing `---`
+    if let Some(close_pos) = after_open.find("\n---") {
+        let fm = after_open[..close_pos].trim_end();
+        let body_start = close_pos + 4; // past `\n---`
+        let body = after_open[body_start..].trim_start_matches('\n');
+        (fm, body)
+    } else {
+        ("", text)
+    }
+}
+
+/// Extract lines from the first fenced code block (``` ... ```) in the document.
+fn parse_commands_block(text: &str) -> Vec<String> {
+    let mut in_block = false;
+    let mut cmds = Vec::new();
+
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") {
+            in_block = !in_block;
+            continue;
+        }
+        if in_block && !trimmed.is_empty() {
+            cmds.push(trimmed.to_string());
+        }
+    }
+    cmds
+}
+
+// ──────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    // ── MockDraftProvider ─────────────────────
+
+    struct MockDraftProvider {
+        response: String,
+    }
+
+    impl MockDraftProvider {
+        fn new(response: impl Into<String>) -> Self {
+            MockDraftProvider {
+                response: response.into(),
+            }
+        }
+    }
+
+    impl SkillDraftProvider for MockDraftProvider {
+        fn draft(&self, _prompt: &str) -> Result<String> {
+            Ok(self.response.clone())
+        }
+    }
+
+    struct ErrorProvider;
+
+    impl SkillDraftProvider for ErrorProvider {
+        fn draft(&self, _prompt: &str) -> Result<String> {
+            Err(Error::Other("provider unavailable".into()))
+        }
+    }
+
+    // ── to_kebab ─────────────────────────────
+
+    #[test]
+    fn kebab_lowercases_and_replaces_spaces() {
+        assert_eq!(to_kebab("Cleanup Merged Branches"), "cleanup-merged-branches");
+    }
+
+    #[test]
+    fn kebab_strips_punctuation() {
+        assert_eq!(
+            to_kebab("Cleanup Merged Branches!"),
+            "cleanup-merged-branches"
+        );
+    }
+
+    #[test]
+    fn kebab_collapses_multiple_separators() {
+        assert_eq!(to_kebab("foo--bar  baz"), "foo-bar-baz");
+    }
+
+    #[test]
+    fn kebab_empty_returns_generated() {
+        assert_eq!(to_kebab("!!!"), "generated");
+    }
+
+    #[test]
+    fn kebab_already_kebab_unchanged() {
+        assert_eq!(to_kebab("merge-delete"), "merge-delete");
+    }
+
+    // ── make_unique_name ─────────────────────
+
+    #[test]
+    fn unique_name_no_collision() {
+        let existing = vec!["bar".to_string()];
+        assert_eq!(make_unique_name("foo", &existing), "foo");
+    }
+
+    #[test]
+    fn unique_name_first_collision() {
+        let existing = vec!["foo".to_string()];
+        assert_eq!(make_unique_name("foo", &existing), "foo-v2");
+    }
+
+    #[test]
+    fn unique_name_multiple_collisions() {
+        let existing = vec!["foo".to_string(), "foo-v2".to_string()];
+        assert_eq!(make_unique_name("foo", &existing), "foo-v3");
+    }
+
+    #[test]
+    fn unique_name_empty_existing() {
+        assert_eq!(make_unique_name("foo", &[]), "foo");
+    }
+
+    // ── split_frontmatter ────────────────────
+
+    #[test]
+    fn split_finds_frontmatter() {
+        let doc = "---\nname: foo\n---\n\nbody text";
+        let (fm, body) = split_frontmatter(doc);
+        assert_eq!(fm, "name: foo");
+        assert_eq!(body, "body text");
+    }
+
+    #[test]
+    fn split_no_frontmatter() {
+        let doc = "just plain text";
+        let (fm, body) = split_frontmatter(doc);
+        assert_eq!(fm, "");
+        assert_eq!(body, "just plain text");
+    }
+
+    // ── build_prompt ─────────────────────────
+
+    #[test]
+    fn prompt_contains_slug_and_count() {
+        let c = Candidate {
+            slug: "merge-delete".to_string(),
+            normalized_commands: vec!["gh pr merge --squash".to_string()],
+            occurrence_count: 5,
+        };
+        let prompt = build_prompt(&c);
+        assert!(prompt.contains("merge-delete"), "prompt missing slug");
+        assert!(prompt.contains('5'), "prompt missing occurrence count");
+        assert!(prompt.contains("gh pr merge"), "prompt missing command");
+    }
+
+    // ── parse_llm_response ───────────────────
+
+    const VALID_RESPONSE: &str = "---\nname: cleanup-merged-branches\nversion: \"0.1.0\"\ndescription: \"Squash-merge a PR and delete its remote branch.\"\nsource: mined\nscore: 0.5\n---\n\n## Overview\n\nThis skill squash-merges a pull request and removes the remote branch.\n\n## Steps\n\n1. Run `gh pr merge --squash --delete-branch`.\n2. Delete the remote tracking ref.\n";
+
+    #[test]
+    fn parse_valid_response() {
+        let skill = parse_llm_response(VALID_RESPONSE, "fallback").unwrap();
+        assert_eq!(skill.frontmatter.name, "cleanup-merged-branches");
+        assert!((skill.frontmatter.score - 0.5).abs() < f32::EPSILON);
+        assert!(skill.body.contains("squash-merges"));
+    }
+
+    #[test]
+    fn parse_missing_frontmatter_falls_back_to_slug() {
+        let raw = "No frontmatter here, just prose.";
+        let skill = parse_llm_response(raw, "my-slug").unwrap();
+        assert_eq!(skill.frontmatter.name, "my-slug");
+        assert!(skill.body.contains("No frontmatter"));
+    }
+
+    #[test]
+    fn parse_invalid_yaml_falls_back() {
+        // Construct a document with `---` delimiters but invalid YAML inside.
+        let bad = "---\nkey: [unclosed\n---\nbody";
+        let skill = parse_llm_response(bad, "fallback-slug").unwrap();
+        assert_eq!(skill.frontmatter.name, "fallback-slug");
+    }
+
+    // ── apply_pii_redaction ──────────────────
+
+    #[test]
+    fn pii_email_is_redacted() {
+        let skill = Skill {
+            frontmatter: LearningSkillFrontmatter {
+                name: "test".to_string(),
+                version: "0.1.0".to_string(),
+                source: SkillSource::Mined,
+                scope: SkillScope::Project,
+                score: 0.5,
+                locked: false,
+                critical_paths_touched: vec![],
+                fail_count: 0,
+            },
+            body: "Contact developer@example.com for help.".to_string(),
+            source_path: None,
+        };
+        let cleaned = apply_pii_redaction(skill);
+        assert!(
+            !cleaned.body.contains("developer@example.com"),
+            "email not redacted: {}",
+            cleaned.body
+        );
+        assert!(cleaned.body.contains("<EMAIL>"));
+    }
+
+    // ── generate ─────────────────────────────
+
+    #[test]
+    fn generate_returns_skill_with_correct_name() {
+        let candidate = Candidate {
+            slug: "merge-delete".to_string(),
+            normalized_commands: vec![
+                "gh pr merge --squash --delete-branch".to_string(),
+                "git push origin --delete <BRANCH>".to_string(),
+            ],
+            occurrence_count: 3,
+        };
+        let provider = MockDraftProvider::new(VALID_RESPONSE);
+        let opts = GenerateOptions::default();
+        let skill = generate(&candidate, &provider, &opts).unwrap();
+        assert_eq!(skill.frontmatter.name, "cleanup-merged-branches");
+        assert_eq!(skill.frontmatter.source, SkillSource::Mined);
+    }
+
+    #[test]
+    fn generate_deduplicates_name() {
+        let candidate = Candidate {
+            slug: "cleanup-merged-branches".to_string(),
+            normalized_commands: vec!["gh pr merge --squash".to_string()],
+            occurrence_count: 3,
+        };
+        let provider = MockDraftProvider::new(VALID_RESPONSE);
+        let opts = GenerateOptions {
+            existing_skill_names: vec!["cleanup-merged-branches".to_string()],
+        };
+        let skill = generate(&candidate, &provider, &opts).unwrap();
+        assert_eq!(skill.frontmatter.name, "cleanup-merged-branches-v2");
+    }
+
+    #[test]
+    fn generate_propagates_provider_error() {
+        let candidate = Candidate {
+            slug: "test".to_string(),
+            normalized_commands: vec![],
+            occurrence_count: 1,
+        };
+        let provider = ErrorProvider;
+        let opts = GenerateOptions::default();
+        assert!(generate(&candidate, &provider, &opts).is_err());
+    }
+
+    // ── load_candidate_file ──────────────────
+
+    #[test]
+    fn load_candidate_file_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("mined-merge-delete-abcd1234.md");
+        let content = "---\nname: mined-merge-delete\nversion: \"0.1.0\"\nsource: mined\nscope: project\nscore: 0.0\nlocked: false\ncritical_paths_touched: []\nfail_count: 0\n---\n\n## Commands\n\nDetected in 3 session(s).\n\n```\ngh pr merge --squash --delete-branch\ngit push origin --delete <BRANCH>\n```\n";
+        std::fs::write(&path, content).unwrap();
+        let candidate = load_candidate_file(&path).unwrap();
+        assert_eq!(candidate.slug, "mined-merge-delete");
+        assert_eq!(candidate.normalized_commands.len(), 2);
+        assert!(candidate.normalized_commands[0].contains("gh pr merge"));
+    }
+
+    #[test]
+    fn load_candidate_file_missing_returns_err() {
+        let result = load_candidate_file(Path::new("/nonexistent/path/skill.md"));
+        assert!(result.is_err());
+    }
 }

--- a/plans/0147-gar-644-skill-generator.md
+++ b/plans/0147-gar-644-skill-generator.md
@@ -1,0 +1,208 @@
+# Plan 0147 — GAR-644: Skill Generator — LLM-assisted skill drafting
+
+**Status:** 🚧 In Progress (2026-05-18)
+**Issue:** [GAR-644](https://linear.app/chatgpt25/issue/GAR-644) (sub-issue 3/10 of [GAR-641](https://linear.app/chatgpt25/issue/GAR-641))
+**Branch:** `routine/202605181219-gar-644-skill-generator`
+**Epic parent:** Fase 1.4 — Garra Learning Agent (`epic:learning-agent`)
+
+---
+
+## Goal
+
+Implement `garraia-learning::generator` — the Skill Generator component (3/10 of the
+Learning Agent epic). Takes a `Candidate` produced by the Skill Miner and generates a
+polished Markdown skill document via an LLM provider (provider-agnostic via trait).
+
+Unblocks the Mine → **Generate** → Validate → Promote pipeline.
+
+---
+
+## Architecture
+
+```text
+crates/garraia-learning/src/generator.rs   (replace stub)
+  SkillDraftProvider trait                  sync, Send+Sync, mockable
+  Candidate struct                          in-memory representation of mined candidate
+  GenerateOptions struct                    existing_skill_names for dedup
+  pub fn generate(candidate, provider, opts) main entry point → Skill
+  pub fn load_candidate_file(path)          parse mined-*.md file into Candidate
+  fn build_prompt(candidate)               fills SKILL_DRAFT_PROMPT template
+  fn parse_llm_response(raw, slug)          extracts frontmatter + body from LLM output
+  fn to_kebab(s)                           any string → kebab-case
+  fn make_unique_name(base, existing)      append -v2 / -v3 on collision
+  fn apply_pii_redaction(skill) -> Skill   delegates to miner::redact()
+
+crates/garraia-learning/src/generator.rs   SKILL_DRAFT_PROMPT const (embedded template)
+```
+
+No Cargo.toml changes needed — `serde_yaml` is already a workspace dependency.
+
+---
+
+## Tech stack
+
+- Rust edition 2024 (existing crate)
+- `serde_yaml` (workspace) — parse candidate frontmatter + serialize generated frontmatter
+- `garraia-common::Error`/`Result` — error propagation
+- `miner::redact()` — PII redaction reused from Skill Miner
+
+---
+
+## Design invariants
+
+- **No `unwrap()` in production paths.** All I/O and parse errors propagate via `?`.
+- **Provider-agnostic**: `dyn SkillDraftProvider` with no dependency on `garraia-agents`.
+  The sync trait can be bridged to async at the call site via `tokio::task::block_in_place`
+  when wired into the gateway.
+- **PII redaction applied automatically** to the generated body via `miner::redact()`.
+- **Name deduplication**: if `name` collides with `existing_skill_names`, append `-v2`, `-v3`, …
+- **Kebab-case names only**: non-conforming LLM output is normalized via `to_kebab()`.
+- **Graceful parse fallback**: if the LLM returns a body without valid YAML frontmatter,
+  construct a minimal `Skill` using the candidate slug as name rather than returning `Err`.
+- **Prompt is a `const` string** embedded in `generator.rs` — no runtime file-read.
+
+---
+
+## Validações pré-plano
+
+- [x] `garraia-learning` crate exists with stub `generator.rs`.
+- [x] `serde_yaml` is a workspace dependency (used in `miner.rs`).
+- [x] `garraia-common::Error::Other(String)` variant available.
+- [x] `miner::redact()` is `pub` and takes `&str` → `String` (confirmed in miner.rs:166).
+- [x] `LearningSkillFrontmatter`, `SkillSource`, `SkillScope` are all `pub` in `lib.rs`.
+- [x] GAR-644 in Backlog (no duplicate generator implementation in main).
+- [x] `cargo check -p garraia-learning` is green on current main.
+
+---
+
+## Out of scope
+
+- CLI `garra skills generate` wiring in `garraia-cli` (deferred to CLI slice).
+- Real LLM integration tests against OpenRouter/OpenAI/Ollama (feature-gated stub is sufficient).
+- Skill promotion to active registry (GAR-645, GAR-649).
+- Embedding-based retrieval (GAR-646 — prereq: Fase 2.1).
+- Auto-updater for existing skills (GAR-648).
+
+---
+
+## Rollback
+
+Only `crates/garraia-learning/src/generator.rs` changes. Reverting the PR restores the
+one-liner stub. No database schema changes. No new crates.
+
+---
+
+## §12 Open questions
+
+| # | Question | Resolution |
+|---|---|---|
+| 1 | Should the LLM provider trait be async? | No for this slice. Sync trait is simpler to test and can be bridged async at call site. |
+| 2 | What if LLM returns invalid YAML frontmatter? | Fallback: construct minimal Skill with slug as name + raw body. Log a `tracing::warn!`. |
+| 3 | Should PII in generated text return `Err` or be silently redacted? | Silently redact (apply `miner::redact()`); return the cleaned Skill. |
+| 4 | Do we need a `prompts/` directory? | No — prompt is a `const` embedded in `generator.rs`. Avoids runtime file-read. |
+| 5 | Integration tests against real LLMs? | Feature-gated under `#[cfg(feature = "integration-tests")]`; not enabled in CI. |
+
+---
+
+## File structure
+
+```
+crates/garraia-learning/
+└── src/
+    └── generator.rs          full implementation (~260 LOC, replaces 7-line stub)
+plans/
+├── README.md                 add row for 0147
+└── 0147-gar-644-skill-generator.md   this file
+```
+
+---
+
+## M1 Tasks
+
+### T1 — Define SkillDraftProvider trait + Candidate + GenerateOptions
+
+- [ ] `pub trait SkillDraftProvider: Send + Sync { fn draft(&self, prompt: &str) -> Result<String>; }`
+- [ ] `pub struct Candidate { slug, normalized_commands, occurrence_count }`
+- [ ] `pub struct GenerateOptions { existing_skill_names: Vec<String> }`
+- [ ] `cargo check -p garraia-learning` green.
+
+### T2 — Implement build_prompt + SKILL_DRAFT_PROMPT const
+
+- [ ] Write prompt template as `const SKILL_DRAFT_PROMPT: &str`.
+- [ ] `fn build_prompt(candidate: &Candidate) -> String` fills template.
+- [ ] Unit test: prompt contains slug + occurrence_count + command list.
+
+### T3 — Implement parse_llm_response (RED → GREEN)
+
+- [ ] Write failing test: response with valid frontmatter → `Skill` with correct name/body.
+- [ ] Write failing test: response without `---` delimiters → fallback to slug-named Skill.
+- [ ] Implement `parse_llm_response(raw: &str, fallback_slug: &str) -> Result<Skill>`.
+- [ ] `cargo test -p garraia-learning generator` green.
+
+### T4 — Implement to_kebab + make_unique_name (RED → GREEN)
+
+- [ ] Write failing test: `to_kebab("Cleanup Merged Branches!")` → `"cleanup-merged-branches"`.
+- [ ] Write failing test: `make_unique_name("foo", &["foo", "foo-v2"])` → `"foo-v3"`.
+- [ ] Implement both helpers.
+- [ ] `cargo test -p garraia-learning generator` green.
+
+### T5 — Implement generate + apply_pii_redaction (RED → GREEN)
+
+- [ ] Write failing test with `MockDraftProvider` returning valid skill YAML + body.
+- [ ] Write failing test: PII in body → redacted automatically.
+- [ ] Write failing test: name collision → `-v2` suffix.
+- [ ] Implement `generate()` + `apply_pii_redaction()`.
+- [ ] `cargo test -p garraia-learning generator` green.
+
+### T6 — Implement load_candidate_file
+
+- [ ] Write failing test: write a `mined-*.md` fixture file → parse into `Candidate`.
+- [ ] Implement `pub fn load_candidate_file(path: &Path) -> Result<Candidate>`.
+- [ ] `cargo test -p garraia-learning generator` green.
+
+### T7 — clippy + workspace check
+
+- [ ] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` clean.
+
+### T8 — Update plans/README.md + ROADMAP §7
+
+- [ ] Add row 0147 to `plans/README.md`.
+- [ ] Update ROADMAP §7: mark GAR-643 item with note that GAR-644 is next.
+
+---
+
+## Risk register
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|-----------|
+| LLM output format varies widely | High | Medium | Robust fallback in `parse_llm_response` |
+| `serde_yaml` parses YAML 1.1 (booleans "yes"/"no") | Low | Low | Use `serde_yaml::from_str` which follows YAML 1.2 |
+| Clippy warns on `dyn SkillDraftProvider` pattern | Low | Low | Use `+ ?Sized` if needed |
+
+---
+
+## Acceptance criteria
+
+- [ ] `cargo test -p garraia-learning -- --test-output immediate 2>&1 | grep -E "test .*(generator|generate|kebab|unique|pii|prompt|parse)" | grep ok` — all generator tests pass.
+- [ ] `generate()` with `MockDraftProvider` returning valid YAML → `Skill` with correct fields.
+- [ ] `generate()` with body containing email → body is PII-redacted.
+- [ ] `generate()` with `existing_skill_names: vec!["foo".into()]` + LLM producing `name: foo` → result is `name: foo-v2`.
+- [ ] `load_candidate_file()` round-trips a miner-written candidate file into `Candidate`.
+- [ ] `cargo clippy --workspace … -D warnings` clean.
+- [ ] CI (Format + Clippy + Test) green.
+
+---
+
+## Cross-references
+
+- Plan 0146 (GAR-643, Skill Miner) — previous slice; `miner::redact()` is reused here.
+- Plan 0144 (GAR-642, Learning Agent scaffold) — `Skill` + `LearningSkillFrontmatter` types.
+- Plan 0145 (GAR-372, embeddings scaffold) — Skill Retriever (GAR-646) will consume.
+- GAR-641 (épico parent) — 3/10 of the Learning Agent.
+- ADR 0010 — Accepted learning architecture.
+
+---
+
+## Estimativa
+
+0.5 / 1 / 2 days. ~260 LOC production, ~130 LOC tests.

--- a/plans/README.md
+++ b/plans/README.md
@@ -154,4 +154,5 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0143 | [GAR-658 — Q11 slice 7: extract rest_v1/tasks/attachments.rs](0143-gar-658-q11-tasks-modularize-slice7.md) | [GAR-658](https://linear.app/chatgpt25/issue/GAR-658) | ✅ Merged 2026-05-17 via PR #388 (`e04fc2c`) |
 | 0144 | [GAR-642 — Learning Agent Architecture: scaffold crate garraia-learning + ADR 0010 Accepted](0144-gar-642-learning-agent-scaffold.md) | [GAR-642](https://linear.app/chatgpt25/issue/GAR-642) | ✅ Merged 2026-05-18 via PR #393 (`9526368`) |
 | 0145 | [GAR-372 — Embeddings & Vector Search: scaffold garraia-embeddings](0145-gar-372-embeddings-scaffold.md) | [GAR-372](https://linear.app/chatgpt25/issue/GAR-372) | ✅ Merged 2026-05-18 via PR #396 (`cfda7ad`) |
-| 0146 | [GAR-643 — Skill Miner: detect repeatable patterns in session logs](0146-gar-643-skill-miner.md) | [GAR-643](https://linear.app/chatgpt25/issue/GAR-643) | 🚧 In Progress |
+| 0146 | [GAR-643 — Skill Miner: detect repeatable patterns in session logs](0146-gar-643-skill-miner.md) | [GAR-643](https://linear.app/chatgpt25/issue/GAR-643) | ✅ Merged 2026-05-18 via PR #400 (`3bb473a`) |
+| 0147 | [GAR-644 — Skill Generator: LLM-assisted skill drafting](0147-gar-644-skill-generator.md) | [GAR-644](https://linear.app/chatgpt25/issue/GAR-644) | 🚧 In Progress |


### PR DESCRIPTION
## Summary

- Implements `garraia-learning::generator` — component 3/10 of the Garra Learning Agent epic ([GAR-641](https://linear.app/chatgpt25/issue/GAR-641)).
- Replaces the 7-line stub in `generator.rs` with a full 580-line implementation + 21 unit tests.
- No new crate dependencies; no schema changes; no breaking API changes.

### Key additions in `crates/garraia-learning/src/generator.rs`

| Symbol | Purpose |
|--------|---------|
| `SkillDraftProvider` trait | Sync, `Send+Sync`, provider-agnostic LLM interface (mockable in tests) |
| `Candidate` | In-memory representation of a mined candidate; builds from `MinedPattern` or candidate file |
| `GenerateOptions` | `existing_skill_names` list for deduplication |
| `generate()` | Main entry: prompt → provider → parse → PII redact → unique name |
| `load_candidate_file()` | Parses `mined-*.md` files written by the Skill Miner |
| `SKILL_DRAFT_PROMPT` | Embedded const prompt template (no runtime file I/O) |
| `to_kebab()` | Normalizes any string to kebab-case |
| `make_unique_name()` | Appends `-v2`/`-v3` on name collision |
| `parse_llm_response()` | YAML frontmatter extraction + graceful fallback if LLM output is malformed |
| `apply_pii_redaction()` | Delegates to `miner::redact()` |

### Design invariants

- No `unwrap()` in production paths.
- PII redaction applied automatically (emails → `<EMAIL>`, long tokens → `<TOKEN>`, home paths → `<HOMEPATH>`).
- Provider-agnostic: no dependency on `garraia-agents`; sync trait bridged async at call site.
- Name deduplication: LLM `name: foo` + existing `["foo"]` → result `foo-v2`.
- Graceful parse fallback: malformed LLM YAML → minimal `Skill` using candidate slug as name.

## Test plan

- [x] `cargo test -p garraia-learning` — 58 tests pass (21 new generator tests + 37 existing miner/safety).
- [x] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` — clean.
- [x] `to_kebab` tests: lowercase, punctuation stripping, collapse, empty → `"generated"`.
- [x] `make_unique_name` tests: no collision, first collision (`-v2`), multiple collisions (`-v3`).
- [x] `split_frontmatter` tests: with/without `---` delimiters.
- [x] `build_prompt` test: prompt contains slug, occurrence count, commands.
- [x] `parse_llm_response` tests: valid YAML, missing frontmatter fallback, invalid YAML fallback.
- [x] `pii_email_is_redacted`: body with `developer@example.com` → `<EMAIL>`.
- [x] `generate_returns_skill_with_correct_name`: mock provider → correct name + source.
- [x] `generate_deduplicates_name`: existing name → `-v2` suffix.
- [x] `generate_propagates_provider_error`: error provider → `Err`.
- [x] `load_candidate_file_roundtrip`: write miner-format file → parse back correctly.
- [x] `load_candidate_file_missing_returns_err`: nonexistent path → `Err`.

## Linear

Closes [GAR-644](https://linear.app/chatgpt25/issue/GAR-644) — Skill Generator (3/10 of [GAR-641](https://linear.app/chatgpt25/issue/GAR-641)).
Plan: [0147](plans/0147-gar-644-skill-generator.md).

https://claude.ai/code/session_012G4CrL4Ku8PkhJiU3WiNzK

---
_Generated by [Claude Code](https://claude.ai/code/session_012G4CrL4Ku8PkhJiU3WiNzK)_