### PR TITLE
feat(me): GAR-860 — GET /v1/me/doc-pages authored doc pages inbox

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -876,6 +876,7 @@ Módulo dentro de `garraia-workspace`. Schema entregue via migration 006 com **R
 - [x] `GET /v1/doc-pages/{page_id}/mentions` — list mentions (cursor-paginated) — plan 0318 / GAR-858
 - [x] `DELETE /v1/doc-pages/{page_id}/mentions/{user_id}` — remove mention (204 idempotent) — plan 0318 / GAR-858
 - [x] `GET /v1/me/doc-page-mentions` — caller @mention inbox for doc pages (cursor-paginated) — plan 0318 / GAR-858
+- [x] `GET /v1/me/doc-pages` — caller-authored doc pages inbox (cursor-paginated) — plan 0322 / GAR-860
 
 **Colaboração em tempo real:**
 

--- a/crates/garraia-gateway/src/rest_v1/me.rs
+++ b/crates/garraia-gateway/src/rest_v1/me.rs
@@ -32,6 +32,9 @@
 //!
 //! `GET /v1/me/doc-page-mentions` — cursor-paginated inbox of doc page @mentions
 //! received by the caller in a given group (plan 0318 / GAR-858).
+//!
+//! `GET /v1/me/doc-pages` — cursor-paginated inbox of doc pages authored by
+//! the caller in a given group (plan 0322 / GAR-860).
 
 use axum::Json;
 use axum::extract::{Path, Query, State};
@@ -2315,6 +2318,190 @@ pub async fn list_my_doc_page_mentions(
     Ok(Json(DocPageMentionsInboxResponse { items, next_cursor }))
 }
 
+// ─── GET /v1/me/doc-pages ────────────────────────────────────────────────────
+
+/// Query parameters for `GET /v1/me/doc-pages`.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ListMyDocPagesQuery {
+    /// Group to scope the inbox. Required — RLS needs `app.current_group_id`.
+    pub group_id: Uuid,
+    /// Keyset cursor — `id` of the last doc page on the previous page.
+    /// Returns pages created earlier than this one (exclusive). Omit for first page.
+    pub after: Option<Uuid>,
+    /// Page size. Default 20, max 100. Values > 100 are clamped to 100.
+    pub limit: Option<i64>,
+    /// When `true`, archived pages (`archived_at IS NOT NULL`) are included.
+    /// Default `false` — archived pages are excluded.
+    pub include_archived: Option<bool>,
+}
+
+/// One doc page entry in the `GET /v1/me/doc-pages` response.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct MyDocPageSummary {
+    /// UUID of the doc page.
+    pub id: Uuid,
+    /// UUID of the group the page belongs to.
+    pub group_id: Uuid,
+    /// UUID of the parent page. `null` for root-level pages.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_page_id: Option<Uuid>,
+    /// Page title.
+    pub title: String,
+    /// Optional emoji or icon identifier.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
+    /// UTC timestamp when the page was soft-deleted (archived). `null` if active.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub archived_at: Option<DateTime<Utc>>,
+    /// UTC timestamp when the page was created.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Response body for `GET /v1/me/doc-pages`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct MyDocPagesResponse {
+    pub items: Vec<MyDocPageSummary>,
+    /// `id` of the last item in this page. Pass as `?after=<uuid>` to fetch the
+    /// next (older) page. Absent when the end has been reached.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<Uuid>,
+}
+
+/// `GET /v1/me/doc-pages` — inbox of doc pages authored by the authenticated caller.
+///
+/// Returns up to `limit` (default 20, max 100) doc pages in `group_id` where
+/// `doc_pages.created_by = caller_user_id`, ordered by
+/// `(created_at DESC, id DESC)`.
+///
+/// Cursor-based pagination via `?after=<last_page_id>`. Optional
+/// `?include_archived=true` includes pages with `archived_at IS NOT NULL`
+/// (archived pages are excluded by default).
+///
+/// FORCE RLS is enforced via `SET LOCAL app.current_user_id` and
+/// `SET LOCAL app.current_group_id` — rows from other groups are invisible.
+/// A cross-group `after=` cursor returns 0 rows (fail-closed, no info leak).
+#[utoipa::path(
+    get,
+    path = "/v1/me/doc-pages",
+    params(ListMyDocPagesQuery),
+    responses(
+        (status = 200, description = "List of authored doc pages, newest first.", body = MyDocPagesResponse),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn list_my_doc_pages(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Query(params): Query<ListMyDocPagesQuery>,
+) -> Result<Json<MyDocPagesResponse>, RestError> {
+    let limit = params.limit.map(|l| l.min(100)).unwrap_or(20).max(1);
+    let group_id = params.group_id;
+    let include_archived = params.include_archived.unwrap_or(false);
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(principal.user_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_group_id', $1, true)")
+        .bind(group_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    // Columns: id, group_id, parent_page_id, title, icon, archived_at, created_at
+    type DocPageInboxRow = (
+        Uuid,
+        Uuid,
+        Option<Uuid>,
+        String,
+        Option<String>,
+        Option<DateTime<Utc>>,
+        DateTime<Utc>,
+    );
+
+    let rows: Vec<DocPageInboxRow> = if let Some(after_id) = params.after {
+        // Cursor subquery: if after_id is not found or belongs to a different
+        // group, the subquery returns NULL → comparison is always false → 0 rows
+        // (fail-closed, no info leak for cross-group cursor attacks).
+        sqlx::query_as(
+            "SELECT id, group_id, parent_page_id, title, icon, archived_at, created_at \
+             FROM doc_pages \
+             WHERE group_id = $1 \
+               AND created_by = $2 \
+               AND ($5 OR archived_at IS NULL) \
+               AND (created_at, id) < ( \
+                   SELECT created_at, id FROM doc_pages \
+                   WHERE id = $3 AND group_id = $1 \
+               ) \
+             ORDER BY created_at DESC, id DESC \
+             LIMIT $4",
+        )
+        .bind(group_id)
+        .bind(principal.user_id)
+        .bind(after_id)
+        .bind(limit)
+        .bind(include_archived)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?
+    } else {
+        sqlx::query_as(
+            "SELECT id, group_id, parent_page_id, title, icon, archived_at, created_at \
+             FROM doc_pages \
+             WHERE group_id = $1 \
+               AND created_by = $2 \
+               AND ($3 OR archived_at IS NULL) \
+             ORDER BY created_at DESC, id DESC \
+             LIMIT $4",
+        )
+        .bind(group_id)
+        .bind(principal.user_id)
+        .bind(include_archived)
+        .bind(limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?
+    };
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    let next_cursor = if rows.len() as i64 == limit {
+        rows.last().map(|(id, ..)| *id)
+    } else {
+        None
+    };
+
+    let items = rows
+        .into_iter()
+        .map(
+            |(id, group_id, parent_page_id, title, icon, archived_at, created_at)| {
+                MyDocPageSummary {
+                    id,
+                    group_id,
+                    parent_page_id,
+                    icon,
+                    title,
+                    archived_at,
+                    created_at,
+                }
+            },
+        )
+        .collect();
+
+    Ok(Json(MyDocPagesResponse { items, next_cursor }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3450,5 +3637,107 @@ mod tests {
         };
         assert!(q.after.is_none());
         assert!(q.limit.is_none());
+    }
+
+    // ─── GET /v1/me/doc-pages tests ──────────────────────────────────────────
+
+    #[test]
+    fn my_doc_pages_response_empty_no_cursor() {
+        let resp = MyDocPagesResponse {
+            items: vec![],
+            next_cursor: None,
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert_eq!(v["items"].as_array().unwrap().len(), 0);
+        assert!(
+            v.get("next_cursor").is_none(),
+            "absent cursor must be omitted"
+        );
+    }
+
+    #[test]
+    fn my_doc_pages_response_with_cursor() {
+        let cursor = Uuid::parse_str("cccccccc-0000-0000-0000-000000000001").unwrap();
+        let resp = MyDocPagesResponse {
+            items: vec![],
+            next_cursor: Some(cursor),
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert_eq!(v["next_cursor"], "cccccccc-0000-0000-0000-000000000001");
+    }
+
+    #[test]
+    fn my_doc_page_summary_serializes_all_fields() {
+        use chrono::TimeZone;
+        let ts = Utc.with_ymd_and_hms(2026, 6, 12, 10, 0, 0).unwrap();
+        let archived_ts = Utc.with_ymd_and_hms(2026, 6, 13, 8, 0, 0).unwrap();
+        let s = MyDocPageSummary {
+            id: Uuid::nil(),
+            group_id: Uuid::nil(),
+            parent_page_id: Some(Uuid::nil()),
+            title: "Meeting notes".to_string(),
+            icon: Some("📝".to_string()),
+            archived_at: Some(archived_ts),
+            created_at: ts,
+        };
+        let v = serde_json::to_value(&s).unwrap();
+        assert!(v.get("id").is_some());
+        assert!(v.get("group_id").is_some());
+        assert!(v.get("parent_page_id").is_some());
+        assert_eq!(v["title"], "Meeting notes");
+        assert_eq!(v["icon"], "📝");
+        assert!(v.get("archived_at").is_some());
+        assert!(v.get("created_at").is_some());
+    }
+
+    #[test]
+    fn my_doc_page_summary_omits_optional_fields_when_none() {
+        use chrono::TimeZone;
+        let ts = Utc.with_ymd_and_hms(2026, 6, 12, 10, 0, 0).unwrap();
+        let s = MyDocPageSummary {
+            id: Uuid::nil(),
+            group_id: Uuid::nil(),
+            parent_page_id: None,
+            title: "Root page".to_string(),
+            icon: None,
+            archived_at: None,
+            created_at: ts,
+        };
+        let v = serde_json::to_value(&s).unwrap();
+        assert!(
+            v.get("parent_page_id").is_none(),
+            "parent_page_id must be absent when None"
+        );
+        assert!(v.get("icon").is_none(), "icon must be absent when None");
+        assert!(
+            v.get("archived_at").is_none(),
+            "archived_at must be absent when None"
+        );
+    }
+
+    #[test]
+    fn list_my_doc_pages_limit_clamp() {
+        let over: i64 = Some(200i64).map(|l| l.min(100)).unwrap_or(20).max(1);
+        let under: i64 = Some(0i64).map(|l| l.min(100)).unwrap_or(20).max(1);
+        let default: i64 = None::<i64>.map(|l| l.min(100)).unwrap_or(20).max(1);
+        assert_eq!(over, 100, "over-limit must be clamped to 100");
+        assert_eq!(under, 1, "zero must be clamped to 1");
+        assert_eq!(default, 20, "no limit defaults to 20");
+    }
+
+    #[test]
+    fn list_my_doc_pages_query_defaults() {
+        let q = ListMyDocPagesQuery {
+            group_id: Uuid::nil(),
+            after: None,
+            limit: None,
+            include_archived: None,
+        };
+        assert!(q.after.is_none());
+        assert!(q.limit.is_none());
+        assert!(
+            !q.include_archived.unwrap_or(false),
+            "default include_archived is false"
+        );
     }
 }

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -328,6 +328,7 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 // Plan 0260 (GAR-788) — GET /v1/me/reactions emoji-reactions inbox.
                 // Plan 0261 (GAR-790) — GET /v1/me/threads thread-participation inbox.
                 // Plan 0318 (GAR-858) — GET /v1/me/doc-page-mentions doc-page @mention inbox.
+                // Plan 0322 (GAR-860) — GET /v1/me/doc-pages authored doc-pages inbox.
                 .route("/v1/me", get(me::get_me).patch(me::patch_me))
                 .route("/v1/me/mentions", get(me::list_my_mentions))
                 .route("/v1/me/tasks", get(me::list_my_tasks))
@@ -351,6 +352,7 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     "/v1/me/doc-page-mentions",
                     get(me::list_my_doc_page_mentions),
                 )
+                .route("/v1/me/doc-pages", get(me::list_my_doc_pages))
                 // Plan 0105 (GAR-580) — groups slice 3: list user's groups.
                 .route(
                     "/v1/groups",
@@ -682,6 +684,7 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 // Plan 0260 (GAR-788) — GET /v1/me/reactions stub.
                 // Plan 0261 (GAR-790) — GET /v1/me/threads stub.
                 // Plan 0318 (GAR-858) — GET /v1/me/doc-page-mentions stub (mode 2).
+                // Plan 0322 (GAR-860) — GET /v1/me/doc-pages stub (mode 2).
                 .route("/v1/me", get(me::get_me).patch(unconfigured_handler))
                 .route("/v1/me/mentions", get(unconfigured_handler))
                 .route("/v1/me/tasks", get(unconfigured_handler))
@@ -700,6 +703,7 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 .route("/v1/me/reactions", get(unconfigured_handler))
                 .route("/v1/me/threads", get(unconfigured_handler))
                 .route("/v1/me/doc-page-mentions", get(unconfigured_handler))
+                .route("/v1/me/doc-pages", get(unconfigured_handler))
                 .route("/v1/groups", post(unconfigured_handler))
                 .route(
                     "/v1/groups/{id}",
@@ -1050,6 +1054,7 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 )
                 .route("/v1/me/reactions", get(unconfigured_handler))
                 .route("/v1/me/doc-page-mentions", get(unconfigured_handler))
+                .route("/v1/me/doc-pages", get(unconfigured_handler))
                 .route("/v1/groups", post(unconfigured_handler))
                 .route(
                     "/v1/groups/{id}",

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -41,10 +41,10 @@ use super::invites::AcceptInviteResponse;
 use super::me::{
     AcceptMyInviteResponse, ChatMembershipSummary, DocPageMentionInboxSummary,
     DocPageMentionsInboxResponse, MeResponse, MentionSummary, MentionsListResponse,
-    MyChatsMembershipResponse, MyFileSummary, MyFilesResponse, MyInvitesResponse, MyMemoryResponse,
-    MyMemorySummary, MyReactionSummary, MyReactionsResponse, MyThreadSummary, MyThreadsResponse,
-    PatchMeRequest, PatchMeResponse, PendingInviteSummary, TaskAssignmentSummary,
-    TasksListResponse,
+    MyChatsMembershipResponse, MyDocPageSummary, MyDocPagesResponse, MyFileSummary, MyFilesResponse,
+    MyInvitesResponse, MyMemoryResponse, MyMemorySummary, MyReactionSummary, MyReactionsResponse,
+    MyThreadSummary, MyThreadsResponse, PatchMeRequest, PatchMeResponse, PendingInviteSummary,
+    TaskAssignmentSummary, TasksListResponse,
 };
 use super::memory::{
     CreateMemoryRequest, ListMemoryResponse, MemoryItemResponse, MemoryItemSummary,
@@ -120,6 +120,7 @@ impl Modify for SecurityAddon {
         super::me::accept_my_invite,
         super::me::list_my_reactions,
         super::me::list_my_threads,
+        super::me::list_my_doc_pages,
         super::groups::create_group,
         super::groups::list_groups,
         super::groups::get_group,
@@ -337,6 +338,8 @@ impl Modify for SecurityAddon {
         AddDocPageMentionRequest,
         DocPageMentionInboxSummary,
         DocPageMentionsInboxResponse,
+        MyDocPageSummary,
+        MyDocPagesResponse,
     )),
     modifiers(&SecurityAddon)
 )]

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -41,10 +41,10 @@ use super::invites::AcceptInviteResponse;
 use super::me::{
     AcceptMyInviteResponse, ChatMembershipSummary, DocPageMentionInboxSummary,
     DocPageMentionsInboxResponse, MeResponse, MentionSummary, MentionsListResponse,
-    MyChatsMembershipResponse, MyDocPageSummary, MyDocPagesResponse, MyFileSummary, MyFilesResponse,
-    MyInvitesResponse, MyMemoryResponse, MyMemorySummary, MyReactionSummary, MyReactionsResponse,
-    MyThreadSummary, MyThreadsResponse, PatchMeRequest, PatchMeResponse, PendingInviteSummary,
-    TaskAssignmentSummary, TasksListResponse,
+    MyChatsMembershipResponse, MyDocPageSummary, MyDocPagesResponse, MyFileSummary,
+    MyFilesResponse, MyInvitesResponse, MyMemoryResponse, MyMemorySummary, MyReactionSummary,
+    MyReactionsResponse, MyThreadSummary, MyThreadsResponse, PatchMeRequest, PatchMeResponse,
+    PendingInviteSummary, TaskAssignmentSummary, TasksListResponse,
 };
 use super::memory::{
     CreateMemoryRequest, ListMemoryResponse, MemoryItemResponse, MemoryItemSummary,

--- a/plans/0322-gar-860-me-doc-pages.md
+++ b/plans/0322-gar-860-me-doc-pages.md
@@ -1,0 +1,117 @@
+# Plan 0322 — GAR-860: GET /v1/me/doc-pages — caller-scoped authored doc pages inbox
+
+> **Status:** In Progress
+> **Linear:** [GAR-860](https://linear.app/chatgpt25/issue/GAR-860)
+> **Branch:** `routine/202606121215-me-doc-pages`
+> **Parent plan:** 0321
+
+## Goal
+
+Add `GET /v1/me/doc-pages` — cursor-paginated inbox of doc pages authored by
+the authenticated caller in a specific group. Extends the `/me/*` inbox family
+(chats, files, tasks, mentions, invites, reactions, threads, doc-page-mentions).
+
+## Architecture
+
+Thin handler in `crates/garraia-gateway/src/rest_v1/me.rs` following the
+established `/me/*` inbox pattern:
+
+1. FORCE RLS via `set_config('app.current_user_id', ...)` +
+   `set_config('app.current_group_id', ...)` before any SQL.
+2. SELECT from `doc_pages` where `group_id = $1 AND created_by = $2`.
+3. Optional `include_archived` bool (default `false`) gates `archived_at IS NULL`.
+4. Keyset cursor on `(created_at DESC, id DESC)`.
+
+No new migration — uses `doc_pages` from migration 026 (GAR-834 / plan 0297).
+
+## Tech stack
+
+Rust (Axum 0.8), sqlx (Postgres), utoipa (OpenAPI), `garraia_auth::Principal`.
+
+## Design invariants
+
+- NO `unwrap()` outside tests.
+- NO SQL string concat — `sqlx::query_as` with positional `$N` params.
+- SET LOCAL both `app.current_user_id` AND `app.current_group_id` before SQL.
+- Cross-group cursor attack is fail-closed: cursor subquery anchors to
+  `group_id = $1`, so a foreign `after=` returns 0 rows (no info leak).
+- Archived pages excluded by default; `include_archived=true` opts in.
+- `next_cursor` absent (omitted in JSON) when the page is the last one.
+
+## Validações pré-plano
+
+- `doc_pages` table has `group_id`, `created_by`, `archived_at`, `created_at`,
+  `id` columns — confirmed in `DocPageRow` in `docs.rs`.
+- `/me/*` inbox pattern well-established — 9 prior inboxes in `me.rs`.
+- No new OpenAPI component types needed — follows `MyFilesResponse` shape.
+
+## Out of scope
+
+- Creating or modifying doc pages (covered by `docs.rs`).
+- Returning blocks, versions, or mentions alongside pages.
+- Any change to the `doc_pages` schema.
+
+## Rollback
+
+Revert the PR. No migration to undo.
+
+## §12 Open questions
+
+None — acceptance criteria fully specified in GAR-860.
+
+## File Structure
+
+```
+crates/garraia-gateway/src/rest_v1/
+  me.rs          ← add ListMyDocPagesQuery, MyDocPageSummary,
+                     MyDocPagesResponse, list_my_doc_pages handler + 6 unit tests
+  mod.rs         ← register route in mode-1 (full), mode-2 (stub), mode-3 (stub)
+  openapi.rs     ← add list_my_doc_pages to ApiDoc paths
+plans/
+  0322-gar-860-me-doc-pages.md   ← this file
+  README.md                       ← add row for plan 0322
+ROADMAP.md                        ← flip [ ] → [x] for GET /v1/me/doc-pages
+```
+
+## M1 Tasks
+
+- [x] T1: Create `plans/0322-gar-860-me-doc-pages.md` + `plans/README.md` row
+- [ ] T2: Implement `list_my_doc_pages` handler in `me.rs` (types + handler + 6 unit tests)
+- [ ] T3: Register route in `mod.rs` (mode-1 real + mode-2 stub + mode-3 stub)
+- [ ] T4: Register in `openapi.rs`
+- [ ] T5: Update `me.rs` module doc-comment to mention new endpoint
+- [ ] T6: Update `ROADMAP.md` §3.4 checklist (`[ ]` → `[x]`)
+- [ ] T7: `cargo check -p garraia-gateway` + clippy clean + tests pass
+- [ ] T8: Commit, push, open PR, CI green, squash-merge
+
+## Risk register
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| `created_by` IS NULL rows silently excluded | Low | Acceptable: NULL means no owner; endpoint is "my pages" |
+| Cross-group cursor leaks info | Low | Cursor subquery anchors `group_id = $1` |
+| `include_archived` bool param serde ambiguity | Low | `Option<bool>` default false; no validation needed |
+
+## Acceptance criteria
+
+- `GET /v1/me/doc-pages?group_id=<uuid>` returns pages where
+  `created_by = caller_user_id` in the group, newest-first.
+- Cursor pagination via `after=<page_uuid>` + `limit=1..100` (default 20).
+- `include_archived=true` includes archived pages; default excludes them.
+- FORCE RLS: `SET LOCAL app.current_user_id` AND `app.current_group_id`.
+- Cross-group `after=` returns 0 rows (fail-closed).
+- Registered in `openapi.rs`.
+- ROADMAP §3.4 updated.
+- `cargo clippy --workspace ... -- -D warnings` passes.
+- 6 unit tests in `me.rs` pass.
+
+## Cross-references
+
+- Migration 026 (`doc_pages`) — GAR-834 / plan 0297
+- Established inbox pattern — plans 0237, 0242, 0245, 0246, 0249, 0255, 0260, 0261, 0318
+- Parent plan: 0321 (health run 121)
+- GAR-860 Linear issue
+
+## Estimativa
+
+< 2 hours. ~150 LOC new code (handler + tests + routes).

--- a/plans/README.md
+++ b/plans/README.md
@@ -330,3 +330,4 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0319 | [GAR-859 — Health run 120 (2026-06-12 ~00:45 ET): all surfaces clean, priority (i)](0319-gar-859-health-run-120.md) | [GAR-859](https://linear.app/chatgpt25/issue/GAR-859) | ✅ Merged 2026-06-12 via PR #732 (`a7a73aa`) |
 | 0320 | [GAR-858 — doc_page_mentions: migration 029, REST handlers, inbox endpoint, OpenAPI wiring](0320-gar-858-doc-page-mentions.md) | [GAR-858](https://linear.app/chatgpt25/issue/GAR-858) | ✅ Merged 2026-06-12 via PR #730 (`cf8be02`) |
 | 0321 | [GAR-861 — Health run 121 (2026-06-12 ~04:45 ET): all surfaces clean, priority (i)](0321-gar-861-health-run-121.md) | [GAR-861](https://linear.app/chatgpt25/issue/GAR-861) | ✅ Merged 2026-06-12 via PR #733 (`dcb12c6`) |
+| 0322 | [GAR-860 — GET /v1/me/doc-pages — caller-scoped authored doc pages inbox](0322-gar-860-me-doc-pages.md) | [GAR-860](https://linear.app/chatgpt25/issue/GAR-860) | In Progress |


### PR DESCRIPTION
## Summary

- Adds `GET /v1/me/doc-pages` — cursor-paginated inbox of doc pages where `created_by = caller_user_id` in a group.
- Extends the established `/me/*` inbox family (9 prior inboxes: mentions, tasks, chats, files, memory, invites, reactions, threads, doc-page-mentions).
- Optional `include_archived=true` query param includes archived pages (default: exclude).
- FORCE RLS: `SET LOCAL app.current_user_id` AND `app.current_group_id` before any SQL.
- Cross-group `after=` cursor is fail-closed: subquery anchors on `group_id = $1`, returning 0 rows for foreign cursors.
- No new migration — uses `doc_pages` table from migration 026 (GAR-834).

## Test plan

- [x] 6 unit tests in `rest_v1::me::tests` — all pass (`cargo test -p garraia-gateway --lib -- tests::my_doc_page tests::list_my_doc_page`)
- [x] `cargo check -p garraia-gateway` clean
- [x] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` exit 0
- [x] Route registered in mode-1 (real handler), mode-2 (stub), mode-3 (stub) in `mod.rs`
- [x] `openapi.rs` updated: handler + `MyDocPageSummary` + `MyDocPagesResponse` components
- [x] ROADMAP.md §3.8 Tier 2 API checklist updated (`[ ]` → `[x]`)
- [x] `plans/0322-gar-860-me-doc-pages.md` created, `plans/README.md` row added

Closes GAR-860.

https://claude.ai/code/session_015utvDc37MkX4zesNKqFEM4

---
_Generated by [Claude Code](https://claude.ai/code/session_015utvDc37MkX4zesNKqFEM4)_