### PR TITLE
feat(learning): GAR-645 Skill Registry — dual-scope persist, list, promote, deprecate

### DIFF
--- a/crates/garraia-learning/src/generator.rs
+++ b/crates/garraia-learning/src/generator.rs
@@ -202,6 +202,7 @@ fn parse_llm_response(raw: &str, fallback_slug: &str) -> Result<Skill> {
                 locked: false,
                 critical_paths_touched: vec![],
                 fail_count: 0,
+                deprecated: false,
             };
 
             // Embed description in body if not already present.
@@ -235,6 +236,7 @@ fn make_fallback_skill(slug: &str, raw_body: &str) -> Skill {
             locked: false,
             critical_paths_touched: vec![],
             fail_count: 0,
+            deprecated: false,
         },
         body: raw_body.trim().to_string(),
         source_path: None,
@@ -500,6 +502,7 @@ mod tests {
                 locked: false,
                 critical_paths_touched: vec![],
                 fail_count: 0,
+                deprecated: false,
             },
             body: "Contact developer@example.com for help.".to_string(),
             source_path: None,

--- a/crates/garraia-learning/src/lib.rs
+++ b/crates/garraia-learning/src/lib.rs
@@ -59,6 +59,9 @@ pub struct LearningSkillFrontmatter {
     /// Consecutive failure count tracked by the Evaluator.
     #[serde(default)]
     pub fail_count: u32,
+    /// Set by the Registry when a skill is retired; preserved for history.
+    #[serde(default)]
+    pub deprecated: bool,
 }
 
 fn default_source() -> SkillSource {

--- a/crates/garraia-learning/src/miner.rs
+++ b/crates/garraia-learning/src/miner.rs
@@ -371,6 +371,7 @@ fn render_candidate(pattern: &MinedPattern) -> String {
         locked: false,
         critical_paths_touched: vec![],
         fail_count: 0,
+        deprecated: false,
     };
 
     let fm_yaml = serde_yaml::to_string(&fm).unwrap_or_else(|_| "{}".to_string());

--- a/crates/garraia-learning/src/registry.rs
+++ b/crates/garraia-learning/src/registry.rs
@@ -1,13 +1,278 @@
+use crate::{LearningSkillFrontmatter, Skill, SkillScope, SkillSource};
 use garraia_common::{Error, Result};
-use std::path::PathBuf;
+use std::fs;
+use std::io::Write as IoWrite;
+use std::path::{Path, PathBuf};
 
-/// Lists skills from both global (`~/.garra/skills/`) and project (`.garra/skills/`) scopes.
+// ──────────────────────────────────────────────
+// Public types
+// ──────────────────────────────────────────────
+
+/// Paths for both registry scopes.
+#[derive(Debug, Clone)]
+pub struct RegistryOptions {
+    /// `~/.garra/skills/` — shared across projects.
+    pub global_dir: PathBuf,
+    /// `.garra/skills/` — versioned with the project.
+    pub project_dir: PathBuf,
+}
+
+impl RegistryOptions {
+    pub fn new(global_dir: PathBuf, project_dir: PathBuf) -> Self {
+        Self {
+            global_dir,
+            project_dir,
+        }
+    }
+
+    /// Build options using the real HOME dir + an explicit project root.
+    pub fn default_with_cwd(project_root: &Path) -> Result<Self> {
+        let home =
+            std::env::var("HOME").map_err(|_| Error::Other("HOME env var not set".into()))?;
+        Ok(Self {
+            global_dir: PathBuf::from(home).join(".garra").join("skills"),
+            project_dir: project_root.join(".garra").join("skills"),
+        })
+    }
+}
+
+// ──────────────────────────────────────────────
+// Lock-file guard
+// ──────────────────────────────────────────────
+
+struct LockGuard(PathBuf);
+
+impl Drop for LockGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.0);
+    }
+}
+
+fn acquire_lock(locks_dir: &Path, name: &str) -> Result<LockGuard> {
+    fs::create_dir_all(locks_dir)?;
+    let lock_path = locks_dir.join(format!("{name}.lock"));
+    fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&lock_path)
+        .map_err(|e| {
+            if e.kind() == std::io::ErrorKind::AlreadyExists {
+                Error::Other(format!(
+                    "skill '{name}' is locked by another process; try again shortly"
+                ))
+            } else {
+                Error::Io(e)
+            }
+        })?;
+    Ok(LockGuard(lock_path))
+}
+
+// ──────────────────────────────────────────────
+// File helpers
+// ──────────────────────────────────────────────
+
+fn skill_path(dir: &Path, name: &str) -> PathBuf {
+    dir.join(format!("{name}.md"))
+}
+
+fn read_skill_file(path: &Path) -> Result<Skill> {
+    let raw = fs::read_to_string(path)?;
+
+    // Expected format: `---\n<yaml>\n---\n<body>`
+    let without_leading = raw.trim_start_matches("---\n");
+    let Some(sep) = without_leading.find("\n---") else {
+        // No closing delimiter — treat whole content as body with empty frontmatter.
+        tracing::warn!(
+            path = %path.display(),
+            "skill file missing YAML frontmatter delimiters; using defaults"
+        );
+        let name = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+        return Ok(Skill {
+            frontmatter: minimal_frontmatter(name),
+            body: raw,
+            source_path: Some(path.to_path_buf()),
+        });
+    };
+
+    let yaml_src = &without_leading[..sep];
+    let body_start = sep + "\n---".len();
+    let body = without_leading[body_start..]
+        .trim_start_matches('\n')
+        .to_string();
+
+    let frontmatter: LearningSkillFrontmatter =
+        serde_yaml::from_str(yaml_src).map_err(|e| Error::Other(e.to_string()))?;
+
+    Ok(Skill {
+        frontmatter,
+        body,
+        source_path: Some(path.to_path_buf()),
+    })
+}
+
+fn write_skill_file(skill: &Skill, path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let yaml =
+        serde_yaml::to_string(&skill.frontmatter).map_err(|e| Error::Other(e.to_string()))?;
+    let mut file = fs::File::create(path)?;
+    writeln!(file, "---")?;
+    file.write_all(yaml.as_bytes())?;
+    writeln!(file, "---")?;
+    if !skill.body.is_empty() {
+        writeln!(file)?;
+        file.write_all(skill.body.as_bytes())?;
+        if !skill.body.ends_with('\n') {
+            writeln!(file)?;
+        }
+    }
+    Ok(())
+}
+
+fn minimal_frontmatter(name: String) -> LearningSkillFrontmatter {
+    LearningSkillFrontmatter {
+        name,
+        version: "0.1.0".into(),
+        source: SkillSource::Mined,
+        scope: SkillScope::Project,
+        score: 0.0,
+        locked: false,
+        critical_paths_touched: vec![],
+        fail_count: 0,
+        deprecated: false,
+    }
+}
+
+/// Scan `dir` for `*.md` files, skipping entries whose names start with `_`.
+fn list_skills_in_dir(dir: &Path) -> Result<Vec<Skill>> {
+    if !dir.exists() {
+        return Ok(vec![]);
+    }
+    let mut skills = Vec::new();
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let fname = entry.file_name();
+        let name = fname.to_string_lossy();
+        // Skip reserved directories/files (_locks/, _candidates/, _deprecated/, etc.)
+        if name.starts_with('_') {
+            continue;
+        }
+        if !name.ends_with(".md") {
+            continue;
+        }
+        let path = entry.path();
+        match read_skill_file(&path) {
+            Ok(skill) => skills.push(skill),
+            Err(e) => {
+                tracing::warn!(path = %path.display(), error = %e, "skipping unreadable skill file");
+            }
+        }
+    }
+    Ok(skills)
+}
+
+fn scope_dir<'a>(opts: &'a RegistryOptions, scope: &SkillScope) -> &'a Path {
+    match scope {
+        SkillScope::Global => &opts.global_dir,
+        SkillScope::Project => &opts.project_dir,
+    }
+}
+
+// ──────────────────────────────────────────────
+// Public API
+// ──────────────────────────────────────────────
+
+/// Lists skills from one or both scopes.
 ///
-/// GAR-645 will implement the full dual-scope registry with lock-file support.
-pub fn list_skills() -> Result<Vec<crate::Skill>> {
-    Err(Error::Other(
-        "Skill Registry not yet implemented (GAR-645)".into(),
-    ))
+/// If `scope` is `None`, returns all skills from both global and project dirs.
+pub fn list_skills(opts: &RegistryOptions, scope: Option<SkillScope>) -> Result<Vec<Skill>> {
+    match scope {
+        Some(s) => list_skills_in_dir(scope_dir(opts, &s)),
+        None => {
+            let mut all = list_skills_in_dir(&opts.global_dir)?;
+            all.extend(list_skills_in_dir(&opts.project_dir)?);
+            Ok(all)
+        }
+    }
+}
+
+/// Returns the first skill whose `frontmatter.name` matches `name`, in the
+/// given scope (or both if `scope` is `None`).
+pub fn get_skill(
+    opts: &RegistryOptions,
+    name: &str,
+    scope: Option<SkillScope>,
+) -> Result<Option<Skill>> {
+    let skills = list_skills(opts, scope)?;
+    Ok(skills.into_iter().find(|s| s.frontmatter.name == name))
+}
+
+/// Writes a skill to the appropriate scope directory, acquiring a lock-file
+/// first to prevent concurrent corruption.
+///
+/// Returns the path where the skill was written.
+pub fn promote(skill: &Skill, opts: &RegistryOptions) -> Result<PathBuf> {
+    let dir = scope_dir(opts, &skill.frontmatter.scope);
+    let locks_dir = dir.join("_locks");
+    let _lock = acquire_lock(&locks_dir, &skill.frontmatter.name)?;
+    let path = skill_path(dir, &skill.frontmatter.name);
+    write_skill_file(skill, &path)?;
+    Ok(path)
+}
+
+/// Marks the named skill as `deprecated = true` by rewriting its file.
+///
+/// Returns `true` if the skill was found and updated, `false` if not found.
+pub fn deprecate(opts: &RegistryOptions, name: &str, scope: SkillScope) -> Result<bool> {
+    let dir = scope_dir(opts, &scope);
+    let path = skill_path(dir, name);
+    if !path.exists() {
+        return Ok(false);
+    }
+    let mut skill = read_skill_file(&path)?;
+    if skill.frontmatter.deprecated {
+        return Ok(true); // already deprecated, nothing to do
+    }
+    skill.frontmatter.deprecated = true;
+    let locks_dir = dir.join("_locks");
+    let _lock = acquire_lock(&locks_dir, name)?;
+    write_skill_file(&skill, &path)?;
+    Ok(true)
+}
+
+/// Lists all candidate skill files in `candidates_dir` (files matching `mined-*.md`).
+///
+/// Files that fail to parse are skipped with a warning.
+pub fn list_candidates(candidates_dir: &Path) -> Result<Vec<crate::generator::Candidate>> {
+    if !candidates_dir.exists() {
+        return Ok(vec![]);
+    }
+    let mut candidates = Vec::new();
+    for entry in fs::read_dir(candidates_dir)? {
+        let entry = entry?;
+        let fname = entry.file_name();
+        let name = fname.to_string_lossy();
+        if !name.starts_with("mined-") || !name.ends_with(".md") {
+            continue;
+        }
+        let path = entry.path();
+        match crate::generator::load_candidate_file(&path) {
+            Ok(c) => candidates.push(c),
+            Err(e) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "skipping unparseable candidate file"
+                );
+            }
+        }
+    }
+    Ok(candidates)
 }
 
 /// Returns the global skills root: `~/.garra/skills/`.
@@ -21,11 +286,274 @@ pub fn project_skills_dir() -> PathBuf {
     PathBuf::from(".garra").join("skills")
 }
 
-/// Promotes a skill candidate into the registry after Safety Gate passes.
-///
-/// GAR-645 will implement persist + git-track.
-pub fn promote(_skill: &crate::Skill) -> Result<()> {
-    Err(Error::Other(
-        "Skill Registry promote not yet implemented (GAR-645)".into(),
-    ))
+// ──────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn make_skill(name: &str, scope: SkillScope, body: &str) -> Skill {
+        Skill {
+            frontmatter: LearningSkillFrontmatter {
+                name: name.to_string(),
+                version: "0.1.0".to_string(),
+                source: SkillSource::Mined,
+                scope,
+                score: 0.0,
+                locked: false,
+                critical_paths_touched: vec![],
+                fail_count: 0,
+                deprecated: false,
+            },
+            body: body.to_string(),
+            source_path: None,
+        }
+    }
+
+    fn opts_in(tmp: &TempDir) -> RegistryOptions {
+        RegistryOptions::new(tmp.path().join("global"), tmp.path().join("project"))
+    }
+
+    // ── read/write round-trip ──────────────────
+
+    #[test]
+    fn round_trip_write_read_preserves_fields() {
+        let tmp = TempDir::new().unwrap();
+        let skill = make_skill(
+            "test-skill",
+            SkillScope::Project,
+            "## Steps\n\nDo the thing.\n",
+        );
+        let path = tmp.path().join("test-skill.md");
+
+        write_skill_file(&skill, &path).unwrap();
+        let loaded = read_skill_file(&path).unwrap();
+
+        assert_eq!(loaded.frontmatter.name, "test-skill");
+        assert_eq!(loaded.frontmatter.version, "0.1.0");
+        assert_eq!(loaded.frontmatter.score, 0.0);
+        assert!(!loaded.frontmatter.deprecated);
+        assert!(loaded.body.contains("Do the thing."));
+    }
+
+    #[test]
+    fn round_trip_preserves_deprecated_flag() {
+        let tmp = TempDir::new().unwrap();
+        let mut skill = make_skill("old-skill", SkillScope::Global, "body");
+        skill.frontmatter.deprecated = true;
+        let path = tmp.path().join("old-skill.md");
+
+        write_skill_file(&skill, &path).unwrap();
+        let loaded = read_skill_file(&path).unwrap();
+
+        assert!(loaded.frontmatter.deprecated);
+    }
+
+    #[test]
+    fn read_file_missing_delimiters_uses_fallback() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("bare.md");
+        fs::write(&path, "No frontmatter here.").unwrap();
+
+        let skill = read_skill_file(&path).unwrap();
+        assert_eq!(skill.frontmatter.name, "bare");
+    }
+
+    // ── list_skills ───────────────────────────
+
+    #[test]
+    fn list_skills_empty_dir_returns_empty() {
+        let tmp = TempDir::new().unwrap();
+        let opts = opts_in(&tmp);
+
+        let result = list_skills(&opts, Some(SkillScope::Project)).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn list_skills_returns_skill_in_dir() {
+        let tmp = TempDir::new().unwrap();
+        let opts = opts_in(&tmp);
+
+        let skill = make_skill("my-skill", SkillScope::Project, "body");
+        promote(&skill, &opts).unwrap();
+
+        let listed = list_skills(&opts, Some(SkillScope::Project)).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].frontmatter.name, "my-skill");
+    }
+
+    #[test]
+    fn list_skills_none_scope_merges_both() {
+        let tmp = TempDir::new().unwrap();
+        let opts = opts_in(&tmp);
+
+        let global_skill = make_skill("global-one", SkillScope::Global, "body");
+        let project_skill = make_skill("project-one", SkillScope::Project, "body");
+        promote(&global_skill, &opts).unwrap();
+        promote(&project_skill, &opts).unwrap();
+
+        let all = list_skills(&opts, None).unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[test]
+    fn list_skills_skips_underscore_files() {
+        let tmp = TempDir::new().unwrap();
+        let opts = opts_in(&tmp);
+
+        // promote a normal skill (creates dir)
+        let skill = make_skill("real-skill", SkillScope::Project, "body");
+        promote(&skill, &opts).unwrap();
+
+        // manually create a _reserved file
+        fs::write(opts.project_dir.join("_index.md"), "should be skipped").unwrap();
+
+        let listed = list_skills(&opts, Some(SkillScope::Project)).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].frontmatter.name, "real-skill");
+    }
+
+    // ── get_skill ─────────────────────────────
+
+    #[test]
+    fn get_skill_found() {
+        let tmp = TempDir::new().unwrap();
+        let opts = opts_in(&tmp);
+
+        let skill = make_skill("find-me", SkillScope::Project, "body");
+        promote(&skill, &opts).unwrap();
+
+        let found = get_skill(&opts, "find-me", Some(SkillScope::Project)).unwrap();
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().frontmatter.name, "find-me");
+    }
+
+    #[test]
+    fn get_skill_not_found_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let opts = opts_in(&tmp);
+
+        let found = get_skill(&opts, "ghost", Some(SkillScope::Project)).unwrap();
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn get_skill_wrong_scope_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let opts = opts_in(&tmp);
+
+        let skill = make_skill("scoped-skill", SkillScope::Global, "body");
+        promote(&skill, &opts).unwrap();
+
+        // Looking in Project scope shouldn't find a Global skill
+        let found = get_skill(&opts, "scoped-skill", Some(SkillScope::Project)).unwrap();
+        assert!(found.is_none());
+    }
+
+    // ── promote ───────────────────────────────
+
+    #[test]
+    fn promote_creates_file_in_correct_dir() {
+        let tmp = TempDir::new().unwrap();
+        let opts = opts_in(&tmp);
+
+        let skill = make_skill("new-skill", SkillScope::Project, "## Do stuff\n");
+        let path = promote(&skill, &opts).unwrap();
+
+        assert!(path.exists());
+        assert_eq!(path, opts.project_dir.join("new-skill.md"));
+    }
+
+    #[test]
+    fn promote_is_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        let opts = opts_in(&tmp);
+
+        let mut skill = make_skill("idem-skill", SkillScope::Project, "v1");
+        promote(&skill, &opts).unwrap();
+
+        skill.body = "v2".into();
+        promote(&skill, &opts).unwrap();
+
+        let loaded = read_skill_file(&opts.project_dir.join("idem-skill.md")).unwrap();
+        assert_eq!(loaded.body.trim(), "v2");
+    }
+
+    // ── deprecate ─────────────────────────────
+
+    #[test]
+    fn deprecate_sets_flag_on_existing_skill() {
+        let tmp = TempDir::new().unwrap();
+        let opts = opts_in(&tmp);
+
+        let skill = make_skill("old-skill", SkillScope::Project, "body");
+        promote(&skill, &opts).unwrap();
+
+        let updated = deprecate(&opts, "old-skill", SkillScope::Project).unwrap();
+        assert!(updated);
+
+        let loaded = read_skill_file(&opts.project_dir.join("old-skill.md")).unwrap();
+        assert!(loaded.frontmatter.deprecated);
+    }
+
+    #[test]
+    fn deprecate_unknown_skill_returns_false() {
+        let tmp = TempDir::new().unwrap();
+        let opts = opts_in(&tmp);
+
+        let updated = deprecate(&opts, "ghost", SkillScope::Project).unwrap();
+        assert!(!updated);
+    }
+
+    #[test]
+    fn deprecate_already_deprecated_is_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        let opts = opts_in(&tmp);
+
+        let mut skill = make_skill("dup-depr", SkillScope::Project, "body");
+        skill.frontmatter.deprecated = true;
+        promote(&skill, &opts).unwrap();
+
+        let result = deprecate(&opts, "dup-depr", SkillScope::Project).unwrap();
+        assert!(result);
+    }
+
+    // ── list_candidates ───────────────────────
+
+    #[test]
+    fn list_candidates_empty_dir_returns_empty() {
+        let tmp = TempDir::new().unwrap();
+        let result = list_candidates(tmp.path()).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn list_candidates_parses_mined_files() {
+        let tmp = TempDir::new().unwrap();
+
+        // Write a fixture in the format emitted by miner::render_candidate.
+        let candidate_path = tmp.path().join("mined-git-cleanup.md");
+        fs::write(
+            &candidate_path,
+            "---\nname: mined-git-cleanup\nversion: '0.1.0'\nsource: mined\nscope: project\nscore: 0.0\nlocked: false\ncritical_paths_touched: []\nfail_count: 0\ndeprecated: false\n---\n\n## Commands\n\n```\ngit branch -d main\n```\n",
+        )
+        .unwrap();
+
+        let candidates = list_candidates(tmp.path()).unwrap();
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].slug, "mined-git-cleanup");
+    }
+
+    #[test]
+    fn list_candidates_skips_non_mined_files() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("other-file.md"), "not a candidate").unwrap();
+
+        let result = list_candidates(tmp.path()).unwrap();
+        assert!(result.is_empty());
+    }
 }

--- a/crates/garraia-learning/src/safety.rs
+++ b/crates/garraia-learning/src/safety.rs
@@ -198,6 +198,7 @@ mod tests {
                 locked: false,
                 critical_paths_touched: vec![],
                 fail_count: 0,
+                deprecated: false,
             },
             body: body.to_string(),
             source_path: None,

--- a/plans/0148-gar-645-skill-registry.md
+++ b/plans/0148-gar-645-skill-registry.md
@@ -1,0 +1,176 @@
+# Plan 0148 — GAR-645: Skill Registry — dual-scope persist, list, promote, deprecate
+
+**Status:** 🚧 In Progress (2026-05-18)
+**Issue:** [GAR-645](https://linear.app/chatgpt25/issue/GAR-645) (sub-issue 4/10 of [GAR-641](https://linear.app/chatgpt25/issue/GAR-641))
+**Branch:** `feat/202605181446-gar-645-skill-registry`
+**Epic parent:** Fase 1.4 — Garra Learning Agent (`epic:learning-agent`)
+
+---
+
+## Goal
+
+Implement `garraia-learning::registry` — the Skill Registry component (4/10 of the
+Learning Agent epic). Replaces the 4-stub-function stub with a full dual-scope skill
+store: persist, list, get, promote, deprecate, and list candidates.
+
+Connects the Mine → Generate → **Registry** → Promote pipeline.
+
+---
+
+## Architecture
+
+```text
+crates/garraia-learning/src/registry.rs   (replace stub)
+  RegistryOptions struct                  global_dir + project_dir
+  LockGuard struct                        RAII lock-file in _locks/
+  pub fn list_skills(opts, scope)         scan *.md in scope dir(s), skip _* prefixed
+  pub fn get_skill(opts, name, scope)     find by name in scope dir(s)
+  pub fn promote(skill, opts)             write to scope dir with lock-file guard
+  pub fn deprecate(opts, name, scope)     set deprecated=true in frontmatter, rewrite
+  pub fn list_candidates(dir)             find mined-*.md, parse via generator::load_candidate_file
+  fn read_skill_file(path)               parse YAML frontmatter + body
+  fn write_skill_file(skill, path)       serialize frontmatter + body
+  fn skill_path(dir, name)               dir/<name>.md
+  fn list_skills_in_dir(dir)             scan non-hidden *.md, deserialize each
+  fn acquire_lock(locks_dir, name)       OpenOptions::create_new (atomic on Unix)
+  fn scope_dir(opts, scope)              pick global_dir or project_dir
+
+crates/garraia-learning/src/lib.rs
+  LearningSkillFrontmatter               + deprecated: bool (#[serde(default)])
+```
+
+No Cargo.toml changes — `serde_yaml`, `tempfile` already present.
+
+---
+
+## Tech stack
+
+- Rust edition 2024 (existing crate)
+- `serde_yaml` (workspace) — frontmatter serialization
+- `garraia_common::Error`/`Result` — error propagation
+- `generator::load_candidate_file` — reused for list_candidates
+- `std::fs::OpenOptions::create_new` — atomic lock acquisition
+
+---
+
+## Design invariants
+
+- **No `unwrap()` in production paths.**
+- **Lock-file in `_locks/`** ensures concurrent `promote` calls don't corrupt files.
+- **`_*` prefixed files/dirs skipped** by `list_skills_in_dir` (reserved for `_locks/`, `_candidates/`, `_deprecated/`).
+- **`deprecated` field** added to `LearningSkillFrontmatter` with `#[serde(default)]` — backwards-compatible.
+- **`promote` is idempotent** on name: overwrites existing file after acquiring lock.
+- **`list_candidates`** delegates to `generator::load_candidate_file`; non-parseable files are skipped with `tracing::warn!`.
+
+---
+
+## Validações pré-plano
+
+- [x] `garraia-learning` crate exists with stub `registry.rs`.
+- [x] `serde_yaml` + `tempfile` are available.
+- [x] `garraia_common::Error::Io` is `#[from] std::io::Error`.
+- [x] `generator::load_candidate_file` is `pub`.
+- [x] `LearningSkillFrontmatter`, `SkillScope`, `Skill` are all `pub` in `lib.rs`.
+- [x] `cargo check -p garraia-learning` is green on main.
+
+---
+
+## Out of scope
+
+- CLI `garra skills *` wiring (GAR-650 Human Override slice).
+- `delete_skill` (GAR-650).
+- `lock`/`unlock` skill (GAR-650).
+- Embedding-based retrieval (GAR-646 — prereq: Fase 2.1).
+- Auto-updater PR flow (GAR-648).
+- Git-backed versioning (GAR-650).
+- Score update / EMA tracking (GAR-647 Evaluator).
+
+---
+
+## M1 Tasks
+
+### T1 — Add `deprecated` to LearningSkillFrontmatter
+
+- [ ] `pub deprecated: bool` with `#[serde(default)]` in `lib.rs`.
+- [ ] `cargo check -p garraia-learning` green.
+
+### T2 — Define RegistryOptions + LockGuard
+
+- [ ] `pub struct RegistryOptions { global_dir, project_dir }`
+- [ ] `impl RegistryOptions { pub fn new(…), pub fn default_with_cwd(cwd) }`
+- [ ] `struct LockGuard(PathBuf)` + `Drop` impl.
+- [ ] `fn acquire_lock(locks_dir, name) -> Result<LockGuard>`.
+
+### T3 — Implement read/write helpers (RED → GREEN)
+
+- [ ] `fn read_skill_file(path) -> Result<Skill>` — split on `---` delimiter.
+- [ ] `fn write_skill_file(skill, path) -> Result<()>` — serialize frontmatter + body.
+- [ ] Unit tests: round-trip write → read preserves all fields.
+
+### T4 — Implement list_skills + get_skill (RED → GREEN)
+
+- [ ] `fn list_skills_in_dir(dir) -> Result<Vec<Skill>>` — skip `_*`.
+- [ ] `pub fn list_skills(opts, scope) -> Result<Vec<Skill>>`.
+- [ ] `pub fn get_skill(opts, name, scope) -> Result<Option<Skill>>`.
+- [ ] Tests: empty dir → `[]`; file present → returns skill; wrong scope → None.
+
+### T5 — Implement promote + deprecate (RED → GREEN)
+
+- [ ] `pub fn promote(skill, opts) -> Result<PathBuf>` — mkdir + lock + write.
+- [ ] `pub fn deprecate(opts, name, scope) -> Result<bool>` — read → set flag → write.
+- [ ] Tests: promote writes file; deprecate sets `deprecated=true`; unknown name returns `false`.
+
+### T6 — Implement list_candidates
+
+- [ ] `pub fn list_candidates(candidates_dir) -> Result<Vec<Candidate>>`.
+- [ ] Test: write a `mined-*.md` fixture → list returns Candidate.
+
+### T7 — clippy + workspace check
+
+- [ ] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` clean.
+
+### T8 — Update plans/README.md
+
+- [ ] Add row 0148.
+
+---
+
+## Acceptance criteria
+
+- [ ] `cargo test -p garraia-learning -- registry` — all registry tests pass.
+- [ ] `promote` writes `<name>.md` with valid YAML frontmatter in the correct scope dir.
+- [ ] `list_skills` returns skills from both scopes when `scope = None`.
+- [ ] `deprecate` sets `deprecated: true` and rewrites the file.
+- [ ] `list_candidates` round-trips a mined candidate file into `Candidate`.
+- [ ] `cargo clippy … -D warnings` clean.
+- [ ] CI green.
+
+---
+
+## File structure
+
+```
+crates/garraia-learning/
+└── src/
+    ├── lib.rs          + deprecated field on LearningSkillFrontmatter
+    └── registry.rs     full implementation (~320 LOC, replaces 28-line stub)
+plans/
+├── README.md           add row 0148
+└── 0148-gar-645-skill-registry.md   this file
+```
+
+---
+
+## Cross-references
+
+- Plan 0147 (GAR-644, Skill Generator) — `generate()` output is the `Skill` promoted here.
+- Plan 0146 (GAR-643, Skill Miner) — `load_candidate_file` reused by `list_candidates`.
+- Plan 0144 (GAR-642, Learning Agent scaffold) — `Skill` + `LearningSkillFrontmatter` types.
+- GAR-641 (epic parent) — 4/10 of the Learning Agent.
+- ADR 0010 — Accepted learning architecture.
+
+---
+
+## Estimativa
+
+0.5 / 1 / 2 days. ~320 LOC production, ~150 LOC tests.

--- a/plans/README.md
+++ b/plans/README.md
@@ -156,3 +156,4 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0145 | [GAR-372 — Embeddings & Vector Search: scaffold garraia-embeddings](0145-gar-372-embeddings-scaffold.md) | [GAR-372](https://linear.app/chatgpt25/issue/GAR-372) | ✅ Merged 2026-05-18 via PR #396 (`cfda7ad`) |
 | 0146 | [GAR-643 — Skill Miner: detect repeatable patterns in session logs](0146-gar-643-skill-miner.md) | [GAR-643](https://linear.app/chatgpt25/issue/GAR-643) | ✅ Merged 2026-05-18 via PR #400 (`3bb473a`) |
 | 0147 | [GAR-644 — Skill Generator: LLM-assisted skill drafting](0147-gar-644-skill-generator.md) | [GAR-644](https://linear.app/chatgpt25/issue/GAR-644) | ✅ Merged 2026-05-18 via PR #402 (`da65c63`) |
+| 0148 | [GAR-645 — Skill Registry: dual-scope persist, list, promote, deprecate](0148-gar-645-skill-registry.md) | [GAR-645](https://linear.app/chatgpt25/issue/GAR-645) | 🚧 In Progress (2026-05-18) |


### PR DESCRIPTION
## Summary

- Replaces the 4-stub-function `registry.rs` with a full implementation (~350 LOC production + 18 unit tests).
- Connects the Mine → Generate → **Registry** → Promote pipeline (sub-issue 4/10 of GAR-641).
- Adds `deprecated: bool` (`#[serde(default)]`) to `LearningSkillFrontmatter` — backwards-compatible.

## Changes

**`crates/garraia-learning/src/registry.rs`** (full replacement)
- `RegistryOptions` — holds `global_dir` (`~/.garra/skills/`) + `project_dir` (`.garra/skills/`)
- `LockGuard` — RAII lock-file via `OpenOptions::create_new` (atomic on Unix); lock lives in `_locks/`
- `list_skills(opts, scope)` — scan `*.md`, skip `_*`-prefixed entries
- `get_skill(opts, name, scope)` — lookup by `frontmatter.name`
- `promote(skill, opts)` — mkdir + lock + write; idempotent on name
- `deprecate(opts, name, scope)` — sets `deprecated=true` and rewrites file; returns `false` if not found
- `list_candidates(dir)` — finds `mined-*.md`, delegates to `generator::load_candidate_file`

**`crates/garraia-learning/src/lib.rs`**
- `LearningSkillFrontmatter`: new field `pub deprecated: bool` with `#[serde(default)]`

**`crates/garraia-learning/src/{generator,miner,safety}.rs`**
- Added `deprecated: false` to all `LearningSkillFrontmatter` struct initializers

## Test plan

- [x] `cargo test -p garraia-learning` — **76/76 passed** (18 new registry tests)
- [x] `cargo clippy --workspace … -D warnings` — clean
- [x] `cargo fmt --package garraia-learning` — no drift
- [ ] CI Format + Clippy + Test green

## Test coverage (new)

`round_trip_write_read_preserves_fields`, `round_trip_preserves_deprecated_flag`,
`read_file_missing_delimiters_uses_fallback`, `list_skills_empty_dir_returns_empty`,
`list_skills_returns_skill_in_dir`, `list_skills_none_scope_merges_both`,
`list_skills_skips_underscore_files`, `get_skill_found`, `get_skill_not_found_returns_none`,
`get_skill_wrong_scope_returns_none`, `promote_creates_file_in_correct_dir`,
`promote_is_idempotent`, `deprecate_sets_flag_on_existing_skill`,
`deprecate_unknown_skill_returns_false`, `deprecate_already_deprecated_is_idempotent`,
`list_candidates_parses_mined_files`, `list_candidates_empty_dir_returns_empty`,
`list_candidates_skips_non_mined_files`

## Cross-references

- Plan 0148 (`plans/0148-gar-645-skill-registry.md`)
- Follows plan 0147 (GAR-644 Skill Generator, merged PR #402)
- GAR-641 (epic parent) — 4/10 of the Learning Agent
- ADR 0010 — Accepted learning architecture

https://claude.ai/code/session_012G4CrL4Ku8PkhJiU3WiNzK

---
_Generated by [Claude Code](https://claude.ai/code/session_012G4CrL4Ku8PkhJiU3WiNzK)_