### PR TITLE
feat(chats): GAR-864 — GET /v1/chats/{chat_id}/members/{user_id} — fetch single chat member

### DIFF
--- a/crates/garraia-gateway/src/rest_v1/chats.rs
+++ b/crates/garraia-gateway/src/rest_v1/chats.rs
@@ -2324,6 +2324,98 @@ pub struct ChatMemberDetailResponse {
     pub last_read_at: Option<DateTime<Utc>>,
 }
 
+/// `GET /v1/chats/{chat_id}/members/{user_id}` — fetch a single chat member.
+///
+/// Returns 404 for non-members, archived chats, or chats in another group
+/// (no 403 existence leak).
+#[utoipa::path(
+    get,
+    path = "/v1/chats/{chat_id}/members/{user_id}",
+    params(
+        ("chat_id" = Uuid, Path, description = "Chat UUID."),
+        ("user_id" = Uuid, Path, description = "Member user UUID."),
+    ),
+    responses(
+        (status = 200, description = "Chat member detail.", body = ChatMemberDetailResponse),
+        (status = 400, description = "Missing X-Group-Id header.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+        (status = 403, description = "Caller is not a group member.", body = super::problem::ProblemDetails),
+        (status = 404, description = "Chat not found, archived, in another group, or user is not a member.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn get_chat_member(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Path((chat_id, target_user_id)): Path<(Uuid, Uuid)>,
+) -> Result<Json<ChatMemberDetailResponse>, RestError> {
+    let group_id = principal
+        .group_id
+        .ok_or_else(|| RestError::BadRequest("X-Group-Id header is required".into()))?;
+
+    if !can(&principal, Action::ChatsRead) {
+        return Err(RestError::Forbidden);
+    }
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(principal.user_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_group_id', $1, true)")
+        .bind(group_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    // Verify the chat exists in the caller's group (404, no 403 — no cross-tenant leak).
+    let chat_exists: Option<(bool,)> = sqlx::query_as(
+        "SELECT true FROM chats WHERE id = $1 AND group_id = $2 AND archived_at IS NULL",
+    )
+    .bind(chat_id)
+    .bind(group_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    if chat_exists.is_none() {
+        return Err(RestError::NotFound);
+    }
+
+    type MemberRow = (String, DateTime<Utc>, bool, Option<DateTime<Utc>>);
+    let member: Option<MemberRow> = sqlx::query_as(
+        "SELECT role, joined_at, muted, last_read_at \
+         FROM chat_members \
+         WHERE chat_id = $1 AND user_id = $2",
+    )
+    .bind(chat_id)
+    .bind(target_user_id)
+    .fetch_optional(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    let (role, joined_at, muted, last_read_at) = member.ok_or(RestError::NotFound)?;
+
+    Ok(Json(ChatMemberDetailResponse {
+        user_id: target_user_id,
+        role,
+        joined_at,
+        muted,
+        last_read_at,
+    }))
+}
+
 /// `PATCH /v1/chats/{chat_id}/members/{user_id}` — update muted, last_read_at,
 /// or chat-local role for a chat member.
 ///
@@ -3967,5 +4059,102 @@ mod tests {
             v["root_message_id"].as_str().unwrap(),
             "00000000-0000-0000-0000-000000000000"
         );
+    }
+
+    // ── get_chat_member unit tests ───────────────────────────────────────────
+
+    #[test]
+    fn get_chat_member_response_serializes_all_fields() {
+        let resp = ChatMemberDetailResponse {
+            user_id: Uuid::nil(),
+            role: "member".into(),
+            joined_at: DateTime::parse_from_rfc3339("2026-06-12T19:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            muted: false,
+            last_read_at: None,
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert_eq!(v["role"].as_str().unwrap(), "member");
+        assert!(!v["muted"].as_bool().unwrap());
+        assert!(v["last_read_at"].is_null());
+    }
+
+    #[test]
+    fn get_chat_member_response_muted_true() {
+        let resp = ChatMemberDetailResponse {
+            user_id: Uuid::nil(),
+            role: "owner".into(),
+            joined_at: Utc::now(),
+            muted: true,
+            last_read_at: None,
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert!(v["muted"].as_bool().unwrap());
+        assert_eq!(v["role"].as_str().unwrap(), "owner");
+    }
+
+    #[test]
+    fn get_chat_member_response_last_read_at_some_utc_z() {
+        let ts = DateTime::parse_from_rfc3339("2026-06-12T15:30:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let resp = ChatMemberDetailResponse {
+            user_id: Uuid::nil(),
+            role: "moderator".into(),
+            joined_at: ts,
+            muted: false,
+            last_read_at: Some(ts),
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        let s = v["last_read_at"].as_str().unwrap();
+        assert!(s.ends_with('Z'), "timestamp must be UTC Z: {s}");
+    }
+
+    #[test]
+    fn get_chat_member_response_role_viewer() {
+        let resp = ChatMemberDetailResponse {
+            user_id: Uuid::nil(),
+            role: "viewer".into(),
+            joined_at: Utc::now(),
+            muted: false,
+            last_read_at: None,
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert_eq!(v["role"].as_str().unwrap(), "viewer");
+    }
+
+    #[test]
+    fn get_chat_member_response_nil_uuid_roundtrip() {
+        let id = Uuid::nil();
+        let resp = ChatMemberDetailResponse {
+            user_id: id,
+            role: "member".into(),
+            joined_at: Utc::now(),
+            muted: false,
+            last_read_at: None,
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert_eq!(
+            v["user_id"].as_str().unwrap(),
+            "00000000-0000-0000-0000-000000000000"
+        );
+    }
+
+    #[test]
+    fn get_chat_member_response_joined_at_utc_z() {
+        let ts = DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let resp = ChatMemberDetailResponse {
+            user_id: Uuid::nil(),
+            role: "member".into(),
+            joined_at: ts,
+            muted: false,
+            last_read_at: None,
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        let s = v["joined_at"].as_str().unwrap();
+        assert!(s.ends_with('Z'), "joined_at must be UTC Z: {s}");
     }
 }

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -389,9 +389,12 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     "/v1/chats/{chat_id}/members",
                     get(chats::list_chat_members).post(chats::add_chat_member),
                 )
+                // Plan 0325 (GAR-864) — get single chat member.
                 .route(
                     "/v1/chats/{chat_id}/members/{user_id}",
-                    delete(chats::remove_chat_member).patch(chats::patch_chat_member),
+                    get(chats::get_chat_member)
+                        .delete(chats::remove_chat_member)
+                        .patch(chats::patch_chat_member),
                 )
                 // Plan 0055 (GAR-507) — messages slice 2.
                 .route(
@@ -747,7 +750,9 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 )
                 .route(
                     "/v1/chats/{chat_id}/members/{user_id}",
-                    delete(unconfigured_handler).patch(unconfigured_handler),
+                    get(unconfigured_handler)
+                        .delete(unconfigured_handler)
+                        .patch(unconfigured_handler),
                 )
                 // Plan 0055 (GAR-507) — messages slice 2, fail-soft 503.
                 .route(
@@ -1098,7 +1103,9 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 )
                 .route(
                     "/v1/chats/{chat_id}/members/{user_id}",
-                    delete(unconfigured_handler).patch(unconfigured_handler),
+                    get(unconfigured_handler)
+                        .delete(unconfigured_handler)
+                        .patch(unconfigured_handler),
                 )
                 // Plan 0055 (GAR-507) — messages slice 2, no-auth stub.
                 .route(

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -143,6 +143,7 @@ impl Modify for SecurityAddon {
         super::chats::get_thread,
         super::chats::patch_thread,
         super::chats::patch_chat_member,
+        super::chats::get_chat_member,
         super::chats::typing_indicator,
         super::messages::send_message,
         super::messages::list_messages,

--- a/plans/0325-gar-864-get-chat-member.md
+++ b/plans/0325-gar-864-get-chat-member.md
@@ -1,0 +1,112 @@
+# Plan 0325 — GAR-864: GET /v1/chats/{chat_id}/members/{user_id} — fetch single chat member
+
+> **Status:** In Progress
+> **Linear:** [GAR-864](https://linear.app/chatgpt25/issue/GAR-864)
+> **Branch:** `routine/202606121915-get-chat-member`
+> **Parent plan:** 0323
+
+## Goal
+
+Add `GET /v1/chats/{chat_id}/members/{user_id}` — fetch a single chat member's
+detail. Closes the CRUD gap for chat members: DELETE and PATCH exist
+(plan 0076 / GAR-530 + plan 0227 / GAR-745) but GET single-item was missing.
+Mirrors the same gap closed for group members in plan 0286 / GAR-823.
+
+## Architecture
+
+Thin handler in `crates/garraia-gateway/src/rest_v1/chats.rs` following the
+established single-resource-fetch pattern:
+
+1. `ChatsRead` permission check.
+2. SET LOCAL both `app.current_user_id` AND `app.current_group_id` for FORCE RLS.
+3. Verify chat exists in caller's group (404 if not, no 403 leak).
+4. SELECT `role, joined_at, muted, last_read_at` from `chat_members` WHERE
+   `chat_id = $1 AND user_id = $2`.
+5. Return 404 if no row (member not found / cross-group).
+6. Return 200 + `ChatMemberDetailResponse` (same struct used by PATCH — reuse, no new type).
+
+No new migration. Uses `chat_members` from migration 004; `muted` + `last_read_at`
+added in plan 0227 (GAR-745) — already in main.
+
+## Tech stack
+
+Rust (Axum 0.8), sqlx (Postgres), utoipa (OpenAPI), `garraia_auth::Principal`.
+
+## Design invariants
+
+- NO `unwrap()` outside tests.
+- NO SQL string concat — `sqlx::query_as` with positional `$N` params.
+- SET LOCAL both `app.current_user_id` AND `app.current_group_id` before SQL.
+- Cross-group attack fail-closed: `chats WHERE group_id = $caller_group` guard
+  before querying `chat_members` — foreign chat_id returns 404, no info leak.
+- No audit event on read-only GET.
+
+## Validações pré-plano
+
+- `chat_members` table has `chat_id`, `user_id`, `role`, `joined_at`, `muted`,
+  `last_read_at` — confirmed from `patch_chat_member` handler.
+- `ChatMemberDetailResponse` struct already defined (line ~2317 in `chats.rs`).
+- Route slot `/v1/chats/{chat_id}/members/{user_id}` already registered with
+  DELETE + PATCH — only need to add GET handler.
+- `patch_chat_member` at openapi.rs:145 — add `get_chat_member` alongside.
+
+## Out of scope
+
+- Listing all members (covered by `list_chat_members` / plan 0076 / GAR-530).
+- Modifying member fields (covered by `patch_chat_member` / plan 0227 / GAR-745).
+- Cross-chat member enumeration.
+
+## Rollback
+
+Revert the PR. No migration to undo.
+
+## §12 Open questions
+
+None — acceptance criteria fully specified in GAR-864.
+
+## File structure
+
+```
+crates/garraia-gateway/src/rest_v1/chats.rs     ← new get_chat_member handler + 6 unit tests
+crates/garraia-gateway/src/rest_v1/mod.rs       ← add get(chats::get_chat_member) to 3 branches
+crates/garraia-gateway/src/rest_v1/openapi.rs   ← add super::chats::get_chat_member to paths
+plans/0324-gar-864-get-chat-member.md           ← this file
+plans/README.md                                 ← row 0324 added, row 0323 updated
+```
+
+## M1 Tasks
+
+- [x] T1: Write plan + create Linear issue GAR-864
+- [ ] T2: Implement `get_chat_member` handler in `chats.rs` + 6 unit tests
+- [ ] T3: Wire route in `mod.rs` (all 3 branches)
+- [ ] T4: Register in `openapi.rs`
+- [ ] T5: Commit + push + open PR
+- [ ] T6: Wait for CI green; fix any failures
+- [ ] T7: Squash-merge; mark GAR-864 Done
+- [ ] T8: Update ROADMAP + plans/README.md row 0323/0324
+
+## Risk register
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| `chat_members` columns missing (muted/last_read) | Low | Verified in patch_chat_member |
+| Route conflict with existing DELETE/PATCH | Low | Just add `.get()` to existing route tuple |
+
+## Acceptance criteria
+
+1. `GET /v1/chats/{chat_id}/members/{caller_user_id}` → 200 + `ChatMemberDetailResponse` (5 fields).
+2. `GET /v1/chats/{chat_id}/members/{non_member_id}` → 404.
+3. Archived chat or cross-group chat → 404.
+4. Missing `X-Group-Id` → 400; no JWT → 401; not a group member → 403.
+5. `cargo clippy --workspace` green. 6 unit tests pass.
+6. Route wired in all 3 mod.rs branches; OpenAPI path registered.
+
+## Cross-references
+
+- plan 0076 / GAR-530 — chat member CRUD (list/add/remove)
+- plan 0227 / GAR-745 — PATCH /v1/chats/{chat_id}/members/{user_id} (muted/last_read/role)
+- plan 0286 / GAR-823 — GET /v1/groups/{group_id}/members/{user_id} (parallel gap)
+
+## Estimativa
+
+0.5–1h. Handler ~60 LOC, tests ~80 LOC, routing ~6 LOC, openapi ~1 LOC.

--- a/plans/README.md
+++ b/plans/README.md
@@ -333,3 +333,4 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0322 | [GAR-860 — GET /v1/me/doc-pages — caller-scoped authored doc pages inbox](0322-gar-860-me-doc-pages.md) | [GAR-860](https://linear.app/chatgpt25/issue/GAR-860) | ✅ Merged 2026-06-12 via PR #735 (`21e52ec`) |
 | 0323 | [GAR-863 — Health run 122 (2026-06-12 ~16:45 ET): all surfaces clean, priority (i)](0323-gar-863-health-run-122.md) | [GAR-863](https://linear.app/chatgpt25/issue/GAR-863) | ✅ Merged 2026-06-12 via PR #736 (`f75a51c`) |
 | 0324 | [GAR-865 — Health run 123 (2026-06-12 ~20:45 ET): all surfaces clean, priority (i)](0324-gar-865-health-run-123.md) | [GAR-865](https://linear.app/chatgpt25/issue/GAR-865) | ✅ Merged 2026-06-12 via PR #739 (`4b18dcf`) |
+| 0325 | [GAR-864 — GET /v1/chats/{chat_id}/members/{user_id} — fetch single chat member](0325-gar-864-get-chat-member.md) | [GAR-864](https://linear.app/chatgpt25/issue/GAR-864) | In Progress |


### PR DESCRIPTION
## Summary

- Adds `GET /v1/chats/{chat_id}/members/{user_id}` — fetch a single chat member by user UUID.
- Closes the CRUD gap for chat members: list + add + remove (plan 0076 / GAR-530) + patch muted/role (plan 0227 / GAR-745) + **this: single-item GET**.
- Mirrors the same gap closed for group members in plan 0286 / GAR-823.
- Returns existing `ChatMemberDetailResponse { user_id, role, joined_at, muted, last_read_at }` — no new types.
- Route wired in all 3 `mod.rs` branches (full auth, auth-only stub, no-auth stub). OpenAPI path registered.

## Test plan

- [ ] Format Check passes
- [ ] Clippy passes (0 warnings with `-D warnings`)
- [ ] Test (ubuntu-latest) — 748 unit tests pass (6 new: `get_chat_member_response_*`)
- [ ] Test (macos-latest) passes
- [ ] Test (windows-latest) passes
- [ ] Build Check passes
- [ ] MSRV check passes
- [ ] Security Audit passes
- [ ] Secret Scan passes
- [ ] cargo-deny passes
- [ ] Coverage passes
- [ ] E2E Tests pass
- [ ] Playwright E2E pass
- [ ] Analyze (rust) passes
- [ ] Analyze (javascript-typescript) passes
- [ ] Quality Ratchet passes

## Design notes

- `ChatsRead` permission required (same as `list_chat_members`).
- SET LOCAL both `app.current_user_id` and `app.current_group_id` before any SQL (FORCE RLS requirement).
- Chat-in-group 404 guard before querying `chat_members` — archived chats and cross-group chats return 404, never 403 (no existence leak).
- No audit event on read-only GET.
- No new migration — uses `chat_members` from migration 004; `muted` + `last_read_at` added in plan 0227.

## Linear

[GAR-864](https://linear.app/chatgpt25/issue/GAR-864)

https://claude.ai/code/session_0158ySrCcCDhPRHJYmkRG2Cg

---
_Generated by [Claude Code](https://claude.ai/code/session_0158ySrCcCDhPRHJYmkRG2Cg)_