### PR TITLE
feat(me): GAR-881 — GET /v1/me/audit — personal audit trail

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -633,6 +633,7 @@ Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
 - [x] `DELETE /v1/me/api-keys/{key_id}` — soft-revoke (`revoked_at = now()`), idempotent 204; `ApiKeyRevoked` audit — plan 0331 / [GAR-871](https://linear.app/chatgpt25/issue/GAR-871) ✅
 - [x] `PATCH /v1/me/api-keys/{key_id}` — update label and/or scopes of an active API key; 409 if revoked; `ApiKeyUpdated` audit — plan 0334 / [GAR-874](https://linear.app/chatgpt25/issue/GAR-874) ✅
 - [x] `PATCH /v1/me/password` — change own password: verify current + Argon2id re-hash via `LoginPool` BYPASSRLS; dual-verify PBKDF2 legacy; anti-enumeration 403; `PasswordChanged` audit — plan 0335 / [GAR-876](https://linear.app/chatgpt25/issue/GAR-876) ✅
+- [x] `GET /v1/me/audit` — cursor-paginated personal audit trail (login, logout, signup, password.changed, api_key.*, session.* events); keyset `(created_at DESC, id DESC)`; `action` filter; no PII fields — plan 0340 / [GAR-881](https://linear.app/chatgpt25/issue/GAR-881) ✅
 
 **Chats**
 

--- a/crates/garraia-gateway/src/rest_v1/me.rs
+++ b/crates/garraia-gateway/src/rest_v1/me.rs
@@ -3793,7 +3793,10 @@ pub async fn list_my_audit(
         None
     };
 
-    Ok(Json(MyAuditResponse { events, next_cursor }))
+    Ok(Json(MyAuditResponse {
+        events,
+        next_cursor,
+    }))
 }
 
 #[cfg(test)]
@@ -5565,7 +5568,10 @@ mod tests {
         assert_eq!(v["id"], "00000000-0000-0000-0000-000000000000");
         assert_eq!(v["action"], "password.changed");
         assert_eq!(v["resource_type"], "user_identities");
-        assert!(v["resource_id"].is_null(), "absent resource_id must be null");
+        assert!(
+            v["resource_id"].is_null(),
+            "absent resource_id must be null"
+        );
     }
 
     #[test]

--- a/crates/garraia-gateway/src/rest_v1/me.rs
+++ b/crates/garraia-gateway/src/rest_v1/me.rs
@@ -59,6 +59,11 @@
 //! `PATCH /v1/me/password` — change own password: verify current, re-hash with
 //! Argon2id (plan 0335 / GAR-876). Uses `login_pool` BYPASSRLS for
 //! `user_identities` — NEVER `app_pool` (CLAUDE.md Rule 12).
+//!
+//! `GET /v1/me/audit` — cursor-paginated personal audit trail showing the
+//! caller's own user-scoped events (login, logout, password.changed, api_key.*,
+//! session.*). No `X-Group-Id` required. Events filtered to
+//! `actor_user_id = caller AND group_id = nil-uuid` (plan 0340 / GAR-881).
 
 use argon2::PasswordHasher;
 use axum::Json;
@@ -3594,6 +3599,203 @@ pub async fn patch_my_password(
     Ok(StatusCode::NO_CONTENT)
 }
 
+// ─── GET /v1/me/audit (plan 0340 / GAR-881) ──────────────────────────────────
+
+/// Query parameters for `GET /v1/me/audit`.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ListMyAuditQuery {
+    /// Keyset cursor — UUID of the last audit event received. Omit for the
+    /// first page.
+    pub cursor: Option<Uuid>,
+    /// Page size. Default 50, max 100.
+    pub limit: Option<u32>,
+    /// Optional filter by action string (e.g. `password.changed`). Must be
+    /// non-empty if provided.
+    pub action: Option<String>,
+}
+
+/// One personal audit event returned by `GET /v1/me/audit`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct PersonalAuditEventSummary {
+    pub id: Uuid,
+    pub action: String,
+    pub resource_type: String,
+    pub resource_id: Option<String>,
+    pub metadata: serde_json::Value,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Response body for `GET /v1/me/audit`.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct MyAuditResponse {
+    pub events: Vec<PersonalAuditEventSummary>,
+    /// Opaque cursor for the next page. `None` when end of list is reached.
+    pub next_cursor: Option<Uuid>,
+}
+
+/// `GET /v1/me/audit` — cursor-paginated personal audit trail.
+///
+/// Returns user-scoped audit events (login, logout, password changes, API key
+/// and session management) for the authenticated caller. Only events with
+/// `group_id = nil-uuid` are returned — group-scoped events require
+/// `GET /v1/groups/{group_id}/audit` with `ExportGroup` permission.
+///
+/// No `X-Group-Id` header is required.
+///
+/// ## Error matrix
+///
+/// | Condition                | Status |
+/// |--------------------------|--------|
+/// | Missing/invalid JWT      | 401    |
+/// | Empty `action` filter    | 400    |
+/// | Happy path               | 200    |
+#[utoipa::path(
+    get,
+    path = "/v1/me/audit",
+    params(ListMyAuditQuery),
+    responses(
+        (status = 200, description = "Personal audit events, newest first.", body = MyAuditResponse),
+        (status = 400, description = "Invalid query parameter.", body = super::problem::ProblemDetails),
+        (status = 401, description = "Missing or invalid JWT.", body = super::problem::ProblemDetails),
+    ),
+    security(("bearer" = [])),
+    tag = "me",
+)]
+pub async fn list_my_audit(
+    State(state): State<RestV1FullState>,
+    principal: Principal,
+    Query(params): Query<ListMyAuditQuery>,
+) -> Result<Json<MyAuditResponse>, RestError> {
+    if params.action.as_deref().is_some_and(str::is_empty) {
+        return Err(RestError::BadRequest("action must not be empty".into()));
+    }
+
+    let effective_limit = params.limit.unwrap_or(50).clamp(1, 100);
+    let fetch_limit = (effective_limit as i64) + 1;
+    let nil_uuid = Uuid::nil();
+
+    let pool = state.app_pool.pool_for_handlers();
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+        .bind(principal.user_id.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    sqlx::query("SELECT set_config('app.current_group_id', $1, true)")
+        .bind(nil_uuid.to_string())
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    type AuditRow = (
+        Uuid,
+        String,
+        String,
+        Option<String>,
+        serde_json::Value,
+        DateTime<Utc>,
+    );
+
+    let rows: Vec<AuditRow> = match (params.cursor, &params.action) {
+        (None, None) => sqlx::query_as(
+            "SELECT id, action, resource_type, resource_id, metadata, created_at \
+             FROM audit_events \
+             WHERE actor_user_id = $1 AND group_id = $2 \
+             ORDER BY created_at DESC, id DESC LIMIT $3",
+        )
+        .bind(principal.user_id)
+        .bind(nil_uuid)
+        .bind(fetch_limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?,
+
+        (None, Some(action)) => sqlx::query_as(
+            "SELECT id, action, resource_type, resource_id, metadata, created_at \
+             FROM audit_events \
+             WHERE actor_user_id = $1 AND group_id = $2 AND action = $3 \
+             ORDER BY created_at DESC, id DESC LIMIT $4",
+        )
+        .bind(principal.user_id)
+        .bind(nil_uuid)
+        .bind(action.clone())
+        .bind(fetch_limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?,
+
+        (Some(cursor_id), None) => sqlx::query_as(
+            "SELECT id, action, resource_type, resource_id, metadata, created_at \
+             FROM audit_events \
+             WHERE actor_user_id = $1 AND group_id = $2 \
+               AND (created_at, id) < \
+                   (SELECT created_at, id FROM audit_events \
+                    WHERE id = $3 AND actor_user_id = $1 AND group_id = $2) \
+             ORDER BY created_at DESC, id DESC LIMIT $4",
+        )
+        .bind(principal.user_id)
+        .bind(nil_uuid)
+        .bind(cursor_id)
+        .bind(fetch_limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?,
+
+        (Some(cursor_id), Some(action)) => sqlx::query_as(
+            "SELECT id, action, resource_type, resource_id, metadata, created_at \
+             FROM audit_events \
+             WHERE actor_user_id = $1 AND group_id = $2 AND action = $3 \
+               AND (created_at, id) < \
+                   (SELECT created_at, id FROM audit_events \
+                    WHERE id = $4 AND actor_user_id = $1 AND group_id = $2) \
+             ORDER BY created_at DESC, id DESC LIMIT $5",
+        )
+        .bind(principal.user_id)
+        .bind(nil_uuid)
+        .bind(action.clone())
+        .bind(cursor_id)
+        .bind(fetch_limit)
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?,
+    };
+
+    tx.commit()
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
+
+    let has_more = rows.len() as i64 > (effective_limit as i64);
+    let events: Vec<PersonalAuditEventSummary> = rows
+        .into_iter()
+        .take(effective_limit as usize)
+        .map(
+            |(id, action, resource_type, resource_id, metadata, created_at)| {
+                PersonalAuditEventSummary {
+                    id,
+                    action,
+                    resource_type,
+                    resource_id,
+                    metadata,
+                    created_at,
+                }
+            },
+        )
+        .collect();
+
+    let next_cursor = if has_more {
+        events.last().map(|e| e.id)
+    } else {
+        None
+    };
+
+    Ok(Json(MyAuditResponse { events, next_cursor }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -5312,5 +5514,74 @@ mod tests {
             "00000000-0000-0000-0000-000000000000",
             "group_id must be nil-uuid for user-scoped password audit event"
         );
+    }
+
+    // ── GET /v1/me/audit unit tests ───────────────────────────────────────────
+
+    #[test]
+    fn list_my_audit_empty_action_rejected() {
+        let q = ListMyAuditQuery {
+            cursor: None,
+            limit: None,
+            action: Some(String::new()),
+        };
+        assert!(
+            q.action.as_deref().is_some_and(str::is_empty),
+            "empty action string must trigger 400"
+        );
+    }
+
+    #[test]
+    fn list_my_audit_none_action_is_valid() {
+        let q = ListMyAuditQuery {
+            cursor: None,
+            limit: None,
+            action: None,
+        };
+        assert!(q.action.is_none());
+    }
+
+    #[test]
+    fn list_my_audit_nonempty_action_is_valid() {
+        let q = ListMyAuditQuery {
+            cursor: None,
+            limit: None,
+            action: Some("password.changed".to_string()),
+        };
+        assert!(!q.action.as_deref().unwrap_or("").is_empty());
+    }
+
+    #[test]
+    fn personal_audit_event_summary_serializes_nil_uuid() {
+        let event = PersonalAuditEventSummary {
+            id: Uuid::nil(),
+            action: "password.changed".to_string(),
+            resource_type: "user_identities".to_string(),
+            resource_id: None,
+            metadata: serde_json::json!({}),
+            created_at: DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
+        };
+        let v = serde_json::to_value(&event).unwrap();
+        assert_eq!(v["id"], "00000000-0000-0000-0000-000000000000");
+        assert_eq!(v["action"], "password.changed");
+        assert_eq!(v["resource_type"], "user_identities");
+        assert!(v["resource_id"].is_null(), "absent resource_id must be null");
+    }
+
+    #[test]
+    fn my_audit_response_empty_list_has_no_cursor() {
+        let resp = MyAuditResponse {
+            events: vec![],
+            next_cursor: None,
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert!(v["next_cursor"].is_null());
+        assert!(v["events"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn list_my_audit_limit_clamps_to_100() {
+        let clamped = 200u32.clamp(1, 100);
+        assert_eq!(clamped, 100, "limit must clamp to 100 max");
     }
 }

--- a/crates/garraia-gateway/src/rest_v1/mod.rs
+++ b/crates/garraia-gateway/src/rest_v1/mod.rs
@@ -376,6 +376,8 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                         .delete(me::revoke_my_api_key),
                 )
                 .route("/v1/me/password", patch(me::patch_my_password))
+                // Plan 0340 (GAR-881) — GET /v1/me/audit personal audit trail.
+                .route("/v1/me/audit", get(me::list_my_audit))
                 // Plan 0105 (GAR-580) — groups slice 3: list user's groups.
                 .route(
                     "/v1/groups",
@@ -749,6 +751,9 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                         .patch(unconfigured_handler)
                         .delete(unconfigured_handler),
                 )
+                .route("/v1/me/password", patch(unconfigured_handler))
+                // Plan 0340 (GAR-881) — GET /v1/me/audit stub.
+                .route("/v1/me/audit", get(unconfigured_handler))
                 .route("/v1/groups", post(unconfigured_handler))
                 .route(
                     "/v1/groups/{id}",
@@ -1122,6 +1127,8 @@ pub fn router(app_state: Arc<AppState>) -> Router {
                         .delete(unconfigured_handler),
                 )
                 .route("/v1/me/password", patch(unconfigured_handler))
+                // Plan 0340 (GAR-881) — GET /v1/me/audit stub.
+                .route("/v1/me/audit", get(unconfigured_handler))
                 .route("/v1/groups", post(unconfigured_handler))
                 .route(
                     "/v1/groups/{id}",

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -42,11 +42,11 @@ use super::me::{
     AcceptMyInviteResponse, ApiKeySummary, ChatMembershipSummary, CreateApiKeyRequest,
     CreateApiKeyResponse, DocPageMentionInboxSummary, DocPageMentionsInboxResponse, MeResponse,
     MentionSummary, MentionsListResponse, MyApiKeysResponse, MyAuditResponse,
-    MyChatsMembershipResponse, MyDocPageSummary, MyDocPagesResponse, MyFileSummary, MyFilesResponse,
-    MyInvitesResponse, MyMemoryResponse, MyMemorySummary, MyReactionSummary, MyReactionsResponse,
-    MySessionsResponse, MyThreadSummary, MyThreadsResponse, PatchMeRequest, PatchMeResponse,
-    PatchMyApiKeyRequest, PendingInviteSummary, PersonalAuditEventSummary, SessionSummary,
-    TaskAssignmentSummary, TasksListResponse,
+    MyChatsMembershipResponse, MyDocPageSummary, MyDocPagesResponse, MyFileSummary,
+    MyFilesResponse, MyInvitesResponse, MyMemoryResponse, MyMemorySummary, MyReactionSummary,
+    MyReactionsResponse, MySessionsResponse, MyThreadSummary, MyThreadsResponse, PatchMeRequest,
+    PatchMeResponse, PatchMyApiKeyRequest, PendingInviteSummary, PersonalAuditEventSummary,
+    SessionSummary, TaskAssignmentSummary, TasksListResponse,
 };
 use super::memory::{
     CreateMemoryRequest, ListMemoryResponse, MemoryItemResponse, MemoryItemSummary,

--- a/crates/garraia-gateway/src/rest_v1/openapi.rs
+++ b/crates/garraia-gateway/src/rest_v1/openapi.rs
@@ -41,11 +41,12 @@ use super::invites::AcceptInviteResponse;
 use super::me::{
     AcceptMyInviteResponse, ApiKeySummary, ChatMembershipSummary, CreateApiKeyRequest,
     CreateApiKeyResponse, DocPageMentionInboxSummary, DocPageMentionsInboxResponse, MeResponse,
-    MentionSummary, MentionsListResponse, MyApiKeysResponse, MyChatsMembershipResponse,
-    MyDocPageSummary, MyDocPagesResponse, MyFileSummary, MyFilesResponse, MyInvitesResponse,
-    MyMemoryResponse, MyMemorySummary, MyReactionSummary, MyReactionsResponse, MySessionsResponse,
-    MyThreadSummary, MyThreadsResponse, PatchMeRequest, PatchMeResponse, PatchMyApiKeyRequest,
-    PendingInviteSummary, SessionSummary, TaskAssignmentSummary, TasksListResponse,
+    MentionSummary, MentionsListResponse, MyApiKeysResponse, MyAuditResponse,
+    MyChatsMembershipResponse, MyDocPageSummary, MyDocPagesResponse, MyFileSummary, MyFilesResponse,
+    MyInvitesResponse, MyMemoryResponse, MyMemorySummary, MyReactionSummary, MyReactionsResponse,
+    MySessionsResponse, MyThreadSummary, MyThreadsResponse, PatchMeRequest, PatchMeResponse,
+    PatchMyApiKeyRequest, PendingInviteSummary, PersonalAuditEventSummary, SessionSummary,
+    TaskAssignmentSummary, TasksListResponse,
 };
 use super::memory::{
     CreateMemoryRequest, ListMemoryResponse, MemoryItemResponse, MemoryItemSummary,
@@ -232,6 +233,7 @@ impl Modify for SecurityAddon {
         super::me::get_my_api_key,
         super::me::patch_my_api_key,
         super::me::revoke_my_api_key,
+        super::me::list_my_audit,
     ),
     components(schemas(
         MeResponse,
@@ -357,6 +359,8 @@ impl Modify for SecurityAddon {
         ApiKeySummary,
         MyApiKeysResponse,
         PatchMyApiKeyRequest,
+        PersonalAuditEventSummary,
+        MyAuditResponse,
     )),
     modifiers(&SecurityAddon)
 )]

--- a/plans/0340-gar-881-me-audit.md
+++ b/plans/0340-gar-881-me-audit.md
@@ -1,0 +1,125 @@
+# Plan 0340 — GAR-881 — GET /v1/me/audit — personal audit trail
+
+**Status:** In Progress  
+**Issue:** [GAR-881](https://linear.app/chatgpt25/issue/GAR-881)  
+**Branch:** `routine/202506141215-me-audit`  
+**Estimate:** 2h
+
+---
+
+## Goal
+
+Add `GET /v1/me/audit` — cursor-paginated personal audit log exposing the
+caller's own user-scoped audit events: login, logout, signup, password.changed,
+api_key.{created,revoked,updated}, session.{revoked,all_revoked}.
+
+This completes the self-service security visibility story started in plan 0327
+(sessions) → 0331 (API keys) → 0335 (password change). Users can now
+review their own security events without contacting an admin.
+
+---
+
+## Architecture
+
+- No new migration — `audit_events` table (migration 002) already exists with
+  index `audit_events_actor_created_idx ON audit_events(actor_user_id, created_at DESC)`.
+- Query filter: `actor_user_id = $caller AND group_id = $nil_uuid`. Personal
+  events are stored with `group_id = '00000000-0000-0000-0000-000000000000'`
+  (nil UUID) by convention (see plans 0327, 0331, 0335).
+- RLS: SET LOCAL `app.current_user_id = $caller`, `app.current_group_id = $nil_uuid`.
+  Branch 2 of `audit_events_group_or_self` policy (migration 013) allows the
+  actor to see their own events. Explicit `AND group_id = nil` in WHERE gives
+  defense-in-depth — no cross-group leak even if RLS were misconfigured.
+- Cursor pagination: keyset on `(created_at DESC, id DESC)`, identical to the
+  group audit endpoint (audit.rs, plan 0070).
+- No `X-Group-Id` header required — user-scoped endpoint.
+
+---
+
+## Tech stack
+
+- Rust, Axum 0.8, sqlx (QueryBuilder), utoipa
+- File: `crates/garraia-gateway/src/rest_v1/me.rs` (new handler + DTOs)
+- Files touched: `mod.rs` (route wiring), `openapi.rs` (schema registration)
+
+---
+
+## Design invariants
+
+- **No PII in response**: `actor_label` NOT returned (caller already knows
+  their name); `ip` NOT returned (could enable self-correlation attacks). Only
+  `id`, `action`, `resource_type`, `resource_id`, `metadata`, `created_at`.
+- **No group events leak**: explicit `AND group_id = $nil_uuid` in SELECT.
+- **No audit event emitted for reads** (invariant: no circular noise).
+- Consistent with audit.rs: same query builder pattern, same cursor shape.
+
+---
+
+## Out of scope
+
+- Cross-group audit (needs admin/BYPASSRLS role — GAR-391d, Fase 3.4).
+- `ip` field (browser clients can retrieve their IP from other means).
+- `action` filter is supported; `resource_type` filter is not (personal events
+  have a small known set of actions, filtering by type adds little value).
+
+---
+
+## Rollback
+
+Revert the me.rs + mod.rs + openapi.rs changes. No migration to roll back.
+
+---
+
+## File structure
+
+```
+crates/garraia-gateway/src/rest_v1/
+  me.rs          ← add ListMyAuditQuery, PersonalAuditEventSummary,
+                    MyAuditResponse, list_my_audit handler + 6 tests
+  mod.rs         ← wire route in all 3 branches
+  openapi.rs     ← register handler + schemas
+ROADMAP.md       ← mark GET /v1/me/audit ✅ in §3.4
+plans/README.md  ← add plan row
+```
+
+---
+
+## M1 tasks
+
+- [ ] T1 — DTOs + handler in me.rs
+- [ ] T2 — Route wiring in mod.rs (all 3 branches)
+- [ ] T3 — OpenAPI registration
+- [ ] T4 — ROADMAP + plans/README.md update
+- [ ] T5 — `cargo clippy` clean + `cargo test -p garraia-gateway`
+
+---
+
+## Acceptance criteria
+
+- `GET /v1/me/audit` returns 200 with `events` array and optional `next_cursor`.
+- Events are filtered to `actor_user_id = caller` and `group_id = nil-uuid`.
+- Cursor pagination works: second request with `cursor=<id>` returns next page.
+- `action` query param filters by action string.
+- 401 when JWT missing/invalid.
+- `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` clean.
+- CI ≥20/20 green.
+
+---
+
+## Risk register
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| RLS branch 2 allows cross-group leak | Low | Explicit `AND group_id = nil` in WHERE; defense-in-depth |
+| `metadata` contains PII | Low | Existing handlers emit only `name_len`, not raw names |
+
+---
+
+## Cross-references
+
+- Plan 0070 / GAR-522 — `GET /v1/groups/{group_id}/audit` (group audit)
+- Plan 0327 / GAR-866 — `GET /v1/me/sessions`
+- Plan 0331 / GAR-871 — `POST/GET /v1/me/api-keys`
+- Plan 0335 / GAR-876 — `PATCH /v1/me/password`
+- Migration 002 — `audit_events` table + `actor_created_idx`
+- Migration 013 — `audit_events_group_or_self` WITH CHECK explicit

--- a/plans/README.md
+++ b/plans/README.md
@@ -348,3 +348,4 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0337 | [GAR-878 — Health run 131 (2026-06-14 ~00:48 ET): all surfaces clean, priority (i)](0337-gar-878-health-run-131.md) | [GAR-878](https://linear.app/chatgpt25/issue/GAR-878) | ✅ Merged 2026-06-14 via PR #760 (`e3044c29`) |
 | 0338 | [GAR-879 — Health run 132 (2026-06-14 ~02:27 ET): all surfaces clean, priority (i)](0338-gar-879-health-run-132.md) | [GAR-879](https://linear.app/chatgpt25/issue/GAR-879) | ✅ Merged 2026-06-14 via PR #763 (`7425541`) |
 | 0339 | [GAR-880 — Health run 133 (2026-06-14 ~08:45 ET): all surfaces clean, priority (i)](0339-gar-880-health-run-133.md) | [GAR-880](https://linear.app/chatgpt25/issue/GAR-880) | ✅ Merged 2026-06-14 via PR #764 (`0cba31c`) |
+| 0340 | [GAR-881 — GET /v1/me/audit — personal audit trail](0340-gar-881-me-audit.md) | [GAR-881](https://linear.app/chatgpt25/issue/GAR-881) | 🔄 In Progress |


### PR DESCRIPTION
## Summary

- Adds `GET /v1/me/audit` — cursor-paginated personal audit trail for the authenticated caller
- Filters to `actor_user_id = caller` AND `group_id = nil-uuid` (defense-in-depth: explicit WHERE clause + SET LOCAL RLS vars)
- Returns only `id`, `action`, `resource_type`, `resource_id`, `metadata`, `created_at` — no PII (`ip`, `actor_label` deliberately excluded)
- Optional `action` query param filter; 400 on empty-string value
- Keyset pagination on `(created_at DESC, id DESC)` with `cursor` + `limit` (default 50, max 100)
- 4-branch static SQL pattern (cursor × action) — consistent with other me.rs handlers
- Route wired in all 3 `mod.rs` branches (full-auth, auth-stub, no-auth stub)
- Also fixes missing `/v1/me/password` stub in auth-stub branch (comment existed, route was absent)
- Registered in `openapi.rs` (handler path + `PersonalAuditEventSummary` + `MyAuditResponse` schemas)
- No new migration — uses existing `audit_events` table + `audit_events_actor_created_idx` (migration 002)

## Test plan

- [x] `cargo check -p garraia-gateway --features test-helpers` — clean
- [x] `cargo clippy --workspace --tests --exclude garraia-desktop --features garraia-gateway/test-helpers --no-deps -- -D warnings` — clean
- [x] `cargo test -p garraia-gateway --features test-helpers --lib` — 799/799 passed (includes 6 new unit tests)
- [ ] CI: Format, Clippy, Test×3, Build, MSRV, cargo-deny, Security Audit, Coverage, Analyze, Playwright, E2E, Quality Ratchet, CodeQL ≥ 20/20

## References

- Plan [0340](https://github.com/michelbr84/GarraRUST/blob/routine/202506141215-me-audit/plans/0340-gar-881-me-audit.md) / [GAR-881](https://linear.app/chatgpt25/issue/GAR-881)
- Cross-ref: plan 0327 (sessions), 0331 (API keys), 0335 (password change), 0070 (group audit)

https://claude.ai/code/session_01L3dnnfb2N4jPGXqcbmR1f1

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3dnnfb2N4jPGXqcbmR1f1)_