### PR TITLE
docs(plans): mark plan 0249 / GAR-770 merged (ec6922c, PR #608)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -613,7 +613,7 @@ Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
 - [x] `PATCH /v1/me` (display_name self-update) — plan 0110 / [GAR-599](https://linear.app/chatgpt25/issue/GAR-599) ✅
 - [x] `GET /v1/me/chats` — caller-scoped chat membership inbox (cursor-paginated, type filter) — plan 0245 / [GAR-765](https://linear.app/chatgpt25/issue/GAR-765) ✅
 - [x] `GET /v1/me/files` — caller-scoped uploaded-files inbox (cursor-paginated, optional folder filter) — plan 0246 / [GAR-767](https://linear.app/chatgpt25/issue/GAR-767) ✅
-- [ ] `GET /v1/me/memory` — caller-scoped personal memory inbox (cursor-paginated, optional kind filter) — plan 0249 / [GAR-770](https://linear.app/chatgpt25/issue/GAR-770) 🔄 In Progress
+- [x] `GET /v1/me/memory` — caller-scoped personal memory inbox (cursor-paginated, optional kind filter) — plan 0249 / [GAR-770](https://linear.app/chatgpt25/issue/GAR-770) ✅
 
 **Chats**
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -258,4 +258,4 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0246 | [GAR-767 — GET /v1/me/files (caller-scoped uploaded-files inbox)](0246-gar-767-me-files-inbox.md) | [GAR-767](https://linear.app/chatgpt25/issue/GAR-767) | ✅ Merged 2026-06-01 via PR #603 |
 | 0247 | [GAR-768 — Health run 72 (2026-05-31 ~20:45 ET): all surfaces clean, priority (i)](0247-gar-768-health-run-72.md) | [GAR-768](https://linear.app/chatgpt25/issue/GAR-768) | ✅ Merged 2026-06-01 via PR #604 (`5f08141`) |
 | 0248 | [GAR-769 — Health run 73 (2026-06-01 ~00:45 ET): all surfaces clean, priority (i)](0248-gar-769-health-run-73.md) | [GAR-769](https://linear.app/chatgpt25/issue/GAR-769) | ✅ Merged 2026-06-01 via PR #607 (`b2848a8`) |
-| 0249 | [GAR-770 — GET /v1/me/memory (caller-scoped personal memory inbox)](0249-gar-770-me-memory-inbox.md) | [GAR-770](https://linear.app/chatgpt25/issue/GAR-770) | ⏳ In Progress |
+| 0249 | [GAR-770 — GET /v1/me/memory (caller-scoped personal memory inbox)](0249-gar-770-me-memory-inbox.md) | [GAR-770](https://linear.app/chatgpt25/issue/GAR-770) | ✅ Merged 2026-06-01 via PR #608 (`ec6922c`) |


### PR DESCRIPTION
## Summary

- Flips `[ ]` → `[x]` for `GET /v1/me/memory` in `ROADMAP.md` §3.4
- Updates `plans/README.md` row 0249 to `✅ Merged 2026-06-01 via PR #608 (ec6922c)`

Docs-only follow-up to #608.

## Test plan

- [ ] CI Format Check passes (no Rust changes)

https://claude.ai/code/session_0118VbN7gkjbSWjTGsEa8quS

---
_Generated by [Claude Code](https://claude.ai/code/session_0118VbN7gkjbSWjTGsEa8quS)_