### PR TITLE
fix(deps): GAR-669 Slice 2 — windows-sys 0.52 → 0.61 + HANDLE type fix (garraia-cli)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3339,7 +3339,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "uuid",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/garraia-cli/Cargo.toml
+++ b/crates/garraia-cli/Cargo.toml
@@ -78,7 +78,7 @@ libc = "0.2"
 nix = { version = "0.31", features = ["process"] }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.52", features = [
+windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_System_Threading",
     "Win32_System_Diagnostics_ToolHelp",

--- a/crates/garraia-cli/src/main.rs
+++ b/crates/garraia-cli/src/main.rs
@@ -488,7 +488,7 @@ fn is_process_running(pid: u32) -> bool {
 
     unsafe {
         let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
-        if handle == 0 {
+        if handle.is_null() {
             return false;
         }
 

--- a/plans/0159-gar-669-windows-sys-0.61.md
+++ b/plans/0159-gar-669-windows-sys-0.61.md
@@ -1,0 +1,111 @@
+# Plan 0159 — GAR-669 Slice 2: windows-sys 0.52 → 0.61 (garraia-cli)
+
+**Status:** In Progress
+**Branch:** `routine/202005201220-gar-669-windows-sys-0.61-fix`
+**Linear:** [GAR-669](https://linear.app/chatgpt25/issue/GAR-669)
+**Parent plan:** GAR-669 (Cargo deps breaking API changes)
+
+---
+
+## Goal
+
+Bump `windows-sys` from `0.52` to `0.61` in `crates/garraia-cli/Cargo.toml`, fix the
+breaking API change in `main.rs`, close Dependabot PR #422, and verify the
+`#[cfg(windows)]` Windows-only path compiles on CI (`Test (windows-latest)`).
+
+---
+
+## Architecture
+
+Single-crate change in `garraia-cli`. The only Windows-specific code is
+`is_process_running(pid: u32)` in `crates/garraia-cli/src/main.rs` which calls
+`OpenProcess` / `GetExitCodeProcess` / `CloseHandle`.
+
+**Breaking change in windows-sys 0.61:**
+
+In windows-sys 0.52, `HANDLE = isize`. In windows-sys 0.61:
+```
+pub type HANDLE = *mut core::ffi::c_void;
+```
+
+This means `if handle == 0` is a type error (cannot compare pointer to integer).
+The fix is `if handle.is_null()`.
+
+All other APIs (`GetExitCodeProcess`, `CloseHandle`, `STILL_ACTIVE`, `FALSE`,
+`PROCESS_QUERY_LIMITED_INFORMATION`) remain compatible:
+- `STILL_ACTIVE: NTSTATUS = 0x103_u32 as _` (259i32); `STILL_ACTIVE as u32` = 259u32 ✅
+- `FALSE: windows_sys::core::BOOL = 0i32` ✅
+- `GetExitCodeProcess` and `CloseHandle` accept `HANDLE = *mut c_void` ✅
+
+---
+
+## Tech stack
+
+- `windows-sys 0.61.2` (was 0.52.0) — uses `windows-link 0.2.1` instead of `windows-targets`
+- Feature flags unchanged: `Win32_Foundation`, `Win32_System_Threading`,
+  `Win32_System_Diagnostics_ToolHelp`
+
+---
+
+## Design invariants
+
+- Zero production logic changes beyond the type fix.
+- No `unwrap()` introduced.
+- Lockfile updated automatically by cargo.
+
+---
+
+## Validações pré-plano
+
+- [x] windows-sys 0.61 source inspected: `HANDLE = *mut core::ffi::c_void`
+- [x] `cargo check -p garraia` clean (Linux)
+- [x] Cargo.lock updated to windows-sys 0.61.2
+
+---
+
+## Out of scope
+
+- windows-sys bumps in other crates (transitive deps, not direct)
+- GAR-669 Slice 3 (password-hash 0.6) — separate PR
+
+---
+
+## Rollback
+
+Revert the version change in `Cargo.toml` and the `is_null()` fix in `main.rs`.
+Run `cargo update -p windows-sys --precise 0.52.0`.
+
+---
+
+## M1 Tasks
+
+- [x] T1: Bump `windows-sys` version constraint `0.52` → `0.61` in `crates/garraia-cli/Cargo.toml`
+- [x] T2: Fix `handle == 0` → `handle.is_null()` in `is_process_running`
+- [x] T3: Verify `cargo check -p garraia` clean (Linux)
+- [x] T4: Commit + push
+- [ ] T5: Open PR, wait for CI green (especially `Test (windows-latest)`)
+- [ ] T6: Merge + mark GAR-669 Slice 2 done
+- [ ] T7: Update plans/README.md + ROADMAP.md
+
+---
+
+## Acceptance criteria
+
+- [ ] All CI checks green including `Test (windows-latest)` (compilation-only via `--no-run`)
+- [ ] Dependabot PR #422 can be closed (superseded)
+- [ ] `cargo audit` clean
+
+---
+
+## Cross-references
+
+- [GAR-669](https://linear.app/chatgpt25/issue/GAR-669) — parent issue
+- Dependabot PR #422 — superseded
+- Plan 0158 — GAR-669 Slice 1 (rand_chacha)
+
+---
+
+## Estimativa
+
+- **Baixa:** 1h (version bump + type fix + CI verification)
+- **Provável:** 2h (including CI wait)

--- a/plans/README.md
+++ b/plans/README.md
@@ -167,3 +167,4 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0156 | [GAR-651 — Learning Agent Web UI: skills + learning-logs pages in Garra Glass](0156-gar-651-learning-web-ui.md) | [GAR-651](https://linear.app/chatgpt25/issue/GAR-651) | ✅ Merged 2026-05-20 via PR #443 (`21a13f1`) |
 | 0157 | [GAR-500 — Auto Dream / handoff via .garra-estado.md](0157-gar-500-auto-dream-handoff.md) | [GAR-500](https://linear.app/chatgpt25/issue/GAR-500) | ✅ Merged 2026-05-20 via PR #445 (`f1fb596`) |
 | 0158 | [GAR-669 Slice 1 — rand_chacha 0.9 + rand 0.9 co-bump (garraia-workspace dev-deps)](0158-gar-669-rand-chacha-0.9-dev-dep-co-bump.md) | [GAR-669](https://linear.app/chatgpt25/issue/GAR-669) | ✅ Merged 2026-05-20 via PR #446 (`d9f811ac`) |
+| 0159 | [GAR-669 Slice 2 — windows-sys 0.52 → 0.61 (garraia-cli + HANDLE type fix)](0159-gar-669-windows-sys-0.61.md) | [GAR-669](https://linear.app/chatgpt25/issue/GAR-669) | 🔄 In Progress |


### PR DESCRIPTION
## Summary

- Bumps `windows-sys` from `0.52` to `0.61` in `crates/garraia-cli/Cargo.toml`
- **Root cause of CI failure:** In windows-sys 0.61, `HANDLE` changed type from `isize` to `*mut core::ffi::c_void`, making `handle == 0` a type error (E0308)
- **Fix:** `handle.is_null()` replaces `handle == 0` in `is_process_running()` — `main.rs:491`
- All other APIs unchanged: `STILL_ACTIVE`, `FALSE`, `CloseHandle`, `GetExitCodeProcess` remain compatible
- Supersedes Dependabot PR #422 and previous failed attempt PR #449

## Root cause details

```
// windows-sys 0.52:  pub type HANDLE = isize;        → handle == 0  ✅
// windows-sys 0.61:  pub type HANDLE = *mut c_void;  → handle == 0  ❌ E0308
//                                                      handle.is_null() ✅
```

## Test plan

- [x] `cargo check -p garraia` clean on Linux
- [x] `cargo update -p windows-sys --precise 0.61.2` updated Cargo.lock
- [ ] CI: `Test (windows-latest)` compiles `#[cfg(windows)]` path with windows-sys 0.61 + `is_null()` fix
- [ ] CI: All other checks green (Clippy runs on Linux so already validated implicitly)

https://claude.ai/code/session_01D3C6FYDrqbRUvzBBLeWV2e

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3C6FYDrqbRUvzBBLeWV2e)_