### PR TITLE
fix(ci): GAR-822 — cache swagger-ui zip to fix MSRV + Windows build failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,31 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
+      # utoipa-swagger-ui 9.0.2 build.rs uses reqwest to download the swagger-ui
+      # zip, which intermittently returns a corrupt file on cache miss ("InvalidArchive:
+      # Could not find EOCD"). Pre-download with curl + cache cross-platform. (GAR-822)
+      - name: Set SWAGGER_UI_DOWNLOAD_URL (cross-platform file:// URI)
+        shell: bash
+        run: |
+          mkdir -p "$RUNNER_TEMP/swagger-ui-cache"
+          URI=$(python3 -c "import pathlib,os; print(pathlib.Path(os.environ['RUNNER_TEMP'],'swagger-ui-cache','v5.17.14.zip').as_uri())")
+          echo "SWAGGER_UI_DOWNLOAD_URL=$URI" >> "$GITHUB_ENV"
+
+      - name: Cache Swagger UI zip
+        id: swagger-cache-test
+        uses: actions/cache@v5
+        with:
+          path: ${{ runner.temp }}/swagger-ui-cache
+          key: swagger-ui-v5.17.14-${{ runner.os }}
+
+      - name: Download Swagger UI zip
+        if: steps.swagger-cache-test.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          curl -sSLf --retry 5 --retry-delay 5 \
+            -o "$RUNNER_TEMP/swagger-ui-cache/v5.17.14.zip" \
+            https://github.com/swagger-api/swagger-ui/archive/refs/tags/v5.17.14.zip
+
       - name: Build workspace
         # See clippy job comment: garraia-desktop excluded on CI.
         run: cargo build --workspace --exclude garraia-desktop
@@ -433,7 +458,28 @@ jobs:
       - name: Install Rust 1.93
         uses: dtolnay/rust-toolchain@1.93
 
+      # utoipa-swagger-ui 9.0.2 build.rs uses reqwest to download the swagger-ui
+      # zip, which intermittently returns a corrupt file ("InvalidArchive: Could not
+      # find EOCD"). Pre-download with curl (reliable, retries) and point the build
+      # script to the local file via SWAGGER_UI_DOWNLOAD_URL. (GAR-822)
+      - name: Cache Swagger UI zip
+        id: swagger-cache-msrv
+        uses: actions/cache@v5
+        with:
+          path: /tmp/swagger-ui-cache
+          key: swagger-ui-v5.17.14
+
+      - name: Download Swagger UI zip
+        if: steps.swagger-cache-msrv.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p /tmp/swagger-ui-cache
+          curl -sSLf --retry 5 --retry-delay 5 \
+            -o /tmp/swagger-ui-cache/v5.17.14.zip \
+            https://github.com/swagger-api/swagger-ui/archive/refs/tags/v5.17.14.zip
+
       - name: cargo +1.93 check
+        env:
+          SWAGGER_UI_DOWNLOAD_URL: file:///tmp/swagger-ui-cache/v5.17.14.zip
         run: cargo +1.93 check --workspace --exclude garraia-desktop --locked
 
   # E2E integration test (GAR-216, GAR-438 / plan 0050 Lote 2)

--- a/plans/0284-gar-822-swagger-ci-cache.md
+++ b/plans/0284-gar-822-swagger-ci-cache.md
@@ -1,0 +1,117 @@
+# Plan 0284 — GAR-822: Fix utoipa-swagger-ui intermittent CI download failure
+
+**Health run:** 97 — 2026-06-08 ~09:00 ET  
+**Linear:** [GAR-822](https://linear.app/chatgpt25/issue/GAR-822)  
+**Branch:** `health/202606080900-swagger-ci-fix`  
+**Priority:** (g) — CI failure on main within last 24h (MSRV check)
+
+---
+
+## Goal
+
+Eliminate the intermittent CI failure caused by `utoipa-swagger-ui v9.0.2` build.rs
+downloading the Swagger UI zip via reqwest, which returns a corrupt archive
+(`InvalidArchive: "Could not find EOCD"`). This blocks the MSRV gate consistently
+and the Windows test job on cache-miss runs.
+
+## Root cause
+
+`utoipa-swagger-ui 9.0.2`'s `build.rs` uses `reqwest` (bundled TLS) to download
+`https://github.com/swagger-api/swagger-ui/archive/refs/tags/v5.17.14.zip` at
+compile time. When GitHub's CDN returns a truncated/redirect response (intermittent
+network issue), reqwest saves it as a non-ZIP file that then fails to unzip with
+`InvalidArchive("Could not find EOCD")`.
+
+Evidence:
+- Main CI run `27123420182` (2026-06-08 07:48 UTC): MSRV + Windows both failed
+- PR #681 MSRV job `80040353069` (2026-06-08 07:15 UTC): same error
+- The MSRV job has **no** `target/` cache → every run hits fresh build → consistent failure
+- The Test (windows-latest) job fails on cache-miss → intermittent failure
+
+## Architecture
+
+The [CLAUDE.md local workaround](../CLAUDE.md) already documents this pattern:
+```
+SWAGGER_UI_DOWNLOAD_URL=file:///tmp/swagger-ui-cache/v5.17.14.zip
+```
+Apply the same pattern in CI:
+1. Pre-download with `curl --retry 5` (reliable, handles redirects correctly)
+2. Cache the zip via `actions/cache@v5` (avoids re-download across runs)
+3. Set `SWAGGER_UI_DOWNLOAD_URL=file://...` so build.rs reads from the local file
+
+## Tech stack
+
+- GitHub Actions `actions/cache@v5`
+- `curl` (available on all GHA runners: ubuntu, windows, macos)
+- Python3 `pathlib.Path.as_uri()` for cross-platform `file://` URI generation
+
+## Design invariants
+
+- No secrets in CI env vars (the swagger zip is public)
+- Cross-platform: uses `$RUNNER_TEMP` (GHA built-in) + Python3 for Windows path conversion
+- Idempotent: cache hit skips download; cache miss downloads fresh
+- No changes to Cargo.toml / Cargo.lock (version stays at 9.0.2)
+
+## Out of scope
+
+- Upgrading utoipa-swagger-ui beyond 9.0.2 (separate ADR if needed)
+- Bundling the zip in the repo (increases repo size ~5 MB)
+- Fixing the macOS Test job (it has target/ cache and hasn't shown the failure)
+
+## Rollback
+
+Revert the two hunks in `.github/workflows/ci.yml`. The swagger download reverts to
+reqwest. Pre-existing behaviour restored.
+
+---
+
+## Tasks
+
+### M1 — MSRV job fix (T1)
+
+- [x] Add `Cache Swagger UI zip` step (`actions/cache@v5`, key `swagger-ui-v5.17.14`)
+- [x] Add `Download Swagger UI zip` step (curl with `--retry 5`, conditional on cache miss)
+- [x] Add `SWAGGER_UI_DOWNLOAD_URL: file:///tmp/swagger-ui-cache/v5.17.14.zip` env to `cargo +1.93 check` step
+
+### M2 — Test matrix job fix (T2)
+
+- [x] Add `Set SWAGGER_UI_DOWNLOAD_URL` step (Python3 `pathlib.as_uri()` for cross-platform)
+- [x] Add `Cache Swagger UI zip` step (key `swagger-ui-v5.17.14-${{ runner.os }}`)
+- [x] Add `Download Swagger UI zip` step (curl, conditional on cache miss)
+- [x] Env var flows into `Build workspace` + `Run tests` via `$GITHUB_ENV`
+
+### M3 — Plan + bookkeeping (T3)
+
+- [x] Create `plans/0284-gar-822-swagger-ci-cache.md`
+- [x] Update `plans/README.md`
+- [ ] Push + open PR (base=main)
+- [ ] Merge after CI green
+
+---
+
+## Risk register
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| Windows Python3 path conversion bug | Low | pathlib.as_uri() is well-tested cross-platform |
+| curl download fails in CI too | Very Low | --retry 5 with delay; curl handles redirects correctly unlike reqwest |
+| actions/cache quota exceeded | Very Low | zip is ~5MB, well under 10GB quota |
+| Cache key collision with other repos | None | key includes repo-specific `v5.17.14` version |
+
+## Acceptance criteria
+
+- [ ] MSRV check (1.93) conclusion = success in PR CI
+- [ ] Test (ubuntu-latest) conclusion = success
+- [ ] Test (windows-latest) conclusion = success
+- [ ] Test (macos-latest) conclusion = success
+- [ ] No new failures introduced
+
+## Cross-references
+
+- GAR-441: Prior MSRV fix (version alignment, Done)
+- Plans 0280-0282: Prior health runs that noted this as transient
+- CLAUDE.md §"LOCAL SANDBOX NOTES": documents the local workaround
+
+## Estimativa
+
+1 tarefa, ~30min implementação + CI wait.

--- a/plans/README.md
+++ b/plans/README.md
@@ -292,3 +292,4 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0280 | [GAR-817 — Health run 93 (2026-06-07 ~20:47 ET): all surfaces clean, priority (i)](0280-gar-817-health-run-93.md) | [GAR-817](https://linear.app/chatgpt25/issue/GAR-817) | ✅ Merged via PR #673 (`cf16c4e`) |
 | 0281 | [GAR-818 — Health run 94 (2026-06-07 ~21:01 ET): all surfaces clean, priority (i)](0281-gar-818-health-run-94.md) | [GAR-818](https://linear.app/chatgpt25/issue/GAR-818) | ✅ Merged via PR #676 (`4e2c2a4`) |
 | 0282 | [GAR-819 — Health run 95 (2026-06-08 ~00:45 ET): all surfaces clean, priority (i)](0282-gar-819-health-run-95.md) | [GAR-819](https://linear.app/chatgpt25/issue/GAR-819) | 🔄 In Progress |
+| 0284 | [GAR-822 — fix(ci): cache swagger-ui zip to eliminate utoipa-swagger-ui reqwest build failure (health run 97)](0284-gar-822-swagger-ci-cache.md) | [GAR-822](https://linear.app/chatgpt25/issue/GAR-822) | 🔄 In Progress |


### PR DESCRIPTION
## Summary

Fixes the intermittent CI failure caused by `utoipa-swagger-ui v9.0.2` build.rs downloading the Swagger UI zip via reqwest at compile time.

**Root cause:** GitHub's CDN intermittently returns a corrupt/truncated file → `InvalidArchive("Could not find EOCD")` → build fails.

**Affected jobs:**
- `MSRV check (1.93)`: ubuntu-latest with **no** target/ cache → every fresh build triggers the download → consistent failure
- `Test (windows-latest)`: fails on cache-miss runs (intermittent)

**Evidence:**
- Main CI run `27123420182` (2026-06-08 07:48 UTC): MSRV + Windows both failed
- PR #681 MSRV job `80040353069`: same `InvalidArchive` error

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Add swagger zip pre-download + cache to **MSRV** job (ubuntu, simple) and **Test matrix** job (cross-platform via `$RUNNER_TEMP` + Python3 `pathlib.as_uri()`) |
| `plans/0284-gar-822-swagger-ci-cache.md` | Plan file |
| `plans/README.md` | Row 0284 |

**MSRV job fix:** cache `/tmp/swagger-ui-cache/v5.17.14.zip`, set `SWAGGER_UI_DOWNLOAD_URL=file:///tmp/swagger-ui-cache/v5.17.14.zip` for the `cargo +1.93 check` step.

**Test matrix fix:** cross-platform using `$RUNNER_TEMP` + Python3 `pathlib.Path.as_uri()` to generate the correct `file://` URI on Windows (`file:///D:/a/_temp/...`) and Linux/macOS (`file:///home/runner/work/_temp/...`).

## Test plan

- [ ] MSRV check (1.93): success
- [ ] Test (ubuntu-latest): success
- [ ] Test (windows-latest): success
- [ ] Test (macos-latest): success
- [ ] Format Check: success
- [ ] Clippy Linting: success
- [ ] Build Check: success
- [ ] Security Audit: success
- [ ] cargo-deny: success

## References

- Alert: utoipa-swagger-ui reqwest download failure (intermittent CI)
- Linear: [GAR-822](https://linear.app/chatgpt25/issue/GAR-822)
- Plan: `plans/0284-gar-822-swagger-ci-cache.md`
- Related: PR #681 (health run 96 status note, MSRV failure blocks merge)
- CLAUDE.md §LOCAL SANDBOX NOTES: documents the local `SWAGGER_UI_DOWNLOAD_URL=file://` workaround

https://claude.ai/code/session_01Uu9hZMUfwnrgneYGNLobio

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uu9hZMUfwnrgneYGNLobio)_