### PR TITLE
feat(tasks): GET /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id} — fetch single task comment (GAR-806)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -783,6 +783,7 @@ Módulo dentro de `garraia-workspace`. Schema entregue via migration 006 com **R
 - [x] `DELETE /v1/groups/{group_id}/tasks/{task_id}` (soft delete) — plan 0068 / GAR-518 ✅
 - [x] `POST /v1/groups/{group_id}/tasks/{task_id}/comments` — plan 0069 / GAR-520 ✅
 - [x] `GET /v1/groups/{group_id}/tasks/{task_id}/comments?cursor=...` — plan 0069 / GAR-520 ✅
+- [x] `GET /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}` — fetch single comment (no existence leak for deleted/cross-tenant) — plan 0269 / [GAR-806](https://linear.app/chatgpt25/issue/GAR-806) ✅
 - [x] `DELETE /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}` — plan 0069 / GAR-520 ✅
 - [x] `PATCH /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}` (edit body, sender-only) — plan 0264 / [GAR-795](https://linear.app/chatgpt25/issue/GAR-795) ✅
 - [x] `POST /v1/groups/{group_id}/tasks/{task_id}/assignees` — plan 0077 / GAR-533 ✅
@@ -790,6 +791,7 @@ Módulo dentro de `garraia-workspace`. Schema entregue via migration 006 com **R
 - [x] `DELETE /v1/groups/{group_id}/tasks/{task_id}/assignees/{user_id}` — plan 0077 / GAR-533 ✅
 - [x] `POST /v1/groups/{group_id}/task-labels` — plan 0078 / GAR-536 ✅
 - [x] `GET /v1/groups/{group_id}/task-labels` — plan 0078 / GAR-536 ✅
+- [x] `GET /v1/groups/{group_id}/task-labels/{label_id}` — fetch single label — plan 0267 / [GAR-802](https://linear.app/chatgpt25/issue/GAR-802) ✅
 - [x] `DELETE /v1/groups/{group_id}/task-labels/{label_id}` — plan 0078 / GAR-536 ✅
 - [x] `PATCH /v1/groups/{group_id}/task-labels/{label_id}` — plan 0266 / GAR-800 ✅
 - [x] `POST /v1/groups/{group_id}/tasks/{task_id}/labels` — plan 0078 / GAR-536 ✅

--- a/TODO.md
+++ b/TODO.md
@@ -9,6 +9,19 @@ curtos para a próxima sessão autônoma.
 
 ## Concluído nesta sessão
 
+- GAR-806 / plan 0269 — GET /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}:
+  - `get_task_comment` handler in `comments.rs`: validates group_id, TasksRead check,
+    SET LOCAL both RLS configs, single query (`task_comments WHERE id=$1 AND task_id=$2 AND deleted_at IS NULL`),
+    returns `CommentResponse`; 404 for deleted/cross-group/unknown (no existence leak).
+  - Route wired as `get(tasks::get_task_comment)` alongside delete+patch in all 3 `mod.rs` branches.
+  - `super::tasks::comments::get_task_comment` added to `openapi.rs` paths list.
+  - ROADMAP §3.8 and §3.4 updated with GET single task-label (GAR-802) and GET single comment (GAR-806).
+  - 6 unit tests: serializes all fields, nil author_user_id → null, nil edited_at → null,
+    edited_at UTC ISO-8601 Z, nil UUID round-trip, task_id preserved.
+  - `cargo clippy --workspace` clean (0 warnings). 12 total comments tests pass.
+  - Branch: `routine/202506061830-get-task-comment`.
+
+
 - GAR-800 / plan 0266 — PATCH /v1/groups/{group_id}/task-labels/{label_id}:
   - `PatchTaskLabelRequest { name, color }` + `patch_task_label` handler in `labels.rs`.
   - COALESCE UPDATE (at least one field required → 400, 404 on 0 rows, 409 on duplicate name).

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -474,7 +474,9 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 )
                 .route(
                     "/v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}",
-                    delete(tasks::delete_task_comment).patch(tasks::patch_task_comment),
+                    get(tasks::get_task_comment)
+                        .delete(tasks::delete_task_comment)
+                        .patch(tasks::patch_task_comment),
                 )
                 // Plan 0077 (GAR-533) — task assignees API slice 4.
                 .route(
@@ -793,7 +795,9 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 )
                 .route(
                     "/v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}",
-                    delete(unconfigured_handler).patch(unconfigured_handler),
+                    get(unconfigured_handler)
+                        .delete(unconfigured_handler)
+                        .patch(unconfigured_handler),
                 )
                 .route(
                     "/v1/groups/{group_id}/tasks/{task_id}/assignees",
@@ -1064,7 +1068,9 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 )
                 .route(
                     "/v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}",
-                    delete(unconfigured_handler).patch(unconfigured_handler),
+                    get(unconfigured_handler)
+                        .delete(unconfigured_handler)
+                        .patch(unconfigured_handler),
                 )
                 .route(
                     "/v1/groups/{group_id}/tasks/{task_id}/assignees",

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -153,6 +153,7 @@ impl Modify for SecurityAddon {
         super::tasks::delete_task,
         super::tasks::comments::create_task_comment,
         super::tasks::comments::list_task_comments,
+        super::tasks::comments::get_task_comment,
         super::tasks::comments::delete_task_comment,
         super::tasks::comments::patch_task_comment,
         super::tasks::assignees::add_task_assignee,

--- a/crates/garraia-gateway/src/rest_v1/tasks/comments.rs
+++ b/crates/garraia-gateway/src/rest_v1/tasks/comments.rs
@@ -2,9 +2,10 @@
 //!
 //! Extracted from `rest_v1/tasks/mod.rs` by GAR-635 (plan 0136, Q11 slice 2).
 //!
-//! Four endpoints:
+//! Five endpoints:
 //! - `POST /v1/groups/{group_id}/tasks/{task_id}/comments` — create a comment (plan 0069 / GAR-520)
 //! - `GET /v1/groups/{group_id}/tasks/{task_id}/comments` — cursor-paginated list (plan 0069 / GAR-520)
+//! - `GET /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}` — fetch single comment (plan 0269 / GAR-806)
 //! - `DELETE /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}` — soft-delete (plan 0069 / GAR-520)
 //! - `PATCH /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}` — edit body (plan 0264 / GAR-795)
 
@@ -440,6 +441,78 @@ pub async fn delete_task_comment(
     Ok(StatusCode::NO_CONTENT)
 }
 
+// ─── GET single handler (plan 0269 / GAR-806) ────────────────────────────────
+
+/// `GET /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}` — fetch a single comment.
+///
+/// Returns 200 + `CommentResponse` on success. Returns 404 if the comment does not
+/// exist, has been soft-deleted, or belongs to a different task/group (no existence leak).
+/// Authz: `Action::TasksRead`.
+///
+/// ## Error matrix
+///
+/// | Condition                                      | Status |
+/// |------------------------------------------------|--------|
+/// | Missing/invalid JWT                            | 401    |
+/// | Non-member of group                            | 403    |
+/// | Path group_id ≠ principal group_id             | 403    |
+/// | Comment not found / deleted / cross-tenant     | 404    |
+/// | Happy path                                     | 200    |
+#[utoipa::path(
+    get,
+    path = "/v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ("task_id" = Uuid, Path, description = "Task UUID."),
+        ("comment_id" = Uuid, Path, description = "Comment UUID."),
+    ),
+    responses(
+        (status = 200, description = "Task comment.", body = CommentResponse),
+        (status = 401, description = "Missing or invalid JWT.", body = super::super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::super::problem::ProblemDetails),
+        (status = 404, description = "Comment not found, already deleted, or cross-tenant.", body = super::super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn get_task_comment(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((path_group_id, task_id, comment_id)): Path<(Uuid, Uuid, Uuid)>,
+) -> Result<Json<CommentResponse>, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::TasksRead) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // RLS JOIN policy on task_comments scopes to current group via tasks.
+    // Binding task_id prevents cross-task UUID collisions from leaking existence.
+    let row: Option<CommentRow> = sqlx::query_as(
+        "SELECT id, task_id, author_user_id, author_label, body_md, created_at, edited_at \
+         FROM task_comments \
+         WHERE id = $1 AND task_id = $2 AND deleted_at IS NULL",
+    )
+    .bind(comment_id)
+    .bind(task_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    let row = row.ok_or(RestError::NotFound)?;
+    Ok(Json(CommentResponse::from(row)))
+}
+
 // ─── PATCH handler (plan 0264 / GAR-795) ─────────────────────────────────────
 
 /// Request body for `PATCH /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}`.
@@ -647,5 +720,119 @@ mod tests {
             body_md: "   ".to_string(),
         };
         assert!(req.validate().is_ok());
+    }
+
+    // ─── GET single comment response tests (plan 0269 / GAR-806) ─────────────
+
+    #[test]
+    fn comment_response_serializes_all_fields() {
+        let id = Uuid::nil();
+        let task_id = Uuid::nil();
+        let created_at = DateTime::from_timestamp(0, 0).unwrap();
+        let resp = CommentResponse {
+            id,
+            task_id,
+            author_user_id: None,
+            author_label: "Alice".to_string(),
+            body_md: "hello world".to_string(),
+            created_at,
+            edited_at: None,
+        };
+        let val = serde_json::to_value(&resp).unwrap();
+        assert!(val.get("id").is_some());
+        assert!(val.get("task_id").is_some());
+        assert!(val.get("author_label").is_some());
+        assert!(val.get("body_md").is_some());
+        assert!(val.get("created_at").is_some());
+        assert_eq!(val["body_md"], serde_json::json!("hello world"));
+    }
+
+    #[test]
+    fn comment_response_nil_author_user_id_is_null() {
+        let resp = CommentResponse {
+            id: Uuid::nil(),
+            task_id: Uuid::nil(),
+            author_user_id: None,
+            author_label: "Alice".to_string(),
+            body_md: "test".to_string(),
+            created_at: DateTime::from_timestamp(0, 0).unwrap(),
+            edited_at: None,
+        };
+        let val = serde_json::to_value(&resp).unwrap();
+        assert!(val["author_user_id"].is_null());
+    }
+
+    #[test]
+    fn comment_response_nil_edited_at_is_null() {
+        let resp = CommentResponse {
+            id: Uuid::nil(),
+            task_id: Uuid::nil(),
+            author_user_id: None,
+            author_label: "Alice".to_string(),
+            body_md: "test".to_string(),
+            created_at: DateTime::from_timestamp(0, 0).unwrap(),
+            edited_at: None,
+        };
+        let val = serde_json::to_value(&resp).unwrap();
+        assert!(val["edited_at"].is_null());
+    }
+
+    #[test]
+    fn comment_response_edited_at_is_utc_iso8601() {
+        let edited_at = DateTime::from_timestamp(1_000_000, 0).unwrap();
+        let resp = CommentResponse {
+            id: Uuid::nil(),
+            task_id: Uuid::nil(),
+            author_user_id: None,
+            author_label: "Bob".to_string(),
+            body_md: "edited".to_string(),
+            created_at: DateTime::from_timestamp(0, 0).unwrap(),
+            edited_at: Some(edited_at),
+        };
+        let val = serde_json::to_value(&resp).unwrap();
+        let s = val["edited_at"].as_str().unwrap();
+        assert!(s.ends_with('Z'), "edited_at must end with Z: {s}");
+    }
+
+    #[test]
+    fn comment_response_round_trips_nil_uuid() {
+        let resp = CommentResponse {
+            id: Uuid::nil(),
+            task_id: Uuid::nil(),
+            author_user_id: Some(Uuid::nil()),
+            author_label: "Charlie".to_string(),
+            body_md: "round trip".to_string(),
+            created_at: DateTime::from_timestamp(0, 0).unwrap(),
+            edited_at: None,
+        };
+        let val = serde_json::to_value(&resp).unwrap();
+        assert_eq!(
+            val["id"].as_str().unwrap(),
+            "00000000-0000-0000-0000-000000000000"
+        );
+        assert_eq!(
+            val["task_id"].as_str().unwrap(),
+            "00000000-0000-0000-0000-000000000000"
+        );
+    }
+
+    #[test]
+    fn comment_response_task_id_preserved() {
+        use uuid::uuid;
+        let task_id = uuid!("11111111-1111-1111-1111-111111111111");
+        let resp = CommentResponse {
+            id: Uuid::nil(),
+            task_id,
+            author_user_id: None,
+            author_label: "Dave".to_string(),
+            body_md: "task check".to_string(),
+            created_at: DateTime::from_timestamp(0, 0).unwrap(),
+            edited_at: None,
+        };
+        let val = serde_json::to_value(&resp).unwrap();
+        assert_eq!(
+            val["task_id"].as_str().unwrap(),
+            "11111111-1111-1111-1111-111111111111"
+        );
     }
 }

--- a/crates/garraia-gateway/src/rest_v1/tasks/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/tasks/mod.rs
@@ -19,6 +19,7 @@
 //! **Slice 3 (plan 0069 / GAR-520):**
 //! - `POST /v1/groups/{group_id}/tasks/{task_id}/comments` — create comment
 //! - `GET /v1/groups/{group_id}/tasks/{task_id}/comments` — cursor-paginated comment list
+//! - `GET /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}` — fetch single comment
 //! - `DELETE /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}` — soft-delete comment
 //!
 //! **Slice 4 (plan 0077 / GAR-533):**
@@ -93,10 +94,11 @@ pub use task_lists::{
 
 pub mod comments;
 pub use comments::{
-    __path_create_task_comment, __path_delete_task_comment, __path_list_task_comments,
-    __path_patch_task_comment, CommentResponse, CreateCommentRequest, EditCommentRequest,
-    EditedCommentResponse, ListCommentsQuery, ListCommentsResponse, create_task_comment,
-    delete_task_comment, list_task_comments, patch_task_comment,
+    __path_create_task_comment, __path_delete_task_comment, __path_get_task_comment,
+    __path_list_task_comments, __path_patch_task_comment, CommentResponse, CreateCommentRequest,
+    EditCommentRequest, EditedCommentResponse, ListCommentsQuery, ListCommentsResponse,
+    create_task_comment, delete_task_comment, get_task_comment, list_task_comments,
+    patch_task_comment,
 };
 
 pub mod assignees;

--- a/plans/0269-gar-806-get-task-comment.md
+++ b/plans/0269-gar-806-get-task-comment.md
@@ -1,0 +1,68 @@
+# Plan 0269 — GAR-806: GET /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}
+
+## Goal
+
+Add `GET /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}` to fetch a single
+task comment by UUID, completing the task-comment CRUD surface.
+
+## Architecture
+
+Single new handler `get_task_comment` in `crates/garraia-gateway/src/rest_v1/tasks/comments.rs`,
+following the established pattern of `get_task_label` (GAR-802) and `get_thread` (GAR-798).
+Returns `CommentResponse` (already defined in the same file), no new types needed.
+
+## Tech stack
+
+- Rust / Axum 0.8 — handler follows existing `delete_task_comment` signature
+- sqlx parameterized query, FORCE RLS via `set_rls_context`
+- utoipa path annotation for OpenAPI
+
+## Design invariants
+
+- `deleted_at IS NULL` guard: deleted comments return 404 (no existence leak)
+- `task_id` path param bound in query: cross-task UUID collisions return 404
+- `set_rls_context(group_id)` enforces FORCE RLS JOIN policy on `task_comments`
+- `Action::TasksRead` required
+- No audit event: read-only operation
+
+## Validações pré-plano
+
+- `task_comments` schema confirmed: `id, task_id, author_user_id, author_label, body_md, created_at, edited_at, deleted_at`
+- `CommentRow` + `CommentResponse` already defined and `From<CommentRow>` implemented
+- `check_group_match`, `require_group_id`, `set_rls_context` already imported
+- Route `/v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}` exists with `delete` + `patch` — adding `get` is additive
+
+## Out of scope
+
+- No new migration
+- No audit event for reads
+- No pagination
+
+## Rollback
+
+Revert the 4 file changes (comments.rs handler + test, mod.rs exports + route wire, openapi.rs registration). No schema changes.
+
+## Tasks
+
+- [ ] T1: Add `get_task_comment` handler + 6 unit tests to `comments.rs`
+- [ ] T2: Wire route + export in `mod.rs`
+- [ ] T3: Register in `openapi.rs`
+- [ ] T4: Update `plans/README.md` + ROADMAP §3.8 checklist + TODO.md
+
+## Acceptance criteria
+
+- `GET /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}` returns 200 + `CommentResponse`
+- 404 for missing, deleted, or cross-group comment
+- 403 for `TasksRead` missing
+- `cargo clippy --workspace --tests --exclude garraia-desktop --no-deps -- -D warnings` clean
+- CI 20/20 green
+
+## Cross-references
+
+- Parent epic: GAR-396
+- Same pattern: plan 0267 (GAR-802 GET single task label), plan 0265 (GAR-798 GET single thread)
+- Comments CRUD history: plan 0069 (GAR-520), plan 0264 (GAR-795 PATCH)
+
+## Estimativa
+
+~150 LOC, ~30 min implementation + CI wait.

--- a/plans/README.md
+++ b/plans/README.md
@@ -277,4 +277,5 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0265 | [GAR-798 — GET /v1/threads/{thread_id} — fetch single thread detail](0265-gar-798-get-thread.md) | [GAR-798](https://linear.app/chatgpt25/issue/GAR-798) | ✅ Merged PR #646 (`7913904`) |
 | 0266 | [GAR-800 — PATCH /v1/groups/{group_id}/task-labels/{label_id} (edit task label name/color)](0266-gar-800-task-label-patch.md) | [GAR-800](https://linear.app/chatgpt25/issue/GAR-800) | ✅ Merged PR #649 (`28d052a`) |
 | 0267 | [GAR-802 — GET /v1/groups/{group_id}/task-labels/{label_id} (fetch single task label)](0267-gar-802-get-task-label.md) | [GAR-802](https://linear.app/chatgpt25/issue/GAR-802) | ✅ Merged PR #651 (`afe02ce`) |
-| 0268 | [GAR-805 — Health run 85 (2026-06-06 ~12:47 ET): all surfaces clean, priority (i)](0268-gar-805-health-run-85.md) | [GAR-805](https://linear.app/chatgpt25/issue/GAR-805) | ⏳ In progress |
+| 0268 | [GAR-805 — Health run 85 (2026-06-06 ~12:47 ET): all surfaces clean, priority (i)](0268-gar-805-health-run-85.md) | [GAR-805](https://linear.app/chatgpt25/issue/GAR-805) | ✅ Merged 2026-06-06 via PR #654 (`99448bb`) |
+| 0269 | [GAR-806 — GET /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id} (fetch single task comment)](0269-gar-806-get-task-comment.md) | [GAR-806](https://linear.app/chatgpt25/issue/GAR-806) | ⏳ In progress |


### PR DESCRIPTION
## Summary

- Adds `GET /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}` — the missing read-single endpoint that completes task-comment CRUD
- Handler `get_task_comment` in `rest_v1/tasks/comments.rs` follows the same pattern as GAR-802 (task label) and GAR-798 (thread)
- Returns `CommentResponse` on 200; 404 for deleted/cross-group/unknown (no existence leak); 403 for missing `TasksRead`
- Route wired (with `get`) alongside existing `delete` + `patch` in all 3 `mod.rs` branches
- Registered in `openapi.rs` OpenAPI paths list
- ROADMAP §3.8 updated: added GET single task-label checklist item (GAR-802, was missing) + new GET single comment item (GAR-806)

## Test plan

- [x] 6 new unit tests: all fields serialize, nil `author_user_id` → null, nil `edited_at` → null, `edited_at` ends with `Z`, nil UUID round-trip, `task_id` preserved
- [x] 12 total `rest_v1::tasks::comments` tests pass (6 new + 6 existing)
- [x] `cargo check -p garraia-gateway` clean
- [x] `cargo clippy --workspace --tests --exclude garraia-desktop --no-deps -- -D warnings` clean (0 warnings)
- [x] CI expected: Format, Clippy, Test×3, Build, MSRV, cargo-deny, Security Audit, Coverage, CodeQL, Playwright, E2E, Secret Scan, Dependency Review

Closes GAR-806. Parent epic: GAR-396.

https://claude.ai/code/session_01U7ugJ1w7w3Rwgyqn9t174h

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7ugJ1w7w3Rwgyqn9t174h)_