### PR TITLE
fix(cli,gateway,config): onboarding do install.sh entrega provider ativo (v0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,101 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-16
+
+### Onboarding: `install.sh` → `garraia init` → `garraia start` now actually works
+
+The path the website documents was broken by construction on any fresh machine.
+`garraia init` offered "Store in encrypted vault (**recommended**)" as the
+default, encrypted the API key into `credentials/vault.json`, and left
+`llm.<name>.api_key` as `null`. `install.sh` then ran `exec garraia start` in the
+same shell, with no `GARRAIA_VAULT_PASSPHRASE` — so `try_vault_get` could not
+open the vault, no key resolved, and the gateway came up with
+`0 active / 1 configured` and `skipping openrouter provider main: no API key`.
+The key was on disk, encrypted, and unreadable by the server that needed it.
+
+#### Fixed
+- **Wizard defaults to `config.yml`** (`wizard/mod.rs`) — the storage prompt now
+  offers config first and defaults to it; the vault option's label states that
+  it requires `GARRAIA_VAULT_PASSPHRASE` on *every* start instead of calling
+  itself "recommended". When the vault is chosen, the passphrase reminder is
+  printed as a block instead of a single line that scrolled away unseen. The
+  Telegram bot token had the identical defect and got the identical fix.
+- **`garraia init` can repair a broken config** (`wizard/config_writer.rs`) —
+  `merge_update` was additive-only, so re-running the wizard over a config that
+  already had a keyless `llm.main` *added* `llm.openrouter` and left `main`
+  broken. A freshly-supplied OpenRouter key is now backfilled into pre-existing
+  `openrouter` entries that have no key. A key the operator already set is never
+  overwritten, and the local-Ollama placeholder is never leaked into a real
+  `openai` entry.
+- **`.env` was loaded after the providers were built** (`server.rs`,
+  `bootstrap/channels.rs`) — the only `dotenvy::dotenv()` in the gateway ran
+  inside `build_channels`, ~20 lines *after* `build_agent_runtime` had already
+  read every provider's API-key env var. Anything embedding `Server` directly got
+  working channels and dead providers. The load moved to the top of
+  `Server::run`.
+- **`POST /api/providers` silently discarded persistence failures**
+  (`router.rs`) — the response was `201 {"status":"ok"}` even when
+  `try_vault_set` no-opped for lack of a passphrase, so a provider added through
+  the web console worked until the next restart and then vanished. The handler
+  now reports `"persisted": bool`, says so in the message, and logs a WARN with
+  the remedy.
+
+#### Changed
+- **`config.yml` is written with mode `0600`** (`garraia_config::harden_secret_file`)
+  — it now carries `llm.*.api_key` by default, and `std::fs::write` alone left it
+  at the umask default (commonly `0644`). Applied by `ConfigLoader::save` and by
+  all three wizard write strategies.
+- **One source of truth for API-key resolution**
+  (`garraia_config::provider_keys`) — the question "does this provider have a
+  usable key?" had three different answers: the boot path walked
+  vault → config → env, `/health` checked config `||` env and ignored the vault,
+  and the admin providers list reported `has_secret` from an AES-GCM SQLite store
+  the boot path never reads. All three now share `resolve_api_key_source` and the
+  `provider_key_env` table, which also replaced fifteen hardcoded
+  `("X_API_KEY", "X_API_KEY")` pairs in `build_agent_runtime` and fourteen more in
+  the provider-activation handler. `/api/providers` gained `key_source` and
+  `has_admin_stored_secret` so the store's own state stays visible.
+- **An empty provider env var now counts as absent.** `OPENROUTER_API_KEY=""`
+  previously registered a provider with an empty credential that failed on the
+  first call with an opaque upstream 401; it now reports the actionable "no API
+  key" warning, consistent with the config tier which already ignored empty
+  strings.
+- **The "no API key" warning names all three remedies** — config, env var, *and*
+  unlocking the vault. It previously omitted the vault, which is precisely where
+  the wizard had put the key.
+- **The startup banner stops overstating readiness** (`banner.rs`) — it printed
+  the configured provider name unconditionally, directly above a log line saying
+  that provider had been skipped. It now marks the state
+  (`main ⚠ no API key`) and adds a `File` row naming the config file actually in
+  force, since `ConfigLoader::load` prefers `config.yml` and silently ignores
+  `config.toml` when both exist.
+- Workspace `version = "0.3.0"` (`Cargo.toml`,
+  `crates/garraia-desktop/src-tauri/Cargo.toml`, `tauri.conf.json`). The previous
+  release left `main` at `0.2.1`, so a binary built from `main` announced itself
+  as the released `v0.2.1` and the two were indistinguishable.
+
+#### Added
+- **`garraia config check` validates `llm:`** (`garraia-config/src/check.rs`) —
+  it had no equivalent of the channel token warning, so the failure that took the
+  whole gateway down was the one thing it would not report. It now emits an
+  **Error** for any provider whose key resolves nowhere (consulting the vault, so
+  it cannot disagree with the boot path), an Error for an unrecognized `provider`
+  type, and a Warning when `llm:` is populated but `agent.default_provider` is
+  unset — which silently disables provider auto-fallback.
+
+#### Documentation
+- `docs/installation.md` told operators to edit `~/.garraia/config.yml` while
+  `ConfigLoader::default_config_dir` prefers `~/.config/garraia` whenever it
+  exists, so readers were editing a file the gateway never read. It now documents
+  the real resolution order, the `config.yml` over `config.toml` precedence, the
+  vault passphrase requirement, and `GARRAIA_CONFIG_DIR` as the supported way to
+  consolidate everything under one directory.
+- `README.md` claimed `install.sh` verifies each binary against a per-asset
+  `<asset>.sha256`; it verifies against the aggregate `SHA256SUMS` (the per-asset
+  form is what `garraia update` uses). The `llm:` example now carries the vault
+  passphrase caveat.
+
 ## [0.2.1] - 2026-05-14
 
 ### Auto-update pipeline — fixes 404 on `garraia update`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,7 +3166,7 @@ dependencies = [
 
 [[package]]
 name = "garraia"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3211,7 +3211,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-agents"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3235,7 +3235,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-auth"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3268,7 +3268,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-channels"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-common"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3307,10 +3307,11 @@ dependencies = [
 
 [[package]]
 name = "garraia-config"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "dirs 6.0.0",
  "garraia-common",
+ "garraia-security",
  "notify",
  "secrecy 0.10.3",
  "serde",
@@ -3325,7 +3326,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-db"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3345,7 +3346,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-desktop"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3361,7 +3362,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-embeddings"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -3375,7 +3376,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-gateway"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3461,7 +3462,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-learning"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "garraia-common",
  "garraia-skills",
@@ -3475,7 +3476,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-media"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3493,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-plugins"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3525,7 +3526,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-security"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "base64 0.22.1",
  "garraia-common",
@@ -3541,7 +3542,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-skills"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "garraia-common",
  "reqwest 0.12.28",
@@ -3553,7 +3554,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-storage"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3580,7 +3581,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-telemetry"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3616,7 +3617,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-voice"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3630,7 +3631,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-workspace"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/michelbr84/GarraRUST"

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Desde plan 0127 (PR-B, 2026-05-14) o instalador encadeia automaticamente:
 
 Em contextos sem TTY real (docker build, CI puro), o instalador imprime os "Next steps" legados e sai com código 0 — nunca trava aguardando input.
 
-> A partir de `v0.2.1` (2026-05-14) — primeira release **não-prerelease** do repo — o script consome `GET /repos/michelbr84/GarraRUST/releases/latest` e verifica cada binário contra seu `<asset>.sha256` correspondente.
+> A partir de `v0.2.1` (2026-05-14) — primeira release **não-prerelease** do repo — o script consome `GET /repos/michelbr84/GarraRUST/releases/latest` e verifica o binário baixado contra o arquivo `SHA256SUMS` da release (um único manifesto para todos os assets, via `sha256sum -c`). O formato `<asset>.sha256` é usado pelo `garraia update`, não pelo `install.sh`.
 > Em ARM, certifique-se de que `uname -m` reporta `aarch64`/`arm64` — os assets `garraia-linux-aarch64` e `garraia-macos-aarch64` são best-effort enquanto o cross-compile de `openssl` para ARM64 estabiliza ([release.yml](.github/workflows/release.yml)).
 
 </details>
@@ -695,6 +695,12 @@ gateway:
   session_tokens_required: false # exige token nas rotas /api/* . Padrão: false
 
 llm:
+  # ATENÇÃO sobre `api_key`: a resolução é vault > config > variável de ambiente.
+  # O tier do vault só funciona quando GARRAIA_VAULT_PASSPHRASE está presente no
+  # ambiente do gateway, a CADA start — sem ela o cofre fica ilegível e o provider
+  # é PULADO no boot (`skipping <tipo> provider <nome>: no API key`). Por isso o
+  # `garraia init` grava a chave no próprio config.yml (criado com modo 0600).
+  # Rode `garraia config check` para confirmar que cada provider resolve.
   claude:
     provider: anthropic
     model: claude-sonnet-4-5-20250929

--- a/crates/garraia-cli/src/banner.rs
+++ b/crates/garraia-cli/src/banner.rs
@@ -56,13 +56,47 @@ pub(crate) fn shorten_path(p: &Path) -> String {
 pub fn print_banner(host: &str, port: u16, config: &AppConfig, config_dir: &Path) {
     let version = env!("CARGO_PKG_VERSION");
 
-    // Gather info
-    let provider = config
+    // Gather info.
+    //
+    // Name the provider *and* say whether it will actually come up. The banner
+    // used to print the configured name unconditionally, so an operator whose
+    // key resolved nowhere saw a confident "Provider   main" immediately above
+    // a boot log line saying that very provider had been skipped.
+    let provider = match config
         .agent
         .default_provider
         .as_deref()
         .or_else(|| config.llm.keys().next().map(|s| s.as_str()))
-        .unwrap_or("none");
+    {
+        None => "none".to_string(),
+        Some(key) => match config.llm.get(key) {
+            None => format!("{key} ⚠ not in llm:"),
+            Some(entry) => {
+                if garraia_config::resolve_provider_key_source(
+                    &entry.provider,
+                    entry.api_key.as_deref(),
+                )
+                .is_resolved()
+                {
+                    key.to_string()
+                } else {
+                    format!("{key} ⚠ no API key")
+                }
+            }
+        },
+    };
+
+    // Which config file is actually in force. `ConfigLoader::load` prefers
+    // `config.yml` and silently ignores `config.toml` when both exist, so
+    // showing only the directory left operators editing a file the gateway
+    // never reads.
+    let config_file = if config_dir.join("config.yml").exists() {
+        "config.yml"
+    } else if config_dir.join("config.toml").exists() {
+        "config.toml"
+    } else {
+        "none (using defaults)"
+    };
 
     let channels = if config.channels.is_empty() {
         "none".to_string()
@@ -139,6 +173,7 @@ pub fn print_banner(host: &str, port: u16, config: &AppConfig, config_dir: &Path
     println!("{}", row("", &format!("MCP         {mcp}")));
     println!("{}", row("  Seu assistente pessoal", ""));
     println!("{}", row("", &format!("Config      {config_display}")));
+    println!("{}", row("", &format!("File        {config_file}")));
     println!("{}", row("", &format!("CWD         {cwd_display}")));
     println!("{}", row("", "Press Ctrl+C to stop"));
     println!("{}", row("", ""));

--- a/crates/garraia-cli/src/wizard/config_writer.rs
+++ b/crates/garraia-cli/src/wizard/config_writer.rs
@@ -8,19 +8,25 @@
 //! * `MergeUpdate` — load existing config, patch only the fields the
 //!   wizard owns:
 //!     - `gateway.host`, `gateway.port` — replaced (wizard owns).
-//!     - `llm.*` — only **adds** missing keys; never replaces an
-//!       existing user-customized provider.
+//!     - `llm.*` — **adds** missing keys; never replaces an existing
+//!       user-customized provider. One exception: when the operator supplies
+//!       a cleartext OpenRouter key, it is backfilled into pre-existing
+//!       `openrouter` entries that have **no** key, so re-running the wizard
+//!       repairs a config left keyless by the old vault-by-default flow. A
+//!       key that is already set is never overwritten.
 //!     - `agent.default_provider` — set only when currently `None`.
 //!     - `agent.fallback_providers` — set only when currently empty.
 //!     - `voice.*` — replaced when the wizard just opted into voice;
 //!       otherwise untouched.
 //!     - `channels.telegram` — only added when missing.
 //!
-//! Secret-redaction invariant: API keys never appear in the YAML written
-//! by this module unless the user chose plaintext storage (option 1 in
-//! the existing vault flow). The vault path is handled by the
-//! orchestrator (`mod.rs`); this module only knows about the cleartext
-//! key when explicitly handed one and writes it to `llm.<name>.api_key`.
+//! Secret invariant: API keys appear in the YAML written by this module only
+//! when the operator chose config storage (`SecretStorage::Config`, the
+//! default since v0.3.0). The vault path is handled by the orchestrator
+//! (`mod.rs`); this module only knows about the cleartext key when explicitly
+//! handed one, and writes it to `llm.<name>.api_key`. Because that makes
+//! `config.yml` credential-bearing, [`write_config`] clamps the file to mode
+//! `0600` via `garraia_config::harden_secret_file` on every strategy.
 
 #![allow(dead_code)] // M1.7 orchestrator wires these in.
 
@@ -214,6 +220,31 @@ fn telegram_channel(tg: &TelegramChoice) -> ChannelConfig {
     }
 }
 
+/// Backfill a freshly-collected cleartext key into pre-existing `llm:` entries
+/// of the same provider type that have no key of their own.
+///
+/// Without this, `merge_update` was purely additive, and re-running
+/// `garraia init` could not repair a broken config. An operator whose config
+/// already had a keyless `llm.main` — exactly what the pre-0.3.0 wizard wrote
+/// when it defaulted to the credential vault — would get a *second* entry
+/// `llm.openrouter` while `llm.main` stayed keyless, and `build_agent_runtime`
+/// kept skipping `main` with "no API key" on every boot.
+///
+/// Only entries whose `api_key` is absent or empty are filled; a key the
+/// operator already set is never touched. Deliberately **not** applied to the
+/// local-Ollama provider, which registers under `provider: "openai"` with a
+/// placeholder key — backfilling that would overwrite a real, intentionally
+/// env-var-backed OpenAI entry with the Ollama placeholder.
+fn backfill_missing_api_key(existing: &mut AppConfig, provider_type: &str, api_key: &str) {
+    for entry in existing.llm.values_mut() {
+        if entry.provider == provider_type
+            && entry.api_key.as_deref().unwrap_or_default().is_empty()
+        {
+            entry.api_key = Some(api_key.to_string());
+        }
+    }
+}
+
 /// Patch `existing` in place with the additive `MergeUpdate` rules.
 /// See module docs for which fields are wizard-owned vs. user-owned.
 pub fn merge_update(existing: &mut AppConfig, outcome: &WizardOutcome) {
@@ -221,6 +252,9 @@ pub fn merge_update(existing: &mut AppConfig, outcome: &WizardOutcome) {
     existing.gateway.port = outcome.port;
 
     if let Some(cloud) = &outcome.openrouter {
+        if let Some(key) = cloud.api_key_plaintext.as_deref() {
+            backfill_missing_api_key(existing, "openrouter", key);
+        }
         existing
             .llm
             .entry(cloud.key.clone())
@@ -311,6 +345,11 @@ pub fn write_config(
                 .with_context(|| format!("write {}", config_path.display()))?;
         }
     }
+    // The wizard now writes `llm.*.api_key` into this file by default, so it
+    // must not be left at the umask default (commonly 0644). Applies to all
+    // three strategies — they converge on the same `config_path`.
+    garraia_config::harden_secret_file(&config_path)
+        .with_context(|| format!("restrict permissions on {}", config_path.display()))?;
     Ok(config_path)
 }
 
@@ -355,6 +394,133 @@ mod tests {
             system_prompt: None,
             telegram: None,
         }
+    }
+
+    /// Same shape as `outcome_cloud_only` but carrying a cleartext key, i.e.
+    /// the operator picked `SecretStorage::Config` (the v0.3.0 default).
+    fn outcome_cloud_with_key(key: &str) -> WizardOutcome {
+        let mut out = outcome_cloud_only();
+        out.openrouter = Some(CloudLlmChoice {
+            key: "openrouter".into(),
+            model: "openrouter/auto".into(),
+            api_key_plaintext: Some(key.into()),
+        });
+        out
+    }
+
+    /// The config the pre-0.3.0 wizard left behind when it defaulted to the
+    /// vault: a structurally perfect provider entry named `main` with no key.
+    fn legacy_keyless_main() -> AppConfig {
+        let mut cfg = AppConfig::default();
+        cfg.llm.insert(
+            "main".into(),
+            LlmProviderConfig {
+                provider: "openrouter".into(),
+                model: Some("openrouter/auto".into()),
+                api_key: None,
+                base_url: Some("https://openrouter.ai/api/v1".into()),
+                extra: Default::default(),
+            },
+        );
+        cfg
+    }
+
+    #[test]
+    fn config_storage_writes_api_key_into_llm_entry() {
+        let dir = tempdir().unwrap();
+        let out = outcome_cloud_with_key("test-key-abc");
+        let path = write_config(dir.path(), &out, ExistingConfigStrategy::FirstWrite).unwrap();
+        let cfg: AppConfig = serde_yaml::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+        assert_eq!(
+            cfg.llm.get("openrouter").unwrap().api_key.as_deref(),
+            Some("test-key-abc"),
+            "a key collected under SecretStorage::Config must reach llm.*.api_key"
+        );
+    }
+
+    /// The regression that made `garraia init` unable to repair itself: a second
+    /// run added `llm.openrouter` and left `llm.main` keyless, so the gateway
+    /// kept logging `skipping openrouter provider main: no API key`.
+    #[test]
+    fn merge_update_backfills_key_into_existing_keyless_entry() {
+        let mut existing = legacy_keyless_main();
+        merge_update(&mut existing, &outcome_cloud_with_key("recovered-key"));
+
+        assert_eq!(
+            existing.llm.get("main").unwrap().api_key.as_deref(),
+            Some("recovered-key"),
+            "the pre-existing keyless `main` entry must be repaired, not orphaned"
+        );
+    }
+
+    #[test]
+    fn merge_update_never_overwrites_a_key_the_operator_already_set() {
+        let mut existing = legacy_keyless_main();
+        existing.llm.get_mut("main").unwrap().api_key = Some("operator-owned".into());
+
+        merge_update(&mut existing, &outcome_cloud_with_key("wizard-key"));
+
+        assert_eq!(
+            existing.llm.get("main").unwrap().api_key.as_deref(),
+            Some("operator-owned"),
+            "an already-configured key is user-owned and must survive the wizard"
+        );
+    }
+
+    /// When the operator chose vault or env storage there is no cleartext to
+    /// backfill, so the old additive behaviour must be preserved exactly.
+    #[test]
+    fn merge_update_without_cleartext_leaves_existing_entry_keyless() {
+        let mut existing = legacy_keyless_main();
+        merge_update(&mut existing, &outcome_cloud_only());
+
+        assert!(
+            existing.llm.get("main").unwrap().api_key.is_none(),
+            "no cleartext was collected, so nothing may be invented"
+        );
+    }
+
+    /// The local-Ollama provider registers as `provider: "openai"` with a
+    /// placeholder key. Backfill must not leak that placeholder into a real,
+    /// intentionally env-var-backed OpenAI entry.
+    #[test]
+    fn merge_update_does_not_touch_unrelated_provider_types() {
+        let mut existing = legacy_keyless_main();
+        existing.llm.insert(
+            "my-openai".into(),
+            LlmProviderConfig {
+                provider: "openai".into(),
+                model: Some("gpt-4o".into()),
+                api_key: None,
+                base_url: None,
+                extra: Default::default(),
+            },
+        );
+
+        merge_update(&mut existing, &outcome_cloud_with_key("openrouter-only"));
+
+        assert!(
+            existing.llm.get("my-openai").unwrap().api_key.is_none(),
+            "an openai entry must not receive the openrouter key"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_config_clamps_permissions_to_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().unwrap();
+        let out = outcome_cloud_with_key("secret-in-file");
+        let path = write_config(dir.path(), &out, ExistingConfigStrategy::FirstWrite).unwrap();
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(
+            mode & 0o777,
+            0o600,
+            "config.yml now carries the API key; got {:o}",
+            mode & 0o777
+        );
     }
 
     #[test]

--- a/crates/garraia-cli/src/wizard/mod.rs
+++ b/crates/garraia-cli/src/wizard/mod.rs
@@ -41,6 +41,67 @@ use local_stack::{
 /// Default cloud model — matches `chat.rs` (`openrouter/auto`).
 const DEFAULT_OPENROUTER_MODEL: &str = "openrouter/auto";
 
+/// Where the wizard persists a secret it just collected.
+///
+/// The ordering of the variants is the ordering of the prompt, and
+/// [`SecretStorage::Config`] is deliberately first and default. Vaulting a
+/// secret requires `GARRAIA_VAULT_PASSPHRASE` to be present in the *gateway's*
+/// environment at every single start; the wizard cannot arrange that, so a
+/// vault default meant `garraia init` → `garraia start` produced an encrypted
+/// key the server could not open and a provider that silently never came up.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SecretStorage {
+    /// Into `config.yml`, which [`write_config`] clamps to mode `0600`.
+    Config,
+    /// Into `credentials/vault.json`, AES-encrypted under a passphrase the
+    /// operator must re-supply out-of-band on every start.
+    Vault,
+    /// Nowhere — the operator exports the env var themselves.
+    Env,
+}
+
+/// Prompt for where to keep `what` (a human label like `"OpenRouter API key"`),
+/// naming `env_var` in the skip option so the operator knows the exact variable.
+fn prompt_secret_storage(what: &str, env_var: &str) -> Result<SecretStorage> {
+    let choices = [
+        "Store in config.yml (recommended — the file is chmod 0600)".to_string(),
+        "Store in the encrypted vault (needs GARRAIA_VAULT_PASSPHRASE on every start)".to_string(),
+        format!("Skip storing (I will export {env_var} myself)"),
+    ];
+    let picked = Select::new()
+        .with_prompt(format!("How should the {what} be stored?"))
+        .items(&choices)
+        .default(0)
+        .interact()
+        .with_context(|| format!("{what} storage choice cancelled"))?;
+    Ok(match picked {
+        0 => SecretStorage::Config,
+        1 => SecretStorage::Vault,
+        _ => SecretStorage::Env,
+    })
+}
+
+/// Tell the operator, unmissably, that a vaulted secret is inert until the
+/// passphrase reaches the gateway. Printed as a block rather than a one-line
+/// `println!` because the previous single line scrolled away behind the wizard's
+/// remaining output and the boot log, and operators never saw it.
+fn print_vault_passphrase_warning() {
+    println!();
+    println!("  ┌─────────────────────────────────────────────────────────────────┐");
+    println!("  │  ⚠  ATENÇÃO — leia antes de iniciar o Garra                     │");
+    println!("  └─────────────────────────────────────────────────────────────────┘");
+    println!("  Seus segredos foram cifrados no cofre. O servidor NÃO consegue");
+    println!("  abri-lo sozinho: ele precisa da mesma senha, via variável de");
+    println!("  ambiente, em TODA inicialização. Sem ela o Garra sobe, mas os");
+    println!("  provedores e canais ficam desligados.");
+    println!();
+    println!("    export GARRAIA_VAULT_PASSPHRASE='<a senha que você acabou de criar>'");
+    println!();
+    println!("  Para que isso sobreviva a reboots, coloque a linha acima no seu");
+    println!("  ~/.bashrc, ou num EnvironmentFile da sua unit systemd.");
+    println!();
+}
+
 /// `GARRAIA_BOOTSTRAP_LOCAL=0` disables the GPU/local-stack prompts even
 /// when a GPU is detected. Any other value (or unset) keeps the prompts
 /// gated by [`EnvSnapshot::supports_local_stack`].
@@ -234,21 +295,13 @@ pub fn run_wizard(config_dir: &Path) -> Result<()> {
         let token = token.trim().to_string();
 
         if !token.is_empty() {
-            let choices = &[
-                "Store in encrypted vault (recommended)",
-                "Store as plaintext in config.yml",
-                "Skip storing (use env var)",
-            ];
-            let storage = Select::new()
-                .with_prompt("How should the Telegram bot token be stored?")
-                .items(choices)
-                .default(0)
-                .interact()
-                .context("telegram storage choice cancelled")?;
-            match storage {
-                0 => telegram_token_for_vault = Some(token.clone()),
-                1 => telegram_token_plaintext = Some(token.clone()),
-                _ => {}
+            // Same defect as the OpenRouter key: a vault default left the
+            // channel silently offline on every restart, because the gateway
+            // has no passphrase to open the vault with.
+            match prompt_secret_storage("Telegram bot token", "TELEGRAM_BOT_TOKEN")? {
+                SecretStorage::Config => telegram_token_plaintext = Some(token.clone()),
+                SecretStorage::Vault => telegram_token_for_vault = Some(token.clone()),
+                SecretStorage::Env => {}
             }
         }
     }
@@ -262,8 +315,10 @@ pub fn run_wizard(config_dir: &Path) -> Result<()> {
     };
 
     // --- 10. Vault (cloud key + telegram token) ---------------------------
-    let openrouter_for_vault =
-        openrouter_api_key_plaintext.filter(|_| openrouter_should_use_vault(&openrouter_choice));
+    // `collect_openrouter` / the Telegram prompt hand back a cleartext secret
+    // only when the operator explicitly chose the vault, so no further
+    // filtering is needed here.
+    let openrouter_for_vault = openrouter_api_key_plaintext;
     let needs_vault = openrouter_for_vault.is_some() || telegram_token_for_vault.is_some();
     if needs_vault {
         open_or_create_vault(
@@ -271,6 +326,7 @@ pub fn run_wizard(config_dir: &Path) -> Result<()> {
             openrouter_for_vault.as_deref(),
             telegram_token_for_vault.as_deref(),
         )?;
+        print_vault_passphrase_warning();
     }
 
     // --- 11. Build outcome + write config ---------------------------------
@@ -371,26 +427,15 @@ fn collect_openrouter(out: &mut Option<CloudLlmChoice>) -> Result<Option<String>
         .context("OpenRouter key input cancelled")?;
     let api_key = api_key.trim().to_string();
 
-    let storage_choice = if !api_key.is_empty() {
-        let choices = &[
-            "Store in encrypted vault (recommended)",
-            "Store as plaintext in config.yml",
-            "Skip storing (use env var)",
-        ];
-        Select::new()
-            .with_prompt("How should the OpenRouter key be stored?")
-            .items(choices)
-            .default(0)
-            .interact()
-            .context("key storage choice cancelled")?
+    let storage = if api_key.is_empty() {
+        SecretStorage::Env
     } else {
-        2 // skip — env var
+        prompt_secret_storage("OpenRouter API key", "OPENROUTER_API_KEY")?
     };
 
-    let plaintext_for_config = if storage_choice == 1 && !api_key.is_empty() {
-        Some(api_key.clone())
-    } else {
-        None
+    let plaintext_for_config = match storage {
+        SecretStorage::Config => Some(api_key.clone()),
+        SecretStorage::Vault | SecretStorage::Env => None,
     };
 
     *out = Some(CloudLlmChoice {
@@ -401,18 +446,10 @@ fn collect_openrouter(out: &mut Option<CloudLlmChoice>) -> Result<Option<String>
 
     // Return the cleartext only when the user picked vault — caller
     // forwards into the vault flow.
-    if storage_choice == 0 && !api_key.is_empty() {
-        Ok(Some(api_key))
-    } else {
-        Ok(None)
+    match storage {
+        SecretStorage::Vault => Ok(Some(api_key)),
+        SecretStorage::Config | SecretStorage::Env => Ok(None),
     }
-}
-
-fn openrouter_should_use_vault(choice: &Option<CloudLlmChoice>) -> bool {
-    matches!(
-        choice,
-        Some(c) if c.api_key_plaintext.is_none()
-    )
 }
 
 fn collect_local_stack(env: &EnvSnapshot, out: &mut Option<LocalLlmChoice>) -> Result<()> {
@@ -511,8 +548,9 @@ fn open_or_create_vault(
             .context("passphrase input cancelled")?;
         match garraia_security::CredentialVault::create(&vault_path, &passphrase) {
             Ok(v) => {
+                // The passphrase reminder is printed once, as a block, by
+                // `print_vault_passphrase_warning` after this function returns.
                 println!("  Vault created.");
-                println!("  Set GARRAIA_VAULT_PASSPHRASE env var for server mode.");
                 Some(v)
             }
             Err(e) => {

--- a/crates/garraia-config/Cargo.toml
+++ b/crates/garraia-config/Cargo.toml
@@ -7,6 +7,10 @@ description = "Configuration loading and management for GarraIA"
 
 [dependencies]
 garraia-common = { workspace = true }
+# Needed by `provider_keys` so the vault tier of the API-key precedence chain
+# can be evaluated here rather than duplicated per consumer. No cycle:
+# garraia-security depends only on garraia-common.
+garraia-security = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/garraia-config/src/check.rs
+++ b/crates/garraia-config/src/check.rs
@@ -439,6 +439,78 @@ fn validate(config: &AppConfig) -> Vec<Finding> {
         }
     }
 
+    // llm.*: a provider entry whose API key resolves nowhere is skipped at
+    // startup, leaving the gateway up with zero usable providers — the failure
+    // mode that made `garraia init` → `garraia start` unusable. It is an Error,
+    // not a Warning: the entry is present precisely because the operator wants
+    // that provider, and it will not work.
+    //
+    // Unlike the channel loop below, this consults the credential vault too,
+    // via the same chain `build_agent_runtime` walks, so `config check` cannot
+    // disagree with what the gateway will actually do at boot.
+    for (name, llm) in &config.llm {
+        let Some(var) = crate::provider_keys::provider_key_env(&llm.provider) else {
+            // Keyless (`ollama`) or unknown provider type — the unknown case is
+            // reported separately below.
+            continue;
+        };
+        if crate::provider_keys::resolve_provider_key_source(&llm.provider, llm.api_key.as_deref())
+            .is_resolved()
+        {
+            continue;
+        }
+        push_err(
+            &mut findings,
+            &format!("llm.{name}"),
+            format!(
+                "provider '{name}' (type={}) has no API key and will be skipped at startup. \
+                 Fix it in any one of three ways: set `llm.{name}.api_key` in config.yml, \
+                 export {var}, or export {vault} to unlock the credential vault.",
+                llm.provider,
+                vault = crate::provider_keys::VAULT_PASSPHRASE_ENV
+            ),
+        );
+    }
+
+    // An `llm:` entry whose `provider` the runtime does not recognize is
+    // silently dropped with `warn!("unknown LLM provider type")` at boot.
+    for (name, llm) in &config.llm {
+        let known = crate::provider_keys::provider_key_env(&llm.provider).is_some()
+            || matches!(llm.provider.as_str(), "ollama" | "echo");
+        if !known {
+            push_err(
+                &mut findings,
+                &format!("llm.{name}"),
+                format!(
+                    "provider '{name}' has unknown type `{}` — the runtime will skip it. \
+                     Did you mean one of: openrouter, openai, anthropic, ollama, gemini, \
+                     mistral, deepseek, qwen, cohere?",
+                    llm.provider
+                ),
+            );
+        }
+    }
+
+    // A populated `llm:` with no `agent.default_provider` silently disables the
+    // provider auto-fallback path in `build_agent_runtime`, so an unreachable or
+    // rate-limited provider has nowhere to fail over to.
+    if !config.llm.is_empty() && config.agent.default_provider.is_none() {
+        push_warn(
+            &mut findings,
+            "agent.default_provider",
+            format!(
+                "`llm:` defines {} provider(s) but agent.default_provider is unset — \
+                 provider auto-fallback is disabled. Set it to one of: {}.",
+                config.llm.len(),
+                {
+                    let mut keys: Vec<&str> = config.llm.keys().map(|k| k.as_str()).collect();
+                    keys.sort();
+                    keys.join(", ")
+                }
+            ),
+        );
+    }
+
     // mobile.persona: plan 0042 §5.3 — suspiciously short strings are
     // flagged as Warning (valid shape, unusual content). Threshold of
     // 10 chars picks up accidental "hi" / "test" without slapping
@@ -468,8 +540,9 @@ fn validate(config: &AppConfig) -> Vec<Finding> {
     // Channels: warn when a channel is enabled but its well-known token
     // env var is not set and no inline credential is present. This helps
     // operators catch the common mistake of enabling a channel without
-    // providing the secret. We only check env vars here — the vault is
-    // runtime-only and out of scope for config-check.
+    // providing the secret. Kept a Warning (not an Error like `llm.*` above)
+    // because a disabled channel degrades one surface, while a keyless LLM
+    // provider leaves the whole gateway unable to answer.
     for (name, ch) in &config.channels {
         let enabled = ch.enabled.unwrap_or(true);
         if !enabled {
@@ -814,6 +887,118 @@ mod tests {
         assert_eq!(report.file_used, None);
         assert!(report.used_defaults);
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// Builds the config the broken onboarding flow produced: a structurally
+    /// perfect openrouter entry named `main` with `api_key: null`.
+    fn config_with_keyless_openrouter() -> AppConfig {
+        let mut cfg = AppConfig::default();
+        cfg.llm.insert(
+            "main".into(),
+            LlmProviderConfig {
+                provider: "openrouter".into(),
+                model: Some("openrouter/auto".into()),
+                api_key: None,
+                base_url: Some("https://openrouter.ai/api/v1".into()),
+                extra: Default::default(),
+            },
+        );
+        cfg.agent.default_provider = Some("main".into());
+        cfg
+    }
+
+    /// The check that would have told the operator exactly what was wrong
+    /// instead of leaving them with a cryptic boot warning.
+    #[test]
+    fn keyless_llm_provider_is_reported_as_an_error() {
+        // SAFETY: unique-to-this-test read of a well-known var; we only remove it.
+        unsafe { std::env::remove_var("OPENROUTER_API_KEY") };
+
+        let findings = validate(&config_with_keyless_openrouter());
+        let hit = findings
+            .iter()
+            .find(|f| f.field == "llm.main")
+            .expect("a keyless llm entry must produce a finding");
+
+        assert!(matches!(hit.severity, Severity::Error));
+        // The message must name all three remedies — the old boot warning
+        // mentioned only config and env, never the vault.
+        assert!(hit.message.contains("llm.main.api_key"));
+        assert!(hit.message.contains("OPENROUTER_API_KEY"));
+        assert!(hit.message.contains("GARRAIA_VAULT_PASSPHRASE"));
+    }
+
+    #[test]
+    fn llm_provider_with_key_in_config_produces_no_finding() {
+        let mut cfg = config_with_keyless_openrouter();
+        cfg.llm.get_mut("main").unwrap().api_key = Some("sk-or-test".into());
+
+        let findings = validate(&cfg);
+        assert!(
+            !findings.iter().any(|f| f.field == "llm.main"),
+            "a provider with a key in config.yml must not be flagged"
+        );
+    }
+
+    #[test]
+    fn keyless_ollama_is_not_flagged() {
+        let mut cfg = AppConfig::default();
+        cfg.llm.insert(
+            "local".into(),
+            LlmProviderConfig {
+                provider: "ollama".into(),
+                model: Some("qwen3".into()),
+                api_key: None,
+                base_url: None,
+                extra: Default::default(),
+            },
+        );
+        cfg.agent.default_provider = Some("local".into());
+
+        let findings = validate(&cfg);
+        assert!(
+            !findings.iter().any(|f| f.field == "llm.local"),
+            "ollama needs no API key and must never be reported as missing one"
+        );
+    }
+
+    #[test]
+    fn unknown_provider_type_is_reported() {
+        let mut cfg = AppConfig::default();
+        cfg.llm.insert(
+            "typo".into(),
+            LlmProviderConfig {
+                provider: "openrouterr".into(),
+                model: None,
+                api_key: Some("k".into()),
+                base_url: None,
+                extra: Default::default(),
+            },
+        );
+        cfg.agent.default_provider = Some("typo".into());
+
+        let findings = validate(&cfg);
+        let hit = findings
+            .iter()
+            .find(|f| f.field == "llm.typo")
+            .expect("an unknown provider type must be reported");
+        assert!(matches!(hit.severity, Severity::Error));
+        assert!(hit.message.contains("unknown type"));
+    }
+
+    #[test]
+    fn populated_llm_without_default_provider_warns_about_lost_fallback() {
+        let mut cfg = config_with_keyless_openrouter();
+        cfg.llm.get_mut("main").unwrap().api_key = Some("sk-or-test".into());
+        cfg.agent.default_provider = None;
+
+        let findings = validate(&cfg);
+        let hit = findings
+            .iter()
+            .find(|f| f.field == "agent.default_provider")
+            .expect("an unset default_provider alongside llm entries must warn");
+        assert!(matches!(hit.severity, Severity::Warning));
+        assert!(hit.message.contains("auto-fallback"));
     }
 
     #[test]

--- a/crates/garraia-config/src/lib.rs
+++ b/crates/garraia-config/src/lib.rs
@@ -2,16 +2,21 @@ pub mod auth;
 pub mod check;
 pub mod loader;
 pub mod model;
+pub mod provider_keys;
 pub mod watcher;
 
 pub use auth::{AuthConfig, AuthConfigError};
 pub use check::{ConfigCheck, ConfigSummary, Finding, Severity, SourceReport, run_check};
-pub use loader::ConfigLoader;
+pub use loader::{ConfigLoader, harden_secret_file};
 pub use model::{
     AUTH_ACCESS_TTL_MAX_SECS, AUTH_ACCESS_TTL_MIN_SECS, AUTH_REFRESH_TTL_MAX_SECS,
     AUTH_REFRESH_TTL_MIN_SECS, AUTH_SUPPORTED_JWT_ALGORITHMS, AgentConfig, AppConfig, AuthSection,
     ChannelConfig, EmbeddingProviderConfig, GatewayConfig, LlmProviderConfig, MAX_PATCH_BYTES_MAX,
     MAX_PATCH_BYTES_MIN, McpServerConfig, MemoryConfig, NamedAgentConfig, S3StorageConfig,
     StorageBackend, StorageConfig, TimeoutConfig, TypeTimeout, VoiceConfig,
+};
+pub use provider_keys::{
+    KeySource, default_vault_path, provider_key_env, resolve_api_key, resolve_api_key_source,
+    resolve_provider_key_source, vault_present_but_locked,
 };
 pub use watcher::ConfigWatcher;

--- a/crates/garraia-config/src/loader.rs
+++ b/crates/garraia-config/src/loader.rs
@@ -142,6 +142,10 @@ impl ConfigLoader {
     }
 
     /// Save the given AppConfig to config.yml in the config directory.
+    ///
+    /// The file is written with mode `0600` on Unix — `llm.*.api_key` and
+    /// `gateway.api_key` live in here, so a umask-default `0644` would leave
+    /// provider credentials world-readable.
     pub fn save(&self, config: &AppConfig) -> Result<()> {
         let yaml_path = self.config_dir.join("config.yml");
 
@@ -155,9 +159,38 @@ impl ConfigLoader {
             ))
         })?;
 
+        harden_secret_file(&yaml_path)?;
+
         info!("saved updated config to {}", yaml_path.display());
         Ok(())
     }
+}
+
+/// Restrict `path` to owner-only read/write (`0600`) on Unix.
+///
+/// Call this after writing any file that can hold a credential — `config.yml`
+/// carries `llm.*.api_key` since the onboarding wizard stopped defaulting to
+/// the credential vault, and `std::fs::write` alone leaves the file at whatever
+/// the process umask allows (commonly `0644`).
+///
+/// No-op on non-Unix targets, where the parent directory ACL governs access.
+pub fn harden_secret_file(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(|e| {
+            Error::Config(format!(
+                "failed to restrict permissions on {}: {e}",
+                path.display()
+            ))
+        })?;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -178,6 +211,43 @@ mod tests {
             std::process::id(),
             nanos
         ))
+    }
+
+    /// `config.yml` holds `llm.*.api_key` since the wizard stopped defaulting
+    /// to the credential vault. A umask-default `0644` would make provider
+    /// credentials world-readable, so `save` must clamp the mode to `0600`.
+    #[cfg(unix)]
+    #[test]
+    fn save_writes_config_with_owner_only_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = temp_dir("save-perms");
+        fs::create_dir_all(&dir).expect("failed to create temp dir");
+
+        // Pre-create the file world-readable so we prove `save` tightens an
+        // existing loose mode, not merely that a fresh file happens to be 0600.
+        let path = dir.join("config.yml");
+        fs::write(&path, "gateway:\n  host: \"127.0.0.1\"\n").expect("failed to seed config");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644))
+            .expect("failed to loosen permissions");
+
+        let loader = ConfigLoader::with_dir(&dir);
+        loader
+            .save(&crate::model::AppConfig::default())
+            .expect("save should succeed");
+
+        let mode = fs::metadata(&path)
+            .expect("config should exist after save")
+            .permissions()
+            .mode();
+        assert_eq!(
+            mode & 0o777,
+            0o600,
+            "config.yml must be owner-only; got {:o}",
+            mode & 0o777
+        );
+
+        let _ = fs::remove_dir_all(dir);
     }
 
     #[test]

--- a/crates/garraia-config/src/provider_keys.rs
+++ b/crates/garraia-config/src/provider_keys.rs
@@ -1,0 +1,266 @@
+//! The single source of truth for "does this LLM provider have a usable API key?"
+//!
+//! Before this module the question had **three** different answers depending on
+//! which surface you asked:
+//!
+//! * `garraia-gateway::bootstrap` walked vault → config → env (the only one that
+//!   decided whether a provider actually came up),
+//! * `/health` checked config `||` env and ignored the vault entirely, so it
+//!   reported `"no API key configured"` for providers the gateway had
+//!   successfully loaded from the vault,
+//! * the admin providers list reported `has_secret` from an AES-GCM SQLite store
+//!   that the boot path never reads at all.
+//!
+//! They could disagree on the same machine at the same moment, which is how a
+//! provider could look configured everywhere and still be skipped at startup.
+//! Everything now routes through [`resolve_api_key`] / [`resolve_api_key_source`].
+//!
+//! This lives in `garraia-config` rather than in the gateway because
+//! `garraia-config::check` (backing `garraia config check`) needs the same
+//! answer, and the gateway is a *consumer* of this crate, not a provider to it.
+
+use std::path::{Path, PathBuf};
+
+use crate::loader::ConfigLoader;
+
+/// Environment variable carrying the credential-vault passphrase.
+///
+/// Note the casing: this is **not** the same variable as the mixed-case
+/// `GarraIA_VAULT_PASSPHRASE` consulted by [`crate::auth`] as a JWT-secret
+/// fallback. The two are genuinely distinct and easy to confuse.
+pub const VAULT_PASSPHRASE_ENV: &str = "GARRAIA_VAULT_PASSPHRASE";
+
+/// Where a resolved API key came from, or why none was found.
+///
+/// Callers that only need the key itself should use [`resolve_api_key`]; the
+/// source matters for diagnostics (`garraia config check`, `/api/diagnostics`,
+/// the startup banner) where "the key is in the vault but the vault is locked"
+/// must read differently from "there is no key anywhere".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeySource {
+    /// Decrypted out of `credentials/vault.json`.
+    Vault,
+    /// Read from `llm.<name>.api_key` in `config.yml`.
+    Config,
+    /// Read from the provider's environment variable.
+    Env,
+    /// Nothing resolved — the provider will be skipped at startup.
+    Missing,
+}
+
+impl KeySource {
+    /// Whether a provider with this source will actually come up.
+    pub fn is_resolved(self) -> bool {
+        !matches!(self, KeySource::Missing)
+    }
+
+    /// Short human-readable label for reports and log lines.
+    pub fn label(self) -> &'static str {
+        match self {
+            KeySource::Vault => "credential vault",
+            KeySource::Config => "config.yml",
+            KeySource::Env => "environment variable",
+            KeySource::Missing => "not configured",
+        }
+    }
+}
+
+/// The environment variable (and credential-vault entry name — they are the
+/// same string by convention) that holds the API key for `provider`.
+///
+/// Returns `None` for providers that need no key: `ollama` talks to a local
+/// daemon, and `echo` is the feature-gated dev provider. An unknown provider
+/// string also yields `None`, matching the gateway's
+/// `warn!("unknown LLM provider type")` arm.
+///
+/// Keep in lockstep with the `match llm_config.provider.as_str()` arms in
+/// `garraia-gateway/src/bootstrap/mod.rs` — `parity_with_bootstrap_arms` in the
+/// gateway's test module asserts the two agree.
+pub fn provider_key_env(provider: &str) -> Option<&'static str> {
+    Some(match provider {
+        "anthropic" => "ANTHROPIC_API_KEY",
+        "openai" => "OPENAI_API_KEY",
+        "sansa" => "SANSA_API_KEY",
+        "deepseek" => "DEEPSEEK_API_KEY",
+        "mistral" => "MISTRAL_API_KEY",
+        "gemini" => "GEMINI_API_KEY",
+        "falcon" => "FALCON_API_KEY",
+        "jais" => "JAIS_API_KEY",
+        "qwen" => "QWEN_API_KEY",
+        "yi" => "YI_API_KEY",
+        "cohere" => "COHERE_API_KEY",
+        "minimax" => "MINIMAX_API_KEY",
+        "moonshot" => "MOONSHOT_API_KEY",
+        "openrouter" => "OPENROUTER_API_KEY",
+        // `ollama` needs no key; `echo` is the dev provider; anything else is
+        // unknown to the runtime and gets skipped regardless.
+        _ => return None,
+    })
+}
+
+/// Default credential-vault path under the resolved config directory.
+pub fn default_vault_path() -> PathBuf {
+    ConfigLoader::default_config_dir()
+        .join("credentials")
+        .join("vault.json")
+}
+
+/// Whether a vault file exists on disk but no passphrase is available to open
+/// it — the state in which secrets are present yet unreadable, and providers go
+/// silently offline.
+pub fn vault_present_but_locked(vault_path: &Path) -> bool {
+    vault_path.exists() && !vault_passphrase_available()
+}
+
+fn vault_passphrase_available() -> bool {
+    std::env::var(VAULT_PASSPHRASE_ENV)
+        .map(|v| !v.is_empty())
+        .unwrap_or(false)
+}
+
+/// Resolve an API key, reporting where it came from.
+///
+/// Precedence is **vault → config → env**, as in the original implementation in
+/// `garraia-gateway::bootstrap::config`, with one deliberate change: an
+/// **empty** environment variable is now treated as absent rather than as a
+/// valid empty key. Previously `OPENROUTER_API_KEY=""` registered a provider
+/// with an empty credential that then failed on the first HTTP call with an
+/// opaque upstream 401; it now reports [`KeySource::Missing`] and is skipped
+/// with the actionable "no API key" warning. This also makes the env tier
+/// consistent with the config tier, which already ignored empty strings.
+///
+/// `vault_key` and `env_var` are the same string for every provider today; both
+/// are taken separately so a future rename of one cannot silently retarget the
+/// other.
+pub fn resolve_api_key_source(
+    config_key: Option<&str>,
+    vault_key: &str,
+    env_var: &str,
+) -> (KeySource, Option<String>) {
+    // 1. Credential vault — only readable when the passphrase is in the env.
+    if let Some(val) = garraia_security::try_vault_get(&default_vault_path(), vault_key) {
+        return (KeySource::Vault, Some(val));
+    }
+
+    // 2. Config file value.
+    if let Some(key) = config_key.filter(|k| !k.is_empty()) {
+        return (KeySource::Config, Some(key.to_string()));
+    }
+
+    // 3. Environment variable.
+    if let Some(val) = std::env::var(env_var).ok().filter(|v| !v.is_empty()) {
+        return (KeySource::Env, Some(val));
+    }
+
+    (KeySource::Missing, None)
+}
+
+/// Resolve an API key using the precedence chain vault → config → env.
+///
+/// Thin wrapper over [`resolve_api_key_source`] for call sites that do not care
+/// where the key came from.
+pub fn resolve_api_key(config_key: Option<&str>, vault_key: &str, env_var: &str) -> Option<String> {
+    resolve_api_key_source(config_key, vault_key, env_var).1
+}
+
+/// Resolve the key for a configured `llm:` entry, keyed off its `provider`
+/// field. Providers that need no key (`ollama`, `echo`) report
+/// [`KeySource::Config`] with no value, since absence of a key is not a fault
+/// for them.
+pub fn resolve_provider_key_source(provider: &str, config_key: Option<&str>) -> KeySource {
+    match provider_key_env(provider) {
+        Some(var) => resolve_api_key_source(config_key, var, var).0,
+        // Keyless provider — nothing to resolve, nothing missing.
+        None => KeySource::Config,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Env-var mutation is process-global, so the precedence tests share one
+    /// serialized test to avoid cross-talk with the rest of the suite.
+    #[test]
+    fn precedence_is_config_then_env_when_vault_is_absent() {
+        let var = "GARRAIA_TEST_PROVIDER_KEYS_PRECEDENCE";
+        // SAFETY: unique variable name, mutated and removed within this test.
+        unsafe { std::env::remove_var(var) };
+
+        // Nothing anywhere.
+        let (src, val) = resolve_api_key_source(None, "NONEXISTENT_VAULT_KEY", var);
+        assert_eq!(src, KeySource::Missing);
+        assert!(val.is_none());
+
+        // Env only.
+        unsafe { std::env::set_var(var, "from-env") };
+        let (src, val) = resolve_api_key_source(None, "NONEXISTENT_VAULT_KEY", var);
+        assert_eq!(src, KeySource::Env);
+        assert_eq!(val.as_deref(), Some("from-env"));
+
+        // Config beats env.
+        let (src, val) = resolve_api_key_source(Some("from-config"), "NONEXISTENT_VAULT_KEY", var);
+        assert_eq!(src, KeySource::Config);
+        assert_eq!(val.as_deref(), Some("from-config"));
+
+        // An empty config value is not a value — must fall through to env.
+        let (src, val) = resolve_api_key_source(Some(""), "NONEXISTENT_VAULT_KEY", var);
+        assert_eq!(src, KeySource::Env);
+        assert_eq!(val.as_deref(), Some("from-env"));
+
+        // An empty env var is likewise not a value.
+        unsafe { std::env::set_var(var, "") };
+        let (src, _) = resolve_api_key_source(None, "NONEXISTENT_VAULT_KEY", var);
+        assert_eq!(src, KeySource::Missing);
+
+        unsafe { std::env::remove_var(var) };
+    }
+
+    #[test]
+    fn keyless_providers_are_never_reported_missing() {
+        assert!(provider_key_env("ollama").is_none());
+        assert!(provider_key_env("echo").is_none());
+        assert!(provider_key_env("totally-unknown").is_none());
+
+        assert_eq!(
+            resolve_provider_key_source("ollama", None),
+            KeySource::Config
+        );
+        assert!(resolve_provider_key_source("ollama", None).is_resolved());
+    }
+
+    #[test]
+    fn every_known_provider_maps_to_an_api_key_var() {
+        for p in [
+            "anthropic",
+            "openai",
+            "sansa",
+            "deepseek",
+            "mistral",
+            "gemini",
+            "falcon",
+            "jais",
+            "qwen",
+            "yi",
+            "cohere",
+            "minimax",
+            "moonshot",
+            "openrouter",
+        ] {
+            let var = provider_key_env(p).unwrap_or_else(|| panic!("{p} must map to a var"));
+            assert!(
+                var.ends_with("_API_KEY"),
+                "{p} maps to {var}, which breaks the *_API_KEY convention"
+            );
+        }
+    }
+
+    #[test]
+    fn key_source_labels_distinguish_resolved_from_missing() {
+        assert!(KeySource::Vault.is_resolved());
+        assert!(KeySource::Config.is_resolved());
+        assert!(KeySource::Env.is_resolved());
+        assert!(!KeySource::Missing.is_resolved());
+        assert_eq!(KeySource::Missing.label(), "not configured");
+    }
+}

--- a/crates/garraia-config/src/provider_keys.rs
+++ b/crates/garraia-config/src/provider_keys.rs
@@ -74,8 +74,9 @@ impl KeySource {
 /// `warn!("unknown LLM provider type")` arm.
 ///
 /// Keep in lockstep with the `match llm_config.provider.as_str()` arms in
-/// `garraia-gateway/src/bootstrap/mod.rs` — `parity_with_bootstrap_arms` in the
-/// gateway's test module asserts the two agree.
+/// `garraia-gateway/src/bootstrap/mod.rs`. The gateway test
+/// `bootstrap::config::tests::provider_key_table_covers_every_arm_of_the_boot_loop`
+/// asserts the two agree, including that `ollama` and `echo` stay keyless.
 pub fn provider_key_env(provider: &str) -> Option<&'static str> {
     Some(match provider {
         "anthropic" => "ANTHROPIC_API_KEY",

--- a/crates/garraia-desktop/src-tauri/Cargo.toml
+++ b/crates/garraia-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "garraia-desktop"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 description = "Garra Desktop — Clippy-style AI assistant overlay"
 license = "MIT"

--- a/crates/garraia-desktop/src-tauri/tauri.conf.json
+++ b/crates/garraia-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "garraia-desktop",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "identifier": "org.garraia.desktop",
   "build": {
     "frontendDist": "../ui",

--- a/crates/garraia-gateway/src/admin/providers.rs
+++ b/crates/garraia-gateway/src/admin/providers.rs
@@ -57,7 +57,23 @@ pub async fn admin_list_providers(
         let active = active_ids.contains(&id.to_string());
         let mut model = None;
         let mut models = Vec::new();
-        let has_secret = {
+        let config_entry = config.llm.get(*id);
+
+        // `has_secret` drives the "Set"/"Missing" badge in the admin UI, so it
+        // must mean "the gateway can actually obtain a key for this provider" —
+        // the same vault -> config -> env chain `build_agent_runtime` walks.
+        // It previously reported the presence of a row in the admin AES-GCM
+        // secrets store, which the boot path never reads, so the console could
+        // show "Set" for a provider guaranteed to be skipped at startup.
+        let key_source = garraia_config::resolve_provider_key_source(
+            id,
+            config_entry.and_then(|c| c.api_key.as_deref()),
+        );
+        let has_secret = *needs_key && key_source.is_resolved();
+
+        // The admin store's own state stays visible under its own name, so no
+        // information is lost — it just no longer masquerades as boot readiness.
+        let has_admin_stored_secret = {
             let guard = state.store.lock().await;
             guard.get_secret_meta("default", id, "api_key").is_some()
         };
@@ -72,8 +88,6 @@ pub async fn admin_list_providers(
             }
         }
 
-        let config_entry = config.llm.get(*id);
-
         providers.push(serde_json::json!({
             "id": id,
             "display_name": display,
@@ -81,6 +95,11 @@ pub async fn admin_list_providers(
             "is_default": default_id.as_deref() == Some(*id),
             "needs_api_key": *needs_key,
             "has_secret": has_secret,
+            // Where the key came from ("config.yml", "credential vault",
+            // "environment variable", "not configured") — lets an operator see
+            // *why* a provider is or isn't ready, not just that it isn't.
+            "key_source": key_source.label(),
+            "has_admin_stored_secret": has_admin_stored_secret,
             "model": model,
             "models": models,
             "base_url": config_entry.and_then(|c| c.base_url.clone()),

--- a/crates/garraia-gateway/src/bootstrap/channels.rs
+++ b/crates/garraia-gateway/src/bootstrap/channels.rs
@@ -2,12 +2,13 @@ use garraia_config::AppConfig;
 use tracing::{info, warn};
 
 /// Build configured channels that can be initialized before state is wrapped in Arc.
+///
+/// `.env` loading used to happen here, but `Server::run` calls
+/// `build_agent_runtime` — which reads the provider API-key env vars — *before*
+/// it calls this function. That meant `.env` provisioned channels while leaving
+/// providers dead for anyone embedding `Server` directly. The load now happens
+/// at the top of `Server::run` instead.
 pub async fn build_channels(config: &AppConfig) -> garraia_channels::ChannelRegistry {
-    // Load .env file if present (idempotent, will not overwrite existing env vars)
-    if let Err(e) = dotenvy::dotenv() {
-        tracing::debug!("no .env file loaded: {e}");
-    }
-
     let registry = garraia_channels::ChannelRegistry::new();
 
     for (name, channel_config) in &config.channels {

--- a/crates/garraia-gateway/src/bootstrap/config.rs
+++ b/crates/garraia-gateway/src/bootstrap/config.rs
@@ -1,20 +1,28 @@
 //! Bootstrap configuration helpers.
 //!
-//! Slice 10.a of GAR-440 (Q10 of EPIC GAR-430 Quality Gates Phase 3.6).
-//! Extracted from `bootstrap.rs` without behavior change — holds the path
-//! resolvers and the API-key precedence chain (vault → config → env) that
-//! every downstream pipeline (agents, channels, state, router, admin)
-//! consumes via `crate::bootstrap::{default_vault_path, resolve_api_key}`.
+//! Slice 10.a of GAR-440 (Q10 of EPIC GAR-430 Quality Gates Phase 3.6)
+//! extracted the path resolvers and the API-key precedence chain out of
+//! `bootstrap.rs`. The precedence chain itself has since moved down into
+//! [`garraia_config::provider_keys`], so that `garraia config check`, `/health`,
+//! and the admin providers list can answer "does this provider have a usable
+//! key?" the same way the boot path does — they previously disagreed, which is
+//! how a provider could look configured on every surface and still be skipped
+//! at startup.
+//!
+//! What remains here is the gateway-facing surface: the re-exports consumed via
+//! `crate::bootstrap::{default_vault_path, resolve_api_key}` (used by
+//! `admin::handlers`, `admin::mcp`, `router`, `state`) and the locked-vault
+//! diagnostic.
 
 use std::path::PathBuf;
 
-/// Default vault path under the user's home directory.
+/// Default vault path under the user's config directory.
+///
+/// Returns `Option` purely to preserve the signature its four call sites
+/// (`router`, `state`, `admin::mcp` ×2) already branch on; the path is always
+/// resolvable.
 pub(crate) fn default_vault_path() -> Option<PathBuf> {
-    Some(
-        garraia_config::ConfigLoader::default_config_dir()
-            .join("credentials")
-            .join("vault.json"),
-    )
+    Some(garraia_config::default_vault_path())
 }
 
 pub(super) fn default_allowlist_path() -> PathBuf {
@@ -26,17 +34,16 @@ pub(super) fn default_allowlist_path() -> PathBuf {
 /// situation that silently disables providers/channels (the keys are encrypted
 /// and we can't open the vault). Without this, the operator only sees a cryptic
 /// "no API key" and has no idea their secrets are right there, locked.
+///
+/// This is the state the pre-v0.3.0 onboarding wizard produced by default: it
+/// encrypted the key into the vault, then `garraia start` had no passphrase to
+/// open it with. The wizard now writes to `config.yml` instead, so this warning
+/// should only fire for operators who deliberately opted into the vault.
 pub(crate) fn warn_if_vault_locked() {
     let Some(vault_path) = default_vault_path() else {
         return;
     };
-    if !vault_path.exists() {
-        return;
-    }
-    let passphrase_set = std::env::var("GARRAIA_VAULT_PASSPHRASE")
-        .map(|v| !v.is_empty())
-        .unwrap_or(false);
-    if passphrase_set {
+    if !garraia_config::vault_present_but_locked(&vault_path) {
         return;
     }
     tracing::warn!(
@@ -48,28 +55,17 @@ pub(crate) fn warn_if_vault_locked() {
     );
 }
 
-/// Resolve an API key using the priority chain: vault -> config -> env var.
+/// Resolve an API key using the priority chain vault -> config -> env var.
+///
+/// Delegates to [`garraia_config::resolve_api_key`]. Also used for channel
+/// tokens (`TELEGRAM_BOT_TOKEN`, `SLACK_BOT_TOKEN`, `WHATSAPP_ACCESS_TOKEN`),
+/// which follow the identical chain.
 pub(crate) fn resolve_api_key(
     config_key: Option<&str>,
     vault_credential_key: &str,
     env_var: &str,
 ) -> Option<String> {
-    // 1. Try credential vault (only works when GARRAIA_VAULT_PASSPHRASE is set)
-    if let Some(vault_path) = default_vault_path()
-        && let Some(val) = garraia_security::try_vault_get(&vault_path, vault_credential_key)
-    {
-        return Some(val);
-    }
-
-    // 2. Config file value
-    if let Some(key) = config_key
-        && !key.is_empty()
-    {
-        return Some(key.to_string());
-    }
-
-    // 3. Environment variable
-    std::env::var(env_var).ok()
+    garraia_config::resolve_api_key(config_key, vault_credential_key, env_var)
 }
 
 #[cfg(test)]
@@ -102,5 +98,41 @@ mod tests {
     fn resolve_api_key_returns_none_when_all_missing() {
         let result = resolve_api_key(None, "NONEXISTENT_VAULT_KEY", "NONEXISTENT_ENV_VAR_99999");
         assert_eq!(result, None);
+    }
+
+    /// Guards the refactor that removed fifteen hardcoded `("X_API_KEY",
+    /// "X_API_KEY")` pairs from `build_agent_runtime`: every provider string the
+    /// boot loop matches on must still resolve to an env var through the shared
+    /// table, and the keyless ones must still report `None`.
+    #[test]
+    fn provider_key_table_covers_every_arm_of_the_boot_loop() {
+        use garraia_config::provider_key_env;
+
+        for (provider, expected) in [
+            ("anthropic", "ANTHROPIC_API_KEY"),
+            ("openai", "OPENAI_API_KEY"),
+            ("sansa", "SANSA_API_KEY"),
+            ("deepseek", "DEEPSEEK_API_KEY"),
+            ("mistral", "MISTRAL_API_KEY"),
+            ("gemini", "GEMINI_API_KEY"),
+            ("falcon", "FALCON_API_KEY"),
+            ("jais", "JAIS_API_KEY"),
+            ("qwen", "QWEN_API_KEY"),
+            ("yi", "YI_API_KEY"),
+            ("cohere", "COHERE_API_KEY"),
+            ("minimax", "MINIMAX_API_KEY"),
+            ("moonshot", "MOONSHOT_API_KEY"),
+            ("openrouter", "OPENROUTER_API_KEY"),
+        ] {
+            assert_eq!(
+                provider_key_env(provider),
+                Some(expected),
+                "boot loop matches on `{provider}` but the shared table disagrees"
+            );
+        }
+
+        // Keyless arms: these must never be reported as missing a key.
+        assert_eq!(provider_key_env("ollama"), None);
+        assert_eq!(provider_key_env("echo"), None);
     }
 }

--- a/crates/garraia-gateway/src/bootstrap/mod.rs
+++ b/crates/garraia-gateway/src/bootstrap/mod.rs
@@ -6,7 +6,7 @@ use garraia_agents::{
     FileWriteTool, McpManager, OllamaEmbeddingProvider, OllamaProvider, OpenAiEmbeddingProvider,
     OpenAiProvider, WebFetchTool, WebSearchTool,
 };
-use garraia_config::AppConfig;
+use garraia_config::{AppConfig, provider_key_env};
 use garraia_db::MemoryStore;
 use tracing::{info, warn};
 
@@ -62,86 +62,94 @@ pub fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
 
     // --- LLM Providers ---
     for (name, llm_config) in &config.llm {
-        match llm_config.provider.as_str() {
-            "anthropic" => {
-                let api_key = resolve_api_key(
-                    llm_config.api_key.as_deref(),
-                    "ANTHROPIC_API_KEY",
-                    "ANTHROPIC_API_KEY",
-                );
+        let provider_type = llm_config.provider.as_str();
 
-                if let Some(key) = api_key {
-                    let provider = AnthropicProvider::new(
-                        key,
-                        llm_config.model.clone(),
-                        llm_config.base_url.clone(),
-                    )
-                    .with_client(llm_client.clone());
-                    runtime.register_provider(Arc::new(provider));
-                    info!("configured anthropic provider: {name}");
-                } else {
-                    warn!(
-                        "skipping anthropic provider {name}: no API key (set api_key in config or ANTHROPIC_API_KEY env var)"
-                    );
-                }
+        // One table lookup and one precedence walk for every provider, rather
+        // than the same three lines duplicated into fifteen match arms. The
+        // table itself lives in `garraia_config::provider_keys` so that
+        // `garraia config check` and `/health` answer "does this provider have
+        // a key?" exactly the way the boot path does.
+        let key_env = provider_key_env(provider_type);
+        let resolved =
+            key_env.and_then(|var| resolve_api_key(llm_config.api_key.as_deref(), var, var));
+
+        // Central fail-fast. The old per-arm message said only "set api_key in
+        // config or <VAR> env var", which omitted the vault — the very place
+        // `garraia init` used to put the key by default, leaving operators
+        // staring at "no API key" while the key sat encrypted on disk.
+        if let Some(var) = key_env
+            && resolved.is_none()
+        {
+            warn!(
+                "skipping {provider_type} provider {name}: no API key. Fix it in any one of \
+                 three ways — set `llm.{name}.api_key` in config.yml, export {var}, or \
+                 unlock the credential vault by exporting {vault_env}.",
+                vault_env = garraia_config::provider_keys::VAULT_PASSPHRASE_ENV
+            );
+            continue;
+        }
+
+        // Past the guard, keyed providers are guaranteed to have resolved a
+        // key; keyless ones (`ollama`, `echo`) never had one to resolve, and
+        // ignore this binding.
+        let api_key = resolved.unwrap_or_default();
+
+        match provider_type {
+            "anthropic" => {
+                let provider = AnthropicProvider::new(
+                    api_key,
+                    llm_config.model.clone(),
+                    llm_config.base_url.clone(),
+                )
+                .with_client(llm_client.clone());
+                runtime.register_provider(Arc::new(provider));
+                info!("configured anthropic provider: {name}");
             }
             "openai" => {
-                let api_key = resolve_api_key(
-                    llm_config.api_key.as_deref(),
-                    "OPENAI_API_KEY",
-                    "OPENAI_API_KEY",
-                );
-
-                if let Some(key) = api_key {
-                    // Health check for local OpenAI-compatible providers (LM Studio, vLLM, etc.)
-                    if let Some(ref base_url) = llm_config.base_url
-                        && (base_url.contains("localhost") || base_url.contains("127.0.0.1"))
-                    {
-                        let addr = base_url
-                            .trim_start_matches("http://")
-                            .trim_start_matches("https://")
-                            .split('/')
-                            .next()
-                            .unwrap_or("localhost:1234");
-                        let sock_addr = if addr.contains(':') {
-                            addr.to_string()
-                        } else {
-                            format!("{}:1234", addr)
-                        };
-                        match std::net::TcpStream::connect_timeout(
-                            &sock_addr.parse().unwrap_or_else(|_| {
-                                std::net::SocketAddr::from(([127, 0, 0, 1], 1234))
-                            }),
-                            std::time::Duration::from_secs(2),
-                        ) {
-                            Ok(_) => {
-                                info!("Local OpenAI provider '{name}' reachable at {base_url}");
-                            }
-                            Err(e) => {
-                                warn!(
-                                    "Local OpenAI provider '{name}' not reachable at {base_url} \
-                                     ({}). Provider registered but may fail. \
-                                     Start the local server or switch default_provider in config.",
-                                    e
-                                );
-                                unreachable_local_providers.push(name.clone());
-                            }
+                // Health check for local OpenAI-compatible providers (LM Studio, vLLM, etc.)
+                if let Some(ref base_url) = llm_config.base_url
+                    && (base_url.contains("localhost") || base_url.contains("127.0.0.1"))
+                {
+                    let addr = base_url
+                        .trim_start_matches("http://")
+                        .trim_start_matches("https://")
+                        .split('/')
+                        .next()
+                        .unwrap_or("localhost:1234");
+                    let sock_addr = if addr.contains(':') {
+                        addr.to_string()
+                    } else {
+                        format!("{}:1234", addr)
+                    };
+                    match std::net::TcpStream::connect_timeout(
+                        &sock_addr
+                            .parse()
+                            .unwrap_or_else(|_| std::net::SocketAddr::from(([127, 0, 0, 1], 1234))),
+                        std::time::Duration::from_secs(2),
+                    ) {
+                        Ok(_) => {
+                            info!("Local OpenAI provider '{name}' reachable at {base_url}");
+                        }
+                        Err(e) => {
+                            warn!(
+                                "Local OpenAI provider '{name}' not reachable at {base_url} \
+                                 ({}). Provider registered but may fail. \
+                                 Start the local server or switch default_provider in config.",
+                                e
+                            );
+                            unreachable_local_providers.push(name.clone());
                         }
                     }
-
-                    let provider = OpenAiProvider::new(
-                        key,
-                        llm_config.model.clone(),
-                        llm_config.base_url.clone(),
-                    )
-                    .with_client(llm_client.clone());
-                    runtime.register_provider(Arc::new(provider));
-                    info!("configured openai provider: {name}");
-                } else {
-                    warn!(
-                        "skipping openai provider {name}: no API key (set api_key in config or OPENAI_API_KEY env var)"
-                    );
                 }
+
+                let provider = OpenAiProvider::new(
+                    api_key,
+                    llm_config.model.clone(),
+                    llm_config.base_url.clone(),
+                )
+                .with_client(llm_client.clone());
+                runtime.register_provider(Arc::new(provider));
+                info!("configured openai provider: {name}");
             }
             "ollama" => {
                 let base_url = llm_config
@@ -187,323 +195,182 @@ pub fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
                 info!("configured ollama provider: {name}");
             }
             "sansa" => {
-                let api_key = resolve_api_key(
-                    llm_config.api_key.as_deref(),
-                    "SANSA_API_KEY",
-                    "SANSA_API_KEY",
-                );
-
-                if let Some(key) = api_key {
-                    let base_url = llm_config
-                        .base_url
-                        .clone()
-                        .or_else(|| Some("https://api.sansaml.com".to_string()));
-                    let model = llm_config
-                        .model
-                        .clone()
-                        .or_else(|| Some("sansa-auto".to_string()));
-                    let provider = OpenAiProvider::new(key, model, base_url)
-                        .with_client(llm_client.clone())
-                        .with_name("sansa");
-                    runtime.register_provider(Arc::new(provider));
-                    info!("configured sansa provider: {name}");
-                } else {
-                    warn!(
-                        "skipping sansa provider {name}: no API key (set api_key in config or SANSA_API_KEY env var)"
-                    );
-                }
+                let base_url = llm_config
+                    .base_url
+                    .clone()
+                    .or_else(|| Some("https://api.sansaml.com".to_string()));
+                let model = llm_config
+                    .model
+                    .clone()
+                    .or_else(|| Some("sansa-auto".to_string()));
+                let provider = OpenAiProvider::new(api_key, model, base_url)
+                    .with_client(llm_client.clone())
+                    .with_name("sansa");
+                runtime.register_provider(Arc::new(provider));
+                info!("configured sansa provider: {name}");
             }
             "deepseek" => {
-                let api_key = resolve_api_key(
-                    llm_config.api_key.as_deref(),
-                    "DEEPSEEK_API_KEY",
-                    "DEEPSEEK_API_KEY",
-                );
-
-                if let Some(key) = api_key {
-                    let base_url = llm_config
-                        .base_url
-                        .clone()
-                        .or_else(|| Some("https://api.deepseek.com".to_string()));
-                    let model = llm_config
-                        .model
-                        .clone()
-                        .or_else(|| Some("deepseek-chat".to_string()));
-                    let provider = OpenAiProvider::new(key, model, base_url)
-                        .with_client(llm_client.clone())
-                        .with_name("deepseek");
-                    runtime.register_provider(Arc::new(provider));
-                    info!("configured deepseek provider: {name}");
-                } else {
-                    warn!(
-                        "skipping deepseek provider {name}: no API key (set api_key in config or DEEPSEEK_API_KEY env var)"
-                    );
-                }
+                let base_url = llm_config
+                    .base_url
+                    .clone()
+                    .or_else(|| Some("https://api.deepseek.com".to_string()));
+                let model = llm_config
+                    .model
+                    .clone()
+                    .or_else(|| Some("deepseek-chat".to_string()));
+                let provider = OpenAiProvider::new(api_key, model, base_url)
+                    .with_client(llm_client.clone())
+                    .with_name("deepseek");
+                runtime.register_provider(Arc::new(provider));
+                info!("configured deepseek provider: {name}");
             }
             "mistral" => {
-                let api_key = resolve_api_key(
-                    llm_config.api_key.as_deref(),
-                    "MISTRAL_API_KEY",
-                    "MISTRAL_API_KEY",
-                );
-
-                if let Some(key) = api_key {
-                    let base_url = llm_config
-                        .base_url
-                        .clone()
-                        .or_else(|| Some("https://api.mistral.ai".to_string()));
-                    let model = llm_config
-                        .model
-                        .clone()
-                        .or_else(|| Some("mistral-large-latest".to_string()));
-                    let provider = OpenAiProvider::new(key, model, base_url)
-                        .with_client(llm_client.clone())
-                        .with_name("mistral");
-                    runtime.register_provider(Arc::new(provider));
-                    info!("configured mistral provider: {name}");
-                } else {
-                    warn!(
-                        "skipping mistral provider {name}: no API key (set api_key in config or MISTRAL_API_KEY env var)"
-                    );
-                }
+                let base_url = llm_config
+                    .base_url
+                    .clone()
+                    .or_else(|| Some("https://api.mistral.ai".to_string()));
+                let model = llm_config
+                    .model
+                    .clone()
+                    .or_else(|| Some("mistral-large-latest".to_string()));
+                let provider = OpenAiProvider::new(api_key, model, base_url)
+                    .with_client(llm_client.clone())
+                    .with_name("mistral");
+                runtime.register_provider(Arc::new(provider));
+                info!("configured mistral provider: {name}");
             }
             "gemini" => {
-                let api_key = resolve_api_key(
-                    llm_config.api_key.as_deref(),
-                    "GEMINI_API_KEY",
-                    "GEMINI_API_KEY",
-                );
-
-                if let Some(key) = api_key {
-                    let base_url = llm_config.base_url.clone().or_else(|| {
-                        Some("https://generativelanguage.googleapis.com/v1beta/openai/".to_string())
-                    });
-                    let model = llm_config
-                        .model
-                        .clone()
-                        .or_else(|| Some("gemini-2.5-flash".to_string()));
-                    let provider = OpenAiProvider::new(key, model, base_url)
-                        .with_client(llm_client.clone())
-                        .with_name("gemini");
-                    runtime.register_provider(Arc::new(provider));
-                    info!("configured gemini provider: {name}");
-                } else {
-                    warn!(
-                        "skipping gemini provider {name}: no API key (set api_key in config or GEMINI_API_KEY env var)"
-                    );
-                }
+                let base_url = llm_config.base_url.clone().or_else(|| {
+                    Some("https://generativelanguage.googleapis.com/v1beta/openai/".to_string())
+                });
+                let model = llm_config
+                    .model
+                    .clone()
+                    .or_else(|| Some("gemini-2.5-flash".to_string()));
+                let provider = OpenAiProvider::new(api_key, model, base_url)
+                    .with_client(llm_client.clone())
+                    .with_name("gemini");
+                runtime.register_provider(Arc::new(provider));
+                info!("configured gemini provider: {name}");
             }
             "falcon" => {
-                let api_key = resolve_api_key(
-                    llm_config.api_key.as_deref(),
-                    "FALCON_API_KEY",
-                    "FALCON_API_KEY",
-                );
-
-                if let Some(key) = api_key {
-                    let base_url = llm_config
-                        .base_url
-                        .clone()
-                        .or_else(|| Some("https://api.ai71.ai/v1".to_string()));
-                    let model = llm_config
-                        .model
-                        .clone()
-                        .or_else(|| Some("tiiuae/falcon-180b-chat".to_string()));
-                    let provider = OpenAiProvider::new(key, model, base_url)
-                        .with_client(llm_client.clone())
-                        .with_name("falcon");
-                    runtime.register_provider(Arc::new(provider));
-                    info!("configured falcon provider: {name}");
-                } else {
-                    warn!(
-                        "skipping falcon provider {name}: no API key (set api_key in config or FALCON_API_KEY env var)"
-                    );
-                }
+                let base_url = llm_config
+                    .base_url
+                    .clone()
+                    .or_else(|| Some("https://api.ai71.ai/v1".to_string()));
+                let model = llm_config
+                    .model
+                    .clone()
+                    .or_else(|| Some("tiiuae/falcon-180b-chat".to_string()));
+                let provider = OpenAiProvider::new(api_key, model, base_url)
+                    .with_client(llm_client.clone())
+                    .with_name("falcon");
+                runtime.register_provider(Arc::new(provider));
+                info!("configured falcon provider: {name}");
             }
             "jais" => {
-                let api_key = resolve_api_key(
-                    llm_config.api_key.as_deref(),
-                    "JAIS_API_KEY",
-                    "JAIS_API_KEY",
-                );
-
-                if let Some(key) = api_key {
-                    let base_url = llm_config
-                        .base_url
-                        .clone()
-                        .or_else(|| Some("https://api.core42.ai/v1".to_string()));
-                    let model = llm_config
-                        .model
-                        .clone()
-                        .or_else(|| Some("jais-adapted-70b-chat".to_string()));
-                    let provider = OpenAiProvider::new(key, model, base_url)
-                        .with_client(llm_client.clone())
-                        .with_name("jais");
-                    runtime.register_provider(Arc::new(provider));
-                    info!("configured jais provider: {name}");
-                } else {
-                    warn!(
-                        "skipping jais provider {name}: no API key (set api_key in config or JAIS_API_KEY env var)"
-                    );
-                }
+                let base_url = llm_config
+                    .base_url
+                    .clone()
+                    .or_else(|| Some("https://api.core42.ai/v1".to_string()));
+                let model = llm_config
+                    .model
+                    .clone()
+                    .or_else(|| Some("jais-adapted-70b-chat".to_string()));
+                let provider = OpenAiProvider::new(api_key, model, base_url)
+                    .with_client(llm_client.clone())
+                    .with_name("jais");
+                runtime.register_provider(Arc::new(provider));
+                info!("configured jais provider: {name}");
             }
             "qwen" => {
-                let api_key = resolve_api_key(
-                    llm_config.api_key.as_deref(),
-                    "QWEN_API_KEY",
-                    "QWEN_API_KEY",
-                );
-
-                if let Some(key) = api_key {
-                    let base_url = llm_config.base_url.clone().or_else(|| {
-                        Some("https://dashscope-intl.aliyuncs.com/compatible-mode/v1".to_string())
-                    });
-                    let model = llm_config
-                        .model
-                        .clone()
-                        .or_else(|| Some("qwen-plus".to_string()));
-                    let provider = OpenAiProvider::new(key, model, base_url)
-                        .with_client(llm_client.clone())
-                        .with_name("qwen");
-                    runtime.register_provider(Arc::new(provider));
-                    info!("configured qwen provider: {name}");
-                } else {
-                    warn!(
-                        "skipping qwen provider {name}: no API key (set api_key in config or QWEN_API_KEY env var)"
-                    );
-                }
+                let base_url = llm_config.base_url.clone().or_else(|| {
+                    Some("https://dashscope-intl.aliyuncs.com/compatible-mode/v1".to_string())
+                });
+                let model = llm_config
+                    .model
+                    .clone()
+                    .or_else(|| Some("qwen-plus".to_string()));
+                let provider = OpenAiProvider::new(api_key, model, base_url)
+                    .with_client(llm_client.clone())
+                    .with_name("qwen");
+                runtime.register_provider(Arc::new(provider));
+                info!("configured qwen provider: {name}");
             }
             "yi" => {
-                let api_key =
-                    resolve_api_key(llm_config.api_key.as_deref(), "YI_API_KEY", "YI_API_KEY");
-
-                if let Some(key) = api_key {
-                    let base_url = llm_config
-                        .base_url
-                        .clone()
-                        .or_else(|| Some("https://api.lingyiwanwu.com/v1".to_string()));
-                    let model = llm_config
-                        .model
-                        .clone()
-                        .or_else(|| Some("yi-large".to_string()));
-                    let provider = OpenAiProvider::new(key, model, base_url)
-                        .with_client(llm_client.clone())
-                        .with_name("yi");
-                    runtime.register_provider(Arc::new(provider));
-                    info!("configured yi provider: {name}");
-                } else {
-                    warn!(
-                        "skipping yi provider {name}: no API key (set api_key in config or YI_API_KEY env var)"
-                    );
-                }
+                let base_url = llm_config
+                    .base_url
+                    .clone()
+                    .or_else(|| Some("https://api.lingyiwanwu.com/v1".to_string()));
+                let model = llm_config
+                    .model
+                    .clone()
+                    .or_else(|| Some("yi-large".to_string()));
+                let provider = OpenAiProvider::new(api_key, model, base_url)
+                    .with_client(llm_client.clone())
+                    .with_name("yi");
+                runtime.register_provider(Arc::new(provider));
+                info!("configured yi provider: {name}");
             }
             "cohere" => {
-                let api_key = resolve_api_key(
-                    llm_config.api_key.as_deref(),
-                    "COHERE_API_KEY",
-                    "COHERE_API_KEY",
-                );
-
-                if let Some(key) = api_key {
-                    let base_url = llm_config
-                        .base_url
-                        .clone()
-                        .or_else(|| Some("https://api.cohere.com/compatibility/v1".to_string()));
-                    let model = llm_config
-                        .model
-                        .clone()
-                        .or_else(|| Some("command-r-plus".to_string()));
-                    let provider = OpenAiProvider::new(key, model, base_url)
-                        .with_client(llm_client.clone())
-                        .with_name("cohere");
-                    runtime.register_provider(Arc::new(provider));
-                    info!("configured cohere provider: {name}");
-                } else {
-                    warn!(
-                        "skipping cohere provider {name}: no API key (set api_key in config or COHERE_API_KEY env var)"
-                    );
-                }
+                let base_url = llm_config
+                    .base_url
+                    .clone()
+                    .or_else(|| Some("https://api.cohere.com/compatibility/v1".to_string()));
+                let model = llm_config
+                    .model
+                    .clone()
+                    .or_else(|| Some("command-r-plus".to_string()));
+                let provider = OpenAiProvider::new(api_key, model, base_url)
+                    .with_client(llm_client.clone())
+                    .with_name("cohere");
+                runtime.register_provider(Arc::new(provider));
+                info!("configured cohere provider: {name}");
             }
             "minimax" => {
-                let api_key = resolve_api_key(
-                    llm_config.api_key.as_deref(),
-                    "MINIMAX_API_KEY",
-                    "MINIMAX_API_KEY",
-                );
-
-                if let Some(key) = api_key {
-                    let base_url = llm_config
-                        .base_url
-                        .clone()
-                        .or_else(|| Some("https://api.minimaxi.chat/v1".to_string()));
-                    let model = llm_config
-                        .model
-                        .clone()
-                        .or_else(|| Some("MiniMax-Text-01".to_string()));
-                    let provider = OpenAiProvider::new(key, model, base_url)
-                        .with_client(llm_client.clone())
-                        .with_name("minimax");
-                    runtime.register_provider(Arc::new(provider));
-                    info!("configured minimax provider: {name}");
-                } else {
-                    warn!(
-                        "skipping minimax provider {name}: no API key (set api_key in config or MINIMAX_API_KEY env var)"
-                    );
-                }
+                let base_url = llm_config
+                    .base_url
+                    .clone()
+                    .or_else(|| Some("https://api.minimaxi.chat/v1".to_string()));
+                let model = llm_config
+                    .model
+                    .clone()
+                    .or_else(|| Some("MiniMax-Text-01".to_string()));
+                let provider = OpenAiProvider::new(api_key, model, base_url)
+                    .with_client(llm_client.clone())
+                    .with_name("minimax");
+                runtime.register_provider(Arc::new(provider));
+                info!("configured minimax provider: {name}");
             }
             "moonshot" => {
-                let api_key = resolve_api_key(
-                    llm_config.api_key.as_deref(),
-                    "MOONSHOT_API_KEY",
-                    "MOONSHOT_API_KEY",
-                );
-
-                if let Some(key) = api_key {
-                    let base_url = llm_config
-                        .base_url
-                        .clone()
-                        .or_else(|| Some("https://api.moonshot.cn/v1".to_string()));
-                    let model = llm_config
-                        .model
-                        .clone()
-                        .or_else(|| Some("kimi-k2-0711-preview".to_string()));
-                    let provider = OpenAiProvider::new(key, model, base_url)
-                        .with_client(llm_client.clone())
-                        .with_name("moonshot");
-                    runtime.register_provider(Arc::new(provider));
-                    info!("configured moonshot provider: {name}");
-                } else {
-                    warn!(
-                        "skipping moonshot provider {name}: no API key (set api_key in config or MOONSHOT_API_KEY env var)"
-                    );
-                }
+                let base_url = llm_config
+                    .base_url
+                    .clone()
+                    .or_else(|| Some("https://api.moonshot.cn/v1".to_string()));
+                let model = llm_config
+                    .model
+                    .clone()
+                    .or_else(|| Some("kimi-k2-0711-preview".to_string()));
+                let provider = OpenAiProvider::new(api_key, model, base_url)
+                    .with_client(llm_client.clone())
+                    .with_name("moonshot");
+                runtime.register_provider(Arc::new(provider));
+                info!("configured moonshot provider: {name}");
             }
             "openrouter" => {
-                let api_key = resolve_api_key(
-                    llm_config.api_key.as_deref(),
-                    "OPENROUTER_API_KEY",
-                    "OPENROUTER_API_KEY",
-                );
-
-                if let Some(key) = api_key {
-                    let base_url = llm_config
-                        .base_url
-                        .clone()
-                        .or_else(|| Some("https://openrouter.ai/api/v1".to_string()));
-                    let model = llm_config
-                        .model
-                        .clone()
-                        .or_else(|| Some("openai/gpt-4o".to_string()));
-                    let provider = OpenAiProvider::new(key, model, base_url)
-                        .with_client(llm_client.clone())
-                        .with_name("openrouter");
-                    runtime.register_provider(Arc::new(provider));
-                    info!("configured openrouter provider: {name}");
-                } else {
-                    warn!(
-                        "skipping openrouter provider {name}: no API key (set api_key in config or OPENROUTER_API_KEY env var)"
-                    );
-                }
+                let base_url = llm_config
+                    .base_url
+                    .clone()
+                    .or_else(|| Some("https://openrouter.ai/api/v1".to_string()));
+                let model = llm_config
+                    .model
+                    .clone()
+                    .or_else(|| Some("openai/gpt-4o".to_string()));
+                let provider = OpenAiProvider::new(api_key, model, base_url)
+                    .with_client(llm_client.clone())
+                    .with_name("openrouter");
+                runtime.register_provider(Arc::new(provider));
+                info!("configured openrouter provider: {name}");
             }
             // Plan 0051 (GAR-444): deterministic echo provider for dev + CI
             // smoke tests. Gated by `dev-echo-provider` feature on

--- a/crates/garraia-gateway/src/health.rs
+++ b/crates/garraia-gateway/src/health.rs
@@ -132,69 +132,44 @@ pub async fn run_all_checks(state: &SharedState) -> Vec<HealthStatus> {
         let provider = llm_config.provider.clone();
         let base_url = llm_config.base_url.clone();
 
+        // One key-presence check for every provider, using the same
+        // vault -> config -> env chain the boot path uses. Previously this was
+        // duplicated per provider as `api_key.is_some() || env::var(..).is_ok()`,
+        // which ignored the credential vault entirely — so a provider the
+        // gateway had successfully loaded out of the vault was reported here as
+        // "no API key configured". Keyless providers (`ollama`) always resolve.
+        if !garraia_config::resolve_provider_key_source(&provider, llm_config.api_key.as_deref())
+            .is_resolved()
+        {
+            handles.push(tokio::spawn(async move {
+                HealthStatus {
+                    name,
+                    ok: false,
+                    latency_ms: None,
+                    error: Some("no API key configured".to_string()),
+                }
+            }));
+            continue;
+        }
+
         let check_url = match provider.as_str() {
             "ollama" => {
                 let base = base_url.unwrap_or_else(|| "http://localhost:11434".to_string());
                 Some(format!("{}/api/tags", base))
             }
-            "openrouter" => {
-                // Check if API key is configured first
-                let has_key =
-                    llm_config.api_key.is_some() || std::env::var("OPENROUTER_API_KEY").is_ok();
-                if has_key {
-                    Some("https://openrouter.ai/api/v1/models".to_string())
-                } else {
-                    // No API key — report as disabled, don't hit the endpoint
-                    handles.push(tokio::spawn(async move {
-                        HealthStatus {
-                            name,
-                            ok: false,
-                            latency_ms: None,
-                            error: Some("no API key configured".to_string()),
-                        }
-                    }));
-                    continue;
-                }
-            }
+            "openrouter" => Some("https://openrouter.ai/api/v1/models".to_string()),
             "openai" => {
-                let has_key =
-                    llm_config.api_key.is_some() || std::env::var("OPENAI_API_KEY").is_ok();
-                if has_key {
-                    let base = base_url.unwrap_or_else(|| "https://api.openai.com".to_string());
-                    let base = base.trim_end_matches('/');
-                    // Avoid /v1/v1/models when base_url already ends with /v1
-                    let health_url = if base.ends_with("/v1") {
-                        format!("{}/models", base)
-                    } else {
-                        format!("{}/v1/models", base)
-                    };
-                    Some(health_url)
+                let base = base_url.unwrap_or_else(|| "https://api.openai.com".to_string());
+                let base = base.trim_end_matches('/');
+                // Avoid /v1/v1/models when base_url already ends with /v1
+                let health_url = if base.ends_with("/v1") {
+                    format!("{}/models", base)
                 } else {
-                    handles.push(tokio::spawn(async move {
-                        HealthStatus {
-                            name,
-                            ok: false,
-                            latency_ms: None,
-                            error: Some("no API key configured".to_string()),
-                        }
-                    }));
-                    continue;
-                }
+                    format!("{}/v1/models", base)
+                };
+                Some(health_url)
             }
             "anthropic" => {
-                let has_key =
-                    llm_config.api_key.is_some() || std::env::var("ANTHROPIC_API_KEY").is_ok();
-                if !has_key {
-                    handles.push(tokio::spawn(async move {
-                        HealthStatus {
-                            name,
-                            ok: false,
-                            latency_ms: None,
-                            error: Some("no API key configured".to_string()),
-                        }
-                    }));
-                    continue;
-                }
                 // Anthropic doesn't have a simple health endpoint, skip HTTP check
                 handles.push(tokio::spawn(async move {
                     HealthStatus {

--- a/crates/garraia-gateway/src/router.rs
+++ b/crates/garraia-gateway/src/router.rs
@@ -627,7 +627,6 @@ async fn add_provider(
                 body.base_url.clone(),
             );
             state.agents.register_provider(Arc::new(provider));
-            persist_api_key("ANTHROPIC_API_KEY", key);
         }
         "openai" => {
             let Some(key) = &body.api_key else {
@@ -645,7 +644,6 @@ async fn add_provider(
                 body.base_url.clone(),
             );
             state.agents.register_provider(Arc::new(provider));
-            persist_api_key("OPENAI_API_KEY", key);
         }
         "openrouter" => {
             let Some(key) = &body.api_key else {
@@ -668,7 +666,6 @@ async fn add_provider(
             let provider = garraia_agents::OpenAiProvider::new(key.clone(), model, base_url)
                 .with_name("openrouter");
             state.agents.register_provider(Arc::new(provider));
-            persist_api_key("OPENROUTER_API_KEY", key);
         }
         "sansa" => {
             let Some(key) = &body.api_key else {
@@ -691,7 +688,6 @@ async fn add_provider(
             let provider = garraia_agents::OpenAiProvider::new(key.clone(), model, base_url)
                 .with_name("sansa");
             state.agents.register_provider(Arc::new(provider));
-            persist_api_key("SANSA_API_KEY", key);
         }
         "deepseek" => {
             let Some(key) = &body.api_key else {
@@ -714,7 +710,6 @@ async fn add_provider(
             let provider = garraia_agents::OpenAiProvider::new(key.clone(), model, base_url)
                 .with_name("deepseek");
             state.agents.register_provider(Arc::new(provider));
-            persist_api_key("DEEPSEEK_API_KEY", key);
         }
         "mistral" => {
             let Some(key) = &body.api_key else {
@@ -737,7 +732,6 @@ async fn add_provider(
             let provider = garraia_agents::OpenAiProvider::new(key.clone(), model, base_url)
                 .with_name("mistral");
             state.agents.register_provider(Arc::new(provider));
-            persist_api_key("MISTRAL_API_KEY", key);
         }
         "gemini" => {
             let Some(key) = &body.api_key else {
@@ -759,7 +753,6 @@ async fn add_provider(
             let provider = garraia_agents::OpenAiProvider::new(key.clone(), model, base_url)
                 .with_name("gemini");
             state.agents.register_provider(Arc::new(provider));
-            persist_api_key("GEMINI_API_KEY", key);
         }
         "falcon" => {
             let Some(key) = &body.api_key else {
@@ -782,7 +775,6 @@ async fn add_provider(
             let provider = garraia_agents::OpenAiProvider::new(key.clone(), model, base_url)
                 .with_name("falcon");
             state.agents.register_provider(Arc::new(provider));
-            persist_api_key("FALCON_API_KEY", key);
         }
         "jais" => {
             let Some(key) = &body.api_key else {
@@ -805,7 +797,6 @@ async fn add_provider(
             let provider =
                 garraia_agents::OpenAiProvider::new(key.clone(), model, base_url).with_name("jais");
             state.agents.register_provider(Arc::new(provider));
-            persist_api_key("JAIS_API_KEY", key);
         }
         "qwen" => {
             let Some(key) = &body.api_key else {
@@ -824,7 +815,6 @@ async fn add_provider(
             let provider =
                 garraia_agents::OpenAiProvider::new(key.clone(), model, base_url).with_name("qwen");
             state.agents.register_provider(Arc::new(provider));
-            persist_api_key("QWEN_API_KEY", key);
         }
         "yi" => {
             let Some(key) = &body.api_key else {
@@ -844,7 +834,6 @@ async fn add_provider(
             let provider =
                 garraia_agents::OpenAiProvider::new(key.clone(), model, base_url).with_name("yi");
             state.agents.register_provider(Arc::new(provider));
-            persist_api_key("YI_API_KEY", key);
         }
         "cohere" => {
             let Some(key) = &body.api_key else {
@@ -867,7 +856,6 @@ async fn add_provider(
             let provider = garraia_agents::OpenAiProvider::new(key.clone(), model, base_url)
                 .with_name("cohere");
             state.agents.register_provider(Arc::new(provider));
-            persist_api_key("COHERE_API_KEY", key);
         }
         "minimax" => {
             let Some(key) = &body.api_key else {
@@ -890,7 +878,6 @@ async fn add_provider(
             let provider = garraia_agents::OpenAiProvider::new(key.clone(), model, base_url)
                 .with_name("minimax");
             state.agents.register_provider(Arc::new(provider));
-            persist_api_key("MINIMAX_API_KEY", key);
         }
         "moonshot" => {
             let Some(key) = &body.api_key else {
@@ -913,7 +900,6 @@ async fn add_provider(
             let provider = garraia_agents::OpenAiProvider::new(key.clone(), model, base_url)
                 .with_name("moonshot");
             state.agents.register_provider(Arc::new(provider));
-            persist_api_key("MOONSHOT_API_KEY", key);
         }
         "ollama" => {
             let provider =
@@ -935,19 +921,60 @@ async fn add_provider(
         state.agents.set_default_provider_id(provider_type);
     }
 
+    // Persist once, centrally, keyed off the shared provider->env-var table.
+    // The per-arm `persist_api_key(...)` calls that used to live above threw
+    // away the return value, so a vault write that no-opped for lack of
+    // `GARRAIA_VAULT_PASSPHRASE` still produced `201 {"status":"ok"}`. The
+    // provider then worked for the rest of the process lifetime and vanished on
+    // restart — one of the two ways "I added the provider correctly" was true
+    // and the gateway still came up with no providers.
+    let persisted = match (
+        garraia_config::provider_key_env(provider_type),
+        body.api_key.as_deref(),
+    ) {
+        (Some(vault_key), Some(key)) => persist_api_key(vault_key, key),
+        // Keyless provider (ollama): nothing to persist, nothing to warn about.
+        _ => true,
+    };
+
+    let message = if persisted {
+        format!("provider '{provider_type}' activated")
+    } else {
+        tracing::warn!(
+            "provider '{provider_type}' is active in memory but its API key was NOT persisted: \
+             the credential vault needs {vault_env} to be set. The provider will be gone after \
+             the next restart. Either export {vault_env} and try again, or put the key in \
+             `llm.{provider_type}.api_key` in config.yml.",
+            vault_env = garraia_config::provider_keys::VAULT_PASSPHRASE_ENV
+        );
+        format!(
+            "provider '{provider_type}' activated for this session only — the API key could not \
+             be persisted (the credential vault requires {} to be set), so it will be lost on \
+             restart.",
+            garraia_config::provider_keys::VAULT_PASSPHRASE_ENV
+        )
+    };
+
     (
         axum::http::StatusCode::CREATED,
         axum::Json(serde_json::json!({
             "status": "ok",
-            "message": format!("provider '{provider_type}' activated"),
+            "message": message,
+            // `false` means in-memory only — the caller must persist the key
+            // another way if it should survive a restart.
+            "persisted": persisted,
         })),
     )
 }
 
-/// Best-effort: persist an API key in the vault.
-fn persist_api_key(vault_key: &str, value: &str) {
-    if let Some(vault_path) = crate::bootstrap::default_vault_path() {
-        garraia_security::try_vault_set(&vault_path, vault_key, value);
+/// Best-effort: persist an API key in the vault. Returns `false` when the write
+/// did not happen — most commonly because `GARRAIA_VAULT_PASSPHRASE` is unset,
+/// which `garraia_security::try_vault_set` reports by returning `false` without
+/// logging anything itself.
+fn persist_api_key(vault_key: &str, value: &str) -> bool {
+    match crate::bootstrap::default_vault_path() {
+        Some(vault_path) => garraia_security::try_vault_set(&vault_path, vault_key, value),
+        None => false,
     }
 }
 

--- a/crates/garraia-gateway/src/server.rs
+++ b/crates/garraia-gateway/src/server.rs
@@ -74,6 +74,16 @@ impl GatewayServer {
     }
 
     pub async fn run(self) -> Result<()> {
+        // Load `.env` before anything reads the environment. This must precede
+        // `build_agent_runtime`, which resolves every provider's API key from
+        // env vars: when the load lived in `build_channels` (called ~20 lines
+        // below) `.env` provisioned channels but never providers, so an
+        // embedder of `Server` got working Telegram and zero LLMs. Idempotent,
+        // and it never overwrites an already-set variable.
+        if let Err(e) = dotenvy::dotenv() {
+            tracing::debug!("no .env file loaded: {e}");
+        }
+
         let addr = format!("{}:{}", self.config.gateway.host, self.config.gateway.port);
         let tls_cert = self.config.gateway.tls_cert_path.clone();
         let tls_key = self.config.gateway.tls_key_path.clone();

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -118,7 +118,20 @@ Skip toggles:
 
 ### 2. Configure
 
-Edit `~/.garraia/config.yml`:
+`garraia init` writes this for you. To edit it by hand, first find the file the
+gateway actually reads — the startup banner prints both the directory (`Config`)
+and the filename (`File`).
+
+The config directory is resolved in this order:
+
+1. `$GARRAIA_CONFIG_DIR`, when set — the supported way to keep everything under
+   a single directory of your choosing.
+2. `~/.config/garraia` (XDG), when it exists. **This is the default for new
+   installs.**
+3. `~/.garraia`, when it exists and the XDG path does not (legacy).
+
+Within that directory, `config.yml` wins over `config.toml`; if both exist the
+TOML file is silently ignored.
 
 ```yaml
 gateway:
@@ -129,13 +142,28 @@ llm:
   main:
     provider: openai
     model: gpt-4o
-    api_key: "sk-..."  # or use vault
+    api_key: "sk-..."
 
 channels:
   telegram:
     enabled: true
     bot_token: "YOUR_BOT_TOKEN"
 ```
+
+The API key is resolved per provider in the order **credential vault → this
+file → environment variable** (`OPENAI_API_KEY`, `OPENROUTER_API_KEY`, …). If
+none of the three yields a key, the provider is skipped at startup and the
+gateway comes up unable to answer.
+
+> **The credential vault needs a passphrase on every start.** If you store keys
+> in the vault, the gateway can only open it when `GARRAIA_VAULT_PASSPHRASE` is
+> present in *its* environment — the wizard cannot arrange that for you. Export
+> it from your shell profile or a systemd `EnvironmentFile`. This is why
+> `garraia init` now defaults to writing the key into `config.yml`, which it
+> creates with mode `0600`.
+
+Run `garraia config check` to verify: it reports which file is in force and
+fails with an explicit error for any provider whose key resolves nowhere.
 
 ### 3. Start
 

--- a/plans/0351-onboarding-provider-key-resolution.md
+++ b/plans/0351-onboarding-provider-key-resolution.md
@@ -1,0 +1,137 @@
+# Plan 0351 — onboarding do `install.sh` entrega provider ativo
+
+**Status:** Entregue (PR #823)
+**Autor:** Claude Opus 5 (sessão interativa 2026-08-16, America/New_York)
+**Data:** 2026-08-16 (America/New_York)
+**Branch:** `fix/gar-onboarding-provider-key-resolution`
+**Epic:** `epic:cli` / onboarding
+**Release:** `v0.3.0`
+
+---
+
+## §1 Sintoma reportado
+
+Usuário instalou pelo comando do site (https://garraia.org/) num pod RunPod
+limpo, configurou o provider OpenRouter no wizard, e não conseguiu conversar com
+o Garra. Log:
+
+```text
+WARN garraia_gateway::bootstrap: skipping openrouter provider main: no API key
+     (set api_key in config or OPENROUTER_API_KEY env var)
+...
+║  Total: 0 active / 1 configured     ║
+║  ❌ main             no API key configured ║
+```
+
+## §2 Causa raiz
+
+O caminho documentado pelo site falha **por construção** em qualquer máquina
+nova. Não é config errada do operador.
+
+1. `install.sh:258` roda `garraia init </dev/tty`.
+2. O wizard (`wizard/mod.rs`, e o `wizard.rs` do v0.2.1) oferece três opções de
+   storage com **default no índice 0, "Store in encrypted vault (recommended)"**.
+3. `vault.set("OPENROUTER_API_KEY", &api_key)` cifra a chave em
+   `credentials/vault.json` e deixa `llm_config.api_key = None` → o config sai
+   com `llm.main.api_key: null`. (O v0.2.1 escreve a chave de mapa literal
+   `main`, o que explica o nome no log.)
+4. O wizard imprime `Set GARRAIA_VAULT_PASSPHRASE env var for server mode.` —
+   um `println!` solto que sobe na tela e desaparece.
+5. `install.sh:270` faz `exec garraia start` **no mesmo shell, sem exportar a
+   passphrase**.
+6. `resolve_api_key` percorre vault → config → env:
+   - vault ✗ — `try_vault_get` (`garraia-security/src/credentials.rs:189`) exige
+     `GARRAIA_VAULT_PASSPHRASE` e devolve `None`;
+   - config ✗ — `api_key` é `null`;
+   - env ✗ — nada exportado.
+7. Provider pulado → gateway sobe sem nenhum provider → impossível conversar.
+
+**O cofre é um buraco negro write-only para uso headless.** A chave está no
+disco, cifrada, e o servidor não tem como abri-la. No v0.2.1 nem o
+`warn_if_vault_locked` (plan 0250 / GAR-771) existia, então o operador só via o
+"no API key" enigmático.
+
+### §2.1 Segundo caminho com o mesmo sintoma
+
+`POST /api/providers` (página Providers do console web) devolve
+`201 {"status":"ok"}`, registra o provider em memória, e chama `try_vault_set`,
+que retorna `false` **sem log** quando falta a passphrase
+(`credentials.rs:202-206`). O `bool` era descartado em `router.rs:950`. O
+provider funciona pelo resto da vida do processo e desaparece no restart.
+
+### §2.2 Três regras divergentes de "esse provider tem chave?"
+
+| Superfície | Regra | Consequência |
+| --- | --- | --- |
+| `bootstrap` (a verdade) | vault → config → env | decide se o provider sobe |
+| `/health` | config `\|\|` env | reportava "no API key" para provider carregado do cofre |
+| `admin/providers` | store SQLite do admin | `has_secret: true` para chave que o boot nunca lê |
+
+## §3 Decisões
+
+| Decisão | Escolha | Razão |
+| --- | --- | --- |
+| Storage default | `config.yml` com `0600` | Cofre com passphrase guardada ao lado do ciphertext não é mais seguro que um `0600`; e `gateway.api_key` já morava em texto no config. Cofre segue disponível para deploys que injetam a passphrase externamente. |
+| Diretório de config | Mantém XDG | Trocar o default é migração breaking; `GARRAIA_CONFIG_DIR` já é a alavanca de consolidação. O que havia de real era drift de docs. |
+| Release | `v0.3.0` no repo público | `install.sh` resolve `/releases/latest` em `michelbr84/GarraRUST`; sem tag nova o curl do site segue entregando o v0.2.1. |
+
+## §4 Mudanças entregues
+
+- **P0** wizard grava no `config.yml` por default; rótulo do cofre declara que
+  exige a passphrase a cada start; aviso vira bloco destacado. Mesmo defeito e
+  mesma correção para o token do Telegram.
+- **P0** `merge_update` deixa de ser aditivo-only — backfilla chave nova em
+  entradas `openrouter` pré-existentes sem chave, para que re-rodar `init`
+  conserte um config quebrado. Nunca sobrescreve chave já definida; não aplica ao
+  Ollama (que registra como `provider: openai` com placeholder).
+- **P0** `garraia_config::harden_secret_file` aplica `0600` no `save` e nas três
+  estratégias de escrita do wizard.
+- **P1** `garraia_config::provider_keys` — fonte única (`provider_key_env`,
+  `KeySource`, `resolve_api_key_source`). Remove 15 pares hardcoded em
+  `build_agent_runtime` e 14 no handler de ativação; `/health` e
+  `admin/providers` passam a consumir. `garraia-config` ganha dependência de
+  `garraia-security` (sem ciclo: ambos dependem só de `garraia-common`).
+- **P1** `config check` valida `llm:` — Error sem chave resolvível (consultando
+  o cofre), Error para tipo desconhecido, Warning para `default_provider` ausente
+  com `llm:` populado.
+- **P1** `.env` carregado no topo de `Server::run` (rodava em `build_channels`,
+  ~20 linhas depois de os providers já terem lido as env vars).
+- **P1** `POST /api/providers` reporta `"persisted": bool` + WARN.
+- **P2** banner marca `main ⚠ no API key` e mostra o arquivo em vigor.
+- **P2** `docs/installation.md` (mandava editar `~/.garraia/config.yml`) e
+  `README.md` (`<asset>.sha256` vs `SHA256SUMS`).
+
+### §4.1 Mudança de comportamento declarada
+
+Env var **vazia** passa a contar como ausente. `OPENROUTER_API_KEY=""` antes
+registrava provider com credencial vazia que falhava com 401 opaco no primeiro
+call; agora reporta o aviso acionável. Consistente com o tier de config, que já
+ignorava string vazia.
+
+## §5 Verificação
+
+Gates: `cargo fmt --all -- --check`, `cargo clippy --workspace --exclude
+garraia-desktop --all-targets -- -D warnings`, `garraia-config` 65 testes,
+`garraia` 164, `garraia-gateway` 820 + 19 suítes de integração — todos verdes.
+
+E2E em ambiente pristino (`env -i HOME=… PATH=… GARRAIA_CONFIG_DIR=…`,
+replicando um pod novo):
+
+| Cenário | Resultado |
+| --- | --- |
+| Config do pod (`api_key: null`) → `config check` | `[ERROR] llm.main` nomeando as três remediações, exit `2` (antes: silêncio) |
+| Config do pod → `garra start` | banner `Provider main ⚠ no API key`, aviso com as três remediações, `0 active / 1 configured` |
+| Chave no config → `garra start` | `configured openrouter provider: main`, **`1 active / 1 configured`** |
+| Cofre presente sem passphrase | diagnóstico amigável do plan 0250 continua disparando (sem regressão) |
+
+## §6 Fora de escopo (follow-ups)
+
+- Endurecer o `install.sh` (validar que um provider ficou ativo antes do
+  `exec start`) — considerado e não escolhido.
+- Trocar o default de diretório para `~/.garraia`.
+- Fazer o boot ler a store AES-GCM de `admin/secrets.rs` — 4º caminho de escrita
+  de secret, hoje write-only no que diz respeito ao startup.
+- Unificar `GARRAIA_VAULT_PASSPHRASE` (cofre) e `GarraIA_VAULT_PASSPHRASE`
+  (fallback de auth), documentadas como distintas em `check.rs:134-139`.
+  Confusão latente, merece issue própria.
+- `mcp.json` vs `mcp:` no `config.yml` — duas superfícies de config MCP.


### PR DESCRIPTION
## Problema

O caminho documentado em https://garraia.org/ — `curl -fsSL .../install.sh | sh` → `garraia init` → `garraia start` — **falha por construção em qualquer máquina nova**. Reproduzido num pod RunPod limpo.

Cadeia exata:

1. `install.sh:258` roda `garraia init </dev/tty`.
2. O wizard pergunta onde guardar a chave e o **default é "Store in encrypted vault (recommended)"**.
3. `vault.set("OPENROUTER_API_KEY", …)` cifra a chave e deixa **`llm_config.api_key = None`** → o config sai com `llm.main.api_key: null`.
4. Imprime `Set GARRAIA_VAULT_PASSPHRASE env var for server mode.` — um `println!` que sobe na tela.
5. `install.sh:270` faz `exec garraia start` **no mesmo shell, sem exportar a passphrase**.
6. `resolve_api_key` percorre vault ✗ (`credentials.rs:189` devolve `None` sem passphrase) → config `null` ✗ → env ✗.
7. `WARN skipping openrouter provider main: no API key` → `0 active / 1 configured` → **impossível conversar com o Garra**.

A chave está no disco, cifrada, e o servidor não tem como abri-la. Agravante: o v0.2.1 não tem o `warn_if_vault_locked` (plan 0250/GAR-771 veio depois), então o operador só vê o "no API key" enigmático.

Um **segundo caminho** com o mesmo sintoma: `POST /api/providers` (página Providers do console) devolve `201 ok`, ativa em memória, e `try_vault_set` falha em silêncio sem passphrase — o provider desaparece no restart.

## Correções

| # | Mudança |
| --- | --- |
| P0 | Wizard grava no `config.yml` por default; rótulo do cofre declara o custo operacional. Mesmo fix para o token do Telegram. |
| P0 | `merge_update` deixa de ser aditivo-only — backfilla chave em entrada existente sem chave, para que re-rodar `init` conserte o config. |
| P0 | `config.yml` escrito com modo `0600`, já que passa a carregar credencial. |
| P1 | Fonte única de verdade em `garraia_config::provider_keys` — remove 3 regras divergentes e 29 pares hardcoded. |
| P1 | `garraia config check` valida `llm:` (Error sem chave resolvível, Error tipo desconhecido, Warning `default_provider` ausente). |
| P1 | `.env` carregado no topo de `Server::run` (rodava ~20 linhas depois de os providers serem construídos). |
| P1 | `POST /api/providers` reporta `"persisted": bool` + WARN em vez de silenciar. |
| P2 | Banner marca `main ⚠ no API key` e mostra qual arquivo de config está em vigor. |
| P2 | `docs/installation.md` mandava editar `~/.garraia/config.yml` mas o loader prefere `~/.config/garraia`. README corrigido sobre `SHA256SUMS`. |

## Mudança de comportamento declarada

Env var **vazia** passa a contar como ausente. `OPENROUTER_API_KEY=""` antes registrava um provider com credencial vazia que falhava no primeiro call com 401 opaco; agora reporta o aviso acionável, consistente com o tier de config que já ignorava string vazia.

## Verificação

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings` ✅
- `garraia-config`: 65 testes ✅ (5 novos) · `garraia` CLI: 164 ✅ (6 novos) · `garraia-gateway`: 820 ✅ · 19 suítes de integração, 0 falhas
- **E2E em ambiente pristino (`env -i`, como um pod novo):**
  - config quebrado do pod → `config check` reporta `[ERROR] llm.main` nomeando as três remediações, exit **2** (antes: não reportava nada)
  - boot com config quebrado → banner `Provider main ⚠ no API key` + aviso com as três remediações + `0 active / 1 configured`
  - boot com chave no config → `configured openrouter provider: main` + **`1 active / 1 configured`**
  - cofre presente sem passphrase → diagnóstico amigável do plan 0250 continua disparando (sem regressão)

## Release

Bump para **0.3.0** em `Cargo.toml`, `src-tauri/Cargo.toml` e `tauri.conf.json`. `main` seguia em `0.2.1`, então um binário de `main` se anunciava como a release `v0.2.1` e os dois eram indistinguíveis.

A tag `v0.3.0` **não** foi criada neste PR — deve ser criada em `main` após o merge, para que `install.sh` (que resolve `/releases/latest` em `michelbr84/GarraRUST`) passe a entregar o binário corrigido. Hoje ele entrega o v0.2.1, 431 commits atrás.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
