### PR TITLE
feat(learning): GAR-647 Skill Evaluator — EMA score + anti-flap deprecation

### DIFF
--- a/crates/garraia-learning/src/evaluator.rs
+++ b/crates/garraia-learning/src/evaluator.rs
@@ -1,12 +1,420 @@
-use garraia_common::{Error, Result};
+use garraia_common::Result;
 
-/// Collects objective metrics after a skill execution (exit code, test pass count,
-/// CI checks, diff stats, log scan). Updates `score` via EMA and increments
-/// `fail_count` on failure.
+// ──────────────────────────────────────────────
+// Public types
+// ──────────────────────────────────────────────
+
+/// Objective signals collected after a skill execution.
+#[derive(Debug, Clone)]
+pub struct EvalSignals {
+    /// Process exit code (0 = success).
+    pub exit_code: i32,
+    /// Number of test cases that passed.
+    pub tests_passed: u32,
+    /// Number of test cases that failed.
+    pub tests_failed: u32,
+    /// Total lines changed in the diff produced by the skill.
+    pub lines_changed: u32,
+    /// Number of files touched by the skill.
+    pub files_changed: u32,
+    /// True if the output log contains "ERROR" (case-insensitive).
+    pub log_has_errors: bool,
+    /// True if the output log contains "panic" or "PANIC".
+    pub log_has_panics: bool,
+    /// Elapsed time in milliseconds (optional; not used in scoring yet).
+    pub latency_ms: Option<u64>,
+}
+
+impl EvalSignals {
+    /// Build signals from a simple exit-code-only context (no test runner).
+    pub fn from_exit_code(exit_code: i32) -> Self {
+        Self {
+            exit_code,
+            tests_passed: 0,
+            tests_failed: 0,
+            lines_changed: 0,
+            files_changed: 0,
+            log_has_errors: exit_code != 0,
+            log_has_panics: false,
+            latency_ms: None,
+        }
+    }
+}
+
+/// Qualitative outcome of an evaluation run.
+#[derive(Debug, Clone, PartialEq)]
+pub enum EvalOutcome {
+    Pass,
+    Fail { reason: String },
+    Deprecated { reason: String },
+}
+
+/// Result returned by [`evaluate`].
+#[derive(Debug, Clone)]
+pub struct EvalResult {
+    /// Updated EMA score after this evaluation.
+    pub new_score: f32,
+    /// Updated consecutive failure count.
+    pub fail_count: u32,
+    /// Whether this evaluation triggered deprecation.
+    pub deprecated: bool,
+    /// Qualitative outcome with optional reason.
+    pub outcome: EvalOutcome,
+}
+
+/// Configuration for the EMA score update and deprecation thresholds.
+#[derive(Debug, Clone)]
+pub struct EmaConfig {
+    /// EMA smoothing factor: 0 < alpha ≤ 1. Higher = more reactive.
+    pub alpha: f32,
+    /// Score below this threshold triggers deprecation.
+    pub deprecate_threshold: f32,
+    /// Consecutive failures before anti-flap deprecation.
+    pub anti_flap_threshold: u32,
+}
+
+impl Default for EmaConfig {
+    fn default() -> Self {
+        Self {
+            alpha: 0.3,
+            deprecate_threshold: 0.3,
+            anti_flap_threshold: crate::Skill::ANTI_FLAP_THRESHOLD,
+        }
+    }
+}
+
+// ──────────────────────────────────────────────
+// Public API
+// ──────────────────────────────────────────────
+
+/// Evaluate a skill execution and mutate the skill's score + fail_count.
 ///
-/// GAR-647 will implement the full evaluator pipeline.
-pub fn evaluate(_skill: &mut crate::Skill, _exit_code: i32) -> Result<()> {
-    Err(Error::Other(
-        "Skill Evaluator not yet implemented (GAR-647)".into(),
-    ))
+/// Scoring rubric (weights):
+/// - exit_code == 0:                              +0.40
+/// - tests_failed == 0 && tests_passed > 0:       +0.30  (else +0.10 when no tests)
+/// - !log_has_errors && !log_has_panics:           +0.20
+/// - files_changed > 0:                           +0.10
+///
+/// EMA: `new_score = alpha * raw + (1 - alpha) * current_score`
+///
+/// Deprecation triggers:
+/// - new_score < config.deprecate_threshold
+/// - OR consecutive fail_count >= config.anti_flap_threshold
+pub fn evaluate(
+    skill: &mut crate::Skill,
+    signals: &EvalSignals,
+    config: &EmaConfig,
+) -> Result<EvalResult> {
+    let raw = compute_raw_score(signals);
+    let new_score = update_ema(skill.frontmatter.score, raw, config.alpha);
+    skill.frontmatter.score = new_score;
+
+    let failure = is_failure(signals);
+    if failure {
+        skill.frontmatter.fail_count = skill.frontmatter.fail_count.saturating_add(1);
+    } else {
+        skill.frontmatter.fail_count = 0;
+    }
+
+    let anti_flap_fired = skill.frontmatter.fail_count >= config.anti_flap_threshold;
+    let score_too_low = new_score < config.deprecate_threshold;
+    let should_deprecate = anti_flap_fired || score_too_low;
+
+    if should_deprecate {
+        skill.frontmatter.deprecated = true;
+    }
+
+    let outcome = if should_deprecate {
+        let reason = if anti_flap_fired {
+            format!(
+                "anti-flap: {} consecutive failures (threshold {})",
+                skill.frontmatter.fail_count, config.anti_flap_threshold
+            )
+        } else {
+            format!(
+                "score {:.3} below deprecation threshold {:.3}",
+                new_score, config.deprecate_threshold
+            )
+        };
+        EvalOutcome::Deprecated { reason }
+    } else if failure {
+        let reason = failure_reason(signals);
+        EvalOutcome::Fail { reason }
+    } else {
+        EvalOutcome::Pass
+    };
+
+    Ok(EvalResult {
+        new_score,
+        fail_count: skill.frontmatter.fail_count,
+        deprecated: should_deprecate,
+        outcome,
+    })
+}
+
+// ──────────────────────────────────────────────
+// Private helpers
+// ──────────────────────────────────────────────
+
+fn compute_raw_score(signals: &EvalSignals) -> f32 {
+    let mut score = 0.0_f32;
+
+    if signals.exit_code == 0 {
+        score += 0.40;
+    }
+
+    if signals.tests_failed == 0 && signals.tests_passed > 0 {
+        score += 0.30;
+    } else if signals.tests_failed == 0 {
+        score += 0.10;
+    }
+
+    if !signals.log_has_errors && !signals.log_has_panics {
+        score += 0.20;
+    }
+
+    if signals.files_changed > 0 {
+        score += 0.10;
+    }
+
+    score.clamp(0.0, 1.0)
+}
+
+fn update_ema(current: f32, raw: f32, alpha: f32) -> f32 {
+    let alpha = alpha.clamp(0.0, 1.0);
+    (alpha * raw + (1.0 - alpha) * current).clamp(0.0, 1.0)
+}
+
+fn is_failure(signals: &EvalSignals) -> bool {
+    signals.exit_code != 0 || signals.log_has_panics || signals.tests_failed > 0
+}
+
+fn failure_reason(signals: &EvalSignals) -> String {
+    let mut parts = Vec::new();
+    if signals.exit_code != 0 {
+        parts.push(format!("exit_code={}", signals.exit_code));
+    }
+    if signals.log_has_panics {
+        parts.push("panic in log".into());
+    }
+    if signals.tests_failed > 0 {
+        parts.push(format!("{} test(s) failed", signals.tests_failed));
+    }
+    if parts.is_empty() {
+        "unknown failure".into()
+    } else {
+        parts.join(", ")
+    }
+}
+
+// ──────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{LearningSkillFrontmatter, Skill, SkillScope, SkillSource};
+
+    fn make_skill(score: f32) -> Skill {
+        Skill {
+            frontmatter: LearningSkillFrontmatter {
+                name: "eval-test".into(),
+                version: "0.1.0".into(),
+                source: SkillSource::Mined,
+                scope: SkillScope::Project,
+                score,
+                locked: false,
+                critical_paths_touched: vec![],
+                fail_count: 0,
+                deprecated: false,
+            },
+            body: String::new(),
+            source_path: None,
+        }
+    }
+
+    fn success_signals() -> EvalSignals {
+        EvalSignals {
+            exit_code: 0,
+            tests_passed: 5,
+            tests_failed: 0,
+            lines_changed: 10,
+            files_changed: 2,
+            log_has_errors: false,
+            log_has_panics: false,
+            latency_ms: Some(120),
+        }
+    }
+
+    fn failure_signals() -> EvalSignals {
+        EvalSignals {
+            exit_code: 1,
+            tests_passed: 0,
+            tests_failed: 2,
+            lines_changed: 0,
+            files_changed: 0,
+            log_has_errors: true,
+            log_has_panics: false,
+            latency_ms: None,
+        }
+    }
+
+    #[test]
+    fn raw_score_full_success() {
+        let score = compute_raw_score(&success_signals());
+        assert!((score - 1.0).abs() < 1e-5, "expected 1.0, got {score}");
+    }
+
+    #[test]
+    fn raw_score_full_failure() {
+        let score = compute_raw_score(&failure_signals());
+        assert!((score - 0.0).abs() < 1e-5, "expected 0.0, got {score}");
+    }
+
+    #[test]
+    fn raw_score_no_tests_partial() {
+        let s = EvalSignals {
+            exit_code: 0,
+            tests_passed: 0,
+            tests_failed: 0,
+            lines_changed: 5,
+            files_changed: 1,
+            log_has_errors: false,
+            log_has_panics: false,
+            latency_ms: None,
+        };
+        let score = compute_raw_score(&s);
+        // exit(0.40) + no_tests(0.10) + no_errors(0.20) + files(0.10) = 0.80
+        assert!((score - 0.80).abs() < 1e-5, "expected 0.80, got {score}");
+    }
+
+    #[test]
+    fn raw_score_panic_in_log_loses_log_bonus() {
+        let s = EvalSignals {
+            exit_code: 0,
+            tests_passed: 5,
+            tests_failed: 0,
+            lines_changed: 3,
+            files_changed: 1,
+            log_has_errors: false,
+            log_has_panics: true,
+            latency_ms: None,
+        };
+        let score = compute_raw_score(&s);
+        // exit(0.40) + tests(0.30) + no log bonus + files(0.10) = 0.80
+        assert!((score - 0.80).abs() < 1e-5, "expected 0.80, got {score}");
+    }
+
+    #[test]
+    fn ema_from_zero_with_perfect_score() {
+        // current=0.0, raw=1.0, alpha=0.3 → 0.3
+        let result = update_ema(0.0, 1.0, 0.3);
+        assert!((result - 0.30).abs() < 1e-5, "expected 0.30, got {result}");
+    }
+
+    #[test]
+    fn ema_stable_at_one() {
+        assert!((update_ema(1.0, 1.0, 0.3) - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn ema_clamps_to_valid_range() {
+        assert!((update_ema(0.0, 0.0, 0.3) - 0.0).abs() < 1e-5);
+        assert!((update_ema(1.0, 1.0, 1.0) - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn evaluate_success_increases_score() {
+        let mut skill = make_skill(0.5);
+        let result = evaluate(&mut skill, &success_signals(), &EmaConfig::default()).unwrap();
+        assert!(result.new_score > 0.5);
+        assert_eq!(result.fail_count, 0);
+        assert!(!result.deprecated);
+        assert_eq!(result.outcome, EvalOutcome::Pass);
+    }
+
+    #[test]
+    fn evaluate_failure_increments_fail_count() {
+        let mut skill = make_skill(0.8);
+        let result = evaluate(&mut skill, &failure_signals(), &EmaConfig::default()).unwrap();
+        assert_eq!(result.fail_count, 1);
+        assert!(!result.deprecated);
+        assert!(matches!(result.outcome, EvalOutcome::Fail { .. }));
+    }
+
+    #[test]
+    fn evaluate_success_resets_fail_count() {
+        let mut skill = make_skill(0.7);
+        skill.frontmatter.fail_count = 2;
+        let result = evaluate(&mut skill, &success_signals(), &EmaConfig::default()).unwrap();
+        assert_eq!(result.fail_count, 0);
+        assert_eq!(skill.frontmatter.fail_count, 0);
+    }
+
+    #[test]
+    fn evaluate_three_failures_triggers_anti_flap() {
+        let mut skill = make_skill(0.8);
+        let cfg = EmaConfig::default();
+        evaluate(&mut skill, &failure_signals(), &cfg).unwrap();
+        let r2 = evaluate(&mut skill, &failure_signals(), &cfg).unwrap();
+        assert!(!r2.deprecated);
+        let r3 = evaluate(&mut skill, &failure_signals(), &cfg).unwrap();
+        assert!(r3.deprecated);
+        assert!(skill.frontmatter.deprecated);
+        assert!(matches!(r3.outcome, EvalOutcome::Deprecated { .. }));
+    }
+
+    #[test]
+    fn evaluate_low_score_triggers_deprecation() {
+        let mut skill = make_skill(0.0);
+        let result = evaluate(&mut skill, &failure_signals(), &EmaConfig::default()).unwrap();
+        assert!(result.deprecated);
+        assert!(skill.frontmatter.deprecated);
+    }
+
+    #[test]
+    fn evaluate_score_above_threshold_not_deprecated() {
+        let mut skill = make_skill(0.6);
+        let result = evaluate(&mut skill, &success_signals(), &EmaConfig::default()).unwrap();
+        assert!(!result.deprecated);
+        assert_eq!(result.outcome, EvalOutcome::Pass);
+    }
+
+    #[test]
+    fn evaluate_mutates_skill_score_in_place() {
+        let mut skill = make_skill(0.5);
+        evaluate(&mut skill, &success_signals(), &EmaConfig::default()).unwrap();
+        assert!(skill.frontmatter.score > 0.5);
+    }
+
+    #[test]
+    fn from_exit_code_zero_not_error() {
+        let s = EvalSignals::from_exit_code(0);
+        assert!(!s.log_has_errors);
+    }
+
+    #[test]
+    fn from_exit_code_nonzero_sets_error() {
+        let s = EvalSignals::from_exit_code(1);
+        assert!(s.log_has_errors);
+    }
+
+    #[test]
+    fn failure_reason_includes_all_signals() {
+        let s = EvalSignals {
+            exit_code: 2,
+            tests_passed: 0,
+            tests_failed: 3,
+            lines_changed: 0,
+            files_changed: 0,
+            log_has_errors: false,
+            log_has_panics: true,
+            latency_ms: None,
+        };
+        let reason = failure_reason(&s);
+        assert!(reason.contains("exit_code=2"));
+        assert!(reason.contains("panic"));
+        assert!(reason.contains("3 test(s) failed"));
+    }
 }

--- a/plans/0149-gar-647-skill-evaluator.md
+++ b/plans/0149-gar-647-skill-evaluator.md
@@ -1,0 +1,143 @@
+# Plan 0149 — GAR-647: Skill Evaluator — objective metrics + EMA score update
+
+**Status:** 🚧 In Progress (2026-05-18)
+**Issue:** [GAR-647](https://linear.app/chatgpt25/issue/GAR-647) (sub-issue 5/10 of [GAR-641](https://linear.app/chatgpt25/issue/GAR-641))
+**Branch:** `feat/202605181616-gar-647-skill-evaluator`
+**Epic parent:** Fase 1.4 — Garra Learning Agent (`epic:learning-agent`)
+
+---
+
+## Goal
+
+Implement `garraia-learning::evaluator` — the Skill Evaluator component (5/10 of the
+Learning Agent epic). Replaces the 2-line stub with a full evaluation pipeline.
+
+Takes objective signals from skill execution (exit code, test counts, diff stats,
+log scan) and updates the skill's EMA score. Triggers deprecation when the score
+drops below threshold or when anti-flap fires.
+
+---
+
+## Architecture
+
+```text
+crates/garraia-learning/src/evaluator.rs   (replace stub)
+  EvalSignals struct                       exit_code, tests_passed/failed,
+                                           lines/files_changed, log_has_errors,
+                                           log_has_panics, latency_ms
+  EvalOutcome enum                         Pass | Fail { reason } | Deprecated { reason }
+  EvalResult struct                        new_score, fail_count, deprecated, outcome
+  EmaConfig struct                         alpha (0.3), deprecate_threshold (0.3),
+                                           anti_flap_threshold (3)
+  pub fn evaluate(skill, signals, config)  main entry point — mutates skill, returns EvalResult
+  fn compute_raw_score(signals)            0.0..=1.0 weighted rubric
+  fn update_ema(current, raw, alpha)       α·raw + (1-α)·current
+  fn is_failure(signals)                   exit != 0 || panics || tests_failed > 0
+```
+
+Scoring rubric (weights sum to 1.0):
+- exit_code == 0: +0.40
+- tests_failed == 0 && tests_passed > 0: +0.30 (else +0.10 if no tests)
+- !log_has_errors && !log_has_panics: +0.20
+- files_changed > 0: +0.10
+
+---
+
+## Tech stack
+
+- Rust edition 2024 (existing crate)
+- `garraia_common::Error`/`Result` — error propagation
+- `Skill::ANTI_FLAP_THRESHOLD` — reused constant (3)
+- `Skill::MIN_PROMOTE_SCORE` — reused constant (0.5)
+
+No Cargo.toml changes.
+
+---
+
+## Design invariants
+
+- **No `unwrap()` in production paths.**
+- **`fail_count` resets to 0 on success** (anti-flap: only consecutive failures count).
+- **`deprecated` flag set but file not deleted** — preserves history; Registry handles persistence.
+- **Skill mutation is atomic within the call** — both `score` and `fail_count` update together.
+- **EMA alpha = 0.3 default** — recent signals have 30% weight; avoids over-reacting to noise.
+- **Deprecation threshold = 0.3** — skills below 30% quality are retired.
+
+---
+
+## Validações pré-plano
+
+- [x] `garraia-learning` crate exists with stub `evaluator.rs`.
+- [x] `LearningSkillFrontmatter.score`, `.fail_count`, `.deprecated` all `pub`.
+- [x] `Skill::ANTI_FLAP_THRESHOLD = 3` and `Skill::MIN_PROMOTE_SCORE = 0.5` in `lib.rs`.
+- [x] No external crate deps needed.
+- [x] `cargo check -p garraia-learning` green.
+
+---
+
+## Out of scope
+
+- Actual CI check polling via `gh` API (deferred to Auto-Updater GAR-648).
+- Writing evaluation results to disk / registry (caller's responsibility).
+- Score history file `.garra/skills/_history/<name>.json` (GAR-650 Versioning).
+- Web UI display (GAR-651).
+
+---
+
+## M1 Tasks
+
+### T1 — Define EvalSignals + EvalOutcome + EvalResult + EmaConfig
+
+- [ ] All structs/enums defined and `pub`.
+- [ ] `EmaConfig::default()` with alpha=0.3, deprecate_threshold=0.3, anti_flap=3.
+- [ ] `cargo check -p garraia-learning` green.
+
+### T2 — Implement compute_raw_score + update_ema (RED → GREEN)
+
+- [ ] Tests: exit_code=0, all tests pass, no errors → score ~1.0.
+- [ ] Tests: exit_code=1 → score ~0.0.
+- [ ] Implement helpers.
+
+### T3 — Implement evaluate (RED → GREEN)
+
+- [ ] Test: success → score increases, fail_count=0.
+- [ ] Test: failure → score decreases, fail_count increments.
+- [ ] Test: 3 consecutive failures → deprecated=true.
+- [ ] Test: score < 0.3 after EMA → deprecated=true.
+- [ ] Test: success after failure resets fail_count.
+- [ ] Implement `pub fn evaluate`.
+- [ ] `cargo test -p garraia-learning evaluator` green.
+
+### T4 — clippy + workspace check
+
+- [ ] `cargo clippy --workspace … -D warnings` clean.
+
+### T5 — Update plans/README.md
+
+- [ ] Add row 0149.
+
+---
+
+## Acceptance criteria
+
+- [ ] `cargo test -p garraia-learning -- evaluator` — all evaluator tests pass.
+- [ ] Success signals → score EMA-updated upward, fail_count reset to 0.
+- [ ] 3 consecutive failures → `EvalResult.deprecated = true`, skill.frontmatter.deprecated = true.
+- [ ] Score below 0.3 → deprecated.
+- [ ] `cargo clippy … -D warnings` clean.
+- [ ] CI green.
+
+---
+
+## Cross-references
+
+- Plan 0148 (GAR-645, Skill Registry) — `promote`/`deprecate` consume EvalResult.
+- Plan 0144 (GAR-642, scaffold) — `Skill` types + constants.
+- GAR-641 (epic) — 5/10 of the Learning Agent.
+- ADR 0010 — Accepted learning architecture.
+
+---
+
+## Estimativa
+
+0.5 / 1 / 1.5 days. ~180 LOC production, ~120 LOC tests.

--- a/plans/README.md
+++ b/plans/README.md
@@ -157,3 +157,4 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0146 | [GAR-643 — Skill Miner: detect repeatable patterns in session logs](0146-gar-643-skill-miner.md) | [GAR-643](https://linear.app/chatgpt25/issue/GAR-643) | ✅ Merged 2026-05-18 via PR #400 (`3bb473a`) |
 | 0147 | [GAR-644 — Skill Generator: LLM-assisted skill drafting](0147-gar-644-skill-generator.md) | [GAR-644](https://linear.app/chatgpt25/issue/GAR-644) | ✅ Merged 2026-05-18 via PR #402 (`da65c63`) |
 | 0148 | [GAR-645 — Skill Registry: dual-scope persist, list, promote, deprecate](0148-gar-645-skill-registry.md) | [GAR-645](https://linear.app/chatgpt25/issue/GAR-645) | ✅ Merged 2026-05-18 via PR #404 (`b67d030`) |
+| 0149 | [GAR-647 — Skill Evaluator: objective metrics + EMA score update](0149-gar-647-skill-evaluator.md) | [GAR-647](https://linear.app/chatgpt25/issue/GAR-647) | 🚧 In Progress (2026-05-18) |


### PR DESCRIPTION
## Summary

- Replaces the 2-line stub `evaluator.rs` with a full evaluation pipeline (~260 LOC production + 17 unit tests).
- Closes the Mine → Generate → Registry → **Evaluate** loop (sub-issue 5/10 of GAR-641).
- Note: GAR-646 (Skill Retriever) is blocked on Fase 2.1 embeddings — skipping for now.

## Changes

**`crates/garraia-learning/src/evaluator.rs`** (full replacement)
- `EvalSignals` — exit_code, tests_passed/failed, lines/files_changed, log_has_errors, log_has_panics, latency_ms; `from_exit_code()` convenience constructor
- `EvalOutcome` — `Pass | Fail { reason } | Deprecated { reason }`
- `EvalResult` — new_score, fail_count, deprecated, outcome
- `EmaConfig` — alpha=0.3, deprecate_threshold=0.3, anti_flap_threshold=3 (from `Skill::ANTI_FLAP_THRESHOLD`)
- `evaluate(skill, signals, config)` — computes raw score, applies EMA, resets/increments fail_count, sets deprecated flag

**Scoring rubric** (weights sum to 1.0):
| Signal | Weight |
|--------|--------|
| exit_code == 0 | +0.40 |
| all tests pass (tests_passed > 0) | +0.30 |
| no tests ran (neutral) | +0.10 |
| no log errors/panics | +0.20 |
| files_changed > 0 | +0.10 |

**EMA**: `new_score = 0.3 × raw + 0.7 × current_score`

**Deprecation triggers**:
- new_score < 0.3 (score threshold)
- OR fail_count ≥ 3 (anti-flap: consecutive failures)

## Test plan

- [x] `cargo test -p garraia-learning` — **93/93 passed** (17 new evaluator tests)
- [x] `cargo clippy --workspace … -D warnings` — clean
- [x] `cargo fmt --package garraia-learning` — no drift
- [ ] CI Format + Clippy + Test green

## Test coverage (new 17 tests)

`raw_score_full_success`, `raw_score_full_failure`, `raw_score_no_tests_partial`,
`raw_score_panic_in_log_loses_log_bonus`, `ema_from_zero_with_perfect_score`,
`ema_stable_at_one`, `ema_clamps_to_valid_range`, `evaluate_success_increases_score`,
`evaluate_failure_increments_fail_count`, `evaluate_success_resets_fail_count`,
`evaluate_three_failures_triggers_anti_flap`, `evaluate_low_score_triggers_deprecation`,
`evaluate_score_above_threshold_not_deprecated`, `evaluate_mutates_skill_score_in_place`,
`from_exit_code_zero_not_error`, `from_exit_code_nonzero_sets_error`,
`failure_reason_includes_all_signals`

## Cross-references

- Plan 0149 (`plans/0149-gar-647-skill-evaluator.md`)
- Follows plan 0148 (GAR-645 Skill Registry, merged PR #404)
- GAR-641 (epic parent) — 5/10 of the Learning Agent
- ADR 0010 — Accepted learning architecture

https://claude.ai/code/session_012G4CrL4Ku8PkhJiU3WiNzK

---
_Generated by [Claude Code](https://claude.ai/code/session_012G4CrL4Ku8PkhJiU3WiNzK)_