### PR TITLE
feat(chats): GET /v1/threads/{thread_id} — fetch single thread detail (GAR-798)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -642,6 +642,7 @@ Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
 - [x] `GET /v1/messages/{message_id}/attachments?cursor=...` — list attachments (cursor-paginated) → 200, plan 0182 / [GAR-700](https://linear.app/chatgpt25/issue/GAR-700). ✅
 - [x] `DELETE /v1/messages/{message_id}/attachments/{file_id}` — detach file (idempotent) → 204, plan 0182 / [GAR-700](https://linear.app/chatgpt25/issue/GAR-700). ✅ Done.
 - [x] `GET /v1/chats/{chat_id}/threads?after=<uuid>&limit=<n>&include_resolved=<bool>` — cursor-paginated list of threads in a chat, plan 0225 / [GAR-740](https://linear.app/chatgpt25/issue/GAR-740), 2026-05-29 (Florida).
+- [x] `GET /v1/threads/{thread_id}` — fetch single thread detail (id, chat_id, root_message_id, title, created_by, resolved_at, created_at) — plan 0265 / [GAR-798](https://linear.app/chatgpt25/issue/GAR-798) ✅
 
 **Arquivos**
 

--- a/TODO.md
+++ b/TODO.md
@@ -9,6 +9,18 @@ curtos para a próxima sessão autônoma.
 
 ## Concluído nesta sessão
 
+- GAR-798 / plan 0265 — GET /v1/threads/{thread_id}:
+  - `get_thread` handler in `chats.rs` (before `patch_thread`): validates group_id, ChatsRead check,
+    SET LOCAL both RLS configs, single JOIN query (`message_threads JOIN chats WHERE group_id = $2`),
+    returns `ThreadDetailResponse`; 404 for cross-group or unknown threads (no existence leak).
+  - Route wired as `get(chats::get_thread).patch(chats::patch_thread)` in all 3 `mod.rs` branches.
+  - `super::chats::get_thread` added to `openapi.rs` paths list.
+  - Removed now-unused standalone `patch` import from `mod.rs`.
+  - 6 unit tests: serializes all fields, nil title → null, nil created_by → null,
+    unresolved → null resolved_at, resolved → UTC ISO-8601 Z timestamp, nil UUID round-trip.
+  - `cargo clippy --workspace` clean (0 warnings). Branch: `routine/202506051820-get-thread`.
+  - PR pending CI.
+
 - PR #643 (docs/mark-plan-0263-merged) — merged (20/20 CI green); GAR-794 → Done in Linear.
 
 - GAR-795 / plan 0264 — PATCH /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}:

--- a/crates/garraia-gateway/src/rest_v1/chats.rs
+++ b/crates/garraia-gateway/src/rest_v1/chats.rs
@@ -3941,7 +3941,10 @@ mod tests {
         let v = serde_json::to_value(&resp).unwrap();
         assert!(v["resolved_at"].is_string());
         let s = v["resolved_at"].as_str().unwrap();
-        assert!(s.ends_with('Z'), "resolved_at must be UTC ISO-8601 with Z suffix: {s}");
+        assert!(
+            s.ends_with('Z'),
+            "resolved_at must be UTC ISO-8601 with Z suffix: {s}"
+        );
     }
 
     #[test]

--- a/crates/garraia-gateway/src/rest_v1/chats.rs
+++ b/crates/garraia-gateway/src/rest_v1/chats.rs
@@ -2002,7 +2002,7 @@ impl PatchThreadRequest {
     }
 }
 
-/// Response body for `PATCH /v1/threads/{thread_id}`.
+/// Response body for `GET` and `PATCH /v1/threads/{thread_id}`.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct ThreadDetailResponse {
     pub id: Uuid,
@@ -2012,6 +2012,93 @@ pub struct ThreadDetailResponse {
     pub created_by: Option<Uuid>,
     pub resolved_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
+}
+
+/// `GET /v1/threads/{thread_id}` — fetch a single thread by ID.
+///
+/// Returns 404 for threads that belong to a different group (no existence leak).
+#[utoipa::path(
+    get,
+    path = "/v1/threads/{thread_id}",
+    params(("thread_id" = Uuid, Path, description = "Thread UUID.")),
+    responses(
+        (status = 200, description = "Thread detail.", body = ThreadDetailResponse),
+        (status = 400, description = "Missing X-Group-Id header.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller lacks required permission.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Thread not found or in another group.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn get_thread(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(thread_id): Path<Uuid>,
+) -> Result<Json<ThreadDetailResponse>, RestError> {
+    let group_id = principal
+        .group_id
+        .ok_or_else(|| RestError::BadRequest("X-Group-Id header is required".into()))?;
+
+    if !can(&principal, Action::ChatsRead) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(principal.user_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_group_id', $1, true)")
+        .bind(group_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    type ThreadRow = (
+        Uuid,
+        Uuid,
+        Uuid,
+        Option<String>,
+        Option<Uuid>,
+        Option<DateTime<Utc>>,
+        DateTime<Utc>,
+    );
+    let row: Option<ThreadRow> = sqlx::query_as(
+        "SELECT mt.id, mt.chat_id, mt.root_message_id, mt.title, mt.created_by, \
+         mt.resolved_at, mt.created_at \
+         FROM message_threads mt \
+         JOIN chats c ON c.id = mt.chat_id \
+         WHERE mt.id = $1 AND c.group_id = $2",
+    )
+    .bind(thread_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let (id, chat_id, root_message_id, title, created_by, resolved_at, created_at) =
+        row.ok_or(RestError::NotFound)?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(Json(ThreadDetailResponse {
+        id,
+        chat_id,
+        root_message_id,
+        title,
+        created_by,
+        resolved_at,
+        created_at,
+    }))
 }
 
 /// `PATCH /v1/threads/{thread_id}` — update a thread's title and/or resolve state.
@@ -3761,5 +3848,121 @@ mod tests {
         let result: Result<StatusCode, RestError> = Ok(StatusCode::NO_CONTENT);
         assert!(result.is_ok());
         assert_eq!(result.ok(), Some(StatusCode::NO_CONTENT));
+    }
+
+    // ── GET /v1/threads/{thread_id} ──────────────────────────────────────────
+
+    #[test]
+    fn get_thread_response_serializes_all_fields() {
+        let id = Uuid::new_v4();
+        let chat_id = Uuid::new_v4();
+        let root_message_id = Uuid::new_v4();
+        let created_by = Uuid::new_v4();
+        let now = Utc::now();
+        let resp = ThreadDetailResponse {
+            id,
+            chat_id,
+            root_message_id,
+            title: Some("Release planning".to_owned()),
+            created_by: Some(created_by),
+            resolved_at: Some(now),
+            created_at: now,
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert_eq!(v["id"].as_str().unwrap(), id.to_string());
+        assert_eq!(v["chat_id"].as_str().unwrap(), chat_id.to_string());
+        assert_eq!(
+            v["root_message_id"].as_str().unwrap(),
+            root_message_id.to_string()
+        );
+        assert_eq!(v["title"].as_str().unwrap(), "Release planning");
+        assert_eq!(v["created_by"].as_str().unwrap(), created_by.to_string());
+        assert!(v["resolved_at"].is_string());
+        assert!(v["created_at"].is_string());
+    }
+
+    #[test]
+    fn get_thread_response_nil_title_serializes_null() {
+        let resp = ThreadDetailResponse {
+            id: Uuid::new_v4(),
+            chat_id: Uuid::new_v4(),
+            root_message_id: Uuid::new_v4(),
+            title: None,
+            created_by: Some(Uuid::new_v4()),
+            resolved_at: None,
+            created_at: Utc::now(),
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert!(v["title"].is_null());
+    }
+
+    #[test]
+    fn get_thread_response_nil_created_by_serializes_null() {
+        let resp = ThreadDetailResponse {
+            id: Uuid::new_v4(),
+            chat_id: Uuid::new_v4(),
+            root_message_id: Uuid::new_v4(),
+            title: Some("thread".to_owned()),
+            created_by: None,
+            resolved_at: None,
+            created_at: Utc::now(),
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert!(v["created_by"].is_null());
+    }
+
+    #[test]
+    fn get_thread_response_unresolved_has_null_resolved_at() {
+        let resp = ThreadDetailResponse {
+            id: Uuid::new_v4(),
+            chat_id: Uuid::new_v4(),
+            root_message_id: Uuid::new_v4(),
+            title: None,
+            created_by: None,
+            resolved_at: None,
+            created_at: Utc::now(),
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert!(v["resolved_at"].is_null());
+    }
+
+    #[test]
+    fn get_thread_response_resolved_has_resolved_at_timestamp() {
+        let resolved_at = Utc::now();
+        let resp = ThreadDetailResponse {
+            id: Uuid::new_v4(),
+            chat_id: Uuid::new_v4(),
+            root_message_id: Uuid::new_v4(),
+            title: Some("Sprint retro".to_owned()),
+            created_by: Some(Uuid::new_v4()),
+            resolved_at: Some(resolved_at),
+            created_at: Utc::now(),
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert!(v["resolved_at"].is_string());
+        let s = v["resolved_at"].as_str().unwrap();
+        assert!(s.ends_with('Z'), "resolved_at must be UTC ISO-8601 with Z suffix: {s}");
+    }
+
+    #[test]
+    fn get_thread_response_nil_uuid_round_trips() {
+        let resp = ThreadDetailResponse {
+            id: Uuid::nil(),
+            chat_id: Uuid::nil(),
+            root_message_id: Uuid::nil(),
+            title: None,
+            created_by: None,
+            resolved_at: None,
+            created_at: Utc::now(),
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert_eq!(
+            v["id"].as_str().unwrap(),
+            "00000000-0000-0000-0000-000000000000"
+        );
+        assert_eq!(
+            v["root_message_id"].as_str().unwrap(),
+            "00000000-0000-0000-0000-000000000000"
+        );
     }
 }

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -48,7 +48,7 @@ use std::sync::atomic::AtomicUsize;
 
 use axum::Router;
 use axum::extract::FromRef;
-use axum::routing::{delete, get, head, patch, post};
+use axum::routing::{delete, get, head, post};
 use dashmap::DashMap;
 use garraia_agents::AgentRuntime;
 use garraia_auth::{AppPool, JwtIssuer, LoginPool};
@@ -392,7 +392,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 // Plan 0221 (GAR-740) — chats slice 6: list threads in a chat.
                 .route("/v1/chats/{chat_id}/threads", get(chats::list_chat_threads))
                 // Plan 0227 (GAR-745) — chats slice 7: patch thread (resolve/title).
-                .route("/v1/threads/{thread_id}", patch(chats::patch_thread))
+                // Plan 0265 (GAR-798) — get single thread.
+                .route(
+                    "/v1/threads/{thread_id}",
+                    get(chats::get_thread).patch(chats::patch_thread),
+                )
                 // Plan 0057 (GAR-509) — threads slice 3.
                 // Plan 0109 (GAR-595) — messages slice 6: GET thread messages.
                 .route(
@@ -667,7 +671,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 // Plan 0221 (GAR-740) — chats slice 6: list threads, fail-soft 503.
                 .route("/v1/chats/{chat_id}/threads", get(unconfigured_handler))
                 // Plan 0227 (GAR-745) — chats slice 7: patch thread, fail-soft 503.
-                .route("/v1/threads/{thread_id}", patch(unconfigured_handler))
+                // Plan 0265 (GAR-798) — get single thread, fail-soft 503.
+                .route(
+                    "/v1/threads/{thread_id}",
+                    get(unconfigured_handler).patch(unconfigured_handler),
+                )
                 // Plan 0057 (GAR-509) — threads slice 3, fail-soft 503.
                 // Plan 0109 (GAR-595) — messages slice 6, fail-soft 503.
                 .route(
@@ -917,7 +925,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 // Plan 0221 (GAR-740) — chats slice 6: list threads, no-auth stub.
                 .route("/v1/chats/{chat_id}/threads", get(unconfigured_handler))
                 // Plan 0227 (GAR-745) — chats slice 7: patch thread, no-auth stub.
-                .route("/v1/threads/{thread_id}", patch(unconfigured_handler))
+                // Plan 0265 (GAR-798) — get single thread, no-auth stub.
+                .route(
+                    "/v1/threads/{thread_id}",
+                    get(unconfigured_handler).patch(unconfigured_handler),
+                )
                 // Plan 0057 (GAR-509) — threads slice 3, no-auth stub.
                 // Plan 0109 (GAR-595) — messages slice 6, no-auth stub.
                 .route(

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -125,6 +125,7 @@ impl Modify for SecurityAddon {
         super::uploads::options_uploads,
         super::chats::create_chat,
         super::chats::list_chats,
+        super::chats::get_thread,
         super::chats::patch_thread,
         super::chats::patch_chat_member,
         super::chats::typing_indicator,

--- a/plans/0265-gar-798-get-thread.md
+++ b/plans/0265-gar-798-get-thread.md
@@ -1,0 +1,152 @@
+# Plan 0265 — GAR-798: GET /v1/threads/{thread_id}
+
+**Status:** In Progress
+**Issue:** [GAR-798](https://linear.app/chatgpt25/issue/GAR-798)
+**Branch:** `routine/202506051820-get-thread`
+**Epic:** GAR-509 (threads slice 3 / chats API)
+**Labels:** `epic:ws-chat`, `epic:ws-api`
+
+---
+
+## Goal
+
+Add `GET /v1/threads/{thread_id}` — returns the full `ThreadDetailResponse` for a
+single message thread by ID. Closes the CRUD gap: the route
+`/v1/threads/{thread_id}` is already half-wired via `.patch(chats::patch_thread)`
+but lacks a GET handler. Mobile deep-links that store a `thread_id` (e.g. from a
+push notification) cannot hydrate thread metadata without scanning the full
+`GET /v1/chats/{chat_id}/threads` list.
+
+---
+
+## Architecture
+
+Single new handler `get_thread` in
+`crates/garraia-gateway/src/rest_v1/chats.rs`, placed immediately before the
+existing `patch_thread` (they share the same URL path).
+
+One SQL query (no second round-trip):
+
+```sql
+SELECT mt.id, mt.chat_id, mt.root_message_id, mt.title,
+       mt.created_by, mt.resolved_at, mt.created_at
+FROM   message_threads mt
+JOIN   chats c ON c.id = mt.chat_id
+WHERE  mt.id = $1 AND c.group_id = $2
+```
+
+The JOIN on `chats` provides the cross-tenant guard: threads whose chat belongs to
+a different group silently become 404 (no existence leak).
+
+---
+
+## Tech stack
+
+- Rust / Axum 0.8 / sqlx (Postgres)
+- `garraia-auth`: `Action::ChatsRead` (existing)
+- `garraia-workspace`: `message_threads` (migration 004, no change)
+- utoipa for OpenAPI annotation
+
+---
+
+## Design invariants
+
+- Returns 404 (not 403) for cross-group threads — no existence leak.
+- RLS context (`app.current_user_id` + `app.current_group_id`) SET LOCAL inside
+  the tx (FORCE RLS on `message_threads` via `message_threads_through_chats`
+  policy, identical to `patch_thread`).
+- Response shape is `ThreadDetailResponse` — the struct already used by
+  `patch_thread`, no new type introduced.
+- No audit event — read-only endpoint.
+- No migration — `message_threads` table exists since migration 004.
+
+---
+
+## Validações pré-plano
+
+- [x] `ThreadDetailResponse` struct already exists in `chats.rs` (line ~2007).
+- [x] Route `/v1/threads/{thread_id}` already has `.patch(...)` in all 3 `mod.rs`
+  branches; adding `.get(...)` is additive.
+- [x] `message_threads` has `root_message_id` column (migration 004, confirmed in
+  `patch_thread` line ~2095).
+- [x] No existing `get_thread` function — zero naming conflict.
+
+---
+
+## Out of scope
+
+- `DELETE /v1/threads/{thread_id}` (needs schema change: `deleted_at` column).
+- Reply pagination inside this endpoint (covered by existing
+  `GET /v1/messages/{message_id}/threads`).
+- `reply_count` field in `ThreadDetailResponse` (would add a correlated subquery;
+  deferred to a future enrichment slice).
+
+---
+
+## Rollback
+
+The change is purely additive (new handler + route wiring). Reverting means
+removing `get(chats::get_thread)` from the three `.route(...)` calls and deleting
+the handler. No migration to undo.
+
+---
+
+## File Structure
+
+```
+crates/garraia-gateway/src/rest_v1/
+  chats.rs        ← add get_thread handler + utoipa::path annotation
+  mod.rs          ← add .get(chats::get_thread) in 3 branches
+  openapi.rs      ← add super::chats::get_thread to paths + no new schema needed
+```
+
+---
+
+## M1 — Implement GET /v1/threads/{thread_id}
+
+- [ ] T1: Add `get_thread` handler in `chats.rs` (before `patch_thread`).
+- [ ] T2: Wire `get(chats::get_thread)` in all 3 `mod.rs` branches.
+- [ ] T3: Add `super::chats::get_thread` to `openapi.rs` paths list.
+- [ ] T4: Add 6+ unit tests in `chats.rs` test module.
+- [ ] T5: `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` clean.
+- [ ] T6: Commit, push, open PR.
+
+---
+
+## Risk register
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| Cross-group leak via JOIN | Low | JOIN on `c.group_id = $2` + FORCE RLS prevents it |
+| Naming conflict with existing `get_thread` | None | Grep confirms no such function |
+| OpenAPI duplicate path | None | `patch_thread` already registered; utoipa merges GET+PATCH on same path |
+
+---
+
+## Acceptance criteria
+
+- `GET /v1/threads/{id}` returns 200 + `ThreadDetailResponse` for a known thread
+  in the caller's group.
+- Returns 404 for an unknown thread or a thread in a different group.
+- `cargo clippy --workspace` green.
+- 6+ unit tests pass (serialization, cross-group 404, nil created_by, nil title,
+  resolved thread, nil UUID round-trip).
+- CI 20/20 green.
+- ROADMAP.md §3.4 chats checklist updated.
+
+---
+
+## Cross-references
+
+- Migration 004: `message_threads` schema
+- Plan 0058 / GAR-509: create thread
+- Plan 0225 / GAR-740: list threads in chat
+- Plan 0227 / GAR-745: patch thread
+- Plan 0261 / GAR-790: me/threads inbox
+
+---
+
+## Estimativa
+
+- LOC: ~100 (handler) + ~20 (wiring) + ~15 (openapi) + ~60 (tests) ≈ 195 LOC total
+- Time: ~30 min

--- a/plans/README.md
+++ b/plans/README.md
@@ -274,3 +274,4 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0262 | [GAR-789 — Drop stale RUSTSEC-2026-0097 (rand 0.7.3) from audit.toml](0262-gar-789-drop-stale-rustsec-2026-0097.md) | [GAR-789](https://linear.app/chatgpt25/issue/GAR-789) | ✅ Done (PR #640 / 9f3e760) |
 | 0263 | [GAR-794 — POST /v1/me/invites/{invite_id}/accept (invitee-side authenticated invite acceptance)](0263-gar-794-me-invite-accept.md) | [GAR-794](https://linear.app/chatgpt25/issue/GAR-794) | ✅ Merged 2026-06-05 via PR #642 (`cec4545`) |
 | 0264 | [GAR-795 — PATCH /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id} (edit task comment body)](0264-gar-795-task-comment-patch.md) | [GAR-795](https://linear.app/chatgpt25/issue/GAR-795) | ✅ Merged 2026-06-05 via PR #644 (6974812) |
+| 0265 | [GAR-798 — GET /v1/threads/{thread_id} — fetch single thread detail](0265-gar-798-get-thread.md) | [GAR-798](https://linear.app/chatgpt25/issue/GAR-798) | 🔄 In Progress |


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `GET /v1/threads/{thread_id}` handler (`get_thread`) in `chats.rs`, returning `ThreadDetailResponse` (id, chat_id, root_message_id, title, created_by, resolved_at, created_at).
- Single JOIN query — `message_threads JOIN chats WHERE group_id = $2` — provides cross-tenant isolation; 404 for unknown or cross-group threads (no existence leak).
- Requires `Action::ChatsRead`. RLS context set via `SET LOCAL` for both `app.current_user_id` and `app.current_group_id`.
- Route wired as `get(chats::get_thread).patch(chats::patch_thread)` in all 3 `mod.rs` branches (full-auth, fail-soft 503, no-auth stub).
- `super::chats::get_thread` added to `openapi.rs` paths list.
- Removed now-unused standalone `patch` routing import from `mod.rs`.
- 6 unit tests covering: all-fields serialization, nil title → null, nil created_by → null, unresolved → null resolved_at, resolved → UTC ISO-8601 Z timestamp, nil UUID round-trip.
- `cargo clippy --workspace` clean (0 warnings). No migration needed.

Closes [GAR-798](https://linear.app/chatgpt25/issue/GAR-798).
Plan: [`plans/0265-gar-798-get-thread.md`](plans/0265-gar-798-get-thread.md).

## Test plan

- [x] `cargo check -p garraia-gateway --features test-helpers` — clean
- [x] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` — 0 warnings
- [x] 6 unit tests in `chats.rs` test module covering response serialization
- [ ] CI: Format, Clippy, Test×3, Build, MSRV, cargo-deny, Security Audit, Coverage, Analyze rust, Analyze js-ts, Playwright, E2E, Secret Scan, Dependency Review — all green

https://claude.ai/code/session_01V5YnspFPYAC3kzzrK1cN8T
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5YnspFPYAC3kzzrK1cN8T)_