### PR TITLE
fix(installer,ci,cli): resolve 429 do GitHub e runner macos-13 morto

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         run: shellcheck tests/install_sh/fixtures/garraia-stub.sh
 
       - name: Run shellcheck on installer unit tests
-        run: shellcheck tests/install_sh/checksum_format.sh
+        run: shellcheck tests/install_sh/checksum_format.sh tests/install_sh/resolve_version.sh
 
       - name: Syntax-check the bash test runner
         run: bash -n tests/install_sh/bootstrap_phase.sh
@@ -78,6 +78,9 @@ jobs:
 
       - name: Execute installer checksum-format tests
         run: bash tests/install_sh/checksum_format.sh
+
+      - name: Execute installer resolve-version tests
+        run: bash tests/install_sh/resolve_version.sh
 
   # Lint with clippy (strict — bloqueante desde plan 0049 / GAR-429)
   clippy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,11 @@ jobs:
   # Build for macOS x86_64
   build-macos-x86_64:
     name: Build macOS x86_64
-    runs-on: macos-13
+    # macos-13 was retired by GitHub — jobs targeting it queue forever and
+    # never get a runner, which silently blocks the release job's gate (the
+    # v0.3.0 run sat queued for 10+ hours). macos-15-intel is the supported
+    # Intel image.
+    runs-on: macos-15-intel
     permissions:
       contents: read
     steps:
@@ -226,6 +230,13 @@ jobs:
             echo "::warning ::macOS aarch64 binary not built; release will ship without it."
           fi
 
+          # Ship the installer as a release asset too. Release-asset downloads
+          # go through GitHub's release CDN, which does not enforce the
+          # aggressive per-IP limits that make raw.githubusercontent.com
+          # answer 429 on shared cloud-pod egress IPs:
+          #   curl -fsSL https://github.com/michelbr84/GarraRUST/releases/latest/download/install.sh | sh
+          cp install.sh release/
+
       - name: Get version
         id: version
         run: |
@@ -278,6 +289,7 @@ jobs:
             release/garraia-windows-x86_64.exe
             release/garraia-macos-x86_64
             release/garraia-macos-aarch64
+            release/install.sh
             release/SHA256SUMS
             release/*.sha256
         env:

--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ cargo build --release -p garraia-desktop
 curl -fsSL https://raw.githubusercontent.com/michelbr84/GarraRUST/main/install.sh | sh
 ```
 
+> Se o `raw.githubusercontent.com` responder **HTTP 429** (rate limit por IP —
+> comum em pods cloud com IP de saída compartilhado), o mesmo script está
+> publicado em dois canais alternativos:
+>
+> ```bash
+> curl -fsSL https://github.com/michelbr84/GarraRUST/releases/latest/download/install.sh | sh
+> curl -fsSL https://cdn.jsdelivr.net/gh/michelbr84/GarraRUST@main/install.sh | sh
+> ```
+
 Desde plan 0127 (PR-B, 2026-05-14) o instalador encadeia automaticamente:
 1. download + verificação SHA256 do binário `garraia`,
 2. `garraia init </dev/tty` (o wizard do plan 0126 — detecção de GPU/Ollama, prompts opcionais para instalar Qwen3-14B GGUF, geração de `config.yml` server-friendly),

--- a/crates/garraia-cli/src/wizard/config_writer.rs
+++ b/crates/garraia-cli/src/wizard/config_writer.rs
@@ -59,10 +59,10 @@ pub struct WizardOutcome {
     /// Ordered fallbacks. Empty when only one provider was configured.
     pub fallback_providers: Vec<String>,
 
-    /// OpenRouter cloud entry — populated for cloud-only or cloud-first
-    /// modes. `Some` even when the api_key field is `None` (env-var
-    /// users).
-    pub openrouter: Option<CloudLlmChoice>,
+    /// Cloud provider entry (OpenRouter, OpenAI, Anthropic, …) — populated
+    /// for cloud-only or cloud-first modes. `Some` even when the api_key
+    /// field is `None` (env-var users).
+    pub cloud: Option<CloudLlmChoice>,
 
     /// Local LLM — populated only when the user opted in (GPU detected,
     /// `GARRAIA_BOOTSTRAP_LOCAL != 0`, user confirmed).
@@ -82,9 +82,14 @@ pub struct WizardOutcome {
 
 #[derive(Debug, Clone)]
 pub struct CloudLlmChoice {
-    /// Key used in the `llm:` map. Defaults to `"openrouter"`.
+    /// Key used in the `llm:` map (e.g. `"openrouter"`, `"openai"`).
     pub key: String,
+    /// Provider type string consumed by `build_agent_runtime` — for the
+    /// wizard presets this always equals `key`.
+    pub provider: String,
     pub model: String,
+    /// `None` lets the provider client use its own default endpoint.
+    pub base_url: Option<String>,
     pub api_key_plaintext: Option<String>,
 }
 
@@ -146,7 +151,7 @@ pub fn backup_path_for_with(config_dir: &Path, when: chrono::DateTime<Utc>) -> P
 /// `FirstWrite` and `Backup` paths.
 pub fn build_app_config(outcome: &WizardOutcome) -> AppConfig {
     let mut llm: HashMap<String, LlmProviderConfig> = HashMap::new();
-    if let Some(cloud) = &outcome.openrouter {
+    if let Some(cloud) = &outcome.cloud {
         llm.insert(cloud.key.clone(), cloud_llm_provider(cloud));
     }
     if let Some(local) = &outcome.local_llm {
@@ -185,10 +190,10 @@ pub fn build_app_config(outcome: &WizardOutcome) -> AppConfig {
 
 fn cloud_llm_provider(cloud: &CloudLlmChoice) -> LlmProviderConfig {
     LlmProviderConfig {
-        provider: "openrouter".to_string(),
+        provider: cloud.provider.clone(),
         model: Some(cloud.model.clone()),
         api_key: cloud.api_key_plaintext.clone(),
-        base_url: Some("https://openrouter.ai/api/v1".to_string()),
+        base_url: cloud.base_url.clone(),
         extra: Default::default(),
     }
 }
@@ -251,9 +256,9 @@ pub fn merge_update(existing: &mut AppConfig, outcome: &WizardOutcome) {
     existing.gateway.host = outcome.host.clone();
     existing.gateway.port = outcome.port;
 
-    if let Some(cloud) = &outcome.openrouter {
+    if let Some(cloud) = &outcome.cloud {
         if let Some(key) = cloud.api_key_plaintext.as_deref() {
-            backfill_missing_api_key(existing, "openrouter", key);
+            backfill_missing_api_key(existing, &cloud.provider, key);
         }
         existing
             .llm
@@ -366,9 +371,11 @@ mod tests {
             port: 3888,
             default_provider: "openrouter".into(),
             fallback_providers: vec![],
-            openrouter: Some(CloudLlmChoice {
+            cloud: Some(CloudLlmChoice {
                 key: "openrouter".into(),
+                provider: "openrouter".into(),
                 model: "deepseek/deepseek-chat-v3.5".into(),
+                base_url: Some("https://openrouter.ai/api/v1".into()),
                 api_key_plaintext: None,
             }),
             local_llm: None,
@@ -384,9 +391,11 @@ mod tests {
             port: 3888,
             default_provider: OLLAMA_PROVIDER_KEY.into(),
             fallback_providers: vec!["openrouter".into()],
-            openrouter: Some(CloudLlmChoice {
+            cloud: Some(CloudLlmChoice {
                 key: "openrouter".into(),
+                provider: "openrouter".into(),
                 model: "deepseek/deepseek-chat-v3.5".into(),
+                base_url: Some("https://openrouter.ai/api/v1".into()),
                 api_key_plaintext: None,
             }),
             local_llm: Some(LocalLlmChoice::default()),
@@ -400,9 +409,11 @@ mod tests {
     /// the operator picked `SecretStorage::Config` (the v0.3.0 default).
     fn outcome_cloud_with_key(key: &str) -> WizardOutcome {
         let mut out = outcome_cloud_only();
-        out.openrouter = Some(CloudLlmChoice {
+        out.cloud = Some(CloudLlmChoice {
             key: "openrouter".into(),
+            provider: "openrouter".into(),
             model: "openrouter/auto".into(),
+            base_url: Some("https://openrouter.ai/api/v1".into()),
             api_key_plaintext: Some(key.into()),
         });
         out
@@ -436,6 +447,34 @@ mod tests {
             Some("test-key-abc"),
             "a key collected under SecretStorage::Config must reach llm.*.api_key"
         );
+    }
+
+    /// The wizard's cloud step is no longer OpenRouter-only: a non-OpenRouter
+    /// preset must flow through untouched — its provider type in `provider:`,
+    /// and `base_url` left absent so the client uses its own default endpoint.
+    #[test]
+    fn non_openrouter_preset_writes_generic_provider_entry() {
+        let mut out = outcome_cloud_only();
+        out.default_provider = "openai".into();
+        out.cloud = Some(CloudLlmChoice {
+            key: "openai".into(),
+            provider: "openai".into(),
+            model: "gpt-4o".into(),
+            base_url: None,
+            api_key_plaintext: Some("sk-test".into()),
+        });
+
+        let dir = tempdir().unwrap();
+        let path = write_config(dir.path(), &out, ExistingConfigStrategy::FirstWrite).unwrap();
+        let cfg: AppConfig = serde_yaml::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+        let entry = cfg.llm.get("openai").unwrap();
+        assert_eq!(entry.provider, "openai");
+        assert_eq!(entry.model.as_deref(), Some("gpt-4o"));
+        assert_eq!(
+            entry.base_url, None,
+            "no hardcoded OpenRouter base_url may leak in"
+        );
+        assert_eq!(entry.api_key.as_deref(), Some("sk-test"));
     }
 
     /// The regression that made `garraia init` unable to repair itself: a second

--- a/crates/garraia-cli/src/wizard/mod.rs
+++ b/crates/garraia-cli/src/wizard/mod.rs
@@ -41,6 +41,57 @@ use local_stack::{
 /// Default cloud model — matches `chat.rs` (`openrouter/auto`).
 const DEFAULT_OPENROUTER_MODEL: &str = "openrouter/auto";
 
+/// One cloud provider the wizard can configure end-to-end.
+///
+/// `key` doubles as the `llm:` map key **and** the `provider:` type string
+/// consumed by `build_agent_runtime`; `env_var` doubles as the
+/// credential-vault entry name — the gateway resolves both under the same
+/// identifier (see `garraia-gateway/src/bootstrap/config.rs`).
+struct CloudProviderPreset {
+    key: &'static str,
+    name: &'static str,
+    label: &'static str,
+    env_var: &'static str,
+    default_model: &'static str,
+    /// `None` lets the provider client use its own default endpoint.
+    base_url: Option<&'static str>,
+    key_url: &'static str,
+}
+
+/// Presets offered by the "Which cloud AI provider?" select, in display
+/// order. OpenRouter stays first (and default): one key fronts many models.
+/// Default models mirror the provider crates' own defaults
+/// (`garraia-agents/src/{openai,anthropic}.rs`).
+const CLOUD_PROVIDER_PRESETS: &[CloudProviderPreset] = &[
+    CloudProviderPreset {
+        key: "openrouter",
+        name: "OpenRouter",
+        label: "OpenRouter (recommended — one key, many models)",
+        env_var: "OPENROUTER_API_KEY",
+        default_model: DEFAULT_OPENROUTER_MODEL,
+        base_url: Some("https://openrouter.ai/api/v1"),
+        key_url: "https://openrouter.ai/keys",
+    },
+    CloudProviderPreset {
+        key: "openai",
+        name: "OpenAI",
+        label: "OpenAI (GPT models)",
+        env_var: "OPENAI_API_KEY",
+        default_model: "gpt-4o",
+        base_url: None,
+        key_url: "https://platform.openai.com/api-keys",
+    },
+    CloudProviderPreset {
+        key: "anthropic",
+        name: "Anthropic",
+        label: "Anthropic (Claude models)",
+        env_var: "ANTHROPIC_API_KEY",
+        default_model: "claude-sonnet-4-5-20250929",
+        base_url: None,
+        key_url: "https://console.anthropic.com/settings/keys",
+    },
+];
+
 /// Where the wizard persists a secret it just collected.
 ///
 /// The ordering of the variants is the ordering of the prompt, and
@@ -168,8 +219,8 @@ pub fn run_wizard(config_dir: &Path) -> Result<()> {
                 .with_prompt("Which LLM mode?")
                 .items([
                     "Local-first (Ollama on this GPU + cloud fallback)",
-                    "Cloud-first (OpenRouter primary + Ollama fallback)",
-                    "Cloud-only (OpenRouter — no local stack)",
+                    "Cloud-first (cloud provider primary + Ollama fallback)",
+                    "Cloud-only (OpenRouter / OpenAI / Anthropic — no local stack)",
                 ])
                 .default(0)
                 .interact()
@@ -186,14 +237,14 @@ pub fn run_wizard(config_dir: &Path) -> Result<()> {
     };
     let _ = mode_default;
 
-    let mut openrouter_choice: Option<CloudLlmChoice> = None;
+    let mut cloud_choice: Option<CloudLlmChoice> = None;
     let mut local_choice: Option<LocalLlmChoice> = None;
     let mut fallback_providers: Vec<String> = Vec::new();
 
     // --- 4. Cloud branch ---------------------------------------------------
     let want_cloud = matches!(mode_idx, 0..=2);
-    let openrouter_api_key_plaintext = if want_cloud {
-        collect_openrouter(&mut openrouter_choice)?
+    let cloud_secret_for_vault = if want_cloud {
+        collect_cloud_provider(&mut cloud_choice)?
     } else {
         None
     };
@@ -204,17 +255,17 @@ pub fn run_wizard(config_dir: &Path) -> Result<()> {
     }
 
     // --- 6. Resolve default / fallback ordering ----------------------------
-    let default_provider: String = match (local_choice.as_ref(), openrouter_choice.as_ref()) {
-        (Some(_), Some(_)) if mode_idx == 0 => {
-            fallback_providers = vec!["openrouter".to_string()];
+    let default_provider: String = match (local_choice.as_ref(), cloud_choice.as_ref()) {
+        (Some(_), Some(cloud)) if mode_idx == 0 => {
+            fallback_providers = vec![cloud.key.clone()];
             OLLAMA_PROVIDER_KEY.to_string()
         }
-        (Some(_), Some(_)) if mode_idx == 1 => {
+        (Some(_), Some(cloud)) if mode_idx == 1 => {
             fallback_providers = vec![OLLAMA_PROVIDER_KEY.to_string()];
-            "openrouter".to_string()
+            cloud.key.clone()
         }
         (Some(_), None) => OLLAMA_PROVIDER_KEY.to_string(),
-        (None, Some(_)) => "openrouter".to_string(),
+        (None, Some(cloud)) => cloud.key.clone(),
         _ => {
             // Neither selected — emit a placeholder so the wizard
             // produces a valid `agent.default_provider`. The user can
@@ -315,15 +366,16 @@ pub fn run_wizard(config_dir: &Path) -> Result<()> {
     };
 
     // --- 10. Vault (cloud key + telegram token) ---------------------------
-    // `collect_openrouter` / the Telegram prompt hand back a cleartext secret
-    // only when the operator explicitly chose the vault, so no further
+    // `collect_cloud_provider` / the Telegram prompt hand back a cleartext
+    // secret only when the operator explicitly chose the vault, so no further
     // filtering is needed here.
-    let openrouter_for_vault = openrouter_api_key_plaintext;
-    let needs_vault = openrouter_for_vault.is_some() || telegram_token_for_vault.is_some();
+    let needs_vault = cloud_secret_for_vault.is_some() || telegram_token_for_vault.is_some();
     if needs_vault {
         open_or_create_vault(
             config_dir,
-            openrouter_for_vault.as_deref(),
+            cloud_secret_for_vault
+                .as_ref()
+                .map(|(entry, key)| (entry.as_str(), key.as_str())),
             telegram_token_for_vault.as_deref(),
         )?;
         print_vault_passphrase_warning();
@@ -336,7 +388,7 @@ pub fn run_wizard(config_dir: &Path) -> Result<()> {
         port,
         default_provider,
         fallback_providers,
-        openrouter: openrouter_choice,
+        cloud: cloud_choice,
         local_llm: local_choice,
         voice_enabled,
         system_prompt,
@@ -417,20 +469,35 @@ fn print_env_summary(env: &EnvSnapshot) {
     println!();
 }
 
-fn collect_openrouter(out: &mut Option<CloudLlmChoice>) -> Result<Option<String>> {
+/// Cloud branch: pick one of [`CLOUD_PROVIDER_PRESETS`], then collect and
+/// route its API key. Returns `Some((vault_entry_name, cleartext))` only when
+/// the operator explicitly chose the vault — the caller forwards that pair
+/// into the vault flow.
+fn collect_cloud_provider(out: &mut Option<CloudLlmChoice>) -> Result<Option<(String, String)>> {
+    let labels: Vec<&str> = CLOUD_PROVIDER_PRESETS.iter().map(|p| p.label).collect();
+    let picked = Select::new()
+        .with_prompt("Which cloud AI provider?")
+        .items(&labels)
+        .default(0)
+        .interact()
+        .context("cloud provider choice cancelled")?;
+    let preset = &CLOUD_PROVIDER_PRESETS[picked];
+
+    println!("  No key yet? Create one at {}", preset.key_url);
     let api_key: String = Password::new()
-        .with_prompt(
-            "Enter your OpenRouter API key (or leave blank to use OPENROUTER_API_KEY env var)",
-        )
+        .with_prompt(format!(
+            "Enter your {} API key (or leave blank to use the {} env var)",
+            preset.name, preset.env_var
+        ))
         .allow_empty_password(true)
         .interact()
-        .context("OpenRouter key input cancelled")?;
+        .with_context(|| format!("{} key input cancelled", preset.name))?;
     let api_key = api_key.trim().to_string();
 
     let storage = if api_key.is_empty() {
         SecretStorage::Env
     } else {
-        prompt_secret_storage("OpenRouter API key", "OPENROUTER_API_KEY")?
+        prompt_secret_storage(&format!("{} API key", preset.name), preset.env_var)?
     };
 
     let plaintext_for_config = match storage {
@@ -439,15 +506,17 @@ fn collect_openrouter(out: &mut Option<CloudLlmChoice>) -> Result<Option<String>
     };
 
     *out = Some(CloudLlmChoice {
-        key: "openrouter".to_string(),
-        model: DEFAULT_OPENROUTER_MODEL.to_string(),
+        key: preset.key.to_string(),
+        provider: preset.key.to_string(),
+        model: preset.default_model.to_string(),
+        base_url: preset.base_url.map(str::to_string),
         api_key_plaintext: plaintext_for_config,
     });
 
     // Return the cleartext only when the user picked vault — caller
     // forwards into the vault flow.
     match storage {
-        SecretStorage::Vault => Ok(Some(api_key)),
+        SecretStorage::Vault => Ok(Some((preset.env_var.to_string(), api_key))),
         SecretStorage::Config | SecretStorage::Env => Ok(None),
     }
 }
@@ -522,7 +591,10 @@ fn pick_host_port(env: &EnvSnapshot) -> (String, u16) {
 
 fn open_or_create_vault(
     config_dir: &Path,
-    openrouter_key: Option<&str>,
+    // `(vault entry name, cleartext)` — the entry name is the provider's
+    // env-var identifier, which is also what the gateway looks the secret
+    // up under at boot.
+    cloud_secret: Option<(&str, &str)>,
     telegram_token: Option<&str>,
 ) -> Result<()> {
     let vault_path = config_dir.join("credentials").join("vault.json");
@@ -563,9 +635,9 @@ fn open_or_create_vault(
     };
 
     if let Some(vault) = vault_opt.as_mut() {
-        if let Some(key) = openrouter_key {
-            vault.set("OPENROUTER_API_KEY", key);
-            println!("  OpenRouter API key encrypted in vault.");
+        if let Some((entry, key)) = cloud_secret {
+            vault.set(entry, key);
+            println!("  Cloud provider API key encrypted in vault (entry {entry}).");
         }
         if let Some(tg) = telegram_token {
             vault.set("TELEGRAM_BOT_TOKEN", tg);

--- a/docs/deployment-runpod.md
+++ b/docs/deployment-runpod.md
@@ -117,6 +117,9 @@ fastest path is:
 ```bash
 # Install the binary (once)
 curl -fsSL https://raw.githubusercontent.com/michelbr84/GarraRUST/main/install.sh | sh
+# If that answers HTTP 429 (pod egress IPs are shared and exhaust GitHub's
+# per-IP rate limit), use the release-CDN mirror instead:
+#   curl -fsSL https://github.com/michelbr84/GarraRUST/releases/latest/download/install.sh | sh
 
 # Configure interactively
 garraia init

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,6 +16,18 @@ This guide covers installing GarraIA on various platforms.
 curl -fsSL https://raw.githubusercontent.com/michelbr84/GarraRUST/main/install.sh | sh
 ```
 
+The same script is published through two alternative channels, useful when
+`raw.githubusercontent.com` answers **HTTP 429** (per-IP rate limit — common on
+cloud pods whose egress IP is shared by many users):
+
+```bash
+# Official mirror — GitHub release CDN (no aggressive per-IP limits):
+curl -fsSL https://github.com/michelbr84/GarraRUST/releases/latest/download/install.sh | sh
+
+# Community CDN mirror of the repository's main branch:
+curl -fsSL https://cdn.jsdelivr.net/gh/michelbr84/GarraRUST@main/install.sh | sh
+```
+
 ### Windows
 
 Download the pre-compiled binary from [GitHub Releases](https://github.com/michelbr84/GarraRUST/releases).
@@ -86,8 +98,12 @@ This wizard will (plan 0126):
   - **Local-first** (Ollama on this GPU + cloud fallback) — default
     when an NVIDIA GPU is detected and `GARRAIA_BOOTSTRAP_LOCAL` is not
     set to `0`.
-  - **Cloud-first** (OpenRouter primary + Ollama fallback).
-  - **Cloud-only** (OpenRouter — default for CPU/no-GPU machines).
+  - **Cloud-first** (cloud provider primary + Ollama fallback).
+  - **Cloud-only** (default for CPU/no-GPU machines).
+- On the cloud branch, let you pick the provider — **OpenRouter**
+  (recommended default), **OpenAI**, or **Anthropic** — and prompt for
+  that provider's API key (each preset names its own env var, default
+  model, and key-creation URL).
 - On GPU machines (and only after explicit confirmation), install
   Ollama via the official upstream script and pull
   `hf.co/MaziyarPanahi/Qwen3-14B-GGUF:Q4_K_M`. NVIDIA drivers and CUDA
@@ -234,6 +250,25 @@ curl http://127.0.0.1:3888/api/health
 ```
 
 ## Troubleshooting
+
+### `curl | sh` fails with HTTP 429
+
+`raw.githubusercontent.com` (which serves `install.sh`) and `api.github.com`
+enforce **per-IP** rate limits. Cloud pods (RunPod etc.) share their egress IP
+across many users, so a brand-new pod can be over the quota before you run
+anything. Retry in a few minutes, or use one of the alternative channels:
+
+```bash
+# Official mirror — GitHub release CDN:
+curl -fsSL https://github.com/michelbr84/GarraRUST/releases/latest/download/install.sh | sh
+
+# Community CDN mirror of main:
+curl -fsSL https://cdn.jsdelivr.net/gh/michelbr84/GarraRUST@main/install.sh | sh
+```
+
+Inside the installer itself, downloads retry automatically and the release
+tag is resolved from the `github.com` redirect (not the API), so the 429
+surface is limited to that very first fetch of the script.
 
 ### Port already in use
 

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -7,6 +7,8 @@ A forma mais rápida de começar é utilizando o script de instalação:
 ```bash
 # Instalar (Linux, macOS)
 curl -fsSL https://raw.githubusercontent.com/michelbr84/GarraRUST/main/install.sh | sh
+# Alternativa se o comando acima responder HTTP 429 (rate limit por IP):
+#   curl -fsSL https://github.com/michelbr84/GarraRUST/releases/latest/download/install.sh | sh
 
 # Configuração interativa — escolha seu provedor de LLM e armazene suas chaves de API em um cofre criptografado
 garraia init

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,12 @@
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/michelbr84/GarraRUST/main/install.sh | sh
 #
+# If raw.githubusercontent.com answers 429 (per-IP rate limit — common on
+# cloud pods whose egress IP is shared by many users), the same script is
+# published through two alternative channels:
+#   curl -fsSL https://github.com/michelbr84/GarraRUST/releases/latest/download/install.sh | sh
+#   curl -fsSL https://cdn.jsdelivr.net/gh/michelbr84/GarraRUST@main/install.sh | sh
+#
 # Plan 0127 (PR-B, 2026-05-14): after install_binary the installer
 # auto-runs `garraia init` and `garraia start` when a TTY is available.
 # In true non-interactive contexts (docker build, pure CI) it prints
@@ -39,6 +45,13 @@ set -eu
 
 REPO="michelbr84/GarraRUST"
 BINARY="garraia"
+
+# Every GitHub fetch goes through this wrapper. curl treats HTTP 408/429/5xx
+# as transient under --retry (curl >= 7.66), which matters on cloud pods:
+# their shared egress IPs exhaust GitHub's per-IP rate limits constantly.
+curl_gh() {
+    curl -fsSL --retry 5 --retry-delay 2 "$@"
+}
 
 main() {
     detect_platform
@@ -78,11 +91,19 @@ resolve_version() {
         return
     fi
 
-    # Try /releases/latest first (returns 404 when only prereleases exist).
-    VERSION="$(github_api "https://api.github.com/repos/${REPO}/releases/latest" \
-        | extract_tag_name || true)"
+    # Preferred path: follow the web redirect of /releases/latest and read the
+    # tag out of the final URL. Unlike api.github.com (60 unauthenticated
+    # requests/hour per IP — exhausted immediately on shared cloud-pod egress
+    # IPs), the github.com web endpoint tolerates far more traffic.
+    VERSION="$(resolve_version_from_redirect || true)"
 
-    # Fall back to the most recent non-draft release (includes prereleases).
+    # Fallback: the REST API — /releases/latest first (404s when only
+    # prereleases exist), then the most recent non-draft release.
+    if [ -z "${VERSION}" ]; then
+        VERSION="$(github_api "https://api.github.com/repos/${REPO}/releases/latest" \
+            | extract_tag_name || true)"
+    fi
+
     if [ -z "${VERSION}" ]; then
         VERSION="$(github_api "https://api.github.com/repos/${REPO}/releases" \
             | tr ',' '\n' \
@@ -90,15 +111,33 @@ resolve_version() {
     fi
 
     if [ -z "${VERSION}" ]; then
+        rate_limit_hint
         error "Failed to resolve latest release. Set GARRAIA_VERSION=vX.Y.Z to pin."
     fi
 
     echo "Latest version: ${VERSION}"
 }
 
+# HEAD-follow the /releases/latest redirect (no body download) and print the
+# tag embedded in the final URL. Prints nothing when the redirect does not
+# land on a /releases/tag/<tag> URL (e.g. a repo with no full release yet),
+# letting resolve_version fall back to the API.
+resolve_version_from_redirect() {
+    curl_gh -I -o /dev/null -w '%{url_effective}' \
+        "https://github.com/${REPO}/releases/latest" \
+        | extract_tag_from_release_url
+}
+
+# `…/releases/tag/v0.3.0[?query]` → `v0.3.0`; anything else → empty output.
+# Kept standalone so it can be unit-tested via GARRAIA_INSTALL_SH_LIBRARY=1
+# (see tests/install_sh/resolve_version.sh).
+extract_tag_from_release_url() {
+    sed -n 's|.*/releases/tag/\([^/?]*\).*|\1|p' | head -1
+}
+
 github_api() {
     # Surface curl error code while keeping stderr quiet in success path.
-    curl -fsSL -H "Accept: application/vnd.github+json" "$1"
+    curl_gh -H "Accept: application/vnd.github+json" "$1"
 }
 
 extract_tag_name() {
@@ -133,12 +172,14 @@ download_and_verify() {
     trap 'rm -rf -- "${GARRAIA_TMPDIR}"' EXIT INT TERM
 
     echo "Downloading ${ARTIFACT} from ${VERSION}..."
-    if ! curl -fsSL "${BASE_URL}/${ARTIFACT}" -o "${GARRAIA_TMPDIR}/${ARTIFACT}"; then
+    if ! curl_gh "${BASE_URL}/${ARTIFACT}" -o "${GARRAIA_TMPDIR}/${ARTIFACT}"; then
+        rate_limit_hint
         error "Failed to download ${ARTIFACT} from ${BASE_URL}. The release may not include this platform yet."
     fi
 
     echo "Downloading SHA256SUMS..."
-    if ! curl -fsSL "${BASE_URL}/SHA256SUMS" -o "${GARRAIA_TMPDIR}/SHA256SUMS"; then
+    if ! curl_gh "${BASE_URL}/SHA256SUMS" -o "${GARRAIA_TMPDIR}/SHA256SUMS"; then
+        rate_limit_hint
         error "Failed to download SHA256SUMS. Cannot verify binary integrity."
     fi
 
@@ -283,6 +324,21 @@ print_next_steps_legacy() {
 error() {
     echo "error: $1" >&2
     exit 1
+}
+
+# Printed when a GitHub fetch fails even after curl's retries. On shared
+# cloud pods (RunPod etc.) HTTP 429 here usually means the pod's egress IP —
+# shared by many users — exhausted GitHub's per-IP quota, not that anything
+# is wrong on this machine.
+rate_limit_hint() {
+    echo "" >&2
+    echo "If the failure above was HTTP 429 (rate limit): this machine's shared" >&2
+    echo "egress IP has exhausted GitHub's per-IP quota. You can:" >&2
+    echo "  * retry in a few minutes, or" >&2
+    echo "  * fetch the installer from the release CDN instead:" >&2
+    echo "      curl -fsSL https://github.com/${REPO}/releases/latest/download/install.sh | sh" >&2
+    echo "  * or from the jsDelivr mirror:" >&2
+    echo "      curl -fsSL https://cdn.jsdelivr.net/gh/${REPO}@main/install.sh | sh" >&2
 }
 
 # Library mode (plan 0127 §M1.3): when sourced by the test runner with

--- a/tests/install_sh/resolve_version.sh
+++ b/tests/install_sh/resolve_version.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Unit tests for the network-free pieces of `resolve_version` in `install.sh`.
+#
+# Context: unauthenticated api.github.com allows 60 requests/hour **per IP**.
+# Cloud pods (RunPod etc.) share their egress IP across many users, so the
+# installer's original API-based version lookup 429'd/403'd routinely. The
+# fix resolves the tag from the `github.com/<repo>/releases/latest` redirect
+# URL instead, keeping the API as fallback. These tests pin the URL → tag
+# parser; the network path is exercised by the live installer.
+#
+# Strategy mirrors checksum_format.sh: source install.sh with
+# GARRAIA_INSTALL_SH_LIBRARY=1 so main() does not run, then invoke the
+# functions directly.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+install_sh="${repo_root}/install.sh"
+
+case "$(uname -s)" in
+    Linux|Darwin) : ;;
+    *)
+        echo "resolve_version.sh: skipping on $(uname -s) — install.sh is Linux/macOS only."
+        exit 0
+        ;;
+esac
+
+export GARRAIA_INSTALL_SH_LIBRARY=1
+# shellcheck source=/dev/null
+. "${install_sh}"
+
+results_pass=0
+results_fail=0
+
+pass() { echo "  PASS: $1"; results_pass=$((results_pass + 1)); }
+fail() { echo "  FAIL: $1" >&2; results_fail=$((results_fail + 1)); }
+
+# assert_eq <label> <expected> <actual>
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "${expected}" = "${actual}" ]; then
+        pass "${label}"
+    else
+        fail "${label} — expected [${expected}] got [${actual}]"
+    fi
+}
+
+echo "== extract_tag_from_release_url =="
+
+# --- the canonical shape github.com redirects /releases/latest to -----------
+got="$(printf '%s' "https://github.com/michelbr84/GarraRUST/releases/tag/v0.3.0" \
+    | extract_tag_from_release_url)"
+assert_eq "canonical tag URL" "v0.3.0" "${got}"
+
+# --- query string after the tag must not leak into the version --------------
+got="$(printf '%s' "https://github.com/michelbr84/GarraRUST/releases/tag/v0.3.0?foo=bar" \
+    | extract_tag_from_release_url)"
+assert_eq "query string stripped" "v0.3.0" "${got}"
+
+# --- prerelease-style tags survive intact ------------------------------------
+got="$(printf '%s' "https://github.com/michelbr84/GarraRUST/releases/tag/v0.1.0-beta.1" \
+    | extract_tag_from_release_url)"
+assert_eq "prerelease tag kept whole" "v0.1.0-beta.1" "${got}"
+
+# --- repo with no full release: redirect lands on /releases (no /tag/) ------
+got="$(printf '%s' "https://github.com/michelbr84/GarraRUST/releases" \
+    | extract_tag_from_release_url || true)"
+assert_eq "no-tag URL -> empty (API fallback takes over)" "" "${got}"
+
+# --- non-redirected URL (rate-limited HTML page, error body, etc.) ----------
+got="$(printf '%s' "https://github.com/michelbr84/GarraRUST/releases/latest" \
+    | extract_tag_from_release_url || true)"
+assert_eq "unredirected /latest -> empty" "" "${got}"
+
+echo ""
+echo "== resolve_version (pin short-circuit) =="
+
+# A pinned GARRAIA_VERSION must never touch the network. Poison curl via PATH
+# so any accidental network call fails the test loudly.
+work="$(mktemp -d)"
+trap 'rm -rf -- "${work}"' EXIT
+cat > "${work}/curl" <<'EOF'
+#!/bin/sh
+echo "curl must not be invoked when GARRAIA_VERSION is pinned" >&2
+exit 97
+EOF
+chmod +x "${work}/curl"
+
+got="$(PATH="${work}:${PATH}" GARRAIA_VERSION="v9.9.9" sh -c "
+    export GARRAIA_INSTALL_SH_LIBRARY=1
+    . '${install_sh}'
+    resolve_version >/dev/null
+    printf '%s' \"\${VERSION}\"
+")"
+assert_eq "pinned version bypasses network" "v9.9.9" "${got}"
+
+echo ""
+echo "resolve_version.sh: ${results_pass} passed, ${results_fail} failed"
+[ "${results_fail}" -eq 0 ]


### PR DESCRIPTION
## Problema

O fluxo de produto — pod Ubuntu novo + `curl -fsSL …/install.sh | sh` — está quebrado por dois problemas independentes:

1. **HTTP 429 no bootstrap**: `raw.githubusercontent.com` e `api.github.com` aplicam rate limit **por IP**; pods cloud compartilham o IP de saída entre muitos usuários e estouram a cota antes do primeiro uso.
2. **A release v0.3.0 nunca publicou**: o job `build-macos-x86_64` usa `runs-on: macos-13`, runner **aposentado pelo GitHub** — fica `queued` para sempre (run 31996344903 ficou 10+ horas sem receber runner) e o gate do publish nunca libera. A "Latest" continua sendo a v0.2.1, que tem o bug de provider inativo.

## Mudanças

### `release.yml`
- `build-macos-x86_64`: `macos-13` → `macos-15-intel` (imagem Intel suportada).
- `install.sh` publicado como **release asset** → canal alternativo oficial servido pelo CDN de releases (sem rate limit agressivo por IP):
  `curl -fsSL https://github.com/michelbr84/GarraRUST/releases/latest/download/install.sh | sh`

### `install.sh`
- `resolve_version()` resolve a tag seguindo o **redirect** de `github.com/…/releases/latest` (HEAD, sem body) — `api.github.com` (60 req/h por IP) vira só fallback.
- Todos os downloads passam por `curl_gh` com `--retry 5 --retry-delay 2` (curl trata 429/5xx como transientes).
- Falhas persistentes imprimem os canais alternativos (release CDN + mirror jsDelivr).
- Comportamento interativo do plan 0127 preservado intacto (wizard + start via `/dev/tty`, skips, modo library).
- Novo `tests/install_sh/resolve_version.sh` (6 casos): parser do redirect URL → tag e short-circuit de `GARRAIA_VERSION` com `curl` envenenado no `PATH`. Wired no `ci.yml`.

### Wizard (`garraia init`)
- A etapa cloud deixa de ser OpenRouter fixo: Select **"Which cloud AI provider?"** entre **OpenRouter** (default recomendado), **OpenAI** e **Anthropic**, via tabela de presets (modelo default, env var, base_url e URL de criação de chave por provider).
- `CloudLlmChoice` ganha `provider`/`base_url`; o backfill do merge e a entrada do cofre usam o provider escolhido (a entrada do cofre usa o mesmo identificador que o gateway resolve no boot).
- Novo teste: preset não-OpenRouter escreve entrada genérica correta (`provider: openai`, sem base_url vazada do OpenRouter).

### Docs
- Canais alternativos + troubleshooting 429 em `README.md`, `docs/installation.md`, `docs/deployment-runpod.md`, `docs/src/getting_started.md`.

## O que este PR NÃO resolve

O 429 no **primeiro** fetch do `install.sh` via `raw.githubusercontent.com` acontece antes de qualquer código nosso executar — não é tecnicamente eliminável pelo repositório. Mitigação: canais alternativos acima; solução definitiva: vanity URL própria com cache edge (follow-up).

## Testes

- `bash tests/install_sh/{resolve_version,checksum_format,bootstrap_phase}.sh` — 6+5+17 passando.
- `cargo test -p garraia` — 177 passando; `cargo clippy -p garraia` limpo; `cargo fmt --all` aplicado.
- Live: `resolve_version_from_redirect` retornou `v0.2.1` (Latest atual) sem tocar `api.github.com`.

## Pós-merge (tracked fora do PR)

1. Cancelar run travado 31996344903.
2. Re-tag `v0.3.0` no novo commit de `main` (o workflow roda com o `release.yml` do commit da tag) e acompanhar até publicar com `garraia-linux-x86_64` + `SHA256SUMS` + `install.sh`.
3. Smoke test do gate: pod Ubuntu novo → `apt update/upgrade` → one-liner → wizard → provider ativo.
4. Follow-up issue: `get.garraia.cloud` (Cloudflare Worker com cache edge) para tirar o bootstrap de cima do raw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
