### PR TITLE
feat(gateway): GAR-680 — audit-log of SSE chat subscriptions (F-4)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Roadmap unificado do ecossistema GarraIA (CLI, Gateway, Desktop, Mobile, Agents, Channels, Voice) rumo ao padrão **AAA**. Funde o plano de inferência local + workflows agenticos com a nova direção de produto **Group Workspace** (família/equipe multi-tenant) derivada de `deep-research-report.md`.
 >
-> **Última atualização:** 2026-05-21 (local America/New_York) — GAR-496 Repo workflow seguro 🔄 In Progress (plan 0161, PR em CI). GAR-495 ✅ Done (PR #453 `e5a2a08`, capability prompt nativo). Anterior (2026-05-20): GAR-669 Slice 2 (windows-sys 0.52→0.61) + GAR-500 Auto Dream ✅. (2026-05-18): `garraia-embeddings` scaffoldado per ADR 0002 (GAR-372, plan 0145): traits `EmbeddingProvider` + `VectorStore`, strong types, `HybridQuery`, `DeterministicProvider`. 23 unit tests verdes. ADR 0010 promovido Proposed → **Accepted** + crate `garraia-learning` scaffoldado (GAR-642, plan 0144, PR #392). 17 Safety Gate tests verdes. (2026-05-17): Q11 modularization COMPLETA (GAR-635), RUSTSEC-2025-0134 + RUSTSEC-2025-0069 fechados, GAR-410 CredentialVault Done.
+> **Última atualização:** 2026-05-21 (local America/New_York) — GAR-680 Audit-log of SSE chat subscriptions 🔄 In Progress (F-4 follow-up de GAR-678): `WorkspaceAuditAction::{ChatSubscribed, ChatUnsubscribed}` ligados ao handler `stream_chat` (subscribed in-tx pré-commit, unsubscribed via `tokio::spawn` no `ChatStreamGuard::drop`); PII-safe, `subscriber_count` no metadata. Anterior (mesmo dia): GAR-496 Repo workflow seguro 🔄 In Progress (plan 0161, PR em CI). GAR-495 ✅ Done (PR #453 `e5a2a08`, capability prompt nativo). (2026-05-20): GAR-669 Slice 2 (windows-sys 0.52→0.61) + GAR-500 Auto Dream ✅. (2026-05-18): `garraia-embeddings` scaffoldado per ADR 0002 (GAR-372, plan 0145): traits `EmbeddingProvider` + `VectorStore`, strong types, `HybridQuery`, `DeterministicProvider`. 23 unit tests verdes. ADR 0010 promovido Proposed → **Accepted** + crate `garraia-learning` scaffoldado (GAR-642, plan 0144, PR #392). 17 Safety Gate tests verdes. (2026-05-17): Q11 modularization COMPLETA (GAR-635), RUSTSEC-2025-0134 + RUSTSEC-2025-0069 fechados, GAR-410 CredentialVault Done.
 > **Owner:** @michelbr84
 > **Equipe Linear:** GAR
 > **Branch base:** `main`
@@ -624,6 +624,8 @@ Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
 - [x] `GET /v1/messages/{message_id}` — plan 0109 / [GAR-595](https://linear.app/chatgpt25/issue/GAR-595), merged 2026-05-13 via PR #305 (`e8cc44d`). ✅
 - [x] `GET /v1/messages/{message_id}/threads` — plan 0109 / [GAR-595](https://linear.app/chatgpt25/issue/GAR-595), merged 2026-05-13 via PR #305 (`e8cc44d`). ✅
 - [x] SSE `GET /v1/chats/{chat_id}/stream` (broadcast cap-64, backpressure via `stream.lagged`) — plan 0162, merged 2026-05-21 via PR #459. Design: SSE escolhido em vez de WebSocket — canal de chat é server→client apenas; cross-tenant isolation via FORCE RLS + `WHERE group_id = $caller_group_id`.
+  - [ ] **Follow-up F-3** ([GAR-679](https://linear.app/chatgpt25/issue/GAR-679)): SSE rate-limit per user/group sobre `/v1/chats/{id}/stream` — DoS hardening, ainda em Backlog.
+  - 🔄 **Follow-up F-4** ([GAR-680](https://linear.app/chatgpt25/issue/GAR-680)): audit-log das subscriptions SSE (`chat.subscribed` no handler dentro da tx pré-commit + `chat.unsubscribed` via `tokio::spawn` no `Drop` do `ChatStreamGuard`); `subscriber_count` em metadata, PII-safe. Cobertura: 24 unit tests verdes (3 audit_workspace + 21 chats) + cenário S5 em `rest_v1_chats_sse.rs` (integration, CI). 2026-05-21.
 
 **Arquivos**
 

--- a/crates/garraia-auth/src/audit_workspace.rs
+++ b/crates/garraia-auth/src/audit_workspace.rs
@@ -297,6 +297,29 @@ pub enum WorkspaceAuditAction {
     /// Metadata: `{ role }`.
     ChatMemberRemoved,
 
+    /// A subscriber connected to a chat's SSE stream via
+    /// `GET /v1/chats/{chat_id}/stream` (plan 0162 / GAR-678, audit follow-up
+    /// GAR-680). Emitted inside the request transaction, after the chat
+    /// existence + RLS check passes and BEFORE the broadcast receiver is
+    /// created, so a 4xx never produces a `chat.subscribed` row.
+    ///
+    /// `resource_type = "chats"`, `resource_id = "{chat_id}"`.
+    /// Metadata: `{ subscriber_count }` — the count of subscribers that
+    /// will be present after this client joins (pre-subscribe count + 1).
+    /// PII-safe: never carries message bodies or chat names.
+    ChatSubscribed,
+
+    /// A subscriber disconnected from a chat's SSE stream — emitted by the
+    /// RAII `ChatStreamGuard::drop` via `tokio::spawn` (plan 0162 / GAR-678,
+    /// audit follow-up GAR-680). The spawn is fire-and-forget because `Drop`
+    /// is synchronous in Rust; an audit emission failure is logged via
+    /// `tracing::warn` and does not propagate to the client.
+    ///
+    /// `resource_type = "chats"`, `resource_id = "{chat_id}"`.
+    /// Metadata: `{ subscriber_count }` — the count of subscribers that
+    /// remain after this client leaves (post-drop count). PII-safe.
+    ChatUnsubscribed,
+
     /// A user was assigned to a task via
     /// `POST /v1/groups/{group_id}/tasks/{task_id}/assignees`
     /// (plan 0077 / GAR-533, epic GAR-WS-TASKS slice 4).
@@ -515,6 +538,8 @@ impl WorkspaceAuditAction {
             WorkspaceAuditAction::ChatArchived => "chat.archived",
             WorkspaceAuditAction::ChatMemberAdded => "chat.member.added",
             WorkspaceAuditAction::ChatMemberRemoved => "chat.member.removed",
+            WorkspaceAuditAction::ChatSubscribed => "chat.subscribed",
+            WorkspaceAuditAction::ChatUnsubscribed => "chat.unsubscribed",
             WorkspaceAuditAction::TaskAssigneeAdded => "task.assignee.added",
             WorkspaceAuditAction::TaskAssigneeRemoved => "task.assignee.removed",
             WorkspaceAuditAction::TaskLabelCreated => "task_label.created",
@@ -685,6 +710,14 @@ mod tests {
             "chat.member.removed"
         );
         assert_eq!(
+            WorkspaceAuditAction::ChatSubscribed.as_str(),
+            "chat.subscribed"
+        );
+        assert_eq!(
+            WorkspaceAuditAction::ChatUnsubscribed.as_str(),
+            "chat.unsubscribed"
+        );
+        assert_eq!(
             WorkspaceAuditAction::TaskAssigneeAdded.as_str(),
             "task.assignee.added"
         );
@@ -780,6 +813,8 @@ mod tests {
             WorkspaceAuditAction::ChatArchived.as_str(),
             WorkspaceAuditAction::ChatMemberAdded.as_str(),
             WorkspaceAuditAction::ChatMemberRemoved.as_str(),
+            WorkspaceAuditAction::ChatSubscribed.as_str(),
+            WorkspaceAuditAction::ChatUnsubscribed.as_str(),
             WorkspaceAuditAction::TaskAssigneeAdded.as_str(),
             WorkspaceAuditAction::TaskAssigneeRemoved.as_str(),
             WorkspaceAuditAction::TaskLabelCreated.as_str(),

--- a/crates/garraia-gateway/src/rest_v1/chats.rs
+++ b/crates/garraia-gateway/src/rest_v1/chats.rs
@@ -1493,6 +1493,38 @@ pub async fn stream_chat(
         return Err(RestError::NotFound);
     }
 
+    // Audit follow-up F-4 (GAR-680): emit `chat.subscribed` BEFORE the
+    // broadcast receiver is created, but AFTER the chat-exists / RLS check
+    // passes. This guarantees:
+    //
+    // 1. A 404 (cross-tenant or archived chat) never produces an audit row.
+    // 2. The audit row is rolled back together with the RLS context if
+    //    `tx.commit()` fails — no orphan row with no paired `chat.unsubscribed`.
+    // 3. The paired `chat.unsubscribed` is only spawned by the RAII guard,
+    //    which is built BELOW after the commit succeeds — so we never emit
+    //    `chat.unsubscribed` without a prior `chat.subscribed`.
+    //
+    // `subscriber_count` carries the count of subscribers that will exist
+    // after this client joins (pre-subscribe count + 1). PII-safe: no message
+    // body or chat name reaches the metadata.
+    let pre_subscribe_count = state
+        .chat_events
+        .get(&chat_id)
+        .map(|entry| entry.receiver_count())
+        .unwrap_or(0);
+    let projected_subscriber_count = pre_subscribe_count.saturating_add(1);
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::ChatSubscribed,
+        principal.user_id,
+        group_id,
+        "chats",
+        chat_id.to_string(),
+        json!({ "subscriber_count": projected_subscriber_count }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
     // Commit the read-only RLS transaction. The conn returns to the pool;
     // the subsequent `subscribe_chat` is purely in-process.
     tx.commit()
@@ -1503,12 +1535,15 @@ pub async fn stream_chat(
 
     // RAII guard: when `ChatStreamState` is dropped (client disconnect, server
     // close, or stream end), `rx` drops first (declaration order), then
-    // `_guard` runs `cleanup_chat_subscription`, which removes the DashMap
-    // entry iff `receiver_count() == 0`. Closes audit finding F-1.
+    // `_guard` spawns the paired `chat.unsubscribed` audit row and runs
+    // `cleanup_chat_subscription`, which removes the DashMap entry iff
+    // `receiver_count() == 0`. Closes audit findings F-1 and F-4.
     let stream_state = ChatStreamState {
         rx,
         _guard: ChatStreamGuard {
             chat_id,
+            actor_user_id: principal.user_id,
+            group_id,
             state: state.clone(),
         },
     };
@@ -1538,16 +1573,100 @@ struct ChatStreamState {
     _guard: ChatStreamGuard,
 }
 
-/// RAII handle that GCs the chat's broadcast entry when the SSE stream ends.
+/// RAII handle that GCs the chat's broadcast entry AND emits the paired
+/// `chat.unsubscribed` audit row when the SSE stream ends (plan 0162
+/// findings F-1 and F-4 — GAR-680).
+///
+/// `actor_user_id` and `group_id` are captured at handler entry so the
+/// audit emission can happen entirely from `Drop`, where the `Principal`
+/// extractor is long gone.
 struct ChatStreamGuard {
     chat_id: Uuid,
+    actor_user_id: Uuid,
+    group_id: Uuid,
     state: RestV1FullState,
 }
 
 impl Drop for ChatStreamGuard {
     fn drop(&mut self) {
+        // Field declaration order in `ChatStreamState` guarantees `rx`
+        // dropped before this guard runs, so `receiver_count()` reflects
+        // post-leave state (may be 0 if we were the last subscriber).
+        let remaining_subscribers = self
+            .state
+            .chat_events
+            .get(&self.chat_id)
+            .map(|entry| entry.receiver_count())
+            .unwrap_or(0);
+
+        // Fire-and-forget audit emission. `Drop` is synchronous; audit needs
+        // async DB access. We only spawn if there is an active Tokio runtime
+        // — Drop can run in any context (e.g. test teardown outside a runtime),
+        // and calling `tokio::spawn` outside a runtime panics. The
+        // `try_current` probe converts that into a silent no-op.
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            let pool = self.state.app_pool.pool_for_handlers().clone();
+            let chat_id = self.chat_id;
+            let actor_user_id = self.actor_user_id;
+            let group_id = self.group_id;
+            handle.spawn(async move {
+                if let Err(err) =
+                    emit_chat_unsubscribed(&pool, chat_id, actor_user_id, group_id, remaining_subscribers)
+                        .await
+                {
+                    tracing::warn!(
+                        target: "chats.sse.audit",
+                        %chat_id,
+                        error = %err,
+                        "failed to emit chat.unsubscribed audit event"
+                    );
+                }
+            });
+        }
+
+        // GC the DashMap entry iff no subscribers remain (F-1). Idempotent
+        // and runs synchronously so the audit spawn cannot race with a
+        // re-subscribe that would re-create the broadcast channel.
         self.state.cleanup_chat_subscription(self.chat_id);
     }
+}
+
+/// Emit one `chat.unsubscribed` audit row from a fresh transaction. Called
+/// only from `ChatStreamGuard::drop` (plan 0162 audit follow-up F-4 —
+/// GAR-680).
+///
+/// Builds its own short transaction because the original request transaction
+/// committed long before Drop runs. The two `SELECT set_config(...)` calls
+/// re-establish the tenant context that `audit_events_group_or_self` RLS
+/// policy requires (migration 007:161-168).
+async fn emit_chat_unsubscribed(
+    pool: &sqlx::PgPool,
+    chat_id: Uuid,
+    actor_user_id: Uuid,
+    group_id: Uuid,
+    remaining_subscribers: usize,
+) -> anyhow::Result<()> {
+    let mut tx = pool.begin().await?;
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(actor_user_id.to_string())
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query("SELECT set_config('app.current_group_id', $1, true)")
+        .bind(group_id.to_string())
+        .execute(&mut *tx)
+        .await?;
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::ChatUnsubscribed,
+        actor_user_id,
+        group_id,
+        "chats",
+        chat_id.to_string(),
+        json!({ "subscriber_count": remaining_subscribers }),
+    )
+    .await?;
+    tx.commit().await?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/garraia-gateway/src/rest_v1/chats.rs
+++ b/crates/garraia-gateway/src/rest_v1/chats.rs
@@ -1610,9 +1610,14 @@ impl Drop for ChatStreamGuard {
             let actor_user_id = self.actor_user_id;
             let group_id = self.group_id;
             handle.spawn(async move {
-                if let Err(err) =
-                    emit_chat_unsubscribed(&pool, chat_id, actor_user_id, group_id, remaining_subscribers)
-                        .await
+                if let Err(err) = emit_chat_unsubscribed(
+                    &pool,
+                    chat_id,
+                    actor_user_id,
+                    group_id,
+                    remaining_subscribers,
+                )
+                .await
                 {
                     tracing::warn!(
                         target: "chats.sse.audit",

--- a/crates/garraia-gateway/tests/rest_v1_chats_sse.rs
+++ b/crates/garraia-gateway/tests/rest_v1_chats_sse.rs
@@ -26,7 +26,7 @@ use tower::ServiceExt;
 use uuid::Uuid;
 
 use common::Harness;
-use common::fixtures::seed_user_with_group;
+use common::fixtures::{fetch_audit_events_for_group, seed_user_with_group};
 
 fn connect_info() -> axum::extract::ConnectInfo<std::net::SocketAddr> {
     axum::extract::ConnectInfo("127.0.0.1:1".parse().unwrap())
@@ -185,5 +185,99 @@ async fn v1_chats_sse_cross_tenant_isolation() {
         resp.status(),
         StatusCode::NOT_FOUND,
         "S4: archived chat SSE subscription must return 404"
+    );
+
+    // Force the S4 response to drop now so any audit emission triggered by
+    // RAII guard cleanup from earlier scenarios is well-defined before S5.
+    // (S2 was the only scenario that actually built a guard.)
+    drop(resp);
+
+    // ── S5. Audit-log emission (F-4 / GAR-680) ───────────────────────────
+    //
+    // S2 was the only scenario that crossed both the existence check and
+    // the broadcast subscribe. It must produce exactly one
+    // `chat.subscribed` row when the handler runs and one
+    // `chat.unsubscribed` row when the response body drops at end of scope.
+    // Cross-tenant 404 (S1), missing-header 400 (S3), and archived 404 (S4)
+    // must NOT emit anything to group_a's audit_events.
+    //
+    // The `chat.unsubscribed` row is emitted via `tokio::spawn` from
+    // `ChatStreamGuard::drop`, so we briefly poll for it instead of asserting
+    // synchronously — Drop happens immediately when the prior `resp` is
+    // shadowed, but the spawned task runs asynchronously on the runtime.
+    let mut subscribed_seen = false;
+    let mut unsubscribed_seen = false;
+    for _ in 0..30 {
+        let rows = fetch_audit_events_for_group(&h, group_a_id)
+            .await
+            .expect("S5: fetch audit_events for group_a");
+        subscribed_seen = false;
+        unsubscribed_seen = false;
+        let mut chat_a_resource_id_count = 0usize;
+        for (action, actor, resource_type, resource_id, metadata) in &rows {
+            if resource_id != &chat_a_id.to_string() {
+                continue;
+            }
+            chat_a_resource_id_count += 1;
+            assert_eq!(
+                actor,
+                &Some(user_a_id),
+                "S5: actor_user_id must be the subscribing caller"
+            );
+            assert_eq!(
+                resource_type, "chats",
+                "S5: SSE audit rows must point to the `chats` resource"
+            );
+            // PII safety — metadata is structural only.
+            let count = metadata
+                .get("subscriber_count")
+                .and_then(|v| v.as_u64())
+                .unwrap_or_else(|| {
+                    panic!("S5: missing/non-integer subscriber_count in metadata: {metadata:?}")
+                });
+            match action.as_str() {
+                "chat.subscribed" => {
+                    subscribed_seen = true;
+                    assert_eq!(
+                        count, 1,
+                        "S5: first subscriber sees projected subscriber_count = 1"
+                    );
+                }
+                "chat.unsubscribed" => {
+                    unsubscribed_seen = true;
+                    assert_eq!(
+                        count, 0,
+                        "S5: last subscriber leaving sees remaining_subscribers = 0"
+                    );
+                }
+                other => panic!(
+                    "S5: unexpected audit action on chat_a SSE flow: {other} (metadata={metadata:?})"
+                ),
+            }
+            // Defensive — make sure no PII keys leaked into metadata.
+            for forbidden in ["body", "name", "topic", "message"] {
+                assert!(
+                    metadata.get(forbidden).is_none(),
+                    "S5: metadata must not carry `{forbidden}` (got {metadata:?})"
+                );
+            }
+        }
+        if subscribed_seen && unsubscribed_seen {
+            // Cross-tenant + 400 + 404 paths must not pollute group_a's audit.
+            assert_eq!(
+                chat_a_resource_id_count, 2,
+                "S5: only subscribed+unsubscribed rows expected for chat_a (got {chat_a_resource_id_count} rows)"
+            );
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    assert!(
+        subscribed_seen,
+        "S5: chat.subscribed audit row must be emitted on happy-path SSE"
+    );
+    assert!(
+        unsubscribed_seen,
+        "S5: chat.unsubscribed audit row must be emitted when the response is dropped"
     );
 }


### PR DESCRIPTION
## Summary

Closes [GAR-680](https://linear.app/chatgpt25/issue/GAR-680) — audit follow-up F-4 from the PR #459 security review (parent [GAR-678](https://linear.app/chatgpt25/issue/GAR-678) chats SSE slice 3, merged 2026-05-21 in `d25b64c`). Adds paired `chat.subscribed` / `chat.unsubscribed` rows in `audit_events` so SSE subscriber identity is traceable for forensic review of potential payload leaks.

## Design

| Where | Action | When |
|---|---|---|
| `stream_chat` (in-tx) | `chat.subscribed`, metadata `{ subscriber_count: pre + 1 }` | After chat-exists / RLS check, BEFORE `tx.commit()` and BEFORE `subscribe_chat()` — 404s / 400s never emit. |
| `ChatStreamGuard::drop` (spawned) | `chat.unsubscribed`, metadata `{ subscriber_count: remaining }` | `tokio::runtime::Handle::try_current().handle.spawn(…)` — fire-and-forget, sync \`cleanup_chat_subscription\` still runs. |

- **Ordering invariant:** Drop guard is built only AFTER the subscribed audit + commit succeed, so we can never emit unsubscribed without a paired subscribed.
- **Race safety:** `remaining_subscribers` is snapshotted from the DashMap BEFORE the spawn, so a concurrent re-subscribe cannot inflate the count.
- **PII safety:** metadata carries only \`subscriber_count\` — never message body, chat name, or topic. Matches the \`message.sent\` audit precedent (\`messages.rs\` ~L253).
- **Runtime safety:** \`try_current()\` probe avoids panics when Drop runs outside a Tokio runtime (e.g. test teardown). Failure logs \`tracing::warn\` and does not affect the client.

## Files

- \`crates/garraia-auth/src/audit_workspace.rs\` — two new \`WorkspaceAuditAction\` variants + as_str + Display + tests.
- \`crates/garraia-gateway/src/rest_v1/chats.rs\` — \`stream_chat\` emits subscribed in-tx; \`ChatStreamGuard\` gains \`actor_user_id\`+\`group_id\`; Drop spawns audit + cleans up.
- \`crates/garraia-gateway/tests/rest_v1_chats_sse.rs\` — new S5 scenario polls \`fetch_audit_events_for_group\` and asserts the paired rows with no PII metadata.
- \`ROADMAP.md\` — header + GAR-678 SSE bullet updated.

## Test plan

- [x] \`cargo check -p garraia-auth -p garraia-gateway --tests\` — clean.
- [x] \`cargo clippy -p garraia-auth -p garraia-gateway --tests -- -D warnings\` — clean.
- [x] \`cargo test -p garraia-auth audit_workspace\` — 3/3 pass (as_str_stable, distinct_strings, display_delegates).
- [x] \`cargo test -p garraia-gateway --lib rest_v1::chats\` — 21/21 pass (existing + struct shape).
- [ ] CI \`e2e\` job (\`v1_chats_sse_cross_tenant_isolation\`, Postgres-gated) — covers S1–S5 including the new audit-row assertions.

## Risk assessment

- **Surface:** 4 files, +255/-5. No schema migration, no new dependencies.
- **Security posture:** Strictly additive observability. No change to authn/authz logic. RLS context re-established inside the spawned tx via the same \`SELECT set_config(...)\` pattern as every other handler in this module.
- **Performance:** One extra INSERT per SSE connect (in the existing request transaction) + one extra short tx per disconnect (off the hot path). No impact on message delivery latency.

## Open follow-ups

- [GAR-679](https://linear.app/chatgpt25/issue/GAR-679) (F-3, Medium, Backlog) — SSE rate-limit per user/group. Out of scope of this PR.
- Future: align \`garraia_sse_active_subscriptions\` metric (when F-3 lands) with the audit-row counts. Acceptance criterion 3 from the issue body is partially satisfied — once the metric exists, a single observation runbook will tie both signals together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)