### PR TITLE
fix(telemetry): upgrade OpenTelemetry 0.26 → 0.32, close RUSTSEC-2025-0052

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,7 +116,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -127,7 +127,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -230,21 +230,10 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
 ]
 
 [[package]]
@@ -286,21 +275,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.5.0",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,7 +298,7 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -335,14 +309,14 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
 dependencies = [
- "async-channel 2.5.0",
+ "async-channel",
  "async-io",
  "async-lock",
  "async-signal",
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener 5.4.1",
+ "event-listener",
  "futures-lite",
  "rustix",
 ]
@@ -374,33 +348,6 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-std"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
-dependencies = [
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io",
- "async-lock",
- "async-process",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -753,7 +700,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tower 0.5.3",
+ "tower",
  "tracing",
 ]
 
@@ -905,38 +852,11 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "bytes",
- "futures-util",
- "http 1.4.1",
- "http-body 1.0.1",
- "http-body-util",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper",
- "tower 0.5.3",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "axum-core 0.5.6",
+ "axum-core",
  "base64 0.22.1",
  "bytes",
  "form_urlencoded",
@@ -947,7 +867,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "multer",
@@ -961,30 +881,10 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite 0.29.0",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 1.4.1",
- "http-body 1.0.1",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -1134,7 +1034,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
- "async-channel 2.5.0",
+ "async-channel",
  "async-task",
  "futures-io",
  "futures-lite",
@@ -1180,7 +1080,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic 0.14.6",
+ "tonic",
  "tower-service",
  "url",
  "winapi",
@@ -1192,9 +1092,9 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
 dependencies = [
- "prost 0.14.3",
+ "prost",
  "prost-types",
- "tonic 0.14.6",
+ "tonic",
  "tonic-prost",
  "ureq",
 ]
@@ -1208,7 +1108,7 @@ dependencies = [
  "base64 0.22.1",
  "bollard-buildkit-proto",
  "bytes",
- "prost 0.14.3",
+ "prost",
  "serde",
  "serde_json",
  "serde_repr",
@@ -1636,7 +1536,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2454,7 +2354,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2783,7 +2683,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2818,12 +2718,6 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
@@ -2839,7 +2733,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -3259,7 +3153,7 @@ name = "garraia-agents"
 version = "0.2.1"
 dependencies = [
  "async-trait",
- "axum 0.8.9",
+ "axum",
  "bytes",
  "chrono",
  "futures",
@@ -3285,7 +3179,7 @@ dependencies = [
  "anyhow",
  "argon2",
  "async-trait",
- "axum 0.8.9",
+ "axum",
  "base64 0.22.1",
  "chrono",
  "garraia-workspace",
@@ -3316,7 +3210,7 @@ name = "garraia-channels"
 version = "0.2.1"
 dependencies = [
  "async-trait",
- "axum 0.8.9",
+ "axum",
  "chrono",
  "dirs 6.0.0",
  "futures",
@@ -3426,7 +3320,7 @@ dependencies = [
  "argon2",
  "async-trait",
  "aws-credential-types",
- "axum 0.8.9",
+ "axum",
  "axum-server",
  "base64 0.22.1",
  "bytes",
@@ -3477,7 +3371,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.29.0",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower_governor",
  "tracing",
@@ -3628,17 +3522,16 @@ name = "garraia-telemetry"
 version = "0.2.1"
 dependencies = [
  "anyhow",
- "axum 0.8.9",
+ "axum",
  "metrics",
  "metrics-exporter-prometheus",
- "opentelemetry 0.26.0",
+ "opentelemetry",
  "opentelemetry-otlp",
- "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "serde",
  "thiserror 2.0.18",
  "tokio",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-opentelemetry",
@@ -3806,7 +3699,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
 ]
 
@@ -3995,18 +3888,6 @@ dependencies = [
  "windows-sys 0.59.0",
  "x11rb",
  "xkeysym",
-]
-
-[[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -4460,7 +4341,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -4777,7 +4658,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5035,15 +4916,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5179,9 +5051,6 @@ name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "loom"
@@ -5271,12 +5140,6 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
-
-[[package]]
-name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"
@@ -5477,7 +5340,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5625,7 +5488,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6060,85 +5923,77 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.26.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570074cc999d1a58184080966e5bd3bf3a9a4af650c3b05047c2621e7405cd17"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "opentelemetry"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
  "pin-project-lite",
  "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.4.1",
+ "opentelemetry",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.26.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e1f9c8b032d4f635c730c0efcf731d5e2530ea13fa8bef7939ddc8420696bd"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
- "async-trait",
- "futures-core",
  "http 1.4.1",
- "opentelemetry 0.26.0",
+ "opentelemetry",
+ "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost 0.13.5",
- "thiserror 1.0.69",
+ "prost",
+ "reqwest 0.13.4",
+ "thiserror 2.0.18",
  "tokio",
- "tonic 0.12.3",
+ "tonic",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.26.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d3968ce3aefdcca5c27e3c4ea4391b37547726a70893aab52d3de95d5f8b34"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
- "opentelemetry 0.26.0",
+ "opentelemetry",
  "opentelemetry_sdk",
- "prost 0.13.5",
- "tonic 0.12.3",
+ "prost",
+ "tonic",
+ "tonic-prost",
 ]
 
 [[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db945c1eaea8ac6a9677185357480d215bb6999faa9f691d0c4d4d641eab7a09"
-
-[[package]]
 name = "opentelemetry_sdk"
-version = "0.26.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c627d9f4c9cdc1f21a29ee4bfbd6028fcb8bcf2a857b43f3abdf72c9c862f3"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
- "async-std",
- "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
- "glob",
- "once_cell",
- "opentelemetry 0.26.0",
+ "opentelemetry",
  "percent-encoding",
- "rand 0.8.6",
- "serde_json",
- "thiserror 1.0.69",
+ "portable-atomic",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
 ]
@@ -6166,7 +6021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6757,35 +6612,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
-dependencies = [
- "bytes",
- "prost-derive 0.13.5",
-]
-
-[[package]]
-name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive 0.14.3",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "prost-derive",
 ]
 
 [[package]]
@@ -6807,7 +6639,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost 0.14.3",
+ "prost",
 ]
 
 [[package]]
@@ -6912,7 +6744,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.4",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6949,7 +6781,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7260,7 +7092,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -7279,6 +7111,7 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http 1.4.1",
@@ -7304,7 +7137,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -7510,7 +7343,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7579,7 +7412,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8265,22 +8098,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8399,7 +8222,7 @@ dependencies = [
  "crc",
  "crossbeam-queue",
  "either",
- "event-listener 5.4.1",
+ "event-listener",
  "futures-core",
  "futures-intrusive",
  "futures-io",
@@ -8602,7 +8425,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9307,10 +9130,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9499,7 +9322,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.4",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -9711,42 +9534,12 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum 0.7.9",
- "base64 0.22.1",
- "bytes",
- "h2",
- "http 1.4.1",
- "http-body 1.0.1",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "prost 0.13.5",
- "socket2 0.5.10",
- "tokio",
- "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
- "axum 0.8.9",
+ "axum",
  "base64 0.22.1",
  "bytes",
  "h2",
@@ -9758,11 +9551,11 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.4",
+ "socket2",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -9775,28 +9568,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
- "prost 0.14.3",
- "tonic 0.14.6",
+ "prost",
+ "tonic",
 ]
 
 [[package]]
-name = "tower"
-version = "0.4.13"
+name = "tonic-types"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
 dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.6",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
+ "prost",
+ "prost-types",
+ "tonic",
 ]
 
 [[package]]
@@ -9840,7 +9624,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -9866,14 +9650,14 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44de9b94d849d3c46e06a883d72d408c2de6403367b39df2b1c9d9e7b6736fe6"
 dependencies = [
- "axum 0.8.9",
+ "axum",
  "forwarded-header-value",
  "governor",
  "http 1.4.1",
  "pin-project",
  "thiserror 2.0.18",
- "tonic 0.14.6",
- "tower 0.5.3",
+ "tonic",
+ "tower",
  "tracing",
 ]
 
@@ -9936,12 +9720,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -10021,7 +9805,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10135,7 +9919,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10355,7 +10139,7 @@ version = "9.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
 dependencies = [
- "axum 0.8.9",
+ "axum",
  "base64 0.22.1",
  "mime_guess",
  "regex",
@@ -10415,12 +10199,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "value-bag"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "vcpkg"
@@ -11250,7 +11028,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12148,7 +11926,7 @@ dependencies = [
  "async-trait",
  "blocking",
  "enumflags2",
- "event-listener 5.4.1",
+ "event-listener",
  "futures-core",
  "futures-lite",
  "hex",

--- a/crates/garraia-telemetry/Cargo.toml
+++ b/crates/garraia-telemetry/Cargo.toml
@@ -17,11 +17,11 @@ serde = { workspace = true }
 tokio = { workspace = true }
 
 # OpenTelemetry (direct versions — not in workspace)
-tracing-opentelemetry = "0.32"
-opentelemetry = { version = "0.26", features = ["trace", "metrics"] }
-opentelemetry_sdk = { version = "0.26", features = ["rt-tokio", "trace", "metrics"] }
-opentelemetry-otlp = { version = "0.26", features = ["grpc-tonic", "trace", "metrics"] }
-opentelemetry-semantic-conventions = "0.26"
+# Upgraded from 0.26 → 0.32 (plan 0252 / GAR-711 / RUSTSEC-2025-0052 async-std removed)
+tracing-opentelemetry = "0.33"
+opentelemetry = { version = "0.32", features = ["trace"] }
+opentelemetry_sdk = { version = "0.32", features = ["rt-tokio", "trace"] }
+opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic", "trace"] }
 
 # Metrics
 metrics = "0.24"
@@ -39,5 +39,5 @@ uuid = { version = "1", features = ["v7"] }
 [dev-dependencies]
 tokio = { workspace = true }
 tracing-test = "0.2"
-opentelemetry_sdk = { version = "0.26", features = ["rt-tokio", "trace", "metrics", "testing"] }
-opentelemetry = { version = "0.26", features = ["trace", "metrics"] }
+opentelemetry_sdk = { version = "0.32", features = ["rt-tokio", "trace", "testing"] }
+opentelemetry = { version = "0.32", features = ["trace"] }

--- a/crates/garraia-telemetry/src/lib.rs
+++ b/crates/garraia-telemetry/src/lib.rs
@@ -32,7 +32,7 @@ pub type Config = TelemetryConfig;
 /// so the gateway can spawn its dedicated `/metrics` listener against
 /// the same globally-installed recorder.
 pub struct Guard {
-    tracer_provider: Option<opentelemetry_sdk::trace::TracerProvider>,
+    tracer_provider: Option<opentelemetry_sdk::trace::SdkTracerProvider>,
     metrics_handle: Option<PrometheusHandle>,
 }
 

--- a/crates/garraia-telemetry/src/tracer.rs
+++ b/crates/garraia-telemetry/src/tracer.rs
@@ -1,15 +1,15 @@
 //! OTLP gRPC tracer pipeline.
 
-use opentelemetry::{KeyValue, global};
+use opentelemetry::global;
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::{
     Resource,
-    trace::{self as sdktrace, Sampler, TracerProvider},
+    trace::{Sampler, SdkTracerProvider},
 };
 
 use crate::{Error, config::TelemetryConfig};
 
-pub fn init_tracer(config: &TelemetryConfig) -> Result<Option<TracerProvider>, Error> {
+pub fn init_tracer(config: &TelemetryConfig) -> Result<Option<SdkTracerProvider>, Error> {
     if !config.enabled {
         return Ok(None);
     }
@@ -19,25 +19,21 @@ pub fn init_tracer(config: &TelemetryConfig) -> Result<Option<TracerProvider>, E
         .clone()
         .unwrap_or_else(|| "http://localhost:4317".to_string());
 
-    let resource = Resource::new(vec![KeyValue::new(
-        "service.name",
-        config.service_name.clone(),
-    )]);
+    let resource = Resource::builder_empty()
+        .with_service_name(config.service_name.clone())
+        .build();
 
-    let trace_config = sdktrace::Config::default()
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_tonic()
+        .with_endpoint(endpoint)
+        .build()
+        .map_err(|e| Error::Init(format!("failed to build OTLP exporter: {e}")))?;
+
+    let provider = SdkTracerProvider::builder()
         .with_sampler(Sampler::TraceIdRatioBased(config.sample_ratio))
-        .with_resource(resource);
-
-    let exporter = opentelemetry_otlp::new_exporter()
-        .tonic()
-        .with_endpoint(endpoint);
-
-    let provider = opentelemetry_otlp::new_pipeline()
-        .tracing()
-        .with_exporter(exporter)
-        .with_trace_config(trace_config)
-        .install_batch(opentelemetry_sdk::runtime::Tokio)
-        .map_err(|e| Error::Init(format!("failed to install OTLP tracer: {e}")))?;
+        .with_resource(resource)
+        .with_batch_exporter(exporter)
+        .build();
 
     global::set_tracer_provider(provider.clone());
 

--- a/crates/garraia-telemetry/tests/smoke.rs
+++ b/crates/garraia-telemetry/tests/smoke.rs
@@ -3,16 +3,21 @@
 //! These tests deliberately avoid any network I/O. Strategy A uses
 //! `InMemorySpanExporter` from `opentelemetry_sdk`'s `testing` module
 //! (enabled via the `testing` feature in dev-dependencies) to verify that
-//! a span produced against a `TracerProvider` is captured end-to-end.
+//! a span produced against a `SdkTracerProvider` is captured end-to-end.
+//!
+//! API changes from OTel 0.26 → 0.32 (plan 0252 / GAR-711):
+//! - `TracerProvider` → `SdkTracerProvider`
+//! - `opentelemetry_sdk::testing::trace::InMemorySpanExporter`
+//!   → `opentelemetry_sdk::trace::InMemorySpanExporter`
+//! - `force_flush() -> Vec<Result<..>>` → `force_flush() -> OTelSdkResult`
 
 use opentelemetry::trace::{Span as _, Tracer, TracerProvider as _};
-use opentelemetry_sdk::testing::trace::InMemorySpanExporter;
-use opentelemetry_sdk::trace::TracerProvider;
+use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
 
 #[test]
 fn smoke_in_memory_exporter_captures_span() {
     let exporter = InMemorySpanExporter::default();
-    let provider = TracerProvider::builder()
+    let provider = SdkTracerProvider::builder()
         .with_simple_exporter(exporter.clone())
         .build();
 
@@ -23,9 +28,10 @@ fn smoke_in_memory_exporter_captures_span() {
     // SimpleSpanProcessor exports on span end, but force_flush is safe and
     // cheap. We must read spans BEFORE `provider.shutdown()` because the
     // in-memory exporter clears its backing store on shutdown.
-    for result in provider.force_flush() {
-        result.expect("force_flush must succeed for simple exporter");
-    }
+    // In 0.32, force_flush returns a single OTelSdkResult (not Vec<Result<..>>).
+    provider
+        .force_flush()
+        .expect("force_flush must succeed for simple exporter");
 
     let spans = exporter
         .get_finished_spans()

--- a/deny.toml
+++ b/deny.toml
@@ -60,7 +60,9 @@ ignore = [
     "RUSTSEC-2024-0388", # derivative (transitive via poise/serenity)
     "RUSTSEC-2025-0057", # fxhash (transitive via wasmtime)
     "RUSTSEC-2024-0370", # proc-macro-error (transitive, no maintained alt)
-    "RUSTSEC-2025-0052", # async-std (via opentelemetry_sdk 0.26 → garraia-telemetry)
+    # NOTE: RUSTSEC-2025-0052 (async-std unmaintained) CLOSED 2026-06-01.
+    # Resolution: opentelemetry_sdk 0.26 → 0.32 (garraia-telemetry plan 0252 / GAR-711).
+    # opentelemetry_sdk >= 0.28 dropped async-std entirely. Removed from deny.toml.
     # NOTE: RUSTSEC-2025-0134 (rustls-pemfile unmaintained) CLOSED 2026-05-17.
     # Resolution: axum-server 0.7.3 → 0.8.0 (health routine PR
     # chore/sec-20260517-axum-server-0.8). axum-server 0.8 migrated to

--- a/plans/0252-gar-711-otel-0.26-to-0.31.md
+++ b/plans/0252-gar-711-otel-0.26-to-0.31.md
@@ -1,0 +1,106 @@
+# Plan 0252 — GAR-711: Upgrade OpenTelemetry 0.26 → 0.31 (close RUSTSEC-2025-0052)
+
+## Goal
+
+Upgrade `garraia-telemetry`'s OTel stack from 0.26 to 0.31 to eliminate the
+`async-std` transitive dependency flagged by RUSTSEC-2025-0052. Align all OTel
+crates with the version already used by the existing `tracing-opentelemetry 0.32`
+dep, eliminating the duplicate 0.26 / 0.31 pair from the lockfile and removing
+the `deny.toml` carve-out.
+
+## Architecture
+
+`garraia-telemetry` is the sole OTel consumer in the workspace. It wraps four OTel
+crates behind a thin public surface (`init`, `Guard`, `TelemetryConfig`). The
+gateway and CLI use it via the `init(config)` call; internal API types
+(`TracerProvider`) only appear inside the crate itself. No other crate in the
+workspace depends directly on OTel crates.
+
+## Tech stack
+
+- Rust stable (cargo 1.94)
+- `opentelemetry 0.31` + `opentelemetry_sdk 0.31` + `opentelemetry-otlp 0.31`
+- `tracing-opentelemetry 0.32` (already in lockfile, targeting OTel 0.31)
+- `cargo deny` + `cargo audit` for advisory validation
+
+## Design invariants
+
+1. Public surface of `garraia-telemetry` (init / Guard / TelemetryConfig) must not
+   change signatures visible to callers in garraia-gateway and garraia-cli.
+2. Fail-soft contract from plan 0026: `init()` never panics or propagates `Err`.
+3. No new `unwrap()` in production paths.
+4. `deny.toml` carve-out `RUSTSEC-2025-0052` must be removed in the same commit
+   that drops async-std from the lockfile.
+
+## Validações pré-plano
+
+- [x] `async-std` confirmed in lockfile via `opentelemetry_sdk 0.26.0`
+- [x] `RUSTSEC-2025-0052` ignored in `deny.toml:63`
+- [x] `tracing-opentelemetry 0.32.1` already depends on `opentelemetry 0.31.0`
+- [x] No other workspace crate imports OTel 0.26 crates directly
+- [x] `opentelemetry-semantic-conventions` unused in source — safe to remove
+
+## Out of scope
+
+- Metrics pipeline (uses `metrics` / `metrics-exporter-prometheus`, not OTel metrics)
+- `tracing-opentelemetry` version bump (already at 0.32)
+- Any OTel metrics exporter changes
+- Other crates in workspace
+
+## Rollback
+
+Remove the branch. The `deny.toml` carve-out is restored as part of reverting the
+PR. No schema or migration changes.
+
+## Open questions
+
+- None known; OTel 0.31 API changes are well-documented.
+
+## File structure
+
+```
+crates/garraia-telemetry/
+  Cargo.toml          — version bumps, remove rt-tokio + metrics features
+  src/tracer.rs       — new SdkTracerProvider builder API
+  src/lib.rs          — Guard.tracer_provider type: TracerProvider → SdkTracerProvider
+  tests/smoke.rs      — TracerProvider → SdkTracerProvider in test
+deny.toml             — remove RUSTSEC-2025-0052 carve-out
+plans/README.md       — add row 0252
+```
+
+## M1 Tasks
+
+- [x] T1: Branch `routine/202506011215-otel-upgrade` off main
+- [ ] T2: Update `crates/garraia-telemetry/Cargo.toml` — version bumps
+- [ ] T3: Update `src/tracer.rs` — new 0.28+ builder API
+- [ ] T4: Update `src/lib.rs` — `SdkTracerProvider` type
+- [ ] T5: Update `tests/smoke.rs` — `SdkTracerProvider` in test
+- [ ] T6: Remove `RUSTSEC-2025-0052` from `deny.toml`
+- [ ] T7: `cargo check -p garraia-telemetry` + `cargo test -p garraia-telemetry` green
+- [ ] T8: Update `plans/README.md` + `ROADMAP.md`
+
+## Risk register
+
+| Risk | Mitigation |
+|------|-----------|
+| OTel 0.31 API incompatibility | Iterate with `cargo check`; full API documented in migration guide |
+| `rt-tokio` feature removal breaks batch exporter | Keep feature if still needed, drop only if cargo confirms unused |
+| `opentelemetry-semantic-conventions` version mismatch | Crate unused — removed entirely |
+
+## Acceptance criteria
+
+- `cargo check -p garraia-telemetry` exits 0
+- `cargo test -p garraia-telemetry` exits 0
+- `cargo deny --offline check advisories` exits 0 (RUSTSEC-2025-0052 gone from lockfile)
+- `git grep async-std Cargo.lock` returns 0 hits
+- `grep RUSTSEC-2025-0052 deny.toml` returns 0 hits
+
+## Cross-references
+
+- GAR-711: https://linear.app/chatgpt25/issue/GAR-711
+- RUSTSEC-2025-0052: https://rustsec.org/advisories/RUSTSEC-2025-0052.html
+- tracing-opentelemetry 0.32 → opentelemetry 0.31 (confirmed in Cargo.lock)
+
+## Estimativa
+
+0.5 / 1 / 2 horas (baixo / provável / alto)

--- a/plans/README.md
+++ b/plans/README.md
@@ -261,3 +261,4 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0249 | [GAR-770 — GET /v1/me/memory (caller-scoped personal memory inbox)](0249-gar-770-me-memory-inbox.md) | [GAR-770](https://linear.app/chatgpt25/issue/GAR-770) | ✅ Merged 2026-06-01 via PR #608 (`ec6922c`) |
 | 0250 | [GAR-771 — Persona amistosa do Garra (inspirado em OpenHuman): persona default + copy humanizada + erros amigáveis](0250-gar-771-garra-friendly-persona.md) | GAR-771 | ✅ Merged 2026-06-01 via PR #610 (`cbdc702`) |
 | 0251 | [GAR-771 — Health run 74 (2026-06-01 ~08:45 ET): PR #610 persona merged, all surfaces clean, priority (i)](0251-gar-771-health-run-74.md) | [GAR-771](https://linear.app/chatgpt25/issue/GAR-771) | ✅ Merged 2026-06-01 via PR #611 (`3dd4ce3`) |
+| 0252 | [GAR-711 — Upgrade OpenTelemetry 0.26 → 0.32 (RUSTSEC-2025-0052 async-std)](0252-gar-711-otel-0.26-to-0.31.md) | [GAR-711](https://linear.app/chatgpt25/issue/GAR-711) | 🔄 In Progress |


### PR DESCRIPTION
## Summary

- **GAR-711** — Coordinated upgrade of the entire OTel Rust stack in `garraia-telemetry` from 0.26 to 0.32, eliminating the `async-std` transitive dependency flagged by RUSTSEC-2025-0052 (unmaintained).
- Removes the `deny.toml` carve-out for `RUSTSEC-2025-0052` — the advisory no longer appears in the lockfile.
- Aligns `tracing-opentelemetry` (0.32→0.33) to match the new OTel core version.

### Crates upgraded (all in `garraia-telemetry/Cargo.toml`)

| Crate | Before | After |
|---|---|---|
| `opentelemetry` | 0.26 | 0.32 |
| `opentelemetry_sdk` | 0.26 | 0.32 |
| `opentelemetry-otlp` | 0.26 | 0.32 |
| `tracing-opentelemetry` | 0.32 | 0.33 |
| `opentelemetry-semantic-conventions` | 0.26 | removed (unused) |

### API changes (plan 0252)

- `Resource::new()` (now crate-private) → `Resource::builder_empty().with_service_name(name).build()`
- `TracerProvider` → `SdkTracerProvider`
- `new_pipeline().tracing().install_batch(Tokio)` → `SpanExporter::builder().with_tonic()` + `SdkTracerProvider::builder().with_batch_exporter()`
- `InMemorySpanExporter` path: `testing::trace` → `trace` module
- `force_flush()` return type: `Vec<Result<..>>` → single `OTelSdkResult`

## Test plan

- [x] `cargo check -p garraia-telemetry` — clean
- [x] `cargo test -p garraia-telemetry` — 6/6 tests pass (unit + smoke + idempotent)
- [x] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` — clean
- [x] `cargo fmt --check -p garraia-telemetry` — clean
- [x] `git grep async-std Cargo.lock` — 0 hits
- [x] `grep '"RUSTSEC-2025-0052"' deny.toml` — 0 hits
- [ ] CI green on all workflow checks

## References

- Linear: [GAR-711](https://linear.app/chatgpt25/issue/GAR-711)
- RUSTSEC-2025-0052: https://rustsec.org/advisories/RUSTSEC-2025-0052.html
- Plan: `plans/0252-gar-711-otel-0.26-to-0.31.md`

https://claude.ai/code/session_01Gzr3vms6ig2pwSvXcJfH9K

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gzr3vms6ig2pwSvXcJfH9K)_