### PR TITLE
feat(me): GAR-869 — DELETE /v1/me/sessions — revoke all active sessions

### DIFF
--- a/crates/garraia-auth/src/audit_workspace.rs
+++ b/crates/garraia-auth/src/audit_workspace.rs
@@ -690,6 +690,17 @@ pub enum WorkspaceAuditAction {
     /// `resource_type = "sessions"`, `resource_id = "{session_id}"`.
     /// Metadata: `{}` — no PII; device info is not logged.
     SessionRevoked,
+
+    /// All of the caller's active sessions were bulk-revoked via
+    /// `DELETE /v1/me/sessions` (plan 0328 / GAR-869).
+    ///
+    /// Sessions are user-scoped, not group-scoped. `group_id` carries the
+    /// nil-uuid by convention (same as `SessionRevoked` above).
+    ///
+    /// `resource_type = "sessions"`, `resource_id = "{user_id}"`.
+    /// Metadata: `{"count": N}` — number of sessions revoked. No PII.
+    /// Not emitted when `count == 0` (nothing to record).
+    SessionsAllRevoked,
 }
 
 impl WorkspaceAuditAction {
@@ -769,6 +780,7 @@ impl WorkspaceAuditAction {
             WorkspaceAuditAction::DocPageVersionRestored => "doc_page.version_restored",
             WorkspaceAuditAction::DocPageMentionAdded => "doc_page.mention_added",
             WorkspaceAuditAction::SessionRevoked => "session.revoked",
+            WorkspaceAuditAction::SessionsAllRevoked => "session.all_revoked",
         }
     }
 }
@@ -1082,6 +1094,10 @@ mod tests {
             WorkspaceAuditAction::SessionRevoked.as_str(),
             "session.revoked"
         );
+        assert_eq!(
+            WorkspaceAuditAction::SessionsAllRevoked.as_str(),
+            "session.all_revoked"
+        );
     }
 
     #[test]
@@ -1155,6 +1171,7 @@ mod tests {
             WorkspaceAuditAction::DocPageVersionRestored.as_str(),
             WorkspaceAuditAction::DocPageMentionAdded.as_str(),
             WorkspaceAuditAction::SessionRevoked.as_str(),
+            WorkspaceAuditAction::SessionsAllRevoked.as_str(),
         ];
         let unique: std::collections::HashSet<_> = strings.iter().collect();
         assert_eq!(unique.len(), strings.len(), "duplicate action strings");

--- a/crates/garraia-gateway/src/rest_v1/me.rs
+++ b/crates/garraia-gateway/src/rest_v1/me.rs
@@ -2742,6 +2742,85 @@ pub async fn revoke_my_session(
     Ok(StatusCode::NO_CONTENT)
 }
 
+// ─── DELETE /v1/me/sessions ──────────────────────────────────────────────────
+
+/// `DELETE /v1/me/sessions` — revoke ALL of the caller's active sessions
+/// ("sign out from all devices") (plan 0328 / GAR-869).
+///
+/// Atomically sets `revoked_at = now()` on every non-expired, non-revoked
+/// session row owned by the caller. Returns 204 regardless of how many rows
+/// are affected (including zero).
+///
+/// An audit event `SessionsAllRevoked` is emitted only when at least one
+/// session was revoked (`rows_affected > 0`).
+///
+/// No `X-Group-Id` header required — sessions are user-scoped.
+#[utoipa::path(
+    delete,
+    path = "/v1/me/sessions",
+    responses(
+        (status = 204, description = "All active sessions revoked (or none were active)."),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = []))
+)]
+pub async fn revoke_all_my_sessions(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+) -> Result<StatusCode, RestError> {
+    let nil_uuid = Uuid::nil();
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(principal.user_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_group_id', $1, true)")
+        .bind(nil_uuid.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    // FORCE RLS (sessions_owner_only) ensures only the caller's rows are affected.
+    let result = sqlx::query(
+        "UPDATE sessions SET revoked_at = now() \
+         WHERE user_id = $1 AND revoked_at IS NULL AND expires_at > now()",
+    )
+    .bind(principal.user_id)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| RestError::Internal(e.into()))?;
+
+    let count = result.rows_affected();
+
+    if count > 0 {
+        audit_workspace_event(
+            &mut tx,
+            WorkspaceAuditAction::SessionsAllRevoked,
+            principal.user_id,
+            nil_uuid,
+            "sessions",
+            principal.user_id.to_string(),
+            json!({ "count": count }),
+        )
+        .await
+        .map_err(|e| RestError::Internal(anyhow::anyhow!("{e}")))?;
+    }
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -4180,5 +4259,54 @@ mod tests {
             Uuid::parse_str(cursor_str).is_ok(),
             "next_cursor must parse as UUID: {cursor_str}"
         );
+    }
+
+    // ── revoke_all_my_sessions (unit tests — no DB required) ─────────────────
+
+    #[test]
+    fn revoke_all_sessions_audit_action_wire_form() {
+        assert_eq!(
+            WorkspaceAuditAction::SessionsAllRevoked.as_str(),
+            "session.all_revoked"
+        );
+    }
+
+    #[test]
+    fn revoke_all_sessions_audit_action_distinct_from_single() {
+        assert_ne!(
+            WorkspaceAuditAction::SessionsAllRevoked.as_str(),
+            WorkspaceAuditAction::SessionRevoked.as_str(),
+            "bulk-revoke and single-revoke must have distinct audit actions"
+        );
+    }
+
+    #[test]
+    fn revoke_all_sessions_count_metadata_serializes() {
+        let count: u64 = 3;
+        let meta = json!({ "count": count });
+        assert_eq!(meta["count"], 3);
+    }
+
+    #[test]
+    fn revoke_all_sessions_zero_count_metadata_serializes() {
+        let count: u64 = 0;
+        let meta = json!({ "count": count });
+        assert_eq!(meta["count"], 0);
+    }
+
+    #[test]
+    fn revoke_all_sessions_nil_group_uuid() {
+        let nil = Uuid::nil();
+        assert_eq!(
+            nil.to_string(),
+            "00000000-0000-0000-0000-000000000000",
+            "group_id must be nil-uuid for user-scoped session audit"
+        );
+    }
+
+    #[test]
+    fn revoke_all_sessions_resource_type_is_sessions() {
+        let resource_type = "sessions";
+        assert_eq!(resource_type, "sessions");
     }
 }

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -330,6 +330,7 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 // Plan 0318 (GAR-858) — GET /v1/me/doc-page-mentions doc-page @mention inbox.
                 // Plan 0322 (GAR-860) — GET /v1/me/doc-pages authored doc-pages inbox.
                 // Plan 0326 (GAR-866) — GET /v1/me/sessions + DELETE /v1/me/sessions/{id}.
+                // Plan 0328 (GAR-869) — DELETE /v1/me/sessions (revoke all sessions).
                 .route("/v1/me", get(me::get_me).patch(me::patch_me))
                 .route("/v1/me/mentions", get(me::list_my_mentions))
                 .route("/v1/me/tasks", get(me::list_my_tasks))
@@ -354,7 +355,10 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                     get(me::list_my_doc_page_mentions),
                 )
                 .route("/v1/me/doc-pages", get(me::list_my_doc_pages))
-                .route("/v1/me/sessions", get(me::list_my_sessions))
+                .route(
+                    "/v1/me/sessions",
+                    get(me::list_my_sessions).delete(me::revoke_all_my_sessions),
+                )
                 .route(
                     "/v1/me/sessions/{session_id}",
                     delete(me::revoke_my_session),
@@ -695,6 +699,7 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 // Plan 0318 (GAR-858) — GET /v1/me/doc-page-mentions stub (mode 2).
                 // Plan 0322 (GAR-860) — GET /v1/me/doc-pages stub (mode 2).
                 // Plan 0326 (GAR-866) — GET /v1/me/sessions + DELETE /v1/me/sessions/{id} stub.
+                // Plan 0328 (GAR-869) — DELETE /v1/me/sessions (revoke all sessions) stub.
                 .route("/v1/me", get(me::get_me).patch(unconfigured_handler))
                 .route("/v1/me/mentions", get(unconfigured_handler))
                 .route("/v1/me/tasks", get(unconfigured_handler))
@@ -714,7 +719,10 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 .route("/v1/me/threads", get(unconfigured_handler))
                 .route("/v1/me/doc-page-mentions", get(unconfigured_handler))
                 .route("/v1/me/doc-pages", get(unconfigured_handler))
-                .route("/v1/me/sessions", get(unconfigured_handler))
+                .route(
+                    "/v1/me/sessions",
+                    get(unconfigured_handler).delete(unconfigured_handler),
+                )
                 .route("/v1/me/sessions/{session_id}", delete(unconfigured_handler))
                 .route("/v1/groups", post(unconfigured_handler))
                 .route(
@@ -1070,7 +1078,11 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                 .route("/v1/me/reactions", get(unconfigured_handler))
                 .route("/v1/me/doc-page-mentions", get(unconfigured_handler))
                 .route("/v1/me/doc-pages", get(unconfigured_handler))
-                .route("/v1/me/sessions", get(unconfigured_handler))
+                // Plan 0328 (GAR-869) — DELETE /v1/me/sessions (revoke all sessions) stub.
+                .route(
+                    "/v1/me/sessions",
+                    get(unconfigured_handler).delete(unconfigured_handler),
+                )
                 .route("/v1/me/sessions/{session_id}", delete(unconfigured_handler))
                 .route("/v1/groups", post(unconfigured_handler))
                 .route(

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -226,6 +226,7 @@ impl Modify for SecurityAddon {
         super::me::list_my_doc_page_mentions,
         super::me::list_my_sessions,
         super::me::revoke_my_session,
+        super::me::revoke_all_my_sessions,
     ),
     components(schemas(
         MeResponse,

--- a/plans/0328-gar-869-revoke-all-sessions.md
+++ b/plans/0328-gar-869-revoke-all-sessions.md
@@ -1,0 +1,120 @@
+# Plan 0328 — GAR-869: DELETE /v1/me/sessions — revoke all active sessions
+
+> **Status:** In Progress
+> **Linear:** [GAR-869](https://linear.app/chatgpt25/issue/GAR-869)
+> **Branch:** `routine/202606130618-revoke-all-sessions`
+> **Parent plan:** 0327
+
+## Goal
+
+Add `DELETE /v1/me/sessions` — atomically revoke all of the caller's active
+sessions ("sign out from all devices"). Natural companion to plan 0327 / GAR-866
+which added list + single-revoke.
+
+## Architecture
+
+Thin handler in `crates/garraia-gateway/src/rest_v1/me.rs`:
+
+1. `Principal` extractor (no `X-Group-Id` — sessions are user-scoped).
+2. SET LOCAL `app.current_user_id` and `app.current_group_id` (nil-uuid for
+   group) for FORCE RLS (`sessions_owner_only` migration 007).
+3. `UPDATE sessions SET revoked_at = now() WHERE user_id = $1
+    AND revoked_at IS NULL AND expires_at > now()` — bulk revoke.
+4. Return 204 (no body). `rows_affected` tracked for audit metadata.
+5. Emit `SessionsAllRevoked` audit event with `{count: N}` metadata.
+
+New audit action `SessionsAllRevoked` added to `WorkspaceAuditAction` in
+`garraia-auth` alongside the existing `SessionRevoked`.
+
+## Tech stack
+
+Rust (Axum 0.8), sqlx (Postgres), utoipa (OpenAPI), `garraia_auth::Principal`.
+
+## Design invariants
+
+- NO `unwrap()` outside tests.
+- NO SQL string concat — raw string query with positional `$N` params.
+- SET LOCAL both `app.current_user_id` AND `app.current_group_id` before SQL.
+- `group_id` for `audit_workspace` → nil-uuid (sessions are user-scoped; passes
+  `audit_events_group_or_self` WITH CHECK via branch 1 with nil-uuid SET LOCAL).
+- All sessions revoked atomically in one UPDATE statement (no race between
+  listing and revoking).
+- No audit event if `rows_affected == 0` (nothing to record).
+- `refresh_token_hash` never appears in any response.
+
+## Validações pré-plano
+
+- `sessions_owner_only` FORCE RLS (migration 007) ensures cross-user isolation.
+- `SessionRevoked` in `audit_workspace.rs` at line ~692 — add `SessionsAllRevoked`
+  alongside it.
+- Route `/v1/me/sessions` already registered with `get(me::list_my_sessions)` —
+  add `.delete(me::revoke_all_my_sessions)` chain.
+- openapi.rs already has `super::me::list_my_sessions` at line 227 — add
+  `super::me::revoke_all_my_sessions` below it.
+
+## Out of scope
+
+- Revoking only sessions older than a given date (deferred).
+- Selective revoke-except-current (JWT access tokens have no session ID; cannot
+  distinguish current session without adding jti claim — deferred to ADR).
+- Invalidating in-flight access tokens (stateless JWT; they expire naturally in 15min).
+
+## Rollback
+
+Revert the PR. No migration to undo.
+
+## §12 Open questions
+
+None — acceptance criteria fully specified.
+
+## File structure
+
+```
+crates/garraia-auth/src/audit_workspace.rs   ← add SessionsAllRevoked variant + as_str arm + 2 tests
+crates/garraia-gateway/src/rest_v1/me.rs     ← new revoke_all_my_sessions handler + 6 unit tests
+crates/garraia-gateway/src/rest_v1/mod.rs    ← .delete(me::revoke_all_my_sessions) in all 3 branches
+crates/garraia-gateway/src/rest_v1/openapi.rs ← add super::me::revoke_all_my_sessions
+plans/0328-gar-869-revoke-all-sessions.md    ← this file
+plans/README.md                              ← row 0328 added
+```
+
+## M1 Tasks
+
+- [x] T1: Write plan + create Linear issue GAR-869
+- [ ] T2: Add `SessionsAllRevoked` to `audit_workspace.rs` (variant + as_str + 2 tests)
+- [ ] T3: Implement `revoke_all_my_sessions` handler in `me.rs` + 6 unit tests
+- [ ] T4: Wire route in `mod.rs` (all 3 branches)
+- [ ] T5: Register in `openapi.rs`
+- [ ] T6: Commit + push + open PR
+- [ ] T7: Wait for CI green; fix any failures
+- [ ] T8: Squash-merge; mark GAR-869 Done
+- [ ] T9: Update ROADMAP §3.4 me/* + plans/README.md row 0328
+
+## Risk register
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| Conflict with revoke_my_session route | Low | Different route path — `/v1/me/sessions` vs `/{session_id}` |
+| Audit `nil_uuid` failing WITH CHECK | Low | `SessionRevoked` already uses nil-uuid; same pattern |
+| Large batch revoke performance | Very low | Single UPDATE, sessions table is small per user |
+
+## Acceptance criteria
+
+1. `DELETE /v1/me/sessions` → 204; all active caller sessions have `revoked_at` set.
+2. No `refresh_token_hash` in any response.
+3. `SessionsAllRevoked` audit event emitted with `count` metadata; 0-row case emits nothing.
+4. Cross-user isolation: FORCE RLS ensures only caller's sessions affected.
+5. Missing `X-Group-Id` → still works (user-scoped endpoint).
+6. No JWT → 401.
+7. `cargo clippy --workspace` green. 6 unit tests pass in me.rs + 2 in audit_workspace.rs.
+8. Route wired in all 3 mod.rs branches; OpenAPI path registered.
+
+## Cross-references
+
+- plan 0327 / GAR-866 — GET /v1/me/sessions + DELETE /v1/me/sessions/{session_id}
+- audit_workspace.rs line ~692 — SessionRevoked (parallel pattern)
+- sessions_owner_only FORCE RLS — migration 007
+
+## Estimativa
+
+0.5h. Handler ~40 LOC, tests ~80 LOC, routing ~6 LOC, audit_workspace ~15 LOC.

--- a/plans/README.md
+++ b/plans/README.md
@@ -336,3 +336,4 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0325 | [GAR-864 — GET /v1/chats/{chat_id}/members/{user_id} — fetch single chat member](0325-gar-864-get-chat-member.md) | [GAR-864](https://linear.app/chatgpt25/issue/GAR-864) | ✅ Merged 2026-06-12 via PR #738 (`1d3142f`) |
 | 0326 | [GAR-867 — Health run 124 (2026-06-13 ~00:45 ET): all surfaces clean, priority (i)](0326-gar-867-health-run-124.md) | [GAR-867](https://linear.app/chatgpt25/issue/GAR-867) | ✅ Merged 2026-06-13 via PR #744 (`76d6808`) |
 | 0327 | [GAR-866 — GET /v1/me/sessions + DELETE /v1/me/sessions/{session_id} — list and revoke active sessions](0327-gar-866-me-sessions.md) | [GAR-866](https://linear.app/chatgpt25/issue/GAR-866) | In Progress |
+| 0328 | [GAR-869 — DELETE /v1/me/sessions — revoke all active sessions ("sign out from all devices")](0328-gar-869-revoke-all-sessions.md) | [GAR-869](https://linear.app/chatgpt25/issue/GAR-869) | In Progress |


### PR DESCRIPTION
## Summary

- Adds `DELETE /v1/me/sessions` — atomically revokes all of the caller's active sessions ("sign out from all devices"), companion to GAR-866 (#742).
- New `SessionsAllRevoked` variant in `WorkspaceAuditAction` (wire: `"session.all_revoked"`); audit only emitted when `rows_affected > 0`.
- Single atomic `UPDATE sessions SET revoked_at = now() WHERE user_id = $1 AND revoked_at IS NULL AND expires_at > now()` — no race conditions.
- Route wired in all 3 `mod.rs` branches (full-auth, auth-stub, no-auth); `revoke_all_my_sessions` registered in `openapi.rs`.
- Returns 204 (no body). `refresh_token_hash` never appears in any response.

## Design invariants

- `SET LOCAL app.current_user_id` **and** `app.current_group_id` (nil-uuid) before any SQL — satisfies `sessions_owner_only` FORCE RLS (migration 007).
- `group_id` = nil-uuid: user-scoped endpoint; passes `audit_events_group_or_self` WITH CHECK via branch 1.
- No `unwrap()` outside tests; no SQL string concat.

## Test plan

- [ ] `cargo test -p garraia-auth` — 2 new tests: `SessionsAllRevoked.as_str()` + distinct string uniqueness.
- [ ] `cargo test -p garraia-gateway` — 6 new unit tests: audit action wire form, distinct-from-single, count metadata JSON, zero-count metadata, nil-group UUID, resource type.
- [ ] `cargo clippy --workspace` green.
- [ ] CI all checks green.
- [ ] Manual: `DELETE /v1/me/sessions` → 204; sessions table shows `revoked_at` set for all caller sessions.
- [ ] Cross-user isolation: only caller's sessions affected (FORCE RLS enforced).

## Linear

[GAR-869](https://linear.app/chatgpt25/issue/GAR-869) · plan 0328

https://claude.ai/code/session_01Bqxzh76tBr8GXgjNQa4PMP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bqxzh76tBr8GXgjNQa4PMP)_