### PR TITLE
chore(gitignore): ignore .claude/skills/ local discoverable layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,11 @@ Thumbs.db
 # Runtime artifacts from scheduled tasks / loops / cron (auto-regenerated)
 .claude/*.lock
 .claude/scheduled_tasks/
+# Skill-tool discoverable layout (.claude/skills/<name>/SKILL.md). Generated
+# locally by /max-power tooling; bodies drift from the canonical tracked
+# skills/*.md flat layout. Promotion to canonical layout pending a per-skill
+# diff review (rastreado em Linear, vide CLAUDE.md §Skills disponíveis).
+.claude/skills/
 # .claude/settings.json, hooks/, agents/ SÃO commitados (config do projeto)
 
 # Git worktrees — isolated workspaces used by parallel agent execution


### PR DESCRIPTION
## Summary

Adds `.claude/skills/` to `.gitignore`, alongside the sibling Claude Code runtime artifacts (`.claude/sessions/`, `.claude/team-output/`, `.claude/scheduled_tasks/`, `.claude/worktrees/`).

## Why

Audit during 2026-05-21 repo-organize session found 15 untracked `.claude/skills/<name>/SKILL.md` files mirroring the names under tracked `skills/*.md`. Investigation:

- **Bodies differ substantively** between the two layouts (not a simple frontmatter copy — different content blocks, sometimes 17 lines vs 27 lines for the same skill).
- `.claude/skills/<name>/SKILL.md` carries `user_invocable: true` — the canonical layout that the Skill tool loads.
- The flat tracked `skills/*.md` is the **current source of truth**: referenced by `.claude/hooks/session-start.sh:48-53` (listing) and by `CLAUDE.md` (documentation).
- No CI / hooks / scripts reference the `.claude/skills/` path today.

Promoting `.claude/skills/` to canonical layout would require:
1. Per-skill diff review (15 pairs, bodies actually differ)
2. Update of `session-start.sh` listing logic
3. Update of `CLAUDE.md` skill table references
4. Final state decision (single source vs hybrid)

That migration deserves its own focused PR. Until then, `.claude/skills/` is local-only — this commit just prevents accidental tracking of an unreviewed alternate body.

## Test plan

- [ ] CI green (Format Check, Clippy, fmt — no code touched)
- [ ] `git check-ignore -v .claude/skills/foo/SKILL.md` matches `.gitignore:43:.claude/skills/` (verified locally)
- [ ] No tracked files removed (`git ls-files .claude/skills/` returns nothing — was already untracked)

## Follow-up

A new Linear issue will be opened to track the proper canonical-layout migration (per-skill review + hook update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)