### PR TITLE
feat(docs): GAR-835 — Docs Tier 2 scaffold: migration 026 + POST/GET /v1/groups/{group_id}/doc-pages

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -850,15 +850,15 @@ Módulo dentro de `garraia-workspace`. Schema entregue via migration 006 com **R
 
 **Schema:**
 
-- [ ] `doc_pages` (`id`, `group_id`, `parent_page_id`, `title`, `icon`, `cover_file_id`, `created_by`, `created_at`, `updated_at`, `archived_at`)
+- [x] `doc_pages` (`id`, `group_id`, `parent_page_id`, `title`, `icon`, `cover_file_id`, `created_by`, `created_at`, `updated_at`, `archived_at`) — migration 026, plan 0297 / GAR-835
 - [ ] `doc_blocks` (`id`, `page_id`, `parent_block_id`, `position`, `type`, `content_jsonb`, `created_at`, `updated_at`) — tipos: `heading|paragraph|todo|bullet|numbered|code|quote|callout|divider|file_embed|task_embed|chat_embed|image`
 - [ ] `doc_page_versions` (`id`, `page_id`, `snapshot_jsonb`, `created_by`, `created_at`)
 - [ ] `doc_page_mentions` (`page_id`, `mentioned_user_id | mentioned_task_id | mentioned_file_id`)
 
 **API:**
 
-- [ ] `POST /v1/groups/{group_id}/doc-pages`
-- [ ] `GET /v1/groups/{group_id}/doc-pages?parent=...`
+- [x] `POST /v1/groups/{group_id}/doc-pages` — plan 0297 / GAR-835
+- [x] `GET /v1/groups/{group_id}/doc-pages?parent=...` — plan 0297 / GAR-835
 - [ ] `GET /v1/doc-pages/{page_id}` (com blocks)
 - [ ] `PATCH /v1/doc-pages/{page_id}`
 - [ ] `POST /v1/doc-pages/{page_id}/blocks`

--- a/crates/garraia-auth/src/audit_workspace.rs
+++ b/crates/garraia-auth/src/audit_workspace.rs
@@ -619,6 +619,12 @@ pub enum WorkspaceAuditAction {
     /// `resource_type = "message_mentions"`, `resource_id = "{message_id}"`.
     /// Metadata: `{ mention_count: N }` — count only (PII-safe; no user IDs).
     MessageMentionCreated,
+    /// A new doc page was created via
+    /// `POST /v1/groups/{group_id}/doc-pages` (plan 0297 / GAR-834).
+    ///
+    /// `resource_type = "doc_pages"`, `resource_id = "{page_id}"`.
+    /// Metadata: `{ title_len: N }` — length only (no raw title, PII-safe).
+    DocPageCreated,
 }
 
 impl WorkspaceAuditAction {
@@ -687,6 +693,7 @@ impl WorkspaceAuditAction {
             WorkspaceAuditAction::MessageReactionAdded => "message.reaction.added",
             WorkspaceAuditAction::MessageReactionRemoved => "message.reaction.removed",
             WorkspaceAuditAction::MessageMentionCreated => "message.mention.created",
+            WorkspaceAuditAction::DocPageCreated => "doc_page.created",
         }
     }
 }
@@ -955,6 +962,10 @@ mod tests {
         assert_eq!(
             WorkspaceAuditAction::MessageMentionCreated.as_str(),
             "message.mention.created"
+        );
+        assert_eq!(
+            WorkspaceAuditAction::DocPageCreated.as_str(),
+            "doc_page.created"
         );
     }
 

--- a/crates/garraia-gateway/src/rest_v1/docs.rs
+++ b/crates/garraia-gateway/src/rest_v1/docs.rs
@@ -248,13 +248,12 @@ pub async fn create_doc_page(
 
     // Validate parent_page_id if provided.
     if let Some(parent_id) = body.parent_page_id {
-        let parent_exists: Option<(Uuid,)> = sqlx::query_as(
-            "SELECT id FROM doc_pages WHERE id = $1 AND archived_at IS NULL",
-        )
-        .bind(parent_id)
-        .fetch_optional(&mut *tx)
-        .await
-        .map_err(|e| RestError::Internal(e.into()))?;
+        let parent_exists: Option<(Uuid,)> =
+            sqlx::query_as("SELECT id FROM doc_pages WHERE id = $1 AND archived_at IS NULL")
+                .bind(parent_id)
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(|e| RestError::Internal(e.into()))?;
 
         if parent_exists.is_none() {
             return Err(RestError::NotFound);

--- a/crates/garraia-gateway/src/rest_v1/docs.rs
+++ b/crates/garraia-gateway/src/rest_v1/docs.rs
@@ -1,0 +1,544 @@
+//! Doc-pages handlers: `POST` and `GET` (list).
+//!
+//! Plan 0297 / GAR-834 — Docs Tier 2 scaffold.
+//!
+//! Two endpoints on the `garraia_app` RLS-enforced pool:
+//! - `POST /v1/groups/{group_id}/doc-pages` — create a doc page
+//! - `GET  /v1/groups/{group_id}/doc-pages` — cursor-paginated list
+//!
+//! ## Tenant-context protocol
+//!
+//! `doc_pages` uses FORCE RLS with direct `group_id` isolation (migration 026).
+//! Both RLS vars are set via parameterised `set_config` before any SQL.
+//!
+//! ## App-layer group validation
+//!
+//! Path `{group_id}` must equal `principal.group_id` — mismatch returns 403.
+
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use chrono::{DateTime, Utc};
+use garraia_auth::{Action, Principal, WorkspaceAuditAction, audit_workspace_event, can};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use utoipa::{IntoParams, ToSchema};
+use uuid::Uuid;
+
+use super::RestV1FullState;
+use super::problem::RestError;
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const DEFAULT_LIMIT: u32 = 50;
+const MAX_LIMIT: u32 = 100;
+
+// ─── Private DB row struct ────────────────────────────────────────────────────
+
+#[derive(sqlx::FromRow)]
+struct DocPageRow {
+    id: Uuid,
+    group_id: Uuid,
+    parent_page_id: Option<Uuid>,
+    title: String,
+    icon: Option<String>,
+    created_by: Option<Uuid>,
+    created_by_label: String,
+    archived_at: Option<DateTime<Utc>>,
+    created_at: DateTime<Utc>,
+    updated_at: DateTime<Utc>,
+}
+
+// ─── DTOs ─────────────────────────────────────────────────────────────────────
+
+/// Request body for `POST /v1/groups/{group_id}/doc-pages`.
+#[derive(Debug, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CreateDocPageRequest {
+    /// Page title. 1–255 characters.
+    pub title: String,
+    /// Parent page UUID. `null` or absent for a root-level page.
+    pub parent_page_id: Option<Uuid>,
+    /// Optional emoji or icon identifier.
+    pub icon: Option<String>,
+}
+
+impl CreateDocPageRequest {
+    fn validate(&self) -> Result<(), &'static str> {
+        let len = self.title.chars().count();
+        if len == 0 {
+            return Err("title must not be empty");
+        }
+        if len > 255 {
+            return Err("title exceeds 255 character limit");
+        }
+        Ok(())
+    }
+}
+
+/// Full doc page representation returned by `POST`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct DocPageResponse {
+    pub id: Uuid,
+    pub group_id: Uuid,
+    pub parent_page_id: Option<Uuid>,
+    pub title: String,
+    pub icon: Option<String>,
+    pub created_by: Option<Uuid>,
+    pub created_by_label: String,
+    pub archived_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl From<DocPageRow> for DocPageResponse {
+    fn from(r: DocPageRow) -> Self {
+        Self {
+            id: r.id,
+            group_id: r.group_id,
+            parent_page_id: r.parent_page_id,
+            title: r.title,
+            icon: r.icon,
+            created_by: r.created_by,
+            created_by_label: r.created_by_label,
+            archived_at: r.archived_at,
+            created_at: r.created_at,
+            updated_at: r.updated_at,
+        }
+    }
+}
+
+/// Compact doc page item used in `GET /v1/groups/{group_id}/doc-pages`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct DocPageSummary {
+    pub id: Uuid,
+    pub group_id: Uuid,
+    pub parent_page_id: Option<Uuid>,
+    pub title: String,
+    pub icon: Option<String>,
+    pub created_by: Option<Uuid>,
+    pub created_by_label: String,
+    pub archived_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl From<DocPageRow> for DocPageSummary {
+    fn from(r: DocPageRow) -> Self {
+        Self {
+            id: r.id,
+            group_id: r.group_id,
+            parent_page_id: r.parent_page_id,
+            title: r.title,
+            icon: r.icon,
+            created_by: r.created_by,
+            created_by_label: r.created_by_label,
+            archived_at: r.archived_at,
+            created_at: r.created_at,
+            updated_at: r.updated_at,
+        }
+    }
+}
+
+/// Response body for `GET /v1/groups/{group_id}/doc-pages`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ListDocPagesResponse {
+    pub items: Vec<DocPageSummary>,
+    /// Cursor for the next page. `None` when the end of the list is reached.
+    pub next_cursor: Option<Uuid>,
+}
+
+/// Query parameters for `GET /v1/groups/{group_id}/doc-pages`.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ListDocPagesQuery {
+    /// Keyset cursor — UUID of the last item received. Omit for the first page.
+    pub cursor: Option<Uuid>,
+    /// Page size. Default 50, max 100.
+    pub limit: Option<u32>,
+    /// Filter to direct children of this page. Omit for all root-level pages.
+    pub parent_page_id: Option<Uuid>,
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async fn set_rls_context(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    user_id: Uuid,
+    group_id: Uuid,
+) -> Result<(), RestError> {
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(user_id.to_string())
+        .execute(&mut **tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    sqlx::query("SELECT set_config('app.current_group_id', $1, true)")
+        .bind(group_id.to_string())
+        .execute(&mut **tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    Ok(())
+}
+
+fn require_group_id(principal: &Principal) -> Result<Uuid, RestError> {
+    principal
+        .group_id
+        .ok_or_else(|| RestError::BadRequest("X-Group-Id header is required".into()))
+}
+
+fn check_group_match(path_group_id: Uuid, principal_group_id: Uuid) -> Result<(), RestError> {
+    if path_group_id != principal_group_id {
+        Err(RestError::Forbidden)
+    } else {
+        Ok(())
+    }
+}
+
+// ─── Handlers ─────────────────────────────────────────────────────────────────
+
+/// `POST /v1/groups/{group_id}/doc-pages` — create a doc page.
+///
+/// Authz: `Action::DocsWrite`. Path `group_id` must equal `principal.group_id`.
+///
+/// ## Error matrix
+///
+/// | Condition                          | Status |
+/// |------------------------------------|--------|
+/// | Missing/invalid JWT                | 401    |
+/// | Non-member of group                | 403    |
+/// | Path group_id ≠ principal group_id | 403    |
+/// | Validation failure                 | 400    |
+/// | Parent page not in group           | 404    |
+/// | Happy path                         | 201    |
+#[utoipa::path(
+    post,
+    path = "/v1/groups/{group_id}/doc-pages",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+    ),
+    request_body = CreateDocPageRequest,
+    responses(
+        (status = 201, description = "Doc page created.", body = DocPageResponse),
+        (status = 400, description = "Validation error.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Parent page not found in group.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn create_doc_page(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(path_group_id): Path<Uuid>,
+    Json(body): Json<CreateDocPageRequest>,
+) -> Result<(StatusCode, Json<DocPageResponse>), RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::DocsWrite) {
+        return Err(RestError::Forbidden);
+    }
+    body.validate()
+        .map_err(|msg| RestError::BadRequest(msg.into()))?;
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    // Validate parent_page_id if provided.
+    if let Some(parent_id) = body.parent_page_id {
+        let parent_exists: Option<(Uuid,)> = sqlx::query_as(
+            "SELECT id FROM doc_pages WHERE id = $1 AND archived_at IS NULL",
+        )
+        .bind(parent_id)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+        if parent_exists.is_none() {
+            return Err(RestError::NotFound);
+        }
+    }
+
+    let (created_by_label,): (String,) =
+        sqlx::query_as("SELECT display_name FROM users WHERE id = $1")
+            .bind(principal.user_id)
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(|e| RestError::Internal(e.into()))?;
+
+    let title_trimmed = body.title.trim().to_string();
+
+    let row: DocPageRow = sqlx::query_as(
+        "INSERT INTO doc_pages \
+             (group_id, parent_page_id, title, icon, created_by, created_by_label) \
+         VALUES ($1, $2, $3, $4, $5, $6) \
+         RETURNING id, group_id, parent_page_id, title, icon, \
+                   created_by, created_by_label, archived_at, created_at, updated_at",
+    )
+    .bind(group_id)
+    .bind(body.parent_page_id)
+    .bind(&title_trimmed)
+    .bind(&body.icon)
+    .bind(principal.user_id)
+    .bind(&created_by_label)
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let page_id = row.id;
+    let title_len = title_trimmed.chars().count();
+
+    audit_workspace_event(
+        &mut tx,
+        WorkspaceAuditAction::DocPageCreated,
+        principal.user_id,
+        group_id,
+        "doc_pages",
+        page_id.to_string(),
+        json!({ "title_len": title_len }),
+    )
+    .await
+    .map_err(|e| RestError::Internal(anyhow::anyhow!(e)))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok((StatusCode::CREATED, Json(DocPageResponse::from(row))))
+}
+
+/// `GET /v1/groups/{group_id}/doc-pages` — list doc pages (cursor-paginated).
+///
+/// Returns non-archived doc pages for the caller's group, newest first.
+/// Optional `?parent_page_id=` filter for tree traversal.
+/// Authz: `Action::DocsRead`. Path `group_id` must equal `principal.group_id`.
+///
+/// ## Error matrix
+///
+/// | Condition                          | Status |
+/// |------------------------------------|--------|
+/// | Missing/invalid JWT                | 401    |
+/// | Non-member of group                | 403    |
+/// | Path group_id ≠ principal group_id | 403    |
+/// | Happy path                         | 200    |
+#[utoipa::path(
+    get,
+    path = "/v1/groups/{group_id}/doc-pages",
+    params(
+        ("group_id" = Uuid, Path, description = "Group UUID."),
+        ListDocPagesQuery,
+    ),
+    responses(
+        (status = 200, description = "Doc pages.", body = ListDocPagesResponse),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a member or group mismatch.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn list_doc_pages(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path(path_group_id): Path<Uuid>,
+    Query(params): Query<ListDocPagesQuery>,
+) -> Result<Json<ListDocPagesResponse>, RestError> {
+    let group_id = require_group_id(&principal)?;
+    check_group_match(path_group_id, group_id)?;
+    if !can(&principal, Action::DocsRead) {
+        return Err(RestError::Forbidden);
+    }
+
+    let effective_limit = params.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+    let fetch_limit = i64::from(effective_limit + 1);
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+    set_rls_context(&mut tx, principal.user_id, group_id).await?;
+
+    let rows: Vec<DocPageRow> = match (params.cursor, params.parent_page_id) {
+        (Some(cursor_id), Some(parent_id)) => sqlx::query_as(
+            "SELECT id, group_id, parent_page_id, title, icon, \
+                    created_by, created_by_label, archived_at, created_at, updated_at \
+             FROM doc_pages \
+             WHERE group_id = $1 \
+               AND archived_at IS NULL \
+               AND parent_page_id IS NOT DISTINCT FROM $2::uuid \
+               AND (created_at, id) < ( \
+                   SELECT created_at, id FROM doc_pages WHERE id = $3 \
+               ) \
+             ORDER BY created_at DESC, id DESC \
+             LIMIT $4",
+        )
+        .bind(group_id)
+        .bind(parent_id)
+        .bind(cursor_id)
+        .bind(fetch_limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?,
+
+        (Some(cursor_id), None) => sqlx::query_as(
+            "SELECT id, group_id, parent_page_id, title, icon, \
+                    created_by, created_by_label, archived_at, created_at, updated_at \
+             FROM doc_pages \
+             WHERE group_id = $1 \
+               AND archived_at IS NULL \
+               AND (created_at, id) < ( \
+                   SELECT created_at, id FROM doc_pages WHERE id = $2 \
+               ) \
+             ORDER BY created_at DESC, id DESC \
+             LIMIT $3",
+        )
+        .bind(group_id)
+        .bind(cursor_id)
+        .bind(fetch_limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?,
+
+        (None, Some(parent_id)) => sqlx::query_as(
+            "SELECT id, group_id, parent_page_id, title, icon, \
+                    created_by, created_by_label, archived_at, created_at, updated_at \
+             FROM doc_pages \
+             WHERE group_id = $1 \
+               AND archived_at IS NULL \
+               AND parent_page_id IS NOT DISTINCT FROM $2::uuid \
+             ORDER BY created_at DESC, id DESC \
+             LIMIT $3",
+        )
+        .bind(group_id)
+        .bind(parent_id)
+        .bind(fetch_limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?,
+
+        (None, None) => sqlx::query_as(
+            "SELECT id, group_id, parent_page_id, title, icon, \
+                    created_by, created_by_label, archived_at, created_at, updated_at \
+             FROM doc_pages \
+             WHERE group_id = $1 \
+               AND archived_at IS NULL \
+             ORDER BY created_at DESC, id DESC \
+             LIMIT $2",
+        )
+        .bind(group_id)
+        .bind(fetch_limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?,
+    };
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    let has_more = rows.len() as u32 > effective_limit;
+    let items: Vec<DocPageSummary> = rows
+        .into_iter()
+        .take(effective_limit as usize)
+        .map(DocPageSummary::from)
+        .collect();
+    let next_cursor = if has_more {
+        items.last().map(|it| it.id)
+    } else {
+        None
+    };
+
+    Ok(Json(ListDocPagesResponse { items, next_cursor }))
+}
+
+// ─── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn make_row(id: Uuid, group_id: Uuid, title: &str) -> DocPageRow {
+        DocPageRow {
+            id,
+            group_id,
+            parent_page_id: None,
+            title: title.to_string(),
+            icon: None,
+            created_by: Some(Uuid::nil()),
+            created_by_label: "Alice".to_string(),
+            archived_at: None,
+            created_at: Utc.with_ymd_and_hms(2026, 6, 9, 12, 0, 0).unwrap(),
+            updated_at: Utc.with_ymd_and_hms(2026, 6, 9, 12, 0, 0).unwrap(),
+        }
+    }
+
+    #[test]
+    fn doc_page_response_serializes_all_fields() {
+        let id = Uuid::new_v4();
+        let group_id = Uuid::new_v4();
+        let resp = DocPageResponse::from(make_row(id, group_id, "Getting Started"));
+        let v = serde_json::to_value(&resp).unwrap();
+        assert_eq!(v["id"], id.to_string());
+        assert_eq!(v["group_id"], group_id.to_string());
+        assert_eq!(v["title"], "Getting Started");
+        assert!(v["parent_page_id"].is_null());
+        assert!(v["icon"].is_null());
+        assert!(v["archived_at"].is_null());
+        assert_eq!(v["created_by"], Uuid::nil().to_string());
+        assert_eq!(v["created_by_label"], "Alice");
+    }
+
+    #[test]
+    fn doc_page_summary_mirrors_response_fields() {
+        let id = Uuid::new_v4();
+        let group_id = Uuid::new_v4();
+        let summary = DocPageSummary::from(make_row(id, group_id, "Intro"));
+        let v = serde_json::to_value(&summary).unwrap();
+        assert_eq!(v["id"], id.to_string());
+        assert_eq!(v["title"], "Intro");
+    }
+
+    #[test]
+    fn nil_created_by_serializes_as_null() {
+        let mut row = make_row(Uuid::new_v4(), Uuid::new_v4(), "Page");
+        row.created_by = None;
+        let resp = DocPageResponse::from(row);
+        let v = serde_json::to_value(&resp).unwrap();
+        assert!(v["created_by"].is_null());
+    }
+
+    #[test]
+    fn icon_roundtrip() {
+        let mut row = make_row(Uuid::new_v4(), Uuid::new_v4(), "Page");
+        row.icon = Some("📝".to_string());
+        let resp = DocPageResponse::from(row);
+        let v = serde_json::to_value(&resp).unwrap();
+        assert_eq!(v["icon"], "📝");
+    }
+
+    #[test]
+    fn list_doc_pages_response_no_next_cursor_when_exact_page() {
+        let items: Vec<DocPageSummary> = (0..3)
+            .map(|_| DocPageSummary::from(make_row(Uuid::new_v4(), Uuid::new_v4(), "P")))
+            .collect();
+        let resp = ListDocPagesResponse {
+            items,
+            next_cursor: None,
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert_eq!(v["items"].as_array().unwrap().len(), 3);
+        assert!(v["next_cursor"].is_null());
+    }
+
+    #[test]
+    fn create_request_validation_rejects_empty_title() {
+        let req = CreateDocPageRequest {
+            title: "".to_string(),
+            parent_page_id: None,
+            icon: None,
+        };
+        assert_eq!(req.validate(), Err("title must not be empty"));
+    }
+}

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -31,6 +31,7 @@
 
 pub mod audit;
 pub mod chats;
+pub mod docs;
 pub mod files;
 pub mod groups;
 pub mod invites;
@@ -596,6 +597,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                         .patch(files::patch_folder)
                         .delete(files::delete_folder),
                 )
+                // Plan 0297 (GAR-834) — Docs Tier 2 scaffold: doc pages.
+                .route(
+                    "/v1/groups/{group_id}/doc-pages",
+                    post(docs::create_doc_page).get(docs::list_doc_pages),
+                )
                 .merge(rate_limited_routes)
                 .merge(tus_routes)
                 .with_state(full)
@@ -896,6 +902,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                         .patch(unconfigured_handler)
                         .delete(unconfigured_handler),
                 )
+                // Plan 0297 (GAR-834) — Docs Tier 2 scaffold: doc pages stub.
+                .route(
+                    "/v1/groups/{group_id}/doc-pages",
+                    post(unconfigured_handler).get(unconfigured_handler),
+                )
                 .with_state(auth)
                 .merge(SwaggerUi::new("/docs").url("/v1/openapi.json", ApiDoc::openapi()))
         }
@@ -1188,6 +1199,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     head(unconfigured_handler)
                         .patch(unconfigured_handler)
                         .delete(unconfigured_handler),
+                )
+                // Plan 0297 (GAR-834) — Docs Tier 2 scaffold: doc pages stub.
+                .route(
+                    "/v1/groups/{group_id}/doc-pages",
+                    post(unconfigured_handler).get(unconfigured_handler),
                 )
                 .route("/v1/openapi.json", get(unconfigured_handler))
                 .route("/docs", get(unconfigured_handler))

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -13,11 +13,11 @@ use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
 use utoipa::{Modify, OpenApi};
 
 use super::audit::{AuditEventSummary, ListAuditResponse};
-use super::docs::{CreateDocPageRequest, DocPageResponse, DocPageSummary, ListDocPagesResponse};
 use super::chats::{
     ChatListResponse, ChatMemberDetailResponse, ChatResponse, ChatSummary, CreateChatRequest,
     PatchChatMemberRequest, PatchThreadRequest, ThreadDetailResponse,
 };
+use super::docs::{CreateDocPageRequest, DocPageResponse, DocPageSummary, ListDocPagesResponse};
 use super::files::{
     CreateFolderRequest, FileCreatedResponse, FileListResponse, FileSummary,
     FileVersionListResponse, FileVersionResponse, FileVersionSummary, FolderListResponse,

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -13,6 +13,7 @@ use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
 use utoipa::{Modify, OpenApi};
 
 use super::audit::{AuditEventSummary, ListAuditResponse};
+use super::docs::{CreateDocPageRequest, DocPageResponse, DocPageSummary, ListDocPagesResponse};
 use super::chats::{
     ChatListResponse, ChatMemberDetailResponse, ChatResponse, ChatSummary, CreateChatRequest,
     PatchChatMemberRequest, PatchThreadRequest, ThreadDetailResponse,
@@ -190,6 +191,8 @@ impl Modify for SecurityAddon {
         super::files::download_file,
         super::files::list_file_versions,
         super::files::post_new_version,
+        super::docs::create_doc_page,
+        super::docs::list_doc_pages,
     ),
     components(schemas(
         MeResponse,
@@ -289,6 +292,10 @@ impl Modify for SecurityAddon {
         CreateFolderRequest,
         FileVersionSummary,
         FileVersionListResponse,
+        CreateDocPageRequest,
+        DocPageResponse,
+        DocPageSummary,
+        ListDocPagesResponse,
     )),
     modifiers(&SecurityAddon)
 )]

--- a/crates/garraia-workspace/migrations/026_doc_pages.sql
+++ b/crates/garraia-workspace/migrations/026_doc_pages.sql
@@ -1,0 +1,62 @@
+-- Migration 026 — Doc Pages table (Docs Tier 2, plan 0297 / GAR-834)
+--
+-- Creates the `doc_pages` table: a Notion-like hierarchical document store
+-- per group. Only the scaffold (table + RLS + grants + indexes) is added here.
+-- Block-level content (`doc_blocks`) comes in a future slice.
+--
+-- FORCE RLS: all SELECT/INSERT via `garraia_app` role are filtered by
+-- `app.current_group_id` (set via SET LOCAL in every handler before SQL).
+
+CREATE TABLE doc_pages (
+    id               UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    group_id         UUID        NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+    parent_page_id   UUID        REFERENCES doc_pages(id) ON DELETE SET NULL,
+    title            TEXT        NOT NULL CHECK(char_length(title) BETWEEN 1 AND 255),
+    icon             TEXT,
+    cover_file_id    UUID        REFERENCES files(id) ON DELETE SET NULL,
+    created_by       UUID        REFERENCES users(id) ON DELETE SET NULL,
+    created_by_label TEXT        NOT NULL DEFAULT '',
+    settings         JSONB       NOT NULL DEFAULT '{}',
+    archived_at      TIMESTAMPTZ,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- Compound unique for compound FK targets from child tables (future slices).
+    UNIQUE (id, group_id)
+);
+
+-- FORCE RLS: row-level isolation by group.
+ALTER TABLE doc_pages ENABLE ROW LEVEL SECURITY;
+ALTER TABLE doc_pages FORCE ROW LEVEL SECURITY;
+
+-- USING policy: SELECT / UPDATE / DELETE filtered to caller's group.
+-- NULLIF avoids returning rows when app.current_group_id is unset ('').
+CREATE POLICY doc_pages_group_isolation ON doc_pages
+    USING (
+        group_id = NULLIF(
+            current_setting('app.current_group_id', true),
+            ''
+        )::uuid
+    );
+
+-- WITH CHECK policy: INSERT restricted to caller's group.
+CREATE POLICY doc_pages_group_isolation_insert ON doc_pages
+    AS RESTRICTIVE
+    FOR INSERT
+    WITH CHECK (
+        group_id = NULLIF(
+            current_setting('app.current_group_id', true),
+            ''
+        )::uuid
+    );
+
+-- Grant to the app role (garraia_app).
+GRANT SELECT, INSERT, UPDATE ON doc_pages TO garraia_app;
+
+-- Index: list pages by group, newest-first keyset cursor.
+CREATE INDEX doc_pages_group_created_idx
+    ON doc_pages (group_id, created_at DESC, id DESC);
+
+-- Index: parent page traversal (sparse — most pages are root level).
+CREATE INDEX doc_pages_parent_idx
+    ON doc_pages (parent_page_id)
+    WHERE parent_page_id IS NOT NULL;

--- a/plans/0297-gar-835-doc-pages-scaffold.md
+++ b/plans/0297-gar-835-doc-pages-scaffold.md
@@ -1,0 +1,83 @@
+# Plan 0297 — GAR-835: Docs Tier 2 scaffold — migration 026 + POST/GET /v1/groups/{group_id}/doc-pages
+
+## Goal
+
+Bootstrap the Docs Tier 2 surface with:
+
+1. Migration `026_doc_pages.sql` — `doc_pages` table under FORCE RLS.
+2. `POST /v1/groups/{group_id}/doc-pages` — create a doc page.
+3. `GET /v1/groups/{group_id}/doc-pages` — list doc pages (cursor-paginated).
+
+Closes the first slice of ROADMAP §3.8 Tier 2 (Docs), which was entirely
+unchecked. `DocsRead`/`DocsWrite`/`DocsDelete` actions already exist in
+`garraia-auth::Action` (no auth change needed).
+
+## Architecture
+
+Additive handler module `crates/garraia-gateway/src/rest_v1/docs.rs` following
+the same patterns as `tasks/mod.rs` and `files.rs`.
+
+Single new migration (`026`) creates `doc_pages` with FORCE RLS, grants, and
+indexes. No migration required for `doc_blocks` — that is a future slice.
+
+Audit: `DocPageCreated` → `"doc_page.created"` added to `WorkspaceAuditAction`.
+
+## Tech stack
+
+- Rust / Axum 0.8
+- `sqlx` raw queries (INSERT RETURNING, SELECT cursor-keyset)
+- `garraia_auth::{Action, Principal, can}` for authz
+- `audit_workspace_event` for audit (inside tx, before commit)
+- utoipa annotation for OpenAPI
+
+## Design invariants
+
+- SET LOCAL `app.current_user_id` AND `app.current_group_id` before any SQL
+  (FORCE RLS requirement).
+- No existence leak: 404 for "parent_page not in group" follows RLS — UPDATE
+  under RLS on a cross-group row returns 0.
+- Auth: `DocsWrite` for create, `DocsRead` for list.
+- Keyset cursor: `(created_at DESC, id DESC)`, fetch `limit + 1`, return
+  last item id as `next_cursor` when `has_next`.
+- `created_by_label` frozen at creation time (denorm pattern used everywhere).
+- Limit clamped to [1, 100], default 50.
+
+## File structure (changes)
+
+```
+crates/garraia-workspace/migrations/026_doc_pages.sql       (new)
+crates/garraia-auth/src/audit_workspace.rs                  (+3 lines: variant + match arm + test assert)
+crates/garraia-gateway/src/rest_v1/docs.rs                  (new, ~250 lines)
+crates/garraia-gateway/src/rest_v1/mod.rs                   (+8 lines: pub mod + 3-branch routes)
+crates/garraia-gateway/src/rest_v1/openapi.rs               (+8 lines: imports + paths + schemas)
+plans/README.md                                              (+1 row)
+ROADMAP.md                                                   (+2 lines: §3.8 Tier 2 first two items ✅)
+```
+
+## M1 tasks
+
+- [x] T1: Migration `026_doc_pages.sql`
+- [x] T2: Add `DocPageCreated` to `WorkspaceAuditAction`
+- [x] T3: Create `docs.rs` with handlers + 6 unit tests
+- [x] T4: Wire routes in `mod.rs` (pub mod + 3 branches)
+- [x] T5: Register in `openapi.rs`
+- [x] T6: Update ROADMAP.md + plans/README.md; push + open PR
+
+## Acceptance criteria
+
+- `POST /v1/groups/{id}/doc-pages` with `{"title":"My Page"}` → 201 `DocPageResponse`
+- `GET /v1/groups/{id}/doc-pages` → 200 `ListDocPagesResponse`
+- Cross-group attempt → 403 (RLS + group check)
+- `cargo clippy --workspace --tests --exclude garraia-desktop -- -D warnings` clean
+- `cargo test -p garraia-gateway` passes
+
+## Cross-references
+
+- ROADMAP §3.8 Tier 2 (Docs)
+- `garraia-auth::Action::{DocsRead, DocsWrite, DocsDelete}` (already present)
+- Migration 003 (files table — `cover_file_id` FK)
+- Linear: [GAR-835](https://linear.app/chatgpt25/issue/GAR-835)
+
+## Estimativa
+
+0.5 h (padrão establish — cópia + adaptação de task create/list)

--- a/plans/README.md
+++ b/plans/README.md
@@ -305,3 +305,4 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0294 | [GAR-825 — Q6.14: 3-way shard + --features test-support in mutants.yml](0294-gar-825-mutants-shard-test-support.md) | [GAR-825](https://linear.app/chatgpt25/issue/GAR-825) | ✅ Merged via PR #701 (`6060116`) |
 | 0295 | [GAR-832 — Health run 105 (2026-06-09 ~08:45 ET): all surfaces clean, priority (i)](0295-gar-832-health-run-105.md) | [GAR-832](https://linear.app/chatgpt25/issue/GAR-832) | ✅ Merged 2026-06-09 via PR #702 (`3cc8771`) |
 | 0296 | [GAR-833 — Health run 106 (2026-06-09 ~12:45 ET): all surfaces clean, priority (i)](0296-gar-833-health-run-106.md) | [GAR-833](https://linear.app/chatgpt25/issue/GAR-833) | ✅ Merged via PR #704 (`7b0bade`) |
+| 0297 | [GAR-835 — Docs Tier 2 scaffold: migration 026 + POST/GET /v1/groups/{group_id}/doc-pages](0297-gar-835-doc-pages-scaffold.md) | [GAR-835](https://linear.app/chatgpt25/issue/GAR-835) | 🔄 In Progress |


### PR DESCRIPTION
## Summary

- **Migration 026** (`026_doc_pages.sql`): new `doc_pages` table with FORCE RLS, NULLIF fail-closed group isolation policy, `GRANT SELECT/INSERT/UPDATE` to `garraia_app`, keyset index + parent traversal index.
- **`WorkspaceAuditAction::DocPageCreated`** added to `garraia-auth`; `as_str()` → `"doc_page.created"`; stability test assertion added.
- **`crates/garraia-gateway/src/rest_v1/docs.rs`** (new, ~350 lines): `CreateDocPageRequest`, `DocPageResponse`, `DocPageSummary`, `ListDocPagesResponse`, `ListDocPagesQuery`; `create_doc_page` (POST 201) and `list_doc_pages` (GET, cursor-keyset, optional `parent_page_id` filter); 6 unit tests — all pass.
- **`mod.rs`**: `pub mod docs;` added; routes wired in all 3 branches (full / auth-only stub / no-auth stub).
- **`openapi.rs`**: paths `create_doc_page` + `list_doc_pages` and schemas `CreateDocPageRequest`, `DocPageResponse`, `DocPageSummary`, `ListDocPagesResponse` registered.
- **ROADMAP §3.8 Tier 2**: `doc_pages` schema entry + 2 API endpoints marked ✅.

## Test plan

- [x] `cargo check -p garraia-gateway` — clean
- [x] `cargo clippy --workspace --tests --exclude garraia-desktop --no-deps -- -D warnings` — 0 warnings
- [x] `cargo test -p garraia-gateway rest_v1::docs` — 6/6 pass
- [x] `cargo test -p garraia-auth` — 68/68 pass (includes `DocPageCreated` assertion)
- [ ] CI 20/20 green

## Linear

[GAR-835](https://linear.app/chatgpt25/issue/GAR-835)

https://claude.ai/code/session_016twFJyBsPfCsbYgDTMp71i

---
_Generated by [Claude Code](https://claude.ai/code/session_016twFJyBsPfCsbYgDTMp71i)_