### PR TITLE
feat(me): GET /v1/me/files — caller-scoped uploaded-files inbox (plan 0246, GAR-767)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -612,6 +612,7 @@ Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
 - [x] `GET /v1/me` — plan 0015 (skeleton Fase 3.4), entregue 2026-04-14
 - [x] `PATCH /v1/me` (display_name self-update) — plan 0110 / [GAR-599](https://linear.app/chatgpt25/issue/GAR-599) ✅
 - [x] `GET /v1/me/chats` — caller-scoped chat membership inbox (cursor-paginated, type filter) — plan 0245 / [GAR-765](https://linear.app/chatgpt25/issue/GAR-765) ✅
+- [x] `GET /v1/me/files` — caller-scoped uploaded-files inbox (cursor-paginated, optional folder filter) — plan 0246 / [GAR-767](https://linear.app/chatgpt25/issue/GAR-767) ✅
 
 **Chats**
 

--- a/TODO.md
+++ b/TODO.md
@@ -9,6 +9,16 @@ curtos para a próxima sessão autônoma.
 
 ## Concluído nesta sessão
 
+- GAR-767 / plan 0246 — GET /v1/me/files (caller-scoped uploaded-files inbox):
+  - `ListMyFilesQuery` struct with `group_id` (required), `after`, `limit`, `folder_id` (optional).
+  - `MyFileSummary` fields: `id`, `group_id`, `name`, `mime_type`, `size_bytes`, `folder_id` (skip_if_none), `created_at`, `updated_at` (skip_if_none).
+  - `MyFilesResponse` with `items` + `next_cursor` (skip_serializing_if None).
+  - 4-branch query (cursor × folder_id filter), keyset on `(files.created_at DESC, files.id DESC)`.
+  - Route `.route("/v1/me/files", get(me::list_my_files))` registered in all 3 `mod.rs` branches.
+  - OpenAPI annotation + component registration in `openapi.rs`.
+  - 8 new unit tests (serialization, limit clamp, folder filter, cursor, large size).
+  - Branch: `routine/202506010015-me-files-inbox`. GAR-767 In Progress → Done pending CI.
+
 - GAR-765 / plan 0245 — GET /v1/me/chats (caller-scoped chat membership inbox):
   - `ListMyChatsQuery` struct with `group_id` (required), `after`, `limit`, `type` (optional).
   - `ChatMembershipSummary` fields: `chat_id`, `group_id`, `name`, `type`, `role`, `joined_at`, `muted`, `last_read_at`.

--- a/crates/garraia-gateway/src/rest_v1/me.rs
+++ b/crates/garraia-gateway/src/rest_v1/me.rs
@@ -14,6 +14,9 @@
 //!
 //! `GET /v1/me/chats` — cursor-paginated inbox of chats where the caller holds
 //! a `chat_members` row in a given group (plan 0245 / GAR-765).
+//!
+//! `GET /v1/me/files` — cursor-paginated inbox of files uploaded by the caller
+//! in a given group (plan 0246 / GAR-767).
 
 use axum::Json;
 use axum::extract::{Query, State};
@@ -856,6 +859,213 @@ pub async fn list_my_chats(
     Ok(Json(MyChatsMembershipResponse { items, next_cursor }))
 }
 
+// ─── GET /v1/me/files ────────────────────────────────────────────────────────
+
+/// Query parameters for `GET /v1/me/files`.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ListMyFilesQuery {
+    /// Group to scope the file inbox. Required — RLS needs `app.current_group_id`.
+    pub group_id: Uuid,
+    /// Cursor: `id` of the last file on the previous page (keyset on `created_at DESC, id DESC`).
+    pub after: Option<Uuid>,
+    /// Maximum items per page. Clamped to `[1, 100]`; default `50`.
+    pub limit: Option<i64>,
+    /// Optional folder filter. When set, only files directly inside this folder are returned.
+    pub folder_id: Option<Uuid>,
+}
+
+/// One file entry in the `GET /v1/me/files` response.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct MyFileSummary {
+    pub id: Uuid,
+    pub group_id: Uuid,
+    pub name: String,
+    pub mime_type: String,
+    pub size_bytes: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub folder_id: Option<Uuid>,
+    pub created_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
+/// Response body for `GET /v1/me/files`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct MyFilesResponse {
+    pub items: Vec<MyFileSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<Uuid>,
+}
+
+/// RLS is enforced via `SET LOCAL app.current_user_id` and
+/// `SET LOCAL app.current_group_id` — rows from other groups are invisible.
+#[utoipa::path(
+    get,
+    path = "/v1/me/files",
+    params(ListMyFilesQuery),
+    responses(
+        (status = 200, description = "List of files uploaded by caller, newest-created first.", body = MyFilesResponse),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn list_my_files(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Query(params): Query<ListMyFilesQuery>,
+) -> Result<Json<MyFilesResponse>, RestError> {
+    let limit = params.limit.map(|l| l.min(100)).unwrap_or(50).max(1);
+    let group_id = params.group_id;
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(principal.user_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_group_id', $1, true)")
+        .bind(group_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    // Columns: id, group_id, name, mime_type, size_bytes, folder_id, created_at, updated_at
+    type FileRow = (
+        Uuid,
+        Uuid,
+        String,
+        String,
+        i64,
+        Option<Uuid>,
+        DateTime<Utc>,
+        Option<DateTime<Utc>>,
+    );
+
+    let rows: Vec<FileRow> = match (params.after, params.folder_id) {
+        (None, None) => sqlx::query_as(
+            "SELECT id, group_id, name, mime_type, size_bytes, folder_id, \
+                    created_at, updated_at \
+             FROM files \
+             WHERE created_by = $1 \
+               AND group_id = $2 \
+               AND deleted_at IS NULL \
+             ORDER BY created_at DESC, id DESC \
+             LIMIT $3",
+        )
+        .bind(principal.user_id)
+        .bind(group_id)
+        .bind(limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?,
+
+        (None, Some(folder_id)) => sqlx::query_as(
+            "SELECT id, group_id, name, mime_type, size_bytes, folder_id, \
+                    created_at, updated_at \
+             FROM files \
+             WHERE created_by = $1 \
+               AND group_id = $2 \
+               AND folder_id = $3 \
+               AND deleted_at IS NULL \
+             ORDER BY created_at DESC, id DESC \
+             LIMIT $4",
+        )
+        .bind(principal.user_id)
+        .bind(group_id)
+        .bind(folder_id)
+        .bind(limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?,
+
+        (Some(after_id), None) => sqlx::query_as(
+            "SELECT id, group_id, name, mime_type, size_bytes, folder_id, \
+                    created_at, updated_at \
+             FROM files \
+             WHERE created_by = $1 \
+               AND group_id = $2 \
+               AND deleted_at IS NULL \
+               AND (created_at, id) < ( \
+                   SELECT f2.created_at, f2.id \
+                   FROM files f2 \
+                   WHERE f2.id = $3 \
+                     AND f2.group_id = $2 \
+               ) \
+             ORDER BY created_at DESC, id DESC \
+             LIMIT $4",
+        )
+        .bind(principal.user_id)
+        .bind(group_id)
+        .bind(after_id)
+        .bind(limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?,
+
+        (Some(after_id), Some(folder_id)) => sqlx::query_as(
+            "SELECT id, group_id, name, mime_type, size_bytes, folder_id, \
+                    created_at, updated_at \
+             FROM files \
+             WHERE created_by = $1 \
+               AND group_id = $2 \
+               AND folder_id = $3 \
+               AND deleted_at IS NULL \
+               AND (created_at, id) < ( \
+                   SELECT f2.created_at, f2.id \
+                   FROM files f2 \
+                   WHERE f2.id = $4 \
+                     AND f2.group_id = $2 \
+               ) \
+             ORDER BY created_at DESC, id DESC \
+             LIMIT $5",
+        )
+        .bind(principal.user_id)
+        .bind(group_id)
+        .bind(folder_id)
+        .bind(after_id)
+        .bind(limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?,
+    };
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    let next_cursor = if rows.len() as i64 == limit {
+        rows.last().map(|(id, ..)| *id)
+    } else {
+        None
+    };
+
+    let items = rows
+        .into_iter()
+        .map(
+            |(id, group_id, name, mime_type, size_bytes, folder_id, created_at, updated_at)| {
+                MyFileSummary {
+                    id,
+                    group_id,
+                    name,
+                    mime_type,
+                    size_bytes,
+                    folder_id,
+                    created_at,
+                    updated_at,
+                }
+            },
+        )
+        .collect();
+
+    Ok(Json(MyFilesResponse { items, next_cursor }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1214,5 +1424,136 @@ mod tests {
         assert!(q.after.is_none());
         assert!(q.limit.is_none());
         assert!(q.chat_type.is_none());
+    }
+
+    // ── MyFilesResponse / MyFileSummary serialization ─────────────────────────
+
+    #[test]
+    fn my_files_response_empty_no_cursor() {
+        let resp = MyFilesResponse {
+            items: vec![],
+            next_cursor: None,
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert_eq!(v["items"].as_array().unwrap().len(), 0);
+        assert!(v.get("next_cursor").is_none(), "absent cursor must be omitted");
+    }
+
+    #[test]
+    fn my_files_response_with_cursor() {
+        let cursor = Uuid::parse_str("eeeeeeee-0000-0000-0000-000000000005").unwrap();
+        let resp = MyFilesResponse {
+            items: vec![],
+            next_cursor: Some(cursor),
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert_eq!(v["next_cursor"], "eeeeeeee-0000-0000-0000-000000000005");
+    }
+
+    #[test]
+    fn my_file_summary_serializes_all_fields() {
+        let id = Uuid::parse_str("aaaaaaaa-0000-0000-0000-000000000001").unwrap();
+        let group_id = Uuid::parse_str("bbbbbbbb-0000-0000-0000-000000000001").unwrap();
+        let folder_id = Uuid::parse_str("cccccccc-0000-0000-0000-000000000001").unwrap();
+        let summary = MyFileSummary {
+            id,
+            group_id,
+            name: "report.pdf".into(),
+            mime_type: "application/pdf".into(),
+            size_bytes: 12345,
+            folder_id: Some(folder_id),
+            created_at: chrono::DateTime::from_timestamp(0, 0).unwrap(),
+            updated_at: None,
+        };
+        let v = serde_json::to_value(&summary).unwrap();
+        assert_eq!(v["id"], "aaaaaaaa-0000-0000-0000-000000000001");
+        assert_eq!(v["group_id"], "bbbbbbbb-0000-0000-0000-000000000001");
+        assert_eq!(v["name"], "report.pdf");
+        assert_eq!(v["mime_type"], "application/pdf");
+        assert_eq!(v["size_bytes"], 12345);
+        assert_eq!(v["folder_id"], "cccccccc-0000-0000-0000-000000000001");
+        assert!(
+            v.get("updated_at").is_none(),
+            "absent updated_at must be omitted"
+        );
+    }
+
+    #[test]
+    fn my_file_summary_omits_folder_id_when_absent() {
+        let summary = MyFileSummary {
+            id: Uuid::nil(),
+            group_id: Uuid::nil(),
+            name: "photo.jpg".into(),
+            mime_type: "image/jpeg".into(),
+            size_bytes: 500_000,
+            folder_id: None,
+            created_at: chrono::DateTime::from_timestamp(0, 0).unwrap(),
+            updated_at: Some(chrono::DateTime::from_timestamp(1_000_000, 0).unwrap()),
+        };
+        let v = serde_json::to_value(&summary).unwrap();
+        assert!(
+            v.get("folder_id").is_none(),
+            "absent folder_id must be omitted"
+        );
+        assert!(
+            v.get("updated_at").is_some(),
+            "present updated_at must be serialized"
+        );
+    }
+
+    #[test]
+    fn list_my_files_query_defaults() {
+        let q = ListMyFilesQuery {
+            group_id: Uuid::nil(),
+            after: None,
+            limit: None,
+            folder_id: None,
+        };
+        assert!(q.after.is_none());
+        assert!(q.limit.is_none());
+        assert!(q.folder_id.is_none());
+    }
+
+    #[test]
+    fn list_my_files_query_with_all_fields() {
+        let gid = Uuid::parse_str("dddddddd-0000-0000-0000-000000000004").unwrap();
+        let after = Uuid::parse_str("eeeeeeee-0000-0000-0000-000000000005").unwrap();
+        let fid = Uuid::parse_str("ffffffff-0000-0000-0000-000000000006").unwrap();
+        let q = ListMyFilesQuery {
+            group_id: gid,
+            after: Some(after),
+            limit: Some(25),
+            folder_id: Some(fid),
+        };
+        assert_eq!(q.group_id, gid);
+        assert_eq!(q.after, Some(after));
+        assert_eq!(q.limit, Some(25));
+        assert_eq!(q.folder_id, Some(fid));
+    }
+
+    #[test]
+    fn list_my_files_limit_clamp() {
+        let over: i64 = Some(200i64).map(|l| l.min(100)).unwrap_or(50).max(1);
+        let under: i64 = Some(0i64).map(|l| l.min(100)).unwrap_or(50).max(1);
+        let default: i64 = None::<i64>.map(|l| l.min(100)).unwrap_or(50).max(1);
+        assert_eq!(over, 100);
+        assert_eq!(under, 1);
+        assert_eq!(default, 50);
+    }
+
+    #[test]
+    fn my_file_summary_large_size_bytes() {
+        let summary = MyFileSummary {
+            id: Uuid::nil(),
+            group_id: Uuid::nil(),
+            name: "large.bin".into(),
+            mime_type: "application/octet-stream".into(),
+            size_bytes: 5_368_709_120i64,
+            folder_id: None,
+            created_at: chrono::DateTime::from_timestamp(0, 0).unwrap(),
+            updated_at: None,
+        };
+        let v = serde_json::to_value(&summary).unwrap();
+        assert_eq!(v["size_bytes"], 5_368_709_120i64);
     }
 }

--- a/crates/garraia-gateway/src/rest_v1/me.rs
+++ b/crates/garraia-gateway/src/rest_v1/me.rs
@@ -1436,7 +1436,10 @@ mod tests {
         };
         let v = serde_json::to_value(&resp).unwrap();
         assert_eq!(v["items"].as_array().unwrap().len(), 0);
-        assert!(v.get("next_cursor").is_none(), "absent cursor must be omitted");
+        assert!(
+            v.get("next_cursor").is_none(),
+            "absent cursor must be omitted"
+        );
     }
 
     #[test]

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -318,10 +318,12 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 // Plan 0237 (GAR-755) — GET /v1/me/mentions @mention inbox.
                 // Plan 0242 (GAR-763) — GET /v1/me/tasks assigned-task inbox.
                 // Plan 0245 (GAR-765) — GET /v1/me/chats chat membership inbox.
+                // Plan 0246 (GAR-767) — GET /v1/me/files uploaded-files inbox.
                 .route("/v1/me", get(me::get_me).patch(me::patch_me))
                 .route("/v1/me/mentions", get(me::list_my_mentions))
                 .route("/v1/me/tasks", get(me::list_my_tasks))
                 .route("/v1/me/chats", get(me::list_my_chats))
+                .route("/v1/me/files", get(me::list_my_files))
                 // Plan 0105 (GAR-580) — groups slice 3: list user's groups.
                 .route(
                     "/v1/groups",
@@ -562,9 +564,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 // Plan 0110 (GAR-599) — PATCH /v1/me stub (no AppPool in mode 2).
                 // Plan 0237 (GAR-755) — GET /v1/me/mentions stub.
                 // Plan 0242 (GAR-763) — GET /v1/me/tasks stub.
+                // Plan 0246 (GAR-767) — GET /v1/me/files stub.
                 .route("/v1/me", get(me::get_me).patch(unconfigured_handler))
                 .route("/v1/me/mentions", get(unconfigured_handler))
                 .route("/v1/me/tasks", get(unconfigured_handler))
+                .route("/v1/me/files", get(unconfigured_handler))
                 .route("/v1/groups", post(unconfigured_handler))
                 .route(
                     "/v1/groups/{id}",
@@ -784,12 +788,14 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 // Plan 0110 (GAR-599) — PATCH /v1/me stub (no-auth mode).
                 // Plan 0237 (GAR-755) — GET /v1/me/mentions stub.
                 // Plan 0242 (GAR-763) — GET /v1/me/tasks stub.
+                // Plan 0246 (GAR-767) — GET /v1/me/files stub.
                 .route(
                     "/v1/me",
                     get(unconfigured_handler).patch(unconfigured_handler),
                 )
                 .route("/v1/me/mentions", get(unconfigured_handler))
                 .route("/v1/me/tasks", get(unconfigured_handler))
+                .route("/v1/me/files", get(unconfigured_handler))
                 .route("/v1/groups", post(unconfigured_handler))
                 .route(
                     "/v1/groups/{id}",

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -29,8 +29,8 @@ use super::groups::{
 use super::invites::AcceptInviteResponse;
 use super::me::{
     ChatMembershipSummary, MeResponse, MentionSummary, MentionsListResponse,
-    MyChatsMembershipResponse, PatchMeRequest, PatchMeResponse, TaskAssignmentSummary,
-    TasksListResponse,
+    MyChatsMembershipResponse, MyFileSummary, MyFilesResponse, PatchMeRequest, PatchMeResponse,
+    TaskAssignmentSummary, TasksListResponse,
 };
 use super::memory::{
     CreateMemoryRequest, ListMemoryResponse, MemoryItemResponse, MemoryItemSummary,
@@ -98,6 +98,7 @@ impl Modify for SecurityAddon {
         super::me::list_my_mentions,
         super::me::list_my_tasks,
         super::me::list_my_chats,
+        super::me::list_my_files,
         super::groups::create_group,
         super::groups::list_groups,
         super::groups::get_group,
@@ -177,6 +178,8 @@ impl Modify for SecurityAddon {
         MentionsListResponse,
         MyChatsMembershipResponse,
         ChatMembershipSummary,
+        MyFilesResponse,
+        MyFileSummary,
         PatchMeRequest,
         PatchMeResponse,
         TaskAssignmentSummary,

--- a/plans/0246-gar-767-me-files-inbox.md
+++ b/plans/0246-gar-767-me-files-inbox.md
@@ -1,0 +1,136 @@
+# Plan 0246 — GAR-767: GET /v1/me/files (caller-scoped file inbox)
+
+## Goal
+
+Add `GET /v1/me/files` — cursor-paginated inbox of files uploaded by the
+authenticated caller within a given group. Follows the same pattern as
+`GET /v1/me/chats` (plan 0245 / GAR-765) but queries the `files` table
+with `created_by = caller_user_id`.
+
+## Linear
+
+**GAR-767** — REST /v1 — GET /v1/me/files (caller-scoped file inbox)
+<https://linear.app/chatgpt25/issue/GAR-767>
+
+## Architecture
+
+Single handler `me::list_my_files` added to `crates/garraia-gateway/src/rest_v1/me.rs`.
+
+### FORCE RLS protocol
+
+`files` is FORCE RLS via `files_group_isolation` policy (migration 003), keyed
+on `app.current_group_id`. Per CLAUDE.md rule 10, the handler sets **both**
+`app.current_user_id` and `app.current_group_id` inside a transaction, even
+though the files policy only checks `current_group_id`.
+
+`WHERE created_by = $1` is the per-caller filter (functional, not authz). The
+FORCE RLS policy is the cross-group isolation guarantee.
+
+### Pagination
+
+Keyset cursor on `(files.created_at DESC, files.id DESC)`. Cursor token = `file_id`
+(same pattern as `list_my_chats` which uses `chat_id`). Cursor subquery is
+scoped to `group_id = $2` so files in other groups cannot poison the cursor.
+
+### Optional filter
+
+`folder_id: Option<Uuid>` — when present, adds `AND folder_id = $N` to the
+query. This is a direct equality filter, no string interpolation.
+
+### Query branches
+
+4 static SQL strings (no concatenation):
+1. First page, no folder filter
+2. First page, with folder filter
+3. Cursor page, no folder filter
+4. Cursor page, with folder filter
+
+## Tech stack
+
+- Rust / Axum 0.8 / sqlx
+- `files` table (migration 003, FORCE RLS `files_group_isolation`)
+- utoipa `#[utoipa::path(...)]` for OpenAPI registration
+
+## Design invariants
+
+- FORCE RLS: `SET LOCAL app.current_user_id` + `SET LOCAL app.current_group_id` before every query.
+- No PII in audit: this endpoint is read-only — no audit event emitted.
+- Fail-closed cursor: if `after` file_id is not found (deleted or wrong group),
+  the cursor subquery returns NULL → `(created_at, id) < NULL` is always false
+  → empty safe result.
+- Limit clamped: values > 100 clamped to 100; values < 1 clamped to 1; default 50.
+- `deleted_at IS NULL` filter prevents soft-deleted files from appearing.
+
+## Validações pré-plano
+
+- [x] `files` FORCE RLS policy confirmed in migration 003: `group_id = NULLIF(current_setting('app.current_group_id', true), '')::uuid`.
+- [x] `files.created_by` column exists (migration 003 §3.2).
+- [x] `files.deleted_at` column exists (soft-delete, migration 003 §3.2).
+- [x] Handler pattern confirmed in `list_my_chats` (plan 0245).
+- [x] No new migration required (read-only slice).
+
+## Out of scope
+
+- Pagination by `updated_at` ordering (future)
+- Mime-type filter (future)
+- Files shared with caller (not uploaded by caller) (future)
+- Folders the caller created (separate endpoint)
+
+## Rollback
+
+Route deletion + revert of `me.rs` additions + revert of `openapi.rs` additions +
+revert of `mod.rs` route entries. No migration needed (read-only slice).
+
+## File structure
+
+```
+crates/garraia-gateway/src/rest_v1/
+  me.rs            ← add ListMyFilesQuery, MyFileSummary, MyFilesResponse,
+                      list_my_files handler, 8 unit tests
+  mod.rs           ← add /v1/me/files route in all 3 router branches
+  openapi.rs       ← register list_my_files path + MyFilesResponse + MyFileSummary
+ROADMAP.md         ← add [x] GET /v1/me/files checkbox in §3.4
+plans/README.md    ← add plan 0246 row
+TODO.md            ← update
+```
+
+## M1 tasks
+
+- [x] T1: Add `ListMyFilesQuery`, `MyFileSummary`, `MyFilesResponse` types to `me.rs`
+- [x] T2: Add `list_my_files` handler with 4 SQL branches
+- [x] T3: Register route in `mod.rs` (3 router branches)
+- [x] T4: Register path + components in `openapi.rs`
+- [x] T5: Add 8 unit tests in `me.rs`
+- [x] T6: Update `ROADMAP.md` §3.4 + `plans/README.md` + `TODO.md`
+- [ ] T7: Push branch, open PR, wait for CI green
+- [ ] T8: Squash-merge, mark GAR-767 Done
+
+## Risk register
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| files RLS policy not applied (forgot SET LOCAL) | Low | High | Same pattern as list_my_chats; tested in CI integration suite |
+| Cursor poisoning from another group | Low | Medium | Cursor subquery scoped to `group_id = $2` |
+| Large `size_bytes` overflow | Very Low | Low | i64 (8 bytes) covers up to ~9.2 EB |
+
+## Acceptance criteria
+
+1. `GET /v1/me/files?group_id=<uuid>` returns 200 with paginated file list for caller's own files.
+2. Files from another group are invisible (RLS isolation + explicit `group_id = $2`).
+3. Files uploaded by another user are excluded (`created_by = $1`).
+4. Soft-deleted files are excluded (`deleted_at IS NULL`).
+5. `folder_id` filter narrows to that folder when provided.
+6. Cursor pagination: second page starts correctly after `next_cursor`.
+7. OpenAPI schema registered; `cargo clippy --workspace … -D warnings` passes.
+8. ≥8 unit tests green.
+
+## Cross-references
+
+- Plan 0245 (GAR-765): `GET /v1/me/chats` — same handler pattern
+- Plan 0242 (GAR-763): `GET /v1/me/tasks` — same handler pattern
+- Migration 003 (`003_files_and_folders.sql`): `files` schema + FORCE RLS
+- ROADMAP.md §3.4 "Arquivos" + §3.4 "GET /v1/me/files"
+
+## Estimativa
+
+LOC: ~250 (handler + types + tests). Time: 1 routine slice.

--- a/plans/README.md
+++ b/plans/README.md
@@ -255,3 +255,4 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0243 | [GAR-762 — Health run 70 (2026-05-31 ~12:45 ET): PR #594 closed superseded, all surfaces clean, priority (i)](0243-gar-762-health-run-70.md) | [GAR-762](https://linear.app/chatgpt25/issue/GAR-762) | ✅ Merged 2026-05-31 via PR #597 (`b66f6db`) |
 | 0244 | [GAR-764 — Health run 71 (2026-05-31 ~17:05 ET): PR #597+#599 merged, all surfaces clean, priority (i)](0244-gar-764-health-run-71.md) | [GAR-764](https://linear.app/chatgpt25/issue/GAR-764) | ✅ Merged 2026-05-31 via PR #600 (`5e126b1`) |
 | 0245 | [GAR-765 — GET /v1/me/chats (caller-scoped chat membership inbox)](0245-gar-765-me-chats-inbox.md) | [GAR-765](https://linear.app/chatgpt25/issue/GAR-765) | ✅ Merged 2026-05-31 via PR #601 (`2bf1f5b`) |
+| 0246 | [GAR-767 — GET /v1/me/files (caller-scoped uploaded-files inbox)](0246-gar-767-me-files-inbox.md) | [GAR-767](https://linear.app/chatgpt25/issue/GAR-767) | 🔄 In Progress |


### PR DESCRIPTION
## Summary

- Adds `GET /v1/me/files` — cursor-paginated inbox of files uploaded by the authenticated caller within a given group.
- Follows the exact FORCE-RLS + keyset-cursor pattern established by `GET /v1/me/chats` (plan 0245) and `GET /v1/me/tasks` (plan 0242).
- No new migration (read-only slice against the existing `files` table from migration 003).

## What's in this PR

| File | Change |
|------|--------|
| `rest_v1/me.rs` | `ListMyFilesQuery`, `MyFileSummary`, `MyFilesResponse` types + `list_my_files` handler (4 SQL branches) + 8 unit tests |
| `rest_v1/mod.rs` | `/v1/me/files` route registered in all 3 router modes (full + 2 stubs) |
| `rest_v1/openapi.rs` | `list_my_files` path + `MyFilesResponse` + `MyFileSummary` components |
| `ROADMAP.md` | `[x] GET /v1/me/files` checkbox added in §3.4 |
| `plans/0246-gar-767-me-files-inbox.md` | Plan file |
| `plans/README.md` + `TODO.md` | Tracking updated |

## Endpoint spec

```
GET /v1/me/files?group_id=<uuid>[&after=<file_id>][&limit=<n>][&folder_id=<uuid>]
Authorization: Bearer <jwt>

200 OK
{
  "items": [
    {
      "id": "...", "group_id": "...", "name": "report.pdf",
      "mime_type": "application/pdf", "size_bytes": 12345,
      "folder_id": "...",            // omitted when null
      "created_at": "2026-06-01T00:00:00Z",
      "updated_at": "..."            // omitted when null
    }
  ],
  "next_cursor": "..."   // omitted on last page
}
```

**Query params:**
- `group_id` (required) — sets `app.current_group_id` for FORCE RLS
- `after` (optional) — keyset cursor = `file_id` of last item on previous page
- `limit` (optional, default 50, clamped `[1, 100]`)
- `folder_id` (optional) — filter to files directly inside this folder

## FORCE RLS protocol

Both `app.current_user_id` and `app.current_group_id` are `SET LOCAL` inside a transaction before every query (CLAUDE.md rule 10). The `files_group_isolation` policy (migration 003) uses `current_group_id`. `WHERE created_by = $1` is the per-caller functional filter.

## Test plan

- [x] `cargo check -p garraia-gateway` — clean compile
- [x] `cargo test -p garraia-gateway --lib rest_v1::me` — 52 tests pass (8 new)
- [x] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` — zero warnings
- [ ] CI: Format Check, Clippy, Test×3, Build, MSRV, cargo-deny, Security Audit, Coverage, Analyze rust+js, Playwright, E2E, Secret Scan, Dependency Review

Linear: [GAR-767](https://linear.app/chatgpt25/issue/GAR-767)

https://claude.ai/code/session_01E4FYHZNAwqywo7iAyP1dAq

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4FYHZNAwqywo7iAyP1dAq)_