### PR TITLE
fix(docker): sobe imagem chef para rust:1.94-slim (MSRV do workspace)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Ao participar deste projeto, você concorda em ser respeitoso, inclusivo e const
 
 | Ferramenta | Versão mínima | Instalação |
 |------------|---------------|------------|
-| Rust | 1.92 | `rustup update stable` |
+| Rust | 1.94 | `rustup update stable` |
 | Git | qualquer | [git-scm.com](https://git-scm.com) |
 | FFmpeg | 6.x | `apt install ffmpeg` / `brew install ffmpeg` |
 | Node.js (opcional) | 20+ | Para rodar servidores MCP de teste |

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,11 @@
 # ---------------------------------------------------------------------------
 # Stage 1: Chef — prepare recipe for dependency caching
 # ---------------------------------------------------------------------------
-FROM rust:1.92-slim AS chef
+# Keep this tag >= `rust-version` in the workspace Cargo.toml. When it falls
+# behind, `cargo chef cook` aborts the Deploy image build with
+# "rustc X is not supported by the following packages" (Deploy run on the
+# v0.3.0 tag failed exactly this way with 1.92 vs rust-version 1.94).
+FROM rust:1.94-slim AS chef
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         pkg-config libssl-dev \
@@ -61,7 +65,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
 # ---------------------------------------------------------------------------
 # Stage 5: Runtime — minimal production image
 # ---------------------------------------------------------------------------
-# Must match the builder's glibc. `rust:1.92-slim` (chef base, line 9) is
+# Must match the builder's glibc. `rust:1.94-slim` (chef base, Stage 1) is
 # debian:trixie with glibc 2.39, so the `garra` binary is linked against
 # 2.39. Using bookworm here (glibc 2.36) made the binary fail at startup
 # with `GLIBC_2.39 not found` — discovered during the GAR-603 Runpod local

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ This guide covers installing GarraIA on various platforms.
 
 ## Prerequisites
 
-- **Rust 1.92+** (if building from source)
+- **Rust 1.94+** (if building from source)
 - **FFmpeg** (for voice mode)
 - **OpenSSL** (for some features)
 
@@ -25,7 +25,7 @@ Download the pre-compiled binary from [GitHub Releases](https://github.com/miche
 ### Prerequisites
 
 ```bash
-# Install Rust 1.92+
+# Install Rust 1.94+
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 rustup update stable
 
@@ -192,7 +192,7 @@ docker-compose up -d
 ### Manual Docker
 
 ```dockerfile
-FROM rust:1.92-bookworm
+FROM rust:1.94-trixie
 
 RUN apt-get update && apt-get install -y ffmpeg libssl3
 


### PR DESCRIPTION
## Problema

O workflow **Deploy** da tag `v0.3.0` falhou no build da imagem Docker ([run 31996344792](https://github.com/michelbr84/GarraRUST/actions/runs/31996344792)):

```
error: rustc 1.92.0 is not supported by the following packages:
  garraia-auth@0.0.1 requires rustc 1.94
  garraia-telemetry@0.0.1 requires rustc 1.94
```

O `Dockerfile` pinava `rust:1.92-slim` no estágio chef, mas o workspace exige `rust-version = "1.94"` (`Cargo.toml:34`) — o `cargo chef cook` aborta antes de compilar qualquer coisa.

## Mudanças

- `Dockerfile`: `rust:1.92-slim` → `rust:1.94-slim` no estágio chef, com comentário documentando o invariante (a tag deve acompanhar o `rust-version` do workspace). Atualiza também a referência à tag antiga no comentário de compatibilidade glibc do estágio runtime.
- `docs/installation.md`: MSRV 1.92 → 1.94 (prosa + exemplo `FROM rust:1.92-bookworm` → `rust:1.94-trixie`).
- `CONTRIBUTING.md`: tabela de pré-requisitos 1.92 → 1.94.

## Verificação

- `rust:1.94-slim` existe no Docker Hub e tem o **mesmo digest** de `1.94-slim-trixie` — ou seja, segue trixie-based, então o runtime `debian:trixie-slim` continua casando em glibc (o cuidado documentado no próprio Dockerfile desde o GAR-603).
- `rust:1.94-trixie` (usado no exemplo do doc) também verificado no Docker Hub.
- O binário da release **não** é afetado (release.yml usa `dtolnay/rust-toolchain@stable`); só a imagem GHCR quebrava.

Não corrige o build **Linux ARM64** do release.yml (best-effort, história do cross/openssl documentada no próprio workflow) — fica para issue própria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)