### PR TITLE
feat(persona): Garra ganha persona amistosa padrão (plan 0250, GAR-771)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@
 
 <!-- TODO: Adicionar GIF de demonstração do terminal VHS aqui (#103) -->
 
+## 🐾 Conheça o Garra
+
+O **Garra** não é só um endpoint de API — ele é o seu assistente pessoal, e fala
+como um. Desde o primeiro `garra start`, ele se apresenta com nome, conversa em
+português do Brasil na primeira pessoa e mantém um tom caloroso, direto e honesto
+(sem bajulação). Quando algo dá errado, ele explica o que aconteceu e qual é o
+próximo passo — nada de despejar códigos de erro crus.
+
+> _"Oi! 👋 Eu sou o Garra, seu assistente pessoal. Pode falar comigo como você
+> falaria com um amigo."_
+
+Essa personalidade é **o padrão**, mas você manda: defina `agent.system_prompt`
+para dar a ele uma personalidade própria, ou `agent.persona = "neutral"` para um
+tom totalmente neutro. Veja [ADR 0012](docs/adr/0012-garra-persona.md).
+
 ## 🗺️ Roadmap AAA
 
 O desenvolvimento do GarraRUST segue um plano ambicioso de evolução para o tier AAA em 7 fases, consolidado no [ROADMAP.md](ROADMAP.md). Inclui GarraMaxPower nativo (`garra max-power`, registry de skills e Agent Team MVP), Superpowers, TurboQuant+ (KV cache), RAG local (lancedb), MCP + plugins WASM, zero-latency streaming (OpenTelemetry), e a nova direção **Group Workspace** — espaço compartilhado família/equipe multi-tenant com arquivos, chats, memória IA e módulo tipo-Notion (tasks + docs + databases), desenhado em [`deep-research-report.md`](deep-research-report.md). Execução semana a semana acompanhada nos [projects Linear do time GarraIA-RUST](https://linear.app/chatgpt25/team/GAR/projects).

--- a/crates/garraia-agents/src/lib.rs
+++ b/crates/garraia-agents/src/lib.rs
@@ -16,6 +16,7 @@ pub mod multi_agent;
 pub mod ollama;
 pub mod openai;
 pub mod orchestrator;
+pub mod persona;
 pub mod provider_resilience;
 pub mod providers;
 pub mod runtime;
@@ -41,6 +42,10 @@ pub use multi_agent::{
     SubAgentConfig,
 };
 pub use ollama::OllamaProvider;
+pub use persona::{
+    default_persona, resolve_system_prompt, DEFAULT_PERSONA_EN, DEFAULT_PERSONA_PT, Lang,
+    PersonaMode,
+};
 pub use openai::OpenAiProvider;
 pub use orchestrator::{
     Orchestrator, OrchestratorLimits, OrchestratorPlan, OrchestratorStep, OrchestratorSummary,

--- a/crates/garraia-agents/src/lib.rs
+++ b/crates/garraia-agents/src/lib.rs
@@ -42,14 +42,14 @@ pub use multi_agent::{
     SubAgentConfig,
 };
 pub use ollama::OllamaProvider;
-pub use persona::{
-    default_persona, resolve_system_prompt, DEFAULT_PERSONA_EN, DEFAULT_PERSONA_PT, Lang,
-    PersonaMode,
-};
 pub use openai::OpenAiProvider;
 pub use orchestrator::{
     Orchestrator, OrchestratorLimits, OrchestratorPlan, OrchestratorStep, OrchestratorSummary,
     StepDetail, StepStatus, ValidationResult,
+};
+pub use persona::{
+    DEFAULT_PERSONA_EN, DEFAULT_PERSONA_PT, Lang, PersonaMode, default_persona,
+    resolve_system_prompt,
 };
 pub use provider_resilience::{CircuitBreaker, FallbackConfig, ResilienceManager, RetryPolicy};
 pub use providers::{

--- a/crates/garraia-agents/src/persona.rs
+++ b/crates/garraia-agents/src/persona.rs
@@ -1,0 +1,172 @@
+//! Garra's default persona — the warm, human voice it speaks with when the
+//! operator has not supplied a custom `system_prompt`.
+//!
+//! Plan 0250 (GAR-771). Before this module, an unset `system_prompt` meant the
+//! agent fell back to the base model's neutral tone (`unwrap_or_default()` →
+//! empty system message). That made "Garra" feel like a generic LLM rather than
+//! a personal assistant with an identity.
+//!
+//! Design (plan 0250 §2):
+//! - First person, warm, concise, PT-BR first with an EN fallback.
+//! - Helpful and reassuring, never sycophantic.
+//! - Sparing emoji.
+//!
+//! The persona is **always overridable**: any non-empty `system_prompt` from
+//! config or a per-request override wins. Choosing `PersonaMode::Neutral`
+//! restores the pre-0250 behavior (no default system prompt at all).
+
+/// Which voice the agent uses when no explicit `system_prompt` is set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PersonaMode {
+    /// Warm "Garra" persona (plan 0250 default).
+    #[default]
+    Friendly,
+    /// No default system prompt — pre-0250 behavior. The base model's own tone.
+    Neutral,
+}
+
+/// Language used to pick the default persona copy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Lang {
+    /// Brazilian Portuguese (primary audience).
+    #[default]
+    Pt,
+    /// English fallback.
+    En,
+}
+
+impl Lang {
+    /// Best-effort parse from a BCP-47-ish tag or short code. Anything that is
+    /// not clearly English falls back to PT-BR (the primary audience).
+    pub fn from_code(code: &str) -> Self {
+        let c = code.trim().to_ascii_lowercase();
+        if c.starts_with("en") {
+            Lang::En
+        } else {
+            Lang::Pt
+        }
+    }
+}
+
+/// The warm Garra persona in Brazilian Portuguese.
+pub const DEFAULT_PERSONA_PT: &str = "\
+Você é o Garra — um assistente pessoal de IA, leal e prestativo, que conversa \
+em português do Brasil de forma natural e calorosa.
+
+Como você se comporta:
+- Fala na primeira pessoa (\"eu\", \"vou te ajudar\") e com naturalidade, como \
+um colega de confiança — não como um robô.
+- É caloroso, mas direto e conciso: acolhe sem enrolar.
+- Quando algo dá errado, explica de forma tranquila o que aconteceu e qual é o \
+próximo passo, sem despejar mensagens técnicas cruas.
+- Usa emojis com parcimônia (no máximo um, quando agrega) — 👋 ao cumprimentar, \
+🐾 num toque amigável. Nunca poluir.
+- Não bajula (\"que ótima pergunta!\") nem inventa: é gentil, honesto e \
+competente. Se não sabe, diz que não sabe e sugere um caminho.
+- Respeita o usuário e a privacidade dele.
+
+Seu nome é Garra. Você existe para tornar a vida da pessoa (ou da família/equipe) \
+mais fácil.";
+
+/// The warm Garra persona in English.
+pub const DEFAULT_PERSONA_EN: &str = "\
+You are Garra — a loyal, helpful personal AI assistant who speaks naturally and \
+warmly.
+
+How you behave:
+- Speak in the first person (\"I\", \"I'll help you with that\") and \
+conversationally, like a trusted colleague — not like a robot.
+- Be warm but direct and concise: welcoming without padding.
+- When something goes wrong, calmly explain what happened and the next step, \
+instead of dumping raw technical errors.
+- Use emoji sparingly (at most one, when it adds something) — 👋 to greet, 🐾 \
+for a friendly touch. Never clutter.
+- Don't flatter (\"what a great question!\") or make things up: be kind, honest, \
+and competent. If you don't know, say so and suggest a path forward.
+- Respect the user and their privacy.
+
+Your name is Garra. You exist to make the person's (or family's/team's) life \
+easier.";
+
+/// Return the default persona system prompt for the given language.
+pub fn default_persona(lang: Lang) -> &'static str {
+    match lang {
+        Lang::Pt => DEFAULT_PERSONA_PT,
+        Lang::En => DEFAULT_PERSONA_EN,
+    }
+}
+
+/// Resolve the effective base system prompt.
+///
+/// Priority (plan 0250 §5 — operator override always wins):
+/// 1. A non-empty explicit prompt (from config or a per-request override).
+/// 2. Otherwise, the default persona for `lang` — unless `mode` is
+///    [`PersonaMode::Neutral`], in which case there is no default (pre-0250
+///    behavior, returns `None`).
+pub fn resolve_system_prompt(
+    explicit: Option<&str>,
+    mode: PersonaMode,
+    lang: Lang,
+) -> Option<String> {
+    if let Some(p) = explicit
+        && !p.trim().is_empty()
+    {
+        return Some(p.to_string());
+    }
+    match mode {
+        PersonaMode::Friendly => Some(default_persona(lang).to_string()),
+        PersonaMode::Neutral => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lang_parsing_defaults_to_pt() {
+        assert_eq!(Lang::from_code("pt-BR"), Lang::Pt);
+        assert_eq!(Lang::from_code("pt"), Lang::Pt);
+        assert_eq!(Lang::from_code("en-US"), Lang::En);
+        assert_eq!(Lang::from_code("EN"), Lang::En);
+        // Unknown → PT (primary audience).
+        assert_eq!(Lang::from_code("fr"), Lang::Pt);
+        assert_eq!(Lang::from_code(""), Lang::Pt);
+    }
+
+    #[test]
+    fn persona_text_mentions_garra_and_is_nonempty() {
+        assert!(DEFAULT_PERSONA_PT.contains("Garra"));
+        assert!(DEFAULT_PERSONA_EN.contains("Garra"));
+        assert!(default_persona(Lang::Pt).len() > 100);
+        assert!(default_persona(Lang::En).len() > 100);
+    }
+
+    #[test]
+    fn explicit_prompt_always_wins() {
+        let got = resolve_system_prompt(Some("custom voice"), PersonaMode::Friendly, Lang::Pt);
+        assert_eq!(got.as_deref(), Some("custom voice"));
+        // Even in neutral mode an explicit prompt is honored.
+        let got = resolve_system_prompt(Some("custom voice"), PersonaMode::Neutral, Lang::Pt);
+        assert_eq!(got.as_deref(), Some("custom voice"));
+    }
+
+    #[test]
+    fn empty_explicit_falls_back_to_persona() {
+        // None → persona in Friendly mode.
+        let got = resolve_system_prompt(None, PersonaMode::Friendly, Lang::Pt);
+        assert_eq!(got.as_deref(), Some(DEFAULT_PERSONA_PT));
+        // Whitespace-only counts as empty.
+        let got = resolve_system_prompt(Some("   "), PersonaMode::Friendly, Lang::En);
+        assert_eq!(got.as_deref(), Some(DEFAULT_PERSONA_EN));
+    }
+
+    #[test]
+    fn neutral_mode_reproduces_pre_0250_behavior() {
+        // No explicit prompt + neutral → no default (old behavior).
+        let got = resolve_system_prompt(None, PersonaMode::Neutral, Lang::Pt);
+        assert_eq!(got, None);
+        let got = resolve_system_prompt(Some(""), PersonaMode::Neutral, Lang::En);
+        assert_eq!(got, None);
+    }
+}

--- a/crates/garraia-agents/src/runtime.rs
+++ b/crates/garraia-agents/src/runtime.rs
@@ -121,6 +121,12 @@ pub struct AgentRuntime {
     embeddings: Option<Arc<dyn EmbeddingProvider>>,
     tools: Vec<Box<dyn Tool>>,
     system_prompt: Option<String>,
+    /// Plan 0250 (GAR-771): default persona used when `system_prompt` is unset.
+    /// `Friendly` gives Garra a warm default voice; `Neutral` restores the
+    /// pre-0250 behavior (no default system prompt).
+    persona_mode: crate::persona::PersonaMode,
+    /// Plan 0250: language for the default persona copy (PT-BR default).
+    persona_lang: crate::persona::Lang,
     max_tokens: Option<u32>,
     max_context_tokens: Option<usize>,
     max_tool_calls: Option<usize>,
@@ -145,6 +151,8 @@ impl AgentRuntime {
             embeddings: None,
             tools: Vec::new(),
             system_prompt: None,
+            persona_mode: crate::persona::PersonaMode::default(),
+            persona_lang: crate::persona::Lang::default(),
             max_tokens: None,
             max_context_tokens: None,
             max_tool_calls: None,
@@ -218,6 +226,25 @@ impl AgentRuntime {
 
     pub fn set_system_prompt(&mut self, prompt: String) {
         self.system_prompt = Some(prompt);
+    }
+
+    /// Plan 0250 (GAR-771): choose the default persona voice used when no
+    /// explicit `system_prompt` is set.
+    pub fn set_persona_mode(&mut self, mode: crate::persona::PersonaMode) {
+        self.persona_mode = mode;
+    }
+
+    /// Plan 0250: set the language for the default persona copy.
+    pub fn set_persona_lang(&mut self, lang: crate::persona::Lang) {
+        self.persona_lang = lang;
+    }
+
+    /// Plan 0250: resolve the base system prompt, applying the default persona
+    /// fallback when no explicit prompt is configured. An explicit
+    /// (non-empty) prompt always wins; `PersonaMode::Neutral` yields `None`
+    /// (pre-0250 behavior).
+    fn base_system_prompt(&self, explicit: Option<&str>) -> Option<String> {
+        crate::persona::resolve_system_prompt(explicit, self.persona_mode, self.persona_lang)
     }
 
     pub fn set_max_tokens(&mut self, max_tokens: u32) {
@@ -575,9 +602,13 @@ impl AgentRuntime {
                 .ok_or_else(|| Error::Agent("no LLM provider configured".into()))?
         };
 
-        let effective_system_prompt = system_prompt_override
+        // Plan 0250 (GAR-771): resolve override → config prompt → default
+        // persona. An explicit prompt always wins; the persona only fills in
+        // when nothing is configured (and not in Neutral mode).
+        let explicit_prompt = system_prompt_override
             .map(|s| s.to_string())
             .or_else(|| self.system_prompt.clone());
+        let effective_system_prompt = self.base_system_prompt(explicit_prompt.as_deref());
         let effective_model = model_override
             .map(str::trim)
             .filter(|m| !m.is_empty())
@@ -817,7 +848,9 @@ impl AgentRuntime {
             _ => None,
         };
 
-        let system = match (&self.system_prompt, memory_context) {
+        // Plan 0250 (GAR-771): apply default persona fallback here too.
+        let effective_system_prompt = self.base_system_prompt(self.system_prompt.as_deref());
+        let system = match (&effective_system_prompt, memory_context) {
             (Some(prompt), Some(ctx)) => Some(format!("{prompt}\n\n{ctx}")),
             (Some(prompt), None) => Some(prompt.clone()),
             (None, Some(ctx)) => Some(ctx),
@@ -1140,9 +1173,13 @@ impl AgentRuntime {
                 .ok_or_else(|| Error::Agent("no LLM provider configured".into()))?
         };
 
-        let effective_system_prompt = system_prompt_override
+        // Plan 0250 (GAR-771): resolve override → config prompt → default
+        // persona. An explicit prompt always wins; the persona only fills in
+        // when nothing is configured (and not in Neutral mode).
+        let explicit_prompt = system_prompt_override
             .map(|s| s.to_string())
             .or_else(|| self.system_prompt.clone());
+        let effective_system_prompt = self.base_system_prompt(explicit_prompt.as_deref());
         let effective_model = model_override
             .map(str::trim)
             .filter(|m| !m.is_empty())

--- a/crates/garraia-channels/src/commands/builtins/start.rs
+++ b/crates/garraia-channels/src/commands/builtins/start.rs
@@ -17,15 +17,23 @@ impl SlashCommand for StartCommand {
         false
     }
 
-    fn execute(&self, _ctx: &CommandContext) -> CommandResult {
-        Ok(
-            "Welcome to GarraIA! Send me a message and I will respond.\n\n\
-             Commands:\n\
-             /help - show this help\n\
-             /clear - reset conversation history\n\
-             /model [name] - get or set the LLM model\n\
-             /pair - generate invite code (owner only)"
-                .to_string(),
-        )
+    fn execute(&self, ctx: &CommandContext) -> CommandResult {
+        // Plan 0250 (GAR-771): warm, PT-BR-first welcome that introduces Garra
+        // in the first person and nudges the user toward a first interaction.
+        let name = ctx.user_name.trim();
+        let greeting = if name.is_empty() {
+            "Oi! 👋 Eu sou o Garra".to_string()
+        } else {
+            format!("Oi, {name}! 👋 Eu sou o Garra")
+        };
+        Ok(format!(
+            "{greeting}, seu assistente pessoal.\n\n\
+             Pode falar comigo como você falaria com um amigo — é só me mandar \
+             uma mensagem. Por exemplo:\n\
+             • \"Me ajuda a organizar minha semana\"\n\
+             • \"Resume esse texto pra mim\"\n\
+             • \"O que você consegue fazer?\"\n\n\
+             Se quiser ver os atalhos, é só mandar /help. Vamos lá? 🐾"
+        ))
     }
 }

--- a/crates/garraia-cli/src/banner.rs
+++ b/crates/garraia-cli/src/banner.rs
@@ -121,7 +121,7 @@ pub fn print_banner(host: &str, port: u16, config: &AppConfig, config_dir: &Path
 
     println!("{top}");
     println!("{}", row("", ""));
-    println!("{}", row("  Welcome to GarraIA!", "Gateway"));
+    println!("{}", row("  Oi! Eu sou o Garra 🐾", "Gateway"));
     println!("{}", row("", &url));
     println!("{}", row("      _~^~^~_", &"─".repeat(right_w - 2)));
     println!(
@@ -137,7 +137,7 @@ pub fn print_banner(host: &str, port: u16, config: &AppConfig, config_dir: &Path
         row("    / '-----' \\", &format!("Skills      {skills}"))
     );
     println!("{}", row("", &format!("MCP         {mcp}")));
-    println!("{}", row("  Rust · Personal AI", ""));
+    println!("{}", row("  Seu assistente pessoal", ""));
     println!("{}", row("", &format!("Config      {config_display}")));
     println!("{}", row("", &format!("CWD         {cwd_display}")));
     println!("{}", row("", "Press Ctrl+C to stop"));

--- a/crates/garraia-cli/src/wizard/mod.rs
+++ b/crates/garraia-cli/src/wizard/mod.rs
@@ -57,8 +57,8 @@ pub fn run_wizard(config_dir: &Path) -> Result<()> {
     }
 
     println!();
-    println!("  GarraIA Setup Wizard");
-    println!("  ----------------------");
+    println!("  Oi! 👋 Vamos configurar o Garra juntos — leva só um minutinho.");
+    println!("  ----------------------------------------------------------------");
     println!();
 
     // --- 1. Detect the environment -----------------------------------------
@@ -187,13 +187,19 @@ pub fn run_wizard(config_dir: &Path) -> Result<()> {
     };
 
     // --- 8. System prompt --------------------------------------------------
+    // Plan 0250 (GAR-771): leaving this empty now gives Garra its warm default
+    // persona automatically (resolved at runtime). Only fill it in to give Garra
+    // a *custom* personality.
+    println!();
+    println!("  Personalidade: deixe em branco e eu já falo com o jeitinho do Garra.");
+    println!("  (Preencha só se quiser me dar uma personalidade diferente.)");
     let system_prompt_input: String = Input::new()
-        .with_prompt("System prompt (optional)")
-        .default("You are a helpful personal AI assistant.".to_string())
+        .with_prompt("Personalidade do Garra (opcional)")
+        .default(String::new())
         .allow_empty(true)
         .interact_text()
         .context("system prompt input cancelled")?;
-    let system_prompt = if system_prompt_input.is_empty() {
+    let system_prompt = if system_prompt_input.trim().is_empty() {
         None
     } else {
         Some(system_prompt_input)
@@ -291,9 +297,10 @@ pub fn run_wizard(config_dir: &Path) -> Result<()> {
 
     // --- 12. Final summary -------------------------------------------------
     println!();
-    println!("  Config written to {}", written.display());
-    println!("  Next: `garraia start` to launch the gateway in the foreground.");
-    println!("  Press Ctrl+C to stop. To run later in background: garraia start -d");
+    println!("  Prontinho! 🎉 O Garra está configurado e pronto pra te ajudar.");
+    println!("  Config salva em {}", written.display());
+    println!("  Agora é só rodar `garraia start` pra eu entrar no ar.");
+    println!("  Pra parar, é só Ctrl+C. Pra rodar em segundo plano: garraia start -d");
     println!("  Logs: {}/garraia.log", config_dir.display());
     if outcome.voice_enabled {
         println!("  Voice was enabled — see docs/voice.md to install Chatterbox + faster-whisper.");

--- a/crates/garraia-config/src/model.rs
+++ b/crates/garraia-config/src/model.rs
@@ -810,6 +810,31 @@ mod tests {
     }
 
     #[test]
+    fn agent_persona_defaults_to_friendly() {
+        // Plan 0250 (GAR-771): the warm persona is the default; persona_lang
+        // is unset (PT-BR resolved at runtime).
+        let config = AppConfig::default();
+        assert_eq!(config.agent.persona, super::PersonaMode::Friendly);
+        assert!(config.agent.persona_lang.is_none());
+    }
+
+    #[test]
+    fn agent_persona_parses_neutral_lowercase() {
+        // Plan 0250: the config contract is lowercase (`friendly` | `neutral`).
+        let raw = r#"
+gateway:
+  host: "127.0.0.1"
+  port: 3888
+agent:
+  persona: neutral
+  persona_lang: "en"
+"#;
+        let config: AppConfig = serde_yaml::from_str(raw).expect("parse");
+        assert_eq!(config.agent.persona, super::PersonaMode::Neutral);
+        assert_eq!(config.agent.persona_lang.as_deref(), Some("en"));
+    }
+
+    #[test]
     fn parses_memory_and_embedding_config() {
         let raw = r#"
 gateway:

--- a/crates/garraia-config/src/model.rs
+++ b/crates/garraia-config/src/model.rs
@@ -440,9 +440,28 @@ impl Default for MemoryConfig {
     }
 }
 
+/// Plan 0250 (GAR-771): default voice Garra uses when no `system_prompt` is set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PersonaMode {
+    /// Warm "Garra" persona (default — plan 0250).
+    #[default]
+    Friendly,
+    /// No default system prompt; the base model's neutral tone (pre-0250).
+    Neutral,
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AgentConfig {
     pub system_prompt: Option<String>,
+    /// Plan 0250 (GAR-771): which default persona to use when `system_prompt`
+    /// is empty. Defaults to the warm "friendly" Garra voice; set to `neutral`
+    /// to restore the pre-0250 behavior (no default system prompt).
+    #[serde(default)]
+    pub persona: PersonaMode,
+    /// Plan 0250: language for the default persona copy (e.g. "pt-BR", "en").
+    /// Defaults to PT-BR when unset.
+    pub persona_lang: Option<String>,
     pub default_provider: Option<String>,
     pub max_tokens: Option<u32>,
     pub max_context_tokens: Option<usize>,

--- a/crates/garraia-gateway/src/bootstrap/config.rs
+++ b/crates/garraia-gateway/src/bootstrap/config.rs
@@ -21,6 +21,33 @@ pub(super) fn default_allowlist_path() -> PathBuf {
     garraia_config::ConfigLoader::default_config_dir().join("allowlist.json")
 }
 
+/// Plan 0250 (GAR-771): emit one friendly, actionable warning when a credential
+/// vault exists on disk but `GARRAIA_VAULT_PASSPHRASE` is not set — the exact
+/// situation that silently disables providers/channels (the keys are encrypted
+/// and we can't open the vault). Without this, the operator only sees a cryptic
+/// "no API key" and has no idea their secrets are right there, locked.
+pub(crate) fn warn_if_vault_locked() {
+    let Some(vault_path) = default_vault_path() else {
+        return;
+    };
+    if !vault_path.exists() {
+        return;
+    }
+    let passphrase_set = std::env::var("GARRAIA_VAULT_PASSPHRASE")
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
+    if passphrase_set {
+        return;
+    }
+    tracing::warn!(
+        "🔒 Encontrei seu cofre de credenciais em {}, mas preciso da senha pra \
+         abri-lo. Suas chaves estão guardadas e seguras — só defina a variável \
+         GARRAIA_VAULT_PASSPHRASE (a mesma senha que você criou no wizard) e me \
+         reinicie. Sem ela, eu subo, mas os provedores e canais ficam desligados.",
+        vault_path.display()
+    );
+}
+
 /// Resolve an API key using the priority chain: vault -> config -> env var.
 pub(crate) fn resolve_api_key(
     config_key: Option<&str>,

--- a/crates/garraia-gateway/src/bootstrap/mod.rs
+++ b/crates/garraia-gateway/src/bootstrap/mod.rs
@@ -49,6 +49,10 @@ pub fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
     let mut runtime = AgentRuntime::new();
     let mut unreachable_local_providers: Vec<String> = Vec::new();
 
+    // Plan 0250 (GAR-771): if the vault is locked, tell the operator clearly and
+    // early — before the "no API key" warnings that are the *symptom*.
+    config::warn_if_vault_locked();
+
     let llm_client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(
             config.timeouts.llm.default_secs,
@@ -701,6 +705,16 @@ pub fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
     // --- Agent Config ---
     if let Some(prompt) = &config.agent.system_prompt {
         runtime.set_system_prompt(prompt.clone());
+    }
+    // Plan 0250 (GAR-771): wire the default persona. When no `system_prompt` is
+    // configured, Garra speaks with the warm "friendly" voice by default; set
+    // `agent.persona = "neutral"` to opt out.
+    runtime.set_persona_mode(match config.agent.persona {
+        garraia_config::model::PersonaMode::Friendly => garraia_agents::PersonaMode::Friendly,
+        garraia_config::model::PersonaMode::Neutral => garraia_agents::PersonaMode::Neutral,
+    });
+    if let Some(lang) = &config.agent.persona_lang {
+        runtime.set_persona_lang(garraia_agents::Lang::from_code(lang));
     }
     if let Some(max_tokens) = config.agent.max_tokens {
         runtime.set_max_tokens(max_tokens);

--- a/crates/garraia-gateway/src/commands.rs
+++ b/crates/garraia-gateway/src/commands.rs
@@ -47,7 +47,12 @@ pub fn register_commands(registry: &mut CommandRegistry) {
                 .unwrap();
             let registry = state.command_registry.read().unwrap();
             let cmds = registry.list_for_role(ctx.user_role);
-            let mut help = String::from("📋 GarraIA Commands\n\n");
+            // Plan 0250 (GAR-771): warmer, PT-BR help header in Garra's voice.
+            let mut help = String::from(
+                "Claro! 🐾 Aqui está o que eu sei fazer por atalho.\n\
+                 Mas lembra: você não precisa decorar nada — é só falar comigo \
+                 normalmente.\n\n",
+            );
             for (name, desc) in &cmds {
                 help.push_str(&format!("/{name} — {desc}\n"));
             }

--- a/docs/adr/0012-garra-persona.md
+++ b/docs/adr/0012-garra-persona.md
@@ -1,0 +1,80 @@
+# ADR 0012 — Persona Amistosa do Garra (Tom de Voz Padrão)
+
+**Status:** Accepted
+**Date:** 2026-06-01 (America/New_York)
+**Epic:** GAR-771 — Garra Friendly Persona
+**Plan:** [0250](../../plans/0250-gar-771-garra-friendly-persona.md)
+**Inspiração:** [OpenHuman](https://github.com/tinyhumansai/openhuman) — "Simple, UI-first & Human"
+
+---
+
+## Context and Problem Statement
+
+O Garra (GarraIA) é um gateway de IA pessoal multi-canal. Até o plano 0250, quando
+o operador não definia `agent.system_prompt`, o runtime caía em
+`unwrap_or_default()` → **system message vazio**. Na prática, o Garra herdava o tom
+neutro do modelo base e não tinha identidade própria: parecia um LLM genérico, não
+um "assistente pessoal chamado Garra".
+
+O usuário pediu para o produto soar mais **amistoso**, no espírito do OpenHuman, que
+se diferencia por ser caloroso, humano e de baixa fricção.
+
+**Pergunta:** Como dar ao Garra uma voz própria e calorosa por padrão, sem remover o
+controle do operador nem quebrar instalações existentes?
+
+## Decision
+
+1. **Persona padrão "Friendly"**: introduzir `garraia-agents::persona` com um system
+   prompt caloroso em PT-BR (`DEFAULT_PERSONA_PT`) e equivalente EN
+   (`DEFAULT_PERSONA_EN`). Quando nenhum `system_prompt` explícito está configurado,
+   o runtime aplica essa persona.
+
+2. **Override sempre vence**: qualquer `system_prompt` não-vazio (config ou override
+   por requisição) tem prioridade absoluta sobre a persona padrão.
+
+3. **Opt-out explícito**: `agent.persona = "neutral"` restaura exatamente o
+   comportamento pré-0250 (sem system prompt padrão). `friendly` é o default.
+
+4. **Idioma configurável**: `agent.persona_lang` ("pt-BR" default, "en" fallback).
+   Tags desconhecidas caem em PT-BR (público primário).
+
+5. **Copy de superfície humanizada**: `/start`, `/help`, banner CLI e wizard passam a
+   falar com o tom do Garra (PT-BR, primeira pessoa, emoji parcimonioso).
+
+6. **Erros humanizados**: estados de falha comuns para usuário novo (vault trancado
+   sem `GARRAIA_VAULT_PASSPHRASE`, provider sem chave) ganham mensagens claras com o
+   próximo passo, em vez de códigos crus.
+
+## Tom de voz (resumo normativo)
+
+- Primeira pessoa, natural, como um colega de confiança.
+- Caloroso porém conciso; sem bajulação ("que ótima pergunta!").
+- Honesto: se não sabe, diz e sugere um caminho.
+- Emoji parcimonioso (👋 / 🐾), nunca poluir.
+- PT-BR primeiro; EN como fallback paramétrico.
+- Respeita usuário e privacidade.
+
+## Consequences
+
+**Positivas**
+- Garra tem identidade desde o primeiro uso, sem configuração.
+- Onboarding mais acolhedor (wizard/banner) reduz fricção.
+- Erros deixam de intimidar usuários não-técnicos.
+- Zero breaking change: `neutral` reproduz o comportamento antigo (test-provado).
+
+**Custos / Riscos**
+- A persona consome alguns tokens de system prompt por requisição (mitigável via
+  `neutral` em cenários de custo extremo).
+- Copy default em PT-BR pode não servir a todos; mitigado por `persona_lang`.
+
+**Não-escopo (Fase futura)**
+- Mascote visual animado / lip-sync (OpenHuman tem; exige trabalho de desktop).
+- Persona de voz (TTS) afinada.
+- i18n completo além de PT/EN.
+
+## Alternatives Considered
+
+- **Manter system prompt vazio**: rejeitado — é a causa do Garra parecer genérico.
+- **Hardcode da persona sem opt-out**: rejeitado — viola o princípio de controle do
+  operador e quebraria quem depende do tom neutro.
+- **i18n pesado (fluent/gettext)**: adiado — desproporcional para PT/EN agora.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -51,6 +51,7 @@ Rationale curta ("porque sim") é sinal de que a decisão não deveria ser ADR �
 | [0009](0009-web-console-design-system.md) | Web Console design system "Garra Glass" (HTML+CSS custom tokens, zero CDN) | ✅ accepted | 2026-05-13 | [GAR-607](https://linear.app/chatgpt25/issue/GAR-607) |
 | [0010](0010-garra-learning-agent.md) | Garra Learning Agent / Self-Improving Operations Manual | ✅ accepted | 2026-05-17 | [GAR-641](https://linear.app/chatgpt25/issue/GAR-641) |
 | [0011](0011-garra-max-power.md) | GarraMaxPower — Native Agent-Advanced Mode (`garra max-power`) | ✅ accepted | 2026-05-24 | [GAR-492](https://linear.app/chatgpt25/issue/GAR-492) |
+| [0012](0012-garra-persona.md) | Persona Amistosa do Garra — tom de voz padrão (inspirado em OpenHuman) | ✅ accepted | 2026-06-01 | GAR-771 |
 
 Legenda: ✅ accepted · 📋 proposed (aguardando execução) · 🔒 blocked (issue Linear aguardando este ADR ser escrito).
 

--- a/plans/0250-gar-771-garra-friendly-persona.md
+++ b/plans/0250-gar-771-garra-friendly-persona.md
@@ -1,0 +1,158 @@
+# Plan 0250 — Garra Persona Amistosa (inspirado em OpenHuman)
+
+> **Linear:** GAR-771 (a criar) — Epic "Garra Friendly Persona"
+> **Branch:** `claude/garra-friendly-persona`
+> **Autor:** sessão autônoma 2026-06-01 (Florida local time)
+> **Status:** 🔄 In Progress
+> **ADR relacionado:** 0012 (Persona & Tom de Voz do Garra) — criado neste plano
+
+## 1. Contexto e Motivação
+
+O usuário pediu para deixar o **Garra mais amistoso**, no espírito do
+[OpenHuman](https://github.com/tinyhumansai/openhuman) — um assistente de IA
+pessoal cujo diferencial declarado é ser **"Simple, UI-first & Human"**,
+*"Built with the human in mind"*, com onboarding sem fricção (*"no config-first
+setup, no terminal required"*), memória relacional (*"remembers you across
+weeks"*) e uma presença calorosa (mascote com "rosto", voz, emojis,
+linguagem conversacional).
+
+### Diagnóstico do estado atual do Garra
+
+Mapeamento das "superfícies de personalidade" hoje (todas verificadas no código):
+
+| Superfície | Arquivo | Estado atual | Problema |
+|------------|---------|--------------|----------|
+| Persona default do agente | `garraia-agents/src/runtime.rs:578-585` | `system_prompt` → `unwrap_or_default()` = **string vazia** | **Garra não tem personalidade nenhuma por padrão** — responde genérico do modelo base |
+| `/start` (boas-vindas) | `garraia-channels/.../builtins/start.rs:22` | `"Welcome to GarraIA! Send me a message and I will respond."` | Seco, em inglês, transacional, sem calor |
+| `/help` | `garraia-channels/.../builtins/help.rs:19` | `"GarraIA Commands:\n/help - show this help..."` | Lista técnica, sem tom |
+| Banner CLI | `garraia-cli/src/banner.rs:124,140` | `"Welcome to GarraIA!"` / `"Rust · Personal AI"` | OK visualmente (Ferris), mas frio |
+| Wizard | `garraia-cli/src/wizard/mod.rs:60` | `"GarraIA Setup Wizard"` + prompts seções seca | Onboarding funciona mas não acolhe |
+| Erros / fail states | vários | mensagens técnicas (ex.: "no API key", "503") | Intimidam usuário novo |
+
+**Conclusão central:** o maior gap não é visual — é que **Garra não fala como
+o "Garra"**. Sem `system_prompt`, ele herda o tom neutro do modelo. O wizard
+até sugere *"Seu nome é Garra, um assistente pessoal..."* como exemplo, mas
+isso é opcional e a maioria dos usuários deixa vazio.
+
+## 2. Princípios de Design (o "tom Garra")
+
+Inspirado no OpenHuman, mas com identidade própria (PT-BR primeiro, brasileiro,
+caloroso sem ser bajulador):
+
+1. **Humano, não robótico** — fala na primeira pessoa ("eu", "vou te ajudar"),
+   usa contrações naturais, evita jargão.
+2. **PT-BR nativo** — o público primário é brasileiro. Copy default em
+   português, com fallback EN quando `lang=en`.
+3. **Caloroso, conciso** — acolhe sem encher linguiça. Uma saudação curta vale
+   mais que um parágrafo.
+4. **Emojis com parcimônia** — 🦴/🐾/👋 pontuais (a "Garra" remete a um animal
+   leal); nunca poluir.
+5. **Proativo e tranquilizador em erros** — todo erro vira "aqui está o que
+   aconteceu + o próximo passo", nunca um código cru.
+6. **Respeita o usuário** — nada de bajulação vazia ("Que ótima pergunta!").
+   Direto, gentil, competente.
+
+> A personalidade é **configurável e desativável**: tudo entra como *default*,
+> mas o usuário pode sobrescrever via `agent.system_prompt` no config ou
+> `agent.persona = "neutral"`. Nunca forçamos.
+
+## 3. Escopo (slices)
+
+Entrega incremental, cada slice é um PR independente e testável.
+
+### Slice 1 — Persona default (o coração) ⭐
+**Objetivo:** Garra ganha uma voz própria por padrão.
+
+- Novo módulo `garraia-agents/src/persona.rs`:
+  - `pub const DEFAULT_PERSONA_PT: &str` — system prompt caloroso em PT-BR
+    (nome "Garra", assistente pessoal leal, tom do §2).
+  - `pub const DEFAULT_PERSONA_EN: &str` — equivalente em inglês.
+  - `pub fn default_persona(lang: Lang) -> &'static str`.
+- `runtime.rs`: quando `effective_system_prompt` for `None`/vazio, usar
+  `default_persona(...)` em vez de string vazia. Preserva 100% override do
+  usuário (config/CLI continuam ganhando).
+- `garraia-config`: novo campo `agent.persona: Option<PersonaMode>`
+  (`friendly` default | `neutral` | `custom`). `neutral` = comportamento antigo
+  (vazio). `custom` = usa `system_prompt`.
+- Testes: default aplicado quando vazio; override respeitado; `neutral` volta ao
+  vazio; PT vs EN.
+
+### Slice 2 — Copy de boas-vindas e ajuda
+**Objetivo:** primeiras telas que o usuário vê soam como o Garra.
+
+- `start.rs`: nova saudação calorosa em PT-BR (com EN fallback), apresentando
+  o Garra na primeira pessoa + 3 sugestões de primeira interação ("experimente
+  me perguntar...").
+- `help.rs` + registry: cabeçalho amistoso, comandos agrupados com 1 linha de
+  contexto, tom acolhedor.
+- i18n leve: helper `persona_copy(lang)` em `garraia-channels` (sem dependência
+  pesada de i18n; só PT/EN match).
+- Testes: snapshot do texto PT e EN; presença do nome "Garra".
+
+### Slice 3 — Wizard e banner acolhedores
+**Objetivo:** onboarding "OpenHuman-like" — menos fricção, mais calor.
+
+- `wizard/mod.rs`: abertura ("Oi! Vamos configurar o Garra juntos — leva 1
+  minuto 🐾"), microcopy de cada seção reescrita, mensagem final celebrativa
+  ("Pronto! O Garra está de pé. 🎉").
+- `banner.rs`: tagline `"Rust · Personal AI"` → `"Seu assistente pessoal"` +
+  linha de "primeiro passo" quando nenhum provider está ativo.
+- **Persona default no wizard:** quando o usuário deixa o system prompt vazio,
+  gravar a `DEFAULT_PERSONA_PT` no config (em vez de `None`), para que a
+  experiência "amistosa" seja a padrão de fato. (Conecta com Slice 1.)
+- Testes: o `config_writer` grava persona default quando prompt vazio.
+
+### Slice 4 — Erros humanizados (fail-soft friendly)
+**Objetivo:** estados de erro deixam de intimidar.
+
+- Helper central `friendly_error(kind) -> String` para os casos mais comuns que
+  um usuário novo encontra:
+  - provider sem API key → "Ainda não tenho uma chave de API configurada pra
+    falar com o modelo. Rode `garra config` ou defina a variável X."
+  - vault sem passphrase (o caso real do usuário!) → "Suas credenciais estão
+    no cofre, mas preciso da senha pra abri-lo. Defina `GARRAIA_VAULT_PASSPHRASE`
+    e me reinicie."
+  - Telegram sem token → mensagem clara do próximo passo.
+- Aplicar no `bootstrap` (warns) e onde o usuário lê (CLI).
+- **Bônus (resolve dor real da sessão):** aviso explícito no boot quando o
+  vault existe mas a passphrase não está no ambiente.
+- Testes: cada `friendly_error` contém o próximo passo acionável.
+
+### Slice 5 — ADR + docs + ROADMAP
+- `docs/adr/0012-garra-persona.md` — registra a decisão de persona/tom.
+- Atualizar `README` (seção "Conheça o Garra"), `ROADMAP` (item entregue),
+  `plans/README.md`.
+
+## 4. Não-escopo (por ora)
+
+- Mascote visual animado / lip-sync (OpenHuman tem; é Fase futura, exige
+  trabalho de desktop/Tauri grande — fora deste plano).
+- Voz/TTS de personalidade (já existe `garraia-voice`; tuning de persona de voz
+  fica para depois).
+- i18n completo multi-idioma (só PT/EN agora).
+
+## 5. Invariantes / Regras
+
+- **Zero breaking change:** `persona=neutral` reproduz exatamente o
+  comportamento atual (system prompt vazio).
+- **Override do usuário sempre vence** (config `system_prompt` / CLI flag).
+- **Sem `unwrap()` em produção**; `cargo clippy --workspace` limpo.
+- **Sem segredo em copy/log.**
+- Copy default em PT-BR; EN como fallback paramétrico.
+- Cada slice: `cargo check -p <crate>` + testes verdes antes do commit.
+
+## 6. Ordem de execução
+
+Slice 1 → 2 → 3 → 4 → 5. Slice 1 é pré-requisito de 2/3. Cada um vira um commit
+(ou PR) próprio. Para esta sessão, implementaremos **Slices 1–3 + 5** (núcleo da
+persona amistosa) e deixaremos Slice 4 (erros) como follow-up se o tempo apertar
+— mas o aviso do vault (dor real) entra já no Slice 3.
+
+## 7. Critério de Sucesso
+
+- Instalar do zero, rodar `garra` sem configurar system prompt → Garra se
+  apresenta com nome e tom caloroso em PT-BR.
+- `/start` e `/help` no Telegram soam acolhedores.
+- Wizard guia com microcopy amistosa e celebra no fim.
+- `persona=neutral` restaura o comportamento antigo (test-provado).
+- CI verde; merge em `main`.

--- a/plans/README.md
+++ b/plans/README.md
@@ -258,3 +258,4 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0246 | [GAR-767 — GET /v1/me/files (caller-scoped uploaded-files inbox)](0246-gar-767-me-files-inbox.md) | [GAR-767](https://linear.app/chatgpt25/issue/GAR-767) | ✅ Merged 2026-06-01 via PR #603 |
 | 0247 | [GAR-768 — Health run 72 (2026-05-31 ~20:45 ET): all surfaces clean, priority (i)](0247-gar-768-health-run-72.md) | [GAR-768](https://linear.app/chatgpt25/issue/GAR-768) | ✅ Merged 2026-06-01 via PR #604 (`5f08141`) |
 | 0248 | [GAR-769 — Health run 73 (2026-06-01 ~00:45 ET): all surfaces clean, priority (i)](0248-gar-769-health-run-73.md) | [GAR-769](https://linear.app/chatgpt25/issue/GAR-769) | ⏳ In Progress |
+| 0250 | [GAR-771 — Persona amistosa do Garra (inspirado em OpenHuman): persona default + copy humanizada + erros amigáveis](0250-gar-771-garra-friendly-persona.md) | GAR-771 | 🔄 In Progress |


### PR DESCRIPTION
## Resumo

Inspirado no [OpenHuman](https://github.com/tinyhumansai/openhuman) ("Simple, UI-first & Human"), este PR dá ao **Garra** uma voz própria e calorosa **por padrão** — antes, sem `system_prompt` configurado, ele herdava o tom neutro do modelo base e parecia um LLM genérico.

Plano completo: [`plans/0250-gar-771-garra-friendly-persona.md`](https://github.com/michelbr84/GarraRUST/blob/claude/garra-friendly-persona/plans/0250-gar-771-garra-friendly-persona.md) · Decisão: [ADR 0012](https://github.com/michelbr84/GarraRUST/blob/claude/garra-friendly-persona/docs/adr/0012-garra-persona.md)

## O que mudou

### Slice 1 — Persona default (o coração)
- Novo módulo `garraia-agents/src/persona.rs`: `DEFAULT_PERSONA_PT` / `DEFAULT_PERSONA_EN`, `PersonaMode`, `Lang`, `resolve_system_prompt`.
- `runtime.rs`: aplica a persona default quando `system_prompt` está vazio (nos 3 sites de resolução). Setters `set_persona_mode` / `set_persona_lang`.
- `garraia-config`: `AgentConfig.persona` (`friendly` default | `neutral`) + `persona_lang`.

### Slice 2 — Copy de boas-vindas e ajuda (PT-BR, 1ª pessoa)
- `/start`: saudação calorosa que cumprimenta pelo nome + 3 sugestões de primeira interação.
- `/help`: cabeçalho amistoso na voz do Garra.

### Slice 3 — Wizard e banner acolhedores
- Banner: `"Welcome to GarraIA!"` → `"Oi! Eu sou o Garra 🐾"`; tagline → `"Seu assistente pessoal"`.
- Wizard: abertura ("Vamos configurar o Garra juntos — leva só um minutinho"), prompt de personalidade explicando que vazio = persona padrão, e fechamento celebrativo.

### Slice 4 — Erros humanizados (resolve dor real de onboarding)
- `warn_if_vault_locked()`: quando o cofre existe mas `GARRAIA_VAULT_PASSPHRASE` não está setada, o Garra avisa claramente o próximo passo — em vez do críptico "no API key". (Era exatamente o tropeço relatado na instalação.)

### Slice 5 — Docs
- ADR 0012, plan 0250, seção "Conheça o Garra" no README, índices atualizados.

## Invariantes

- **Zero breaking change:** `agent.persona = "neutral"` reproduz exatamente o comportamento pré-0250 (test-provado).
- **Override do usuário sempre vence:** `system_prompt` não-vazio tem prioridade absoluta.
- Sem `unwrap()` em produção; sem segredo em copy/log.

## Test plan

- [x] `cargo test -p garraia-agents` — 139 ok (5 novos testes de persona)
- [x] `cargo test -p garraia-config` / `garraia-channels` — verdes
- [x] `cargo clippy -p garraia-agents -p garraia-config -p garraia-channels` — limpo
- [ ] CI: Format, Clippy, Test×3, Build, MSRV, cargo-deny, Security Audit, Coverage, CodeQL, Playwright, E2E, Secret Scan, Dependency Review

Linear: GAR-771

---
_Generated by [Claude Code](https://claude.ai/code/session_015TdvwjAWnzFTpAYZgxASgA)_