### PR TITLE
feat(learning): GAR-649 implement Skill Safety Gates — hard wall

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1245,6 +1245,8 @@ Quando retomar execução, priorizar **nesta ordem**:
 
 1. ~~**Garra Learning Agent — Skill Auto-Updater ([GAR-648](https://linear.app/chatgpt25/issue/GAR-648), 7/10)**~~ ✅ **Done** (2026-05-18, plan 0150, PR #409 `0000c883`). `ShellRunner` trait + `propose_update_with_runner` + `auto_merge_guard()` + idempotência + 24 unit tests. _(GAR-646 Skill Retriever bloqueado por Fase 2.1 embeddings — skip para depois.)_
 
+1. ~~**Garra Learning Agent — Skill Safety Gates ([GAR-649](https://linear.app/chatgpt25/issue/GAR-649), 8/10)**~~ ✅ **Done** (2026-05-18). `SafetyIntent` + `gate_with_intent` (hard wall, ADR 0010 §"no dev-mode bypass") wirado em `registry::promote_with_intent` e `updater::propose_update_with_runner` ANTES de qualquer side-effect git/gh; denylist amplia para `DELETE..WHERE 1=1` / `chmod -R 777` / `sudo` / `.github/codeql-config.yml`; label `security-audit-passed` waiver ÚNICA para `CriticalPath` (não waive dangerous-command/score/PII/anti-flap); 132 unit tests verdes (11 novos cobrindo waiver semantics + call-sites).
+
 2. **Fase 1.2.1 GarraMaxPower — sub-issues abertas (`GAR-494..GAR-501`)** — 8 sub-issues do épico [GAR-492](https://linear.app/chatgpt25/issue/GAR-492) ainda Backlog. Cresce em paralelo ao Learning Agent porque **compartilham o Safety Gate** (`garraia-tools::safety_gate`) e o crate `garraia-learning` reusa primitivas estabelecidas pelo GarraMaxPower (capability prompt, agent team, `.garra-estado.md`).
 
 3. **Fase 2.1 RAG / embeddings (`GAR-372`)** — pré-requisito direto do Skill Retriever do Learning Agent (componente 4/10). Sem `garraia-embeddings`, o Retriever roda em fallback degradado (match por tag/scope). MVP do Learning Agent pode coexistir, mas Retriever full só com Fase 2.1 pronta.

--- a/crates/garraia-learning/src/registry.rs
+++ b/crates/garraia-learning/src/registry.rs
@@ -1,3 +1,4 @@
+use crate::safety::{self, SafetyIntent};
 use crate::{LearningSkillFrontmatter, Skill, SkillScope, SkillSource};
 use garraia_common::{Error, Result};
 use std::fs;
@@ -212,11 +213,41 @@ pub fn get_skill(
     Ok(skills.into_iter().find(|s| s.frontmatter.name == name))
 }
 
-/// Writes a skill to the appropriate scope directory, acquiring a lock-file
-/// first to prevent concurrent corruption.
+/// Writes a skill to the appropriate scope directory after passing the
+/// hard-wall Safety Gate. Acquires a lock-file first to prevent concurrent
+/// corruption.
+///
+/// GAR-649: every promotion path must traverse `safety::gate_with_intent`.
+/// Use [`promote_with_intent`] to provide approval labels (e.g.
+/// `security-audit-passed`); this entrypoint applies the default intent.
 ///
 /// Returns the path where the skill was written.
 pub fn promote(skill: &Skill, opts: &RegistryOptions) -> Result<PathBuf> {
+    promote_with_intent(skill, opts, &SafetyIntent::default())
+}
+
+/// Like [`promote`] but lets callers attach `SafetyIntent::labels` — in
+/// particular `security-audit-passed` to waive the `CriticalPath` denial.
+///
+/// All other Safety Gate categories (dangerous commands, score threshold,
+/// anti-flap, PII) remain hard walls regardless of labels.
+pub fn promote_with_intent(
+    skill: &Skill,
+    opts: &RegistryOptions,
+    intent: &SafetyIntent,
+) -> Result<PathBuf> {
+    safety::gate_with_intent(skill, intent).map_err(|denial| {
+        tracing::warn!(
+            skill = %skill.frontmatter.name,
+            denial = %denial,
+            "skill.safety_denial during promote"
+        );
+        Error::Other(format!(
+            "safety denial for skill '{}': {denial}",
+            skill.frontmatter.name
+        ))
+    })?;
+
     let dir = scope_dir(opts, &skill.frontmatter.scope);
     let locks_dir = dir.join("_locks");
     let _lock = acquire_lock(&locks_dir, &skill.frontmatter.name)?;
@@ -302,7 +333,9 @@ mod tests {
                 version: "0.1.0".to_string(),
                 source: SkillSource::Mined,
                 scope,
-                score: 0.0,
+                // Above MIN_PROMOTE_SCORE so the post-GAR-649 safety gate
+                // does not refuse fixture-based promotions.
+                score: 0.8,
                 locked: false,
                 critical_paths_touched: vec![],
                 fail_count: 0,
@@ -334,7 +367,7 @@ mod tests {
 
         assert_eq!(loaded.frontmatter.name, "test-skill");
         assert_eq!(loaded.frontmatter.version, "0.1.0");
-        assert_eq!(loaded.frontmatter.score, 0.0);
+        assert_eq!(loaded.frontmatter.score, 0.8);
         assert!(!loaded.frontmatter.deprecated);
         assert!(loaded.body.contains("Do the thing."));
     }
@@ -555,5 +588,53 @@ mod tests {
 
         let result = list_candidates(tmp.path()).unwrap();
         assert!(result.is_empty());
+    }
+
+    // ── GAR-649 RED tests: promote MUST call safety::gate first ──────────
+
+    #[test]
+    fn promote_denied_when_skill_body_has_dangerous_command() {
+        let tmp = TempDir::new().unwrap();
+        let opts = opts_in(&tmp);
+
+        let skill = make_skill("evil-skill", SkillScope::Project, "## Cleanup\nrm -rf /\n");
+        let err = promote(&skill, &opts).unwrap_err();
+        assert!(
+            err.to_string().contains("safety"),
+            "promote should refuse and mention safety; got: {err}"
+        );
+        // And nothing must have been written.
+        assert!(!opts.project_dir.join("evil-skill.md").exists());
+    }
+
+    #[test]
+    fn promote_denied_when_skill_touches_critical_path_without_label() {
+        let tmp = TempDir::new().unwrap();
+        let opts = opts_in(&tmp);
+
+        let mut skill = make_skill("auth-skill", SkillScope::Project, "Innocent body");
+        skill.frontmatter.critical_paths_touched =
+            vec!["crates/garraia-auth/src/lib.rs".to_string()];
+        skill.frontmatter.score = 0.9;
+        let err = promote(&skill, &opts).unwrap_err();
+        assert!(err.to_string().contains("safety"));
+        assert!(!opts.project_dir.join("auth-skill.md").exists());
+    }
+
+    #[test]
+    fn promote_with_intent_allows_critical_path_when_audit_label_present() {
+        let tmp = TempDir::new().unwrap();
+        let opts = opts_in(&tmp);
+
+        let mut skill = make_skill("audited-skill", SkillScope::Project, "Reviewed");
+        skill.frontmatter.critical_paths_touched =
+            vec!["crates/garraia-auth/src/lib.rs".to_string()];
+        skill.frontmatter.score = 0.9;
+
+        let intent = crate::safety::SafetyIntent {
+            labels: vec!["security-audit-passed".to_string()],
+        };
+        let path = promote_with_intent(&skill, &opts, &intent).unwrap();
+        assert!(path.exists());
     }
 }

--- a/crates/garraia-learning/src/safety.rs
+++ b/crates/garraia-learning/src/safety.rs
@@ -23,6 +23,7 @@ pub enum SafetyDenial {
 /// Patterns that are never allowed in a skill body, regardless of context.
 ///
 /// Checked case-insensitively against the full body text.
+/// Hard wall: no `SafetyIntent` label can waive these.
 const DANGEROUS_PATTERNS: &[&str] = &[
     "rm -rf /",
     "rm -rf ~",
@@ -33,6 +34,7 @@ const DANGEROUS_PATTERNS: &[&str] = &[
     "truncate table",
     "drop table",
     "drop database",
+    "where 1=1",
     "git push --force origin main",
     "git push --force-with-lease origin main",
     "git push -f origin main",
@@ -41,8 +43,9 @@ const DANGEROUS_PATTERNS: &[&str] = &[
     "mkfs.",
     "dd if=/dev/zero",
     "dd if=/dev/urandom",
-    "chmod -r 777 /",
-    "chmod 777 /",
+    "chmod 777 ",
+    "chmod -r 777 ",
+    "sudo ",
 ];
 
 /// Paths that require explicit `security-audit-passed` label before promotion.
@@ -54,10 +57,39 @@ const CRITICAL_PATHS: &[&str] = &[
     "crates/garraia-security/",
     "crates/garraia-workspace/migrations/",
     ".github/workflows/",
+    ".github/codeql-config.yml",
     "deny.toml",
     ".gitleaksignore",
     "Cargo.lock",
 ];
+
+/// Caller-provided context for a safety-gate evaluation.
+///
+/// Labels represent explicit human approval signals (e.g. PR labels). The
+/// `security-audit-passed` label is the **only** mechanism that may waive a
+/// `CriticalPath` denial; it does NOT waive `DangerousCommand`, `ScoreTooLow`,
+/// `AntiFlapDeprecated`, or `PiiDetected` — those remain hard walls.
+#[derive(Debug, Default, Clone)]
+pub struct SafetyIntent {
+    pub labels: Vec<String>,
+}
+
+impl SafetyIntent {
+    /// Label that signals an explicit @security-auditor review passed.
+    pub const SECURITY_AUDIT_PASSED: &'static str = "security-audit-passed";
+
+    pub fn has_security_audit_passed(&self) -> bool {
+        self.labels.iter().any(|l| l == Self::SECURITY_AUDIT_PASSED)
+    }
+}
+
+/// Hard-wall Safety Gate (default intent — no label waivers).
+///
+/// Equivalent to [`gate_with_intent`] called with `SafetyIntent::default()`.
+/// Use when no caller-side approval labels apply (e.g. miner self-test).
+pub fn gate(skill: &Skill) -> Result<(), SafetyDenial> {
+    gate_with_intent(skill, &SafetyIntent::default())
+}
 
 /// Hard-wall Safety Gate.
 ///
@@ -65,15 +97,21 @@ const CRITICAL_PATHS: &[&str] = &[
 /// when all checks pass. The first failing check short-circuits — callers must
 /// fix all issues to eventually promote.
 ///
+/// `intent.labels` may contain `security-audit-passed` to waive the
+/// `CriticalPath` check (and only that one). All other checks remain hard
+/// walls regardless of labels (ADR 0010 §"no dev-mode bypass").
+///
 /// Checks (in order):
 /// 1. Dangerous commands in body text.
-/// 2. Critical paths in `critical_paths_touched`.
+/// 2. Critical paths in `critical_paths_touched` (waivable by audit label).
 /// 3. Score below minimum threshold.
 /// 4. Anti-flap: consecutive failure count.
 /// 5. PII patterns in body text.
-pub fn gate(skill: &Skill) -> Result<(), SafetyDenial> {
+pub fn gate_with_intent(skill: &Skill, intent: &SafetyIntent) -> Result<(), SafetyDenial> {
     check_dangerous_commands(skill)?;
-    check_critical_paths(skill)?;
+    if !intent.has_security_audit_passed() {
+        check_critical_paths(skill)?;
+    }
     check_score(skill)?;
     check_anti_flap(skill)?;
     check_pii(skill)?;
@@ -337,5 +375,119 @@ mod tests {
         let err = gate(&skill).unwrap_err();
         // DangerousCommand should fire first
         assert!(matches!(err, SafetyDenial::DangerousCommand(_)));
+    }
+
+    // ── GAR-649 RED tests: new denylist patterns ─────────────────────────
+
+    #[test]
+    fn delete_from_where_1_eq_1_blocked() {
+        let skill = make_skill("DELETE FROM users WHERE 1=1;");
+        let err = gate(&skill).unwrap_err();
+        assert!(matches!(err, SafetyDenial::DangerousCommand(_)));
+    }
+
+    #[test]
+    fn chmod_dash_r_777_any_path_blocked() {
+        let skill = make_skill("chmod -R 777 /var/data");
+        let err = gate(&skill).unwrap_err();
+        assert!(matches!(err, SafetyDenial::DangerousCommand(_)));
+    }
+
+    #[test]
+    fn chmod_777_any_path_blocked() {
+        let skill = make_skill("chmod 777 ~/.ssh");
+        let err = gate(&skill).unwrap_err();
+        assert!(matches!(err, SafetyDenial::DangerousCommand(_)));
+    }
+
+    #[test]
+    fn sudo_blocked() {
+        let skill = make_skill("Run: sudo rm package.deb");
+        let err = gate(&skill).unwrap_err();
+        assert!(matches!(err, SafetyDenial::DangerousCommand(_)));
+    }
+
+    #[test]
+    fn codeql_config_critical_path_blocked() {
+        let mut skill = make_skill("Tweaks CodeQL");
+        skill.frontmatter.critical_paths_touched = vec![".github/codeql-config.yml".to_string()];
+        let err = gate(&skill).unwrap_err();
+        assert!(matches!(err, SafetyDenial::CriticalPath(_)));
+    }
+
+    // ── GAR-649 RED tests: SafetyIntent waiver semantics ─────────────────
+
+    #[test]
+    fn intent_default_blocks_critical_path() {
+        let mut skill = make_skill("Modifies auth");
+        skill.frontmatter.critical_paths_touched =
+            vec!["crates/garraia-auth/src/lib.rs".to_string()];
+        let intent = SafetyIntent::default();
+        let err = gate_with_intent(&skill, &intent).unwrap_err();
+        assert!(matches!(err, SafetyDenial::CriticalPath(_)));
+    }
+
+    #[test]
+    fn intent_security_audit_label_waives_critical_path() {
+        let mut skill = make_skill("Modifies auth, reviewed by @security-auditor");
+        skill.frontmatter.critical_paths_touched =
+            vec!["crates/garraia-auth/src/lib.rs".to_string()];
+        let intent = SafetyIntent {
+            labels: vec!["security-audit-passed".to_string()],
+        };
+        // Label waives ONLY CriticalPath — rest of gate still runs
+        assert!(gate_with_intent(&skill, &intent).is_ok());
+    }
+
+    #[test]
+    fn intent_label_does_not_waive_dangerous_command() {
+        let mut skill = make_skill("rm -rf /");
+        skill.frontmatter.critical_paths_touched =
+            vec!["crates/garraia-auth/src/lib.rs".to_string()];
+        let intent = SafetyIntent {
+            labels: vec!["security-audit-passed".to_string()],
+        };
+        let err = gate_with_intent(&skill, &intent).unwrap_err();
+        // Hard wall: dangerous command short-circuits before critical-path check.
+        assert!(matches!(err, SafetyDenial::DangerousCommand(_)));
+    }
+
+    #[test]
+    fn intent_label_does_not_waive_score_threshold() {
+        let mut skill = make_skill("Good content reviewed by security.");
+        skill.frontmatter.critical_paths_touched =
+            vec!["crates/garraia-auth/src/lib.rs".to_string()];
+        skill.frontmatter.score = 0.3;
+        let intent = SafetyIntent {
+            labels: vec!["security-audit-passed".to_string()],
+        };
+        let err = gate_with_intent(&skill, &intent).unwrap_err();
+        assert!(matches!(err, SafetyDenial::ScoreTooLow { .. }));
+    }
+
+    #[test]
+    fn intent_label_does_not_waive_pii() {
+        let mut skill = make_skill("Contact user@example.com (reviewed by security).");
+        skill.frontmatter.critical_paths_touched =
+            vec!["crates/garraia-auth/src/lib.rs".to_string()];
+        let intent = SafetyIntent {
+            labels: vec!["security-audit-passed".to_string()],
+        };
+        let err = gate_with_intent(&skill, &intent).unwrap_err();
+        assert!(matches!(err, SafetyDenial::PiiDetected(_)));
+    }
+
+    #[test]
+    fn intent_dev_mode_label_does_not_waive_critical_path() {
+        // Per ADR 0010: no "dev mode" bypass. Only the explicit
+        // security-audit-passed label waives CriticalPath.
+        let mut skill = make_skill("Modifies auth");
+        skill.frontmatter.critical_paths_touched =
+            vec!["crates/garraia-auth/src/lib.rs".to_string()];
+        let intent = SafetyIntent {
+            labels: vec!["dev-mode".to_string(), "skip-safety".to_string()],
+        };
+        let err = gate_with_intent(&skill, &intent).unwrap_err();
+        assert!(matches!(err, SafetyDenial::CriticalPath(_)));
     }
 }

--- a/crates/garraia-learning/src/updater.rs
+++ b/crates/garraia-learning/src/updater.rs
@@ -1,4 +1,5 @@
 use crate::Skill;
+use crate::safety::{self, SafetyIntent};
 use garraia_common::{Error, Result};
 use std::path::{Path, PathBuf};
 
@@ -316,6 +317,26 @@ pub fn propose_update_with_runner(
             skill.frontmatter.name
         )));
     }
+
+    // GAR-649 hard wall: run Safety Gate against the *proposed* skill body
+    // BEFORE any git/gh side-effect. A denial must short-circuit with no
+    // branch, no commit, no PR — proving auto-update cannot smuggle in a
+    // dangerous command, critical-path edit, or PII leak.
+    let proposed = Skill {
+        body: evidence.new_body.clone(),
+        ..skill.clone()
+    };
+    safety::gate_with_intent(&proposed, &SafetyIntent::default()).map_err(|denial| {
+        tracing::warn!(
+            skill = %skill.frontmatter.name,
+            denial = %denial,
+            "skill.safety_denial during propose_update"
+        );
+        Error::Other(format!(
+            "safety denial for skill '{}': {denial}",
+            skill.frontmatter.name
+        ))
+    })?;
 
     let source_path = skill.source_path.as_ref().ok_or_else(|| {
         Error::Other("skill has no source_path: cannot commit update to disk".into())
@@ -754,6 +775,37 @@ mod tests {
         let updated = std::fs::read_to_string(&skill_path).unwrap();
         assert!(updated.contains("version: 1.1.0"));
         assert!(updated.contains("Updated body"));
+    }
+
+    // ── GAR-649 RED test: updater MUST call safety::gate first ──────────
+
+    #[test]
+    fn test_propose_update_denied_when_new_body_has_dangerous_command() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tmp_path = tmp.path().to_path_buf();
+        std::fs::create_dir(tmp_path.join(".git")).unwrap();
+
+        let skill_path = tmp_path.join("skill.md");
+        std::fs::write(
+            &skill_path,
+            "---\nname: my-skill\nversion: 1.0.0\n---\n\n## Old body",
+        )
+        .unwrap();
+
+        let skill = make_skill("my-skill", "1.0.0", false, Some(skill_path));
+
+        // new_body contains a dangerous command — must be rejected by safety gate
+        let mut evidence = make_evidence("restructure steps");
+        evidence.new_body = "## Updated\nrm -rf /\n".to_string();
+
+        let runner = MockShellRunner::new(vec![], vec![]);
+        let err = propose_update_with_runner(&skill, evidence, &runner).unwrap_err();
+        assert!(
+            err.to_string().contains("safety"),
+            "expected safety denial, got: {err}"
+        );
+        // And no git/gh side-effects must have run.
+        assert_eq!(runner.git_call_count(), 0);
     }
 
     #[test]


### PR DESCRIPTION
Closes GAR-649. Componente 8/10 do épico [GAR-641](https://linear.app/chatgpt25/issue/GAR-641) (Garra Learning Agent).

> **Reabertura limpa** — PR original (#412) foi fechado automaticamente quando renomeei a branch para satisfazer regra hard standing de naming. Conteúdo idêntico, commit `8ca83a3` preservado.

## Por que

O scaffold de `safety.rs` (PR #393 / GAR-642) tinha `gate()` funcional + 17 unit tests, mas **NINGUÉM chamava o gate** — `registry::promote()` e `updater::propose_update_with_runner()` escreviam direto em disco / abriam PR sem checagem. Hard wall furado.

Esta PR fecha o gap empiricamente identificado, sem recriar o scaffold.

## Gaps fechados

| Entregável GAR-649 | Antes | Depois | Evidência (teste) |
|---|---|---|---|
| `gate` chamado antes de promote | ❌ MISSING | ✅ `registry::promote_with_intent` chama `safety::gate_with_intent` | `promote_denied_when_skill_body_has_dangerous_command` |
| `gate` chamado antes de auto-update PR | ❌ MISSING | ✅ `updater::propose_update_with_runner` chama gate antes de qualquer git/gh side-effect | `test_propose_update_denied_when_new_body_has_dangerous_command` |
| `SafetyIntent { labels }` + waiver `security-audit-passed` | ❌ MISSING | ✅ Único label que waive `CriticalPath` | `intent_security_audit_label_waives_critical_path` |
| Waiver NÃO bypassa dangerous/score/PII | n/a | ✅ Hard wall mantido | `intent_label_does_not_waive_{dangerous_command,score_threshold,pii}` |
| Denylist `DELETE..WHERE 1=1` | ❌ MISSING | ✅ Pattern `where 1=1` | `delete_from_where_1_eq_1_blocked` |
| Denylist `chmod -R 777` (qualquer path) | ❌ só `chmod -r 777 /` | ✅ Pattern `chmod -r 777 ` | `chmod_dash_r_777_any_path_blocked` |
| Denylist `chmod 777` (qualquer path) | ❌ só `chmod 777 /` | ✅ Pattern `chmod 777 ` | `chmod_777_any_path_blocked` |
| Denylist `sudo` em paths críticos | ❌ MISSING | ✅ Pattern `sudo ` (hard wall total) | `sudo_blocked` |
| `.github/codeql-config.yml` em CRITICAL_PATHS | ❌ MISSING | ✅ Adicionado | `codeql_config_critical_path_blocked` |
| Dev-mode bypass | ❌ N/A | ✅ Provado impossível | `intent_dev_mode_label_does_not_waive_critical_path` |

## Critérios de aceite (GAR-649)

- [x] Skill `rm -rf /` → `Err(SafetyDenial::DangerousCommand)` determinístico.
- [x] Skill alterando `crates/garraia-auth/src/lib.rs` sem label `security-audit-passed` → `Err(SafetyDenial::CriticalPath)`.
- [x] Skill score 0.4 → `Err(SafetyDenial::ScoreTooLow)`.
- [x] Skill com 3+ falhas → `Err(SafetyDenial::AntiFlapDeprecated)`.
- [x] Skill com email/path/token no body → `Err(SafetyDenial::PiiDetected)`.
- [x] `cargo test -p garraia-learning safety` cobre cada categoria de denial.
- [ ] Reviewer `@security-auditor` obrigatório — **solicitar revisão manualmente**.

## Out-of-scope (deferido)

- **Audit logs em `audit_events`** (Postgres `workspace.audit_events`): por ora denials via `tracing::warn!` estruturado com `skill.safety_denial`. Wiring fica para sub-issue futura.
- **Reuse de `garraia-tools::safety_gate` (GAR-497)**: consolidação fica para quando GAR-497 aterrissar.

## Test plan

- [x] `cargo test -p garraia-learning` — 132/132 passando (11 novos)
- [x] `cargo clippy -p garraia-learning --all-targets -- -D warnings` — limpo
- [x] `cargo fmt -p garraia-learning -- --check` — limpo
- [ ] CI verde em todos os checks obrigatórios
- [ ] @security-auditor review (per acceptance criteria)

## Guard-rails respeitados

- TDD strict: 11 RED tests antes da implementação, então GREEN, zero refactor cosmético.
- Sem auto-merge (mandatório do épico GAR-641 — humano aprova).
- Sem `--no-verify`, sem `--force`, sem amend.
- Conventional Commits PT-BR ≤72 chars no assunto.
- Não tocou crates/garraia-auth, garraia-security, .github/workflows, ou path RLS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)