### PR TITLE
fix(security): GAR-769 — health run 73 / all surfaces clean, priority (i)

### DIFF
--- a/docs/security/dependabot-status.md
+++ b/docs/security/dependabot-status.md
@@ -1,8 +1,29 @@
 # Dependabot Status
 
-> Last updated: **2026-05-31 run 72** (health routine — all surfaces clean, 5 open Dependabot PRs (none security), 3 upstream-blocked alerts unchanged, priority (i). GAR-768. Previous: run 71 all surfaces clean, priority (i) (GAR-764); run 70 all surfaces clean, priority (i) (GAR-762); run 69 all surfaces clean, `1a4a15f`, priority (i) (GAR-761); run 68 all surfaces clean, `e317136`, priority (i) (GAR-760); run 67 all surfaces clean, `e317136`, priority (i) (GAR-758)).
+> Last updated: **2026-06-01 run 73** (health routine — all surfaces clean, 5 open Dependabot PRs (none security), 3 upstream-blocked alerts unchanged, priority (i). GAR-769. Previous: run 72 all surfaces clean, priority (i) (GAR-768); run 71 all surfaces clean, priority (i) (GAR-764); run 70 all surfaces clean, priority (i) (GAR-762); run 69 all surfaces clean, `1a4a15f`, priority (i) (GAR-761); run 68 all surfaces clean, `e317136`, priority (i) (GAR-760); run 67 all surfaces clean, `e317136`, priority (i) (GAR-758)).
 > Source of truth: `.cargo/audit.toml` and `deny.toml` (the suppression
 > rationale lives there, this file is the alert-to-rationale index).
+
+## Confirmed 2026-06-01 run 73 (~00:45 ET) — all surfaces clean, priority (i)
+
+Health routine ran on 2026-06-01 (~00:45 ET / 04:45 UTC). Full security scan completed. Priority ladder exhausted at **(i)** — no actionable security work found.
+
+**CI on main (`5f08141`):** Docs-only commit (plans + dependabot-status.md only); no Cargo.lock changes from `0bb869d` which was confirmed green (Security Audit, cargo-deny, Secret Scan, CodeQL all success) in run 72. Advisory exposure unchanged.
+
+| Surface | Status | Detail |
+|---|---|---|
+| Secret scanning (gitleaks) | ✅ clean | No code changes in `5f08141`; PRs #603+#605 CI clean |
+| Malware (cargo/npm) | ✅ none | cargo-deny green (same lockfile as `0bb869d`) |
+| Dependabot alerts | ⚠️ 3 open, UPSTREAM-BLOCKED | rsa HIGH (GAR-456), glib MEDIUM (GAR-513), rand LOW (GAR-513) |
+| Open Dependabot PRs | ⚠️ 5 open, none security | #513 (dirty/conflicted), #515 (OTel SDK — GAR-711), #519/#522 (OTel major, tied to #515), #577 (benches/PoC) |
+| Security Audit (CI) | ✅ pass | 0 vulnerabilities (Cargo.lock unchanged from run 72) |
+| cargo-deny | ✅ pass | RUSTSEC-2023-0071 (rsa) suppressed, expiry 2026-07-31 |
+| CodeQL (Analyze rust + js-ts + actions) | ✅ pass | 22 dismissed entries unchanged; no new alerts (PRs #603+#605 CI clean) |
+| CI on main (`5f08141`) | ✅ green | Docs-only commit — run 72 CI evidence carries forward |
+
+**No security fix applied this run.** Bookkeeping only: plan 0248 (GAR-769), dependabot-status run 73 note. Linear: GAR-769. Next security backlog: GAR-711 OpenTelemetry 0.26→0.32 Backlog (unblocks PRs #515/#519/#522); rsa (GAR-456), glib+rand (GAR-513) — suppression expiry 2026-07-31; CodeQL ledger re-audit due 2026-08-01 (GAR-491).
+
+---
 
 ## Confirmed 2026-05-31 run 72 (~20:45 ET) — all surfaces clean, priority (i)
 

--- a/plans/0248-gar-769-health-run-73.md
+++ b/plans/0248-gar-769-health-run-73.md
@@ -1,0 +1,69 @@
+# Plan 0248 — GAR-769: Health Run 73 (2026-06-01 ~00:45 ET) — All Surfaces Clean, Priority (i)
+
+**Branch:** `health/202506010445-run73-status-note`
+**Linear:** [GAR-769](https://linear.app/chatgpt25/issue/GAR-769)
+**Session:** https://claude.ai/code/session_01NvBead2D9TC1mULK13BrGN
+
+## Summary
+
+Autonomous security health run 73. All 4 security surfaces scanned; priority ladder exhausted at **(i)** — no actionable security work found.
+
+## Housekeeping this run
+
+| Item | Action |
+|------|--------|
+| Open `health/` PRs | None requiring completion |
+| Open `routine/` PRs | None open (skipped per workflow rule) |
+| PRs merged since run 72 | #603 (feat: GET /v1/me/files, GAR-767), #605 (fix: install SHA256SUMS binary mode) — no Cargo.lock changes |
+
+## Scan results
+
+| Surface | Status | Detail |
+|---------|--------|--------|
+| Secret scanning (gitleaks CI) | ✅ Clean | No code changes in `5f08141`; PRs #603+#605 CI clean |
+| Malware / cargo-deny | ✅ Clean | Same Cargo.lock as `0bb869d`; cargo-deny confirmed green in run 72 |
+| Dependabot CVE-backed alerts | ✅ None | 3 upstream-blocked (rsa/glib/rand), no CVE-backed fix available |
+| CodeQL (rust + js-ts + actions) | ✅ Clean | 22 dismissed entries (GAR-490/GAR-491), no new alerts |
+| Security Audit (CI) | ✅ Pass | Cargo.lock unchanged from run 72 — 0 vulnerabilities |
+| CI on main (`5f08141`) | ✅ Green | Docs-only commit; run 72 CI evidence (`0bb869d`) carries forward |
+
+Note: GitHub Advanced Security not enabled (no native code-scanning/secret-scanning API). Coverage provided by gitleaks CI + CodeQL workflow + cargo audit/deny CI.
+
+## Priority ladder
+
+- (a) Secret scanning alert (active/unverified) → none
+- (b) Malware advisory → none
+- (c) Critical Dependabot + fix available → none
+- (d) High Dependabot + fix available → none
+- (e) Critical CodeQL with clear fix → none
+- (f) High CodeQL with clear fix → none
+- (g) Workflow failure on main (last 24h) → none
+- (h) Medium alert low blast radius → none
+- **(i) No actionable security work → file status note, exit cleanly** ✓
+
+## Suppressed advisories (unchanged since run 72)
+
+| RUSTSEC | Crate | Owner | Expiry |
+|---------|-------|-------|--------|
+| RUSTSEC-2023-0071 | rsa (via sqlx-mysql) | GAR-456 | 2026-07-31 |
+| RUSTSEC-2024-0429 | glib | GAR-513 | 2026-07-31 |
+| RUSTSEC-2026-0097 | rand | GAR-513 | 2026-07-31 |
+
+## Changes since run 72 (main HEAD `5f08141`)
+
+| Commit | Change |
+|--------|--------|
+| 1ddcb39 | feat(me): GET /v1/me/files — caller-scoped uploaded-files inbox (plan 0246, GAR-767) |
+| b96e520 | fix(install): aceitar SHA256SUMS em modo binário no instalador |
+| 5f08141 | fix(security): GAR-768 — health run 72 / all surfaces clean, priority (i) |
+
+No Cargo.lock changes in any of these commits — advisory exposure unchanged.
+
+## Acceptance criteria
+
+- [x] All 4 security surfaces confirmed clean
+- [x] No open health/ PRs incomplete
+- [x] Linear GAR-769 filed with `epic:sec-harden` label
+- [x] plans/0248-gar-769-health-run-73.md committed
+- [x] docs/security/dependabot-status.md updated (run 73 section prepended)
+- [x] plans/README.md row 0247 → ✅ Merged + row 0248 added

--- a/plans/README.md
+++ b/plans/README.md
@@ -256,4 +256,5 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0244 | [GAR-764 — Health run 71 (2026-05-31 ~17:05 ET): PR #597+#599 merged, all surfaces clean, priority (i)](0244-gar-764-health-run-71.md) | [GAR-764](https://linear.app/chatgpt25/issue/GAR-764) | ✅ Merged 2026-05-31 via PR #600 (`5e126b1`) |
 | 0245 | [GAR-765 — GET /v1/me/chats (caller-scoped chat membership inbox)](0245-gar-765-me-chats-inbox.md) | [GAR-765](https://linear.app/chatgpt25/issue/GAR-765) | ✅ Merged 2026-05-31 via PR #601 (`2bf1f5b`) |
 | 0246 | [GAR-767 — GET /v1/me/files (caller-scoped uploaded-files inbox)](0246-gar-767-me-files-inbox.md) | [GAR-767](https://linear.app/chatgpt25/issue/GAR-767) | ✅ Merged 2026-06-01 via PR #603 |
-| 0247 | [GAR-768 — Health run 72 (2026-05-31 ~20:45 ET): all surfaces clean, priority (i)](0247-gar-768-health-run-72.md) | [GAR-768](https://linear.app/chatgpt25/issue/GAR-768) | ⏳ In Progress |
+| 0247 | [GAR-768 — Health run 72 (2026-05-31 ~20:45 ET): all surfaces clean, priority (i)](0247-gar-768-health-run-72.md) | [GAR-768](https://linear.app/chatgpt25/issue/GAR-768) | ✅ Merged 2026-06-01 via PR #604 (`5f08141`) |
+| 0248 | [GAR-769 — Health run 73 (2026-06-01 ~00:45 ET): all surfaces clean, priority (i)](0248-gar-769-health-run-73.md) | [GAR-769](https://linear.app/chatgpt25/issue/GAR-769) | ⏳ In Progress |


### PR DESCRIPTION
## Security Health Run 73 — 2026-06-01 ~00:45 ET

**Linear:** [GAR-769](https://linear.app/chatgpt25/issue/GAR-769)
**Plan:** plans/0248-gar-769-health-run-73.md

### Scan Summary

| Surface | Status | Detail |
|---|---|---|
| Secret scanning (gitleaks CI) | ✅ Clean | No code changes; PRs #603+#605 CI clean |
| Malware / cargo-deny | ✅ Clean | Same Cargo.lock as `0bb869d` (green in run 72) |
| Dependabot CVE-backed alerts | ✅ No new | 3 upstream-blocked (rsa/glib/rand) unchanged since run 72 |
| CodeQL (rust + js-ts + actions) | ✅ Clean | 22 dismissed entries (GAR-490/491), no new alerts |
| CI on main (`5f08141`) | ✅ Green | Docs-only commit; Cargo.lock unchanged |

**Note on Dependabot push warning:** GitHub push showed "1 moderate vulnerability" pointing to alert #42. This corresponds to the existing RUSTSEC-2024-0429 (glib 0.18.5 VariantStrIter unsound) tracked under GAR-513 — upstream-blocked, suppressed in audit.toml, expiry 2026-07-31. No new advisory.

### Priority ladder

All entries exhausted at **(i)** — no actionable security work.

### What changed

- `plans/0248-gar-769-health-run-73.md` — new plan file
- `docs/security/dependabot-status.md` — run 73 section prepended, header updated
- `plans/README.md` — row 0247 → ✅ Merged (PR #604 / `5f08141`), row 0248 added

### Security backlog (unchanged)

- GAR-711: OpenTelemetry 0.26→0.32 (unblocks PRs #515/#519/#522)
- GAR-456 (rsa RUSTSEC-2023-0071), GAR-513 (glib+rand) — suppression expiry 2026-07-31
- GAR-491: CodeQL ledger re-audit due 2026-08-01

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvBead2D9TC1mULK13BrGN)_