### PR TITLE
feat(chats): GET /v1/threads/{thread_id}/messages — list thread replies by thread_id (GAR-814)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -643,7 +643,8 @@ Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
 - [x] `DELETE /v1/messages/{message_id}/attachments/{file_id}` — detach file (idempotent) → 204, plan 0182 / [GAR-700](https://linear.app/chatgpt25/issue/GAR-700). ✅ Done.
 - [x] `GET /v1/chats/{chat_id}/threads?after=<uuid>&limit=<n>&include_resolved=<bool>` — cursor-paginated list of threads in a chat, plan 0225 / [GAR-740](https://linear.app/chatgpt25/issue/GAR-740), 2026-05-29 (Florida).
 - [x] `GET /v1/threads/{thread_id}` — fetch single thread detail (id, chat_id, root_message_id, title, created_by, resolved_at, created_at) — plan 0265 / [GAR-798](https://linear.app/chatgpt25/issue/GAR-798) ✅
-- [x] `POST /v1/threads/{thread_id}/messages` — post a reply into an existing thread — plan 0276 / [GAR-811](https://linear.app/chatgpt25/issue/GAR-811) ✅
+- [x] `POST /v1/threads/{thread_id}/messages` — post a reply into an existing thread — plan 0278 / [GAR-811](https://linear.app/chatgpt25/issue/GAR-811) ✅
+- [x] `GET /v1/threads/{thread_id}/messages` — list replies in a thread by thread_id (cursor-paginated) — plan 0279 / [GAR-814](https://linear.app/chatgpt25/issue/GAR-814) ✅
 
 **Arquivos**
 

--- a/crates/garraia-gateway/src/rest_v1/messages.rs
+++ b/crates/garraia-gateway/src/rest_v1/messages.rs
@@ -1414,6 +1414,200 @@ pub async fn list_thread_messages(
     }))
 }
 
+// ─── GET /v1/threads/{thread_id}/messages (plan 0279 / GAR-814) ──────────────
+
+/// `GET /v1/threads/{thread_id}/messages` — list replies in a thread by thread
+/// ID.
+///
+/// The caller needs only the `thread_id` (available from
+/// `GET /v1/chats/{chat_id}/threads` or `GET /v1/threads/{thread_id}`).
+/// Cross-group isolation is enforced via JOIN on `chats`. Returns 404 when the
+/// thread does not exist or belongs to a different group (no existence leak).
+#[utoipa::path(
+    get,
+    path = "/v1/threads/{thread_id}/messages",
+    params(
+        ("thread_id" = Uuid, Path, description = "Thread UUID."),
+        ("after" = Option<Uuid>, Query, description = "Cursor for pagination."),
+        ("limit" = Option<i64>, Query, description = "Page size (default 50, max 100)."),
+    ),
+    responses(
+        (status = 200, description = "Thread info and replies.", body = ThreadMessagesResponse),
+        (status = 400, description = "Missing X-Group-Id header or bad limit.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member of the group.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Thread not found or not in caller's group.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn get_thread_messages_by_id(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(thread_id): Path<Uuid>,
+    Query(params): Query<ListThreadMessagesQuery>,
+) -> Result<Json<ThreadMessagesResponse>, RestError> {
+    // 1. X-Group-Id header required.
+    let group_id = match principal.group_id {
+        Some(hdr) => hdr,
+        None => {
+            return Err(RestError::BadRequest(
+                "X-Group-Id header is required".into(),
+            ));
+        }
+    };
+
+    // 2. Capability gate.
+    if !can(&principal, Action::ChatsRead) {
+        return Err(RestError::Forbidden);
+    }
+
+    // 3. Parse + clamp limit.
+    let limit: i64 = match params.limit {
+        None => 50,
+        Some(n) if n < 1 => {
+            return Err(RestError::BadRequest("limit must be at least 1".into()));
+        }
+        Some(n) => n.min(100),
+    };
+
+    // 4. Open transaction with RLS context.
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(principal.user_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_group_id', $1, true)")
+        .bind(group_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    // 5. Look up thread with cross-group isolation.
+    //    0 rows → 404 (no existence leak across groups).
+    type ThreadRow = (Uuid, Uuid, Uuid, Option<String>, Uuid, DateTime<Utc>);
+    let thread_row: Option<ThreadRow> = sqlx::query_as(
+        "SELECT mt.id, mt.chat_id, mt.root_message_id, mt.title, mt.created_by, mt.created_at \
+         FROM message_threads mt \
+         JOIN chats c ON c.id = mt.chat_id \
+         WHERE mt.id = $1 AND c.group_id = $2",
+    )
+    .bind(thread_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let thread = match thread_row {
+        None => return Err(RestError::NotFound),
+        Some((id, chat_id, root_message_id, title, created_by, created_at)) => ThreadResponse {
+            id,
+            chat_id,
+            root_message_id,
+            title,
+            created_by,
+            created_at,
+        },
+    };
+
+    // 6. Fetch replies (cursor-paginated, oldest-first).
+    type ReplyRow = (
+        Uuid,
+        Uuid,
+        Uuid,
+        String,
+        String,
+        Option<Uuid>,
+        bool,
+        DateTime<Utc>,
+    );
+    let rows: Vec<ReplyRow> = if let Some(after_id) = params.after {
+        sqlx::query_as(
+            "SELECT id, chat_id, sender_user_id, sender_label, body, reply_to_id, \
+                    is_bot_response, created_at \
+             FROM messages \
+             WHERE thread_id = $1 \
+               AND deleted_at IS NULL \
+               AND (created_at, id) > ( \
+                   SELECT created_at, id FROM messages \
+                   WHERE id = $2 AND thread_id = $1 AND deleted_at IS NULL \
+               ) \
+             ORDER BY created_at ASC, id ASC \
+             LIMIT $3",
+        )
+        .bind(thread_id)
+        .bind(after_id)
+        .bind(limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?
+    } else {
+        sqlx::query_as(
+            "SELECT id, chat_id, sender_user_id, sender_label, body, reply_to_id, \
+                    is_bot_response, created_at \
+             FROM messages \
+             WHERE thread_id = $1 \
+               AND deleted_at IS NULL \
+             ORDER BY created_at ASC, id ASC \
+             LIMIT $2",
+        )
+        .bind(thread_id)
+        .bind(limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?
+    };
+
+    let messages: Vec<MessageSummary> = rows
+        .into_iter()
+        .map(
+            |(
+                id,
+                chat_id,
+                sender_user_id,
+                sender_label,
+                body,
+                reply_to_id,
+                is_bot_response,
+                created_at,
+            )| {
+                MessageSummary {
+                    id,
+                    chat_id,
+                    sender_user_id,
+                    sender_label,
+                    body,
+                    reply_to_id,
+                    is_bot_response,
+                    created_at,
+                }
+            },
+        )
+        .collect();
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    let next_cursor = if messages.len() as i64 == limit {
+        messages.last().map(|m| m.id)
+    } else {
+        None
+    };
+
+    Ok(Json(ThreadMessagesResponse {
+        thread: Some(thread),
+        messages,
+        next_cursor,
+    }))
+}
+
 // ─── Message Attachments (plan 0182 / GAR-700) ───────────────────────────────
 
 /// Request body for `POST /v1/messages/{message_id}/attachments`.
@@ -2404,5 +2598,74 @@ mod tests {
         );
         let trimmed = req.body.trim().to_string();
         assert_eq!(trimmed, "text");
+    }
+
+    // ── Plan 0279 (GAR-814): get_thread_messages_by_id limit + cursor tests ───
+
+    fn resolve_limit(input: Option<i64>) -> Result<i64, &'static str> {
+        match input {
+            None => Ok(50),
+            Some(n) if n < 1 => Err("limit must be at least 1"),
+            Some(n) => Ok(n.min(100)),
+        }
+    }
+
+    #[test]
+    fn get_thread_messages_limit_default_is_50() {
+        assert_eq!(resolve_limit(None).unwrap(), 50);
+    }
+
+    #[test]
+    fn get_thread_messages_limit_zero_rejected() {
+        assert!(resolve_limit(Some(0)).is_err());
+    }
+
+    #[test]
+    fn get_thread_messages_limit_negative_rejected() {
+        assert!(resolve_limit(Some(-1)).is_err());
+    }
+
+    #[test]
+    fn get_thread_messages_limit_max_clamped_to_100() {
+        assert_eq!(resolve_limit(Some(200)).unwrap(), 100);
+    }
+
+    #[test]
+    fn get_thread_messages_next_cursor_is_last_id_on_full_page() {
+        use chrono::Utc;
+        let limit: i64 = 2;
+        let id_a = Uuid::new_v4();
+        let id_b = Uuid::new_v4();
+        let chat_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let now = Utc::now();
+        let messages: Vec<MessageSummary> = vec![
+            MessageSummary {
+                id: id_a,
+                chat_id,
+                sender_user_id: user_id,
+                sender_label: "a".into(),
+                body: "first".into(),
+                reply_to_id: None,
+                is_bot_response: false,
+                created_at: now,
+            },
+            MessageSummary {
+                id: id_b,
+                chat_id,
+                sender_user_id: user_id,
+                sender_label: "b".into(),
+                body: "second".into(),
+                reply_to_id: None,
+                is_bot_response: false,
+                created_at: now,
+            },
+        ];
+        let next_cursor = if messages.len() as i64 == limit {
+            messages.last().map(|m| m.id)
+        } else {
+            None
+        };
+        assert_eq!(next_cursor, Some(id_b));
     }
 }

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -398,9 +398,10 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     get(chats::get_thread).patch(chats::patch_thread),
                 )
                 // Plan 0274 (GAR-811) — thread reply.
+                // Plan 0279 (GAR-814) — list thread messages by thread_id.
                 .route(
                     "/v1/threads/{thread_id}/messages",
-                    post(messages::send_thread_reply),
+                    post(messages::send_thread_reply).get(messages::get_thread_messages_by_id),
                 )
                 // Plan 0057 (GAR-509) — threads slice 3.
                 // Plan 0109 (GAR-595) — messages slice 6: GET thread messages.
@@ -689,9 +690,10 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     get(unconfigured_handler).patch(unconfigured_handler),
                 )
                 // Plan 0274 (GAR-811) — thread reply, fail-soft 503.
+                // Plan 0279 (GAR-814) — list thread messages, fail-soft 503.
                 .route(
                     "/v1/threads/{thread_id}/messages",
-                    post(unconfigured_handler),
+                    post(unconfigured_handler).get(unconfigured_handler),
                 )
                 // Plan 0057 (GAR-509) — threads slice 3, fail-soft 503.
                 // Plan 0109 (GAR-595) — messages slice 6, fail-soft 503.
@@ -972,9 +974,10 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     get(unconfigured_handler).patch(unconfigured_handler),
                 )
                 // Plan 0274 (GAR-811) — thread reply, no-auth stub.
+                // Plan 0279 (GAR-814) — list thread messages, no-auth stub.
                 .route(
                     "/v1/threads/{thread_id}/messages",
-                    post(unconfigured_handler),
+                    post(unconfigured_handler).get(unconfigured_handler),
                 )
                 // Plan 0057 (GAR-509) — threads slice 3, no-auth stub.
                 // Plan 0109 (GAR-595) — messages slice 6, no-auth stub.

--- a/deny.toml
+++ b/deny.toml
@@ -64,6 +64,8 @@ ignore = [
     # Resolution: wasmtime 28.0.1 → 44.0.0 (GAR-454) removed fxhash from
     # Cargo.lock. advisory-not-detected in cargo deny. Removed from deny.toml.
     "RUSTSEC-2024-0370", # proc-macro-error (transitive, no maintained alt)
+    "RUSTSEC-2026-0173", # proc-macro-error2 (fork also unmaintained; no safe upgrade;
+                         # pulled via aquamarine→teloxide and validator_derive→validator)
     # NOTE: RUSTSEC-2025-0052 (async-std unmaintained) CLOSED 2026-06-01.
     # Resolution: opentelemetry_sdk 0.26 → 0.32 (garraia-telemetry plan 0252 / GAR-711).
     # opentelemetry_sdk >= 0.28 dropped async-std entirely. Removed from deny.toml.

--- a/plans/README.md
+++ b/plans/README.md
@@ -287,4 +287,5 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0275 | [GAR-813 — Health run 90 (2026-06-07 ~04:45 ET): all surfaces clean, priority (i)](0275-gar-813-health-run-90.md) | [GAR-813](https://linear.app/chatgpt25/issue/GAR-813) | ✅ Merged via PR #667 (`f254585`) |
 | 0276 | [GAR-815 — Health run 91 (2026-06-07 ~12:47 ET): all surfaces clean, priority (i)](0276-gar-815-health-run-91.md) | [GAR-815](https://linear.app/chatgpt25/issue/GAR-815) | ✅ Merged via PR #670 (`d3c3324`) |
 | 0277 | [GAR-816 — Health run 92 (2026-06-07 ~12:45 ET): all surfaces clean, priority (i)](0277-gar-816-health-run-92.md) | [GAR-816](https://linear.app/chatgpt25/issue/GAR-816) | ✅ Merged via PR #671 (`be1ccdf5`) |
-| 0278 | [GAR-811 — POST /v1/threads/{thread_id}/messages (thread reply)](0278-gar-811-post-thread-reply.md) | [GAR-811](https://linear.app/chatgpt25/issue/GAR-811) | 🚧 In progress |
+| 0278 | [GAR-811 — POST /v1/threads/{thread_id}/messages (thread reply)](0278-gar-811-post-thread-reply.md) | [GAR-811](https://linear.app/chatgpt25/issue/GAR-811) | ✅ Merged via PR #664 (`6b168f3`) |
+| 0279 | [GAR-814 — GET /v1/threads/{thread_id}/messages (list thread messages by thread_id)](0279-gar-814-get-thread-messages-by-thread-id.md) | [GAR-814](https://linear.app/chatgpt25/issue/GAR-814) | 🚧 In progress |


### PR DESCRIPTION
Closing as duplicate — superseded by PR #675 which includes 6 unit tests (vs 5 here) and a complete merge with main (health runs 0280-0282). GAR-814 implementation continues in #675.