### PR TITLE
feat(cli): add garra verify pipeline subcommand (GAR-501)

### DIFF
--- a/crates/garraia-cli/src/main.rs
+++ b/crates/garraia-cli/src/main.rs
@@ -8,6 +8,7 @@ mod mcp_server;
 mod migrate;
 mod migrate_workspace;
 mod update;
+mod verify;
 mod wizard;
 
 use std::path::PathBuf;
@@ -233,6 +234,32 @@ enum Commands {
         /// checkpoint), `auto` (detect from project state).
         #[arg(long, short = 'm', default_value = "auto", value_parser = ["new", "existing", "auto"])]
         mode: String,
+    },
+
+    /// Run the local validation pipeline: fmt check, clippy, test, flutter
+    /// analyze, gitleaks detect (GAR-501).
+    ///
+    /// Exit codes (sysexits): 0 all pass, 2 step failed.
+    /// Steps `flutter` and `gitleaks` are auto-skipped when the tool is absent.
+    Verify {
+        /// Emit JSON report instead of human-readable output.
+        #[arg(long)]
+        json: bool,
+
+        /// Skip named step(s). Repeatable: --skip fmt --skip test.
+        /// Valid names: fmt, clippy, test, flutter, gitleaks.
+        #[arg(long, value_name = "STEP")]
+        skip: Vec<String>,
+
+        /// Treat any step failure as a hard error (reserved; currently a no-op
+        /// since all failures already return exit 2).
+        #[arg(long)]
+        strict: bool,
+
+        /// Workspace root to run steps from.
+        /// Defaults to the current working directory.
+        #[arg(long, value_name = "DIR")]
+        workspace: Option<std::path::PathBuf>,
     },
 }
 
@@ -638,6 +665,25 @@ fn main() -> Result<()> {
     } = cli.command
     {
         let code = config_cmd::run_config_check(json, strict)?;
+        if code != 0 {
+            std::process::exit(code);
+        }
+        return Ok(());
+    }
+
+    // GAR-501 / plan 0155 — `garra verify` does not need the gateway config;
+    // intercept early so the pipeline can run even without a `.garraia/` dir.
+    if let Commands::Verify {
+        json,
+        skip,
+        workspace,
+        ..
+    } = cli.command
+    {
+        let root = workspace.unwrap_or_else(|| {
+            std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."))
+        });
+        let code = verify::run(json, &skip, &root);
         if code != 0 {
             std::process::exit(code);
         }
@@ -1303,6 +1349,10 @@ async fn async_main(
         }
         Commands::MaxPower { goal, mode } => {
             max_power::run(goal, mode);
+        }
+        Commands::Verify { .. } => {
+            // Handled in main() before the async runtime starts.
+            unreachable!("Commands::Verify is intercepted in main() before async_main");
         }
     }
 

--- a/crates/garraia-cli/src/verify.rs
+++ b/crates/garraia-cli/src/verify.rs
@@ -1,0 +1,426 @@
+//! `garra verify` — local idempotent validation pipeline (GAR-501).
+//!
+//! Runs five steps in sequence: `cargo fmt --check`, `cargo clippy`,
+//! `cargo test`, `flutter analyze`, `gitleaks detect`.  Steps that require a
+//! tool that is not in `PATH` are skipped gracefully; steps that fail return
+//! exit code 2 (sysexits `EX_USAGE`).
+//!
+//! Exit codes:
+//!   0  — all non-skipped steps passed.
+//!   2  — at least one step failed.
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::Instant;
+
+use serde::Serialize;
+
+pub mod exit_codes {
+    pub const OK: i32 = 0;
+    pub const STEP_FAILED: i32 = 2;
+}
+
+/// Outcome of a single verification step.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum StepOutcome {
+    Pass,
+    Fail { exit_code: i32 },
+    Skipped { reason: String },
+}
+
+/// Result of one step, ready for human or JSON reporting.
+#[derive(Debug, Clone, Serialize)]
+pub struct StepResult {
+    pub name: String,
+    pub outcome: StepOutcome,
+    /// Wall-clock duration in milliseconds.  Zero for skipped steps.
+    pub duration_ms: u64,
+    /// Captured output (only populated in `--json` mode).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output: Option<String>,
+}
+
+impl StepResult {
+    fn failed(&self) -> bool {
+        matches!(self.outcome, StepOutcome::Fail { .. })
+    }
+}
+
+/// Top-level JSON report shape (documented in `docs/maxpower/verify-schema.json`).
+#[derive(Serialize)]
+struct Report<'a> {
+    ok: bool,
+    exit_code: i32,
+    steps: &'a [StepResult],
+}
+
+/// Entry point for `garra verify`.
+///
+/// Returns the exit code that `main` should pass to `std::process::exit`.
+pub fn run(json: bool, skip: &[String], workspace_root: &Path) -> i32 {
+    let results = run_steps(skip, workspace_root, json);
+
+    let any_failed = results.iter().any(|r| r.failed());
+    let exit_code = if any_failed {
+        exit_codes::STEP_FAILED
+    } else {
+        exit_codes::OK
+    };
+
+    if json {
+        print_json_report(&results, exit_code);
+    } else {
+        print_human_summary(&results, exit_code);
+    }
+
+    exit_code
+}
+
+/// Detect whether `tool` is available in `PATH` by attempting a no-op invocation.
+fn tool_available(tool: &str) -> bool {
+    Command::new(tool)
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok()
+}
+
+/// Build and run one step.  In capture mode (`json == true`) stdout+stderr are
+/// collected; otherwise they are inherited so the user sees live output.
+fn run_step(
+    name: &'static str,
+    program: &str,
+    args: &[&str],
+    cwd: &Path,
+    capture: bool,
+) -> StepResult {
+    let start = Instant::now();
+
+    let result = if capture {
+        Command::new(program)
+            .args(args)
+            .current_dir(cwd)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+    } else {
+        // Print a header line so the user knows which step is running.
+        println!();
+        println!("── {name} ──────────────────────────────────────────────────");
+        Command::new(program)
+            .args(args)
+            .current_dir(cwd)
+            .stdin(Stdio::null())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .output()
+    };
+
+    let duration_ms = start.elapsed().as_millis() as u64;
+
+    match result {
+        Ok(out) => {
+            let exit_code = out.status.code().unwrap_or(1);
+            let outcome = if out.status.success() {
+                StepOutcome::Pass
+            } else {
+                StepOutcome::Fail { exit_code }
+            };
+            let output = if capture {
+                let mut buf = String::from_utf8_lossy(&out.stdout).into_owned();
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                if !stderr.is_empty() {
+                    buf.push('\n');
+                    buf.push_str(&stderr);
+                }
+                Some(buf)
+            } else {
+                None
+            };
+            StepResult {
+                name: name.to_string(),
+                outcome,
+                duration_ms,
+                output,
+            }
+        }
+        Err(e) => {
+            // Could not spawn the process at all (e.g. binary not found after check).
+            StepResult {
+                name: name.to_string(),
+                outcome: StepOutcome::Fail { exit_code: 127 },
+                duration_ms,
+                output: Some(format!("spawn error: {e}")),
+            }
+        }
+    }
+}
+
+fn skipped(name: &'static str, reason: &str) -> StepResult {
+    StepResult {
+        name: name.to_string(),
+        outcome: StepOutcome::Skipped {
+            reason: reason.to_string(),
+        },
+        duration_ms: 0,
+        output: None,
+    }
+}
+
+fn run_steps(skip: &[String], workspace_root: &Path, capture: bool) -> Vec<StepResult> {
+    let mut results = Vec::new();
+
+    // ── Step 1: cargo fmt --check ──────────────────────────────────────────
+    if skip.iter().any(|s| s == "fmt") {
+        results.push(skipped("fmt", "skipped via --skip"));
+    } else {
+        results.push(run_step(
+            "fmt",
+            "cargo",
+            &["fmt", "--all", "--check"],
+            workspace_root,
+            capture,
+        ));
+    }
+
+    // ── Step 2: cargo clippy ───────────────────────────────────────────────
+    if skip.iter().any(|s| s == "clippy") {
+        results.push(skipped("clippy", "skipped via --skip"));
+    } else {
+        results.push(run_step(
+            "clippy",
+            "cargo",
+            &[
+                "clippy",
+                "--workspace",
+                "--tests",
+                "--exclude",
+                "garraia-desktop",
+                "--no-deps",
+                "--",
+                "-D",
+                "warnings",
+            ],
+            workspace_root,
+            capture,
+        ));
+    }
+
+    // ── Step 3: cargo test ─────────────────────────────────────────────────
+    if skip.iter().any(|s| s == "test") {
+        results.push(skipped("test", "skipped via --skip"));
+    } else {
+        results.push(run_step(
+            "test",
+            "cargo",
+            &[
+                "test",
+                "--workspace",
+                "--no-fail-fast",
+                "--exclude",
+                "garraia-desktop",
+            ],
+            workspace_root,
+            capture,
+        ));
+    }
+
+    // ── Step 4: flutter analyze ────────────────────────────────────────────
+    if skip.iter().any(|s| s == "flutter") {
+        results.push(skipped("flutter", "skipped via --skip"));
+    } else {
+        let mobile_dir = workspace_root.join("apps").join("garraia-mobile");
+        if !mobile_dir.exists() {
+            results.push(skipped("flutter", "apps/garraia-mobile not found"));
+        } else if !tool_available("flutter") {
+            results.push(skipped("flutter", "flutter not in PATH"));
+        } else {
+            results.push(run_step(
+                "flutter",
+                "flutter",
+                &["analyze"],
+                &mobile_dir,
+                capture,
+            ));
+        }
+    }
+
+    // ── Step 5: gitleaks detect ────────────────────────────────────────────
+    if skip.iter().any(|s| s == "gitleaks") {
+        results.push(skipped("gitleaks", "skipped via --skip"));
+    } else if !tool_available("gitleaks") {
+        results.push(skipped("gitleaks", "gitleaks not in PATH"));
+    } else {
+        results.push(run_step(
+            "gitleaks",
+            "gitleaks",
+            &["detect", "--source", ".", "--no-banner"],
+            workspace_root,
+            capture,
+        ));
+    }
+
+    results
+}
+
+fn print_human_summary(results: &[StepResult], exit_code: i32) {
+    println!();
+    println!("── garra verify results ────────────────────────────────────────");
+    for r in results {
+        let (icon, detail) = match &r.outcome {
+            StepOutcome::Pass => ("✓", format!("{}ms", r.duration_ms)),
+            StepOutcome::Fail { exit_code } => {
+                ("✗", format!("exit {exit_code}  {}ms", r.duration_ms))
+            }
+            StepOutcome::Skipped { reason } => ("–", reason.clone()),
+        };
+        println!("  {icon}  {:<12}  {detail}", r.name);
+    }
+    println!();
+    if exit_code == exit_codes::OK {
+        println!("  All checks passed.");
+    } else {
+        println!("  One or more checks failed (exit {exit_code}).");
+    }
+    println!();
+}
+
+fn print_json_report(results: &[StepResult], exit_code: i32) {
+    let report = Report {
+        ok: exit_code == exit_codes::OK,
+        exit_code,
+        steps: results,
+    };
+    match serde_json::to_string_pretty(&report) {
+        Ok(json) => println!("{json}"),
+        Err(e) => eprintln!("error serializing verify report: {e}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn pass(name: &'static str) -> StepResult {
+        StepResult {
+            name: name.to_string(),
+            outcome: StepOutcome::Pass,
+            duration_ms: 10,
+            output: None,
+        }
+    }
+
+    fn fail(name: &'static str, code: i32) -> StepResult {
+        StepResult {
+            name: name.to_string(),
+            outcome: StepOutcome::Fail { exit_code: code },
+            duration_ms: 5,
+            output: None,
+        }
+    }
+
+    fn skip(name: &'static str) -> StepResult {
+        StepResult {
+            name: name.to_string(),
+            outcome: StepOutcome::Skipped {
+                reason: "test".into(),
+            },
+            duration_ms: 0,
+            output: None,
+        }
+    }
+
+    #[test]
+    fn exit_code_ok_when_all_pass() {
+        let results = [pass("fmt"), pass("clippy"), skip("test")];
+        let any_failed = results.iter().any(|r| r.failed());
+        assert!(!any_failed);
+    }
+
+    #[test]
+    fn exit_code_fail_when_one_fails() {
+        let results = [pass("fmt"), fail("clippy", 1), skip("test")];
+        let any_failed = results.iter().any(|r| r.failed());
+        assert!(any_failed);
+    }
+
+    #[test]
+    fn skipped_step_does_not_count_as_failure() {
+        let r = skip("flutter");
+        assert!(!r.failed());
+        assert!(matches!(r.outcome, StepOutcome::Skipped { .. }));
+    }
+
+    #[test]
+    fn json_report_shape() {
+        let results = [pass("fmt"), fail("clippy", 2), skip("flutter")];
+        let exit_code = exit_codes::STEP_FAILED;
+        let report = Report {
+            ok: false,
+            exit_code,
+            steps: &results,
+        };
+        let json = serde_json::to_string(&report).expect("serialize");
+        let v: serde_json::Value = serde_json::from_str(&json).expect("parse");
+        assert_eq!(v["ok"], false);
+        assert_eq!(v["exit_code"], 2);
+        assert!(v["steps"].is_array());
+        assert_eq!(v["steps"][0]["name"], "fmt");
+        assert_eq!(v["steps"][0]["outcome"]["kind"], "pass");
+        assert_eq!(v["steps"][1]["outcome"]["kind"], "fail");
+        assert_eq!(v["steps"][2]["outcome"]["kind"], "skipped");
+    }
+
+    #[test]
+    fn skip_list_matching_is_exact() {
+        let skip_list = ["fmt".to_string(), "clippy".to_string()];
+        assert!(skip_list.iter().any(|s| s == "fmt"));
+        assert!(skip_list.iter().any(|s| s == "clippy"));
+        assert!(!skip_list.iter().any(|s| s == "test"));
+        assert!(!skip_list.iter().any(|s| s == "flutter"));
+    }
+
+    #[test]
+    fn tool_available_returns_false_for_nonexistent() {
+        assert!(!tool_available("__nonexistent_tool_9999__"));
+    }
+
+    #[test]
+    fn tool_available_returns_true_for_cargo() {
+        assert!(tool_available("cargo"));
+    }
+
+    #[test]
+    fn run_skips_all_steps_when_all_in_skip_list() {
+        let all_steps = vec![
+            "fmt".to_string(),
+            "clippy".to_string(),
+            "test".to_string(),
+            "flutter".to_string(),
+            "gitleaks".to_string(),
+        ];
+        // Use a non-existent workspace root — steps are all skipped so no
+        // process is spawned; `Path::new(".")` is fine as fallback.
+        let results = run_steps(&all_steps, Path::new("."), false);
+        assert_eq!(results.len(), 5);
+        for r in &results {
+            assert!(
+                matches!(r.outcome, StepOutcome::Skipped { .. }),
+                "expected skipped for step {}, got {:?}",
+                r.name,
+                r.outcome
+            );
+        }
+    }
+
+    #[test]
+    fn workspace_root_default_is_current_dir() {
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        // Just verify we can construct the mobile path without panicking.
+        let mobile = cwd.join("apps").join("garraia-mobile");
+        let _ = mobile.exists();
+    }
+}

--- a/docs/maxpower/verify-schema.json
+++ b/docs/maxpower/verify-schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "garra verify JSON report (v1)",
+  "description": "Output of `garra verify --json`. Schema is stable; additive changes only.",
+  "type": "object",
+  "required": ["ok", "exit_code", "steps"],
+  "properties": {
+    "ok": {
+      "type": "boolean",
+      "description": "true when exit_code == 0 (all non-skipped steps passed)."
+    },
+    "exit_code": {
+      "type": "integer",
+      "description": "Sysexits-compatible aggregate: 0 ok, 2 step-failed."
+    },
+    "steps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "outcome", "duration_ms"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": ["fmt", "clippy", "test", "flutter", "gitleaks"]
+          },
+          "duration_ms": {
+            "type": "integer",
+            "description": "Wall-clock milliseconds. 0 for skipped steps."
+          },
+          "output": {
+            "type": "string",
+            "description": "Combined stdout+stderr (only present in --json mode)."
+          },
+          "outcome": {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": ["kind"],
+                "properties": { "kind": { "const": "pass" } }
+              },
+              {
+                "type": "object",
+                "required": ["kind", "exit_code"],
+                "properties": {
+                  "kind": { "const": "fail" },
+                  "exit_code": { "type": "integer" }
+                }
+              },
+              {
+                "type": "object",
+                "required": ["kind", "reason"],
+                "properties": {
+                  "kind": { "const": "skipped" },
+                  "reason": { "type": "string" }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/plans/0155-gar-501-garra-verify.md
+++ b/plans/0155-gar-501-garra-verify.md
@@ -1,0 +1,92 @@
+# Plan 0155 — GAR-501: `garra verify` — local idempotent validation pipeline
+
+## Goal
+
+Implement the `garra verify` subcommand in `garraia-cli`: a local, idempotent
+validation pipeline that runs `cargo fmt --check`, `cargo clippy`, `cargo test`,
+`flutter analyze`, and `gitleaks detect` in sequence, reports per-step status,
+and exits with sysexits-compatible codes (0 ok / 2 step-failed).
+
+## Architecture
+
+New module `crates/garraia-cli/src/verify.rs` + new `Commands::Verify` variant in
+`main.rs`. Pattern mirrors `config_cmd.rs` (early-intercept before config load,
+sysexits exit codes, `--json` + `--strict` flags).
+
+The command is synchronous (no async): each step is a `std::process::Command`
+call. Output is streamed (inherited) in human mode; captured in `--json` mode.
+
+## Tech stack
+
+- `std::process::Command` for subprocess invocation — no new deps.
+- `serde_json` (already in `garraia-cli`) for `--json` output.
+- `serde` + `Serialize` for the report structs.
+
+## Design invariants
+
+1. No `unwrap()` in production paths.
+2. Exit code 0 only when all non-skipped steps pass.
+3. Exit code 2 on any step failure.
+4. `flutter` and `gitleaks` steps auto-skip if the tool is absent — never error.
+5. `--skip fmt` (etc.) allows selective opt-out; unknown step names are ignored.
+6. Output schema (`--json`) is stable: `{ ok, exit_code, steps: [{name, outcome, ...}] }`.
+7. `--exclude garraia-desktop` on all `cargo` steps (no GTK/GDK in dev container).
+
+## Out of scope
+
+- Coverage thresholds (Fase 5.2).
+- Mutation testing (Fase 5.2).
+- Auto-fix (`cargo fmt` without `--check`).
+- Parallelism between steps (deferred; steps share stdout and depend on compile cache).
+
+## Rollback
+
+Revert `src/verify.rs` + the `Commands::Verify` + `mod verify` in `main.rs`. Zero
+schema changes; zero new deps.
+
+## File structure
+
+```
+crates/garraia-cli/src/verify.rs    ← new module
+crates/garraia-cli/src/main.rs      ← +Commands::Verify, +mod verify, intercept
+docs/maxpower/verify-schema.json    ← JSON output schema doc
+plans/0155-gar-501-garra-verify.md  ← this file
+plans/README.md                     ← +row for plan 0155
+```
+
+## M1 Tasks
+
+- [x] T1 — Write `verify.rs`: `StepResult`, `StepOutcome`, `run()`, `run_steps()`,
+  `print_human()`, `print_json_report()`
+- [x] T2 — Wire `Commands::Verify` in `main.rs` (early-intercept like `config check`)
+- [x] T3 — Unit tests: `compute_exit_code`, `skip_flag`, JSON serialization shape
+- [x] T4 — `docs/maxpower/verify-schema.json` schema doc
+- [x] T5 — Update `plans/README.md`
+- [x] T6 — `cargo clippy` clean + `cargo test -p garraia`
+
+## Risk register
+
+| Risk | Mitigation |
+|------|-----------|
+| `cargo test` in CI hits gateway compile via SWAGGER_UI | Steps inherit env; user sets `SWAGGER_UI_DOWNLOAD_URL` if needed |
+| Windows `which`-check failure | Use `std::process::Command::output()` probe, not `which` crate |
+| JSON output schema drift | `verify-schema.json` is contract; breaking changes require doc update |
+
+## Acceptance criteria
+
+- `garra verify --help` prints all flags without panic.
+- `cargo test -p garraia` passes with new unit tests for verify module.
+- `cargo clippy --workspace ...` stays clean.
+- `--json` flag emits a valid JSON object matching `verify-schema.json`.
+
+## Cross-references
+
+- GAR-501 (Linear): https://linear.app/chatgpt25/issue/GAR-501
+- GAR-492 (GarraMaxPower epic)
+- Plan 0153 (GAR-494 `garra max-power` skeleton)
+- Plan 0154 (GAR-497 bash safety gate)
+- Plan 0035 (GAR-379 `config check` — UX model)
+
+## Estimativa
+
+0.5 / 1 / 1.5 days.

--- a/plans/README.md
+++ b/plans/README.md
@@ -163,3 +163,4 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0152 | [GAR-668 — Health Run 2 (2026-05-19): RUSTSEC-2026-0145 merged + tokio-tungstenite 0.29 upgrade](0152-health-run2-20260519-tokio-tungstenite-0.29.md) | [GAR-668](https://linear.app/chatgpt25/issue/GAR-668) | ✅ Merged 2026-05-19 via PR #433 (`51382a9c`) |
 | 0153 | [GAR-494 — `garra max-power` skeleton CLI subcommand](0153-gar-494-max-power-skeleton.md) | [GAR-494](https://linear.app/chatgpt25/issue/GAR-494) | ✅ Merged 2026-05-19 via PR #431 (`8a9a915`) |
 | 0154 | [GAR-497 — Bash Safety Gate: centralize denylist in garraia-common](0154-gar-497-bash-safety-gate.md) | [GAR-497](https://linear.app/chatgpt25/issue/GAR-497) | ✅ Merged 2026-05-19 via PR #437 (`f2ab1d9`) |
+| 0155 | [GAR-501 — `garra verify` — local idempotent validation pipeline](0155-gar-501-garra-verify.md) | [GAR-501](https://linear.app/chatgpt25/issue/GAR-501) | 🔁 In progress |


### PR DESCRIPTION
## Summary

Implements `garra verify` — the local idempotent validation pipeline for the GarraMaxPower epic (GAR-492 sub-issue 9/9, plan 0155).

- Five steps in sequence: `cargo fmt --check`, `cargo clippy` (workspace, `-D warnings`, `--exclude garraia-desktop`), `cargo test` (workspace, `--no-fail-fast`, `--exclude garraia-desktop`), `flutter analyze` (auto-skip if absent), `gitleaks detect` (auto-skip if absent)
- Exit codes: 0 all pass, 2 step failed (sysexits-compatible)
- `--json` flag emits structured report (schema: `docs/maxpower/verify-schema.json`)
- `--skip <step>` for selective opt-out; `--strict` reserved for future use
- `--workspace <dir>` override; defaults to current directory
- Early-intercept in `main()` before config load (mirrors `config check` pattern)
- 9 unit tests covering: exit code logic, JSON shape, skip semantics, tool availability probe

## Files changed

| File | Change |
|------|--------|
| `crates/garraia-cli/src/verify.rs` | New module (317 LOC) |
| `crates/garraia-cli/src/main.rs` | `+mod verify`, `Commands::Verify`, early-intercept |
| `docs/maxpower/verify-schema.json` | JSON output schema (stable contract) |
| `plans/0155-gar-501-garra-verify.md` | Plan file |
| `plans/README.md` | Plan row added |

## Test plan

- [x] `cargo clippy --workspace --tests --exclude garraia-desktop --no-deps -- -D warnings` clean
- [x] `cargo test -p garraia -- verify` → 9/9 tests pass
- [x] `cargo test -p garraia` → 122+11+1 tests all pass
- [x] `garra verify --help` shows flags without panic (manual smoke test)
- [x] `--skip fmt --skip clippy --skip test --skip flutter --skip gitleaks` skips all 5 steps → exit 0

## Linear

[GAR-501](https://linear.app/chatgpt25/issue/GAR-501) — garra verify — pipeline local idempotente
Epic: [GAR-492](https://linear.app/chatgpt25/issue/GAR-492) GarraMaxPower

https://claude.ai/code/session_01Q3KzD7jE8T2z8e82a18hyp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3KzD7jE8T2z8e82a18hyp)_