### PR TITLE
chore(deps): criterion 0.5.1 → 0.8.2 + fix deprecated black_box in bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1855,25 +1864,24 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -1881,12 +1889,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -4651,17 +4659,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is-wsl"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4682,6 +4679,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -6066,6 +6072,16 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/crates/garraia-glob/Cargo.toml
+++ b/crates/garraia-glob/Cargo.toml
@@ -16,7 +16,7 @@ notify = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = "3.27"
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.8", features = ["html_reports"] }
 
 [[bench]]
 name = "matching"

--- a/crates/garraia-glob/benches/matching.rs
+++ b/crates/garraia-glob/benches/matching.rs
@@ -1,8 +1,8 @@
 //! GAR-266: Benchmark suite — glob matching at 10k, 100k, 200k paths.
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use std::hint::black_box;
 use garraia_glob::pattern::{GlobConfig, GlobMode, GlobPattern};
+use std::hint::black_box;
 
 // ── Test data generators ──────────────────────────────────────────────────
 

--- a/crates/garraia-glob/benches/matching.rs
+++ b/crates/garraia-glob/benches/matching.rs
@@ -1,6 +1,7 @@
 //! GAR-266: Benchmark suite — glob matching at 10k, 100k, 200k paths.
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use std::hint::black_box;
 use garraia_glob::pattern::{GlobConfig, GlobMode, GlobPattern};
 
 // ── Test data generators ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Bumps `criterion` (dev-dep in `garraia-glob`) from **0.5.1 → 0.8.2**
- Fixes the single clippy blocker: `criterion::black_box` was deprecated in criterion 0.8 in favour of `std::hint::black_box` (stable since Rust 1.66; project MSRV is 1.93)
- Closes Dependabot PR #630 (same change, but #630 lacked the bench fix needed for `-D warnings`)

## What changed

| File | Change |
|------|--------|
| `crates/garraia-glob/Cargo.toml` | `criterion = "0.5"` → `"0.8"` |
| `crates/garraia-glob/benches/matching.rs` | `use criterion::black_box` → `use std::hint::black_box` |
| `Cargo.lock` | criterion 0.5.1 → 0.8.2 + 4 new transitive deps (alloca, itertools, criterion-plot 0.8.2, page_size) |

## Why criterion 0.8?

criterion 0.8 is a quality-only bump (no security advisory):
- Fixes panic with uniform iteration durations
- Adds alloca-based stack-layout randomisation to reduce measurement noise
- Drops async-std support (irrelevant to our benches)
- MSRV 1.86 — well within our 1.93 requirement

## Verification

```
cargo clippy -p garraia-glob --all-targets -- -D warnings  → Finished (no errors)
cargo test -p garraia-glob                                  → 2 passed, 0 failed
cargo audit                                                 → 17 allowed warnings (no vulnerabilities)
```

## Security context (daily routine)

This PR is part of the daily dependency/security routine. Summary for today's run:

| Alert | Severity | Status |
|-------|----------|--------|
| RUSTSEC-2023-0071 (rsa/Marvin Attack) | Moderate | Pre-tracked in deny.toml + audit.toml, expires 2026-07-31 |
| PR #627 (patch-and-minor: hyper+pgvector+aws-*) | — | **All CI green** → safe to merge |
| PR #628 (rand_chacha 0.9→0.10) | — | Blocked — rand 0.10 ecosystem incompatibility (GAR issue created) |
| PR #629 (lopdf 0.34→0.40) | — | Blocked — MSRV + build failure (GAR issue created) |
| PR #630 (criterion 0.5→0.8) | — | Fixed by this PR |

## Test plan

- [ ] Clippy Linting job passes
- [ ] Build Check passes
- [ ] Test (ubuntu/macos/windows) passes
- [ ] MSRV check (1.93) passes
- [ ] cargo-deny passes
- [ ] Security Audit passes

https://claude.ai/code/session_01XwSYMnVW7Z2vHvNnmAnejg

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwSYMnVW7Z2vHvNnmAnejg)_