### PR TITLE
docs(roadmap): mark GAR-645 Done — Skill Registry merged via PR #404 (b67d030)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1229,7 +1229,7 @@ gantt
 
 ## 7. Próximos passos imediatos (próxima sessão)
 
-**Atualizado 2026-05-18** — GAR-644 (Skill Generator) ✅ Done. `generator.rs` implementado com `SkillDraftProvider` trait, `Candidate`, `GenerateOptions`, `generate()`, `load_candidate_file()`, prompt template const, `to_kebab()`, `make_unique_name()`, PII redaction. 21 unit tests; 94.10% line coverage. PR #402 (`da65c63`). Anterior: GAR-643 (Skill Miner) ✅ Done (PR #400). GAR-642 ✅ Done.
+**Atualizado 2026-05-18** — GAR-645 (Skill Registry) ✅ Done. `registry.rs` implementado com `RegistryOptions`, `LockGuard` (lock-file atômico), `list_skills`, `get_skill`, `promote`, `deprecate`, `list_candidates`. `deprecated: bool` adicionado ao `LearningSkillFrontmatter`. 18 unit tests; 90.91% line coverage. PR #404 (`b67d030`). Anterior: GAR-644 ✅ Done (PR #402). GAR-643 ✅ Done (PR #400). GAR-642 ✅ Done.
 
 Quando retomar execução, priorizar **nesta ordem**:
 
@@ -1239,7 +1239,9 @@ Quando retomar execução, priorizar **nesta ordem**:
 
 1. ~~**Garra Learning Agent — Skill Generator ([GAR-644](https://linear.app/chatgpt25/issue/GAR-644), 3/10)**~~ ✅ **Done** (2026-05-18, plan 0147, PR #402 `da65c63`). `SkillDraftProvider` trait + `generate()` + 21 unit tests.
 
-1. **Garra Learning Agent — Skill Registry ([GAR-645](https://linear.app/chatgpt25/issue/GAR-645), 4/10 do épico [GAR-641](https://linear.app/chatgpt25/issue/GAR-641))** — registry de skills geradas: list, get, promote, deprecate. Persiste em `~/.garra/skills/`. Conecta Miner + Generator ao loop Mine→Generate→**Registry**→Promote.
+1. ~~**Garra Learning Agent — Skill Registry ([GAR-645](https://linear.app/chatgpt25/issue/GAR-645), 4/10)**~~ ✅ **Done** (2026-05-18, plan 0148, PR #404 `b67d030`). `RegistryOptions` + lock-file + `list_skills/get_skill/promote/deprecate/list_candidates` + 18 unit tests.
+
+1. **Garra Learning Agent — Skill Evaluator ([GAR-647](https://linear.app/chatgpt25/issue/GAR-647), 5/10 do épico [GAR-641](https://linear.app/chatgpt25/issue/GAR-641))** — mede sucesso via sinais objetivos (exit codes, test counts, diffs). Atualiza score EMA. Skills com score < 0.3 marcadas `deprecated`. _(GAR-646 Skill Retriever bloqueado por Fase 2.1 embeddings — skip para depois.)_
 
 2. **Fase 1.2.1 GarraMaxPower — sub-issues abertas (`GAR-494..GAR-501`)** — 8 sub-issues do épico [GAR-492](https://linear.app/chatgpt25/issue/GAR-492) ainda Backlog. Cresce em paralelo ao Learning Agent porque **compartilham o Safety Gate** (`garraia-tools::safety_gate`) e o crate `garraia-learning` reusa primitivas estabelecidas pelo GarraMaxPower (capability prompt, agent team, `.garra-estado.md`).
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -156,4 +156,4 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0145 | [GAR-372 — Embeddings & Vector Search: scaffold garraia-embeddings](0145-gar-372-embeddings-scaffold.md) | [GAR-372](https://linear.app/chatgpt25/issue/GAR-372) | ✅ Merged 2026-05-18 via PR #396 (`cfda7ad`) |
 | 0146 | [GAR-643 — Skill Miner: detect repeatable patterns in session logs](0146-gar-643-skill-miner.md) | [GAR-643](https://linear.app/chatgpt25/issue/GAR-643) | ✅ Merged 2026-05-18 via PR #400 (`3bb473a`) |
 | 0147 | [GAR-644 — Skill Generator: LLM-assisted skill drafting](0147-gar-644-skill-generator.md) | [GAR-644](https://linear.app/chatgpt25/issue/GAR-644) | ✅ Merged 2026-05-18 via PR #402 (`da65c63`) |
-| 0148 | [GAR-645 — Skill Registry: dual-scope persist, list, promote, deprecate](0148-gar-645-skill-registry.md) | [GAR-645](https://linear.app/chatgpt25/issue/GAR-645) | 🚧 In Progress (2026-05-18) |
+| 0148 | [GAR-645 — Skill Registry: dual-scope persist, list, promote, deprecate](0148-gar-645-skill-registry.md) | [GAR-645](https://linear.app/chatgpt25/issue/GAR-645) | ✅ Merged 2026-05-18 via PR #404 (`b67d030`) |


### PR DESCRIPTION
Doc-only bookkeeping after PR #404 merge.

- ROADMAP §7: GAR-645 struck through as ✅ Done; GAR-647 (Skill Evaluator, 5/10) promoted as next priority. Note: GAR-646 Retriever is blocked on Fase 2.1 embeddings — skipping for now.
- `plans/README.md`: row 0148 updated with merge sha `b67d030` + PR #404.

No code changes.

https://claude.ai/code/session_012G4CrL4Ku8PkhJiU3WiNzK

---
_Generated by [Claude Code](https://claude.ai/code/session_012G4CrL4Ku8PkhJiU3WiNzK)_