### PR TITLE
fix(security,config,gateway): aceita ambas grafias da vault passphrase (#824)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,8 @@ GARRAIA_JWT_SECRET=change-me-generate-with-openssl-rand-hex-32
 # Legacy fallback: accepted by AuthConfig::from_env() when
 # GARRAIA_JWT_SECRET is absent. Kept for zero-breaking-change in dev
 # workflows that predate GAR-379. New deployments SHOULD prefer
-# GARRAIA_JWT_SECRET. If both are set, GARRAIA_JWT_SECRET wins.
+# GARRAIA_JWT_SECRET. Precedence: GARRAIA_JWT_SECRET >
+# GarraIA_VAULT_PASSPHRASE > GARRAIA_VAULT_PASSPHRASE (issue #824).
 # GarraIA_VAULT_PASSPHRASE=change-me-generate-with-openssl-rand-hex-32
 #
 # Personalidade PT-BR do Garra no chat mobile (opcional — tem default embutido)
@@ -37,10 +38,12 @@ GARRAIA_JWT_SECRET=change-me-generate-with-openssl-rand-hex-32
 # Without this, sensitive values are saved as plaintext in mcp.json.
 # Generate a strong passphrase with: openssl rand -hex 32
 #
-# NOTE (plan 0046): case-sensitive. `GarraIA_VAULT_PASSPHRASE` (mixed
-# case) is the legacy alias also accepted by `AuthConfig::from_env` as
-# a fallback for `GARRAIA_JWT_SECRET`. Keep the spelling below for
-# `garraia-security::CredentialVault` ingest.
+# NOTE (plan 0046 + issue #824): the all-caps spelling below is the
+# canonical one. The mixed-case `GarraIA_VAULT_PASSPHRASE` is a
+# DEPRECATED alias — since #824 every consumer (credential vault AND
+# the JWT-secret fallback in `AuthConfig::from_env`) accepts both
+# spellings, with a deprecation warning for the mixed-case one, so a
+# casing slip no longer fails silently. Prefer the spelling below.
 GARRAIA_VAULT_PASSPHRASE=change-me-generate-with-openssl-rand-hex-32
 
 # --- Channel Tokens (optional) ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **Vault-passphrase casing trap eliminated** (issue #824) — the two
+  near-identical env vars `GARRAIA_VAULT_PASSPHRASE` (credential vault) and
+  `GarraIA_VAULT_PASSPHRASE` (legacy JWT-secret fallback) no longer fail
+  silently when the operator picks the "wrong" one. Every consumer now accepts
+  both spellings: the credential vault (`garraia-security`) falls back to the
+  mixed-case alias with a deprecation warning at boot, and
+  `AuthConfig::from_env` accepts the all-caps spelling as its last JWT-secret
+  fallback. Precedence is backwards-compatible — `GARRAIA_JWT_SECRET` >
+  `GarraIA_VAULT_PASSPHRASE` > `GARRAIA_VAULT_PASSPHRASE` for auth, and
+  all-caps > mixed-case for the vault — so deploys that set both spellings
+  with different values keep their exact pre-fix behavior. `garraia config
+  check` gains two warnings: a deprecation notice whenever the mixed-case
+  spelling is set, and a split-values alert when both spellings are set with
+  different values (presence/equality only — values are never emitted).
+
 ## [0.3.0] - 2026-08-16
 
 ### Onboarding: `install.sh` → `garraia init` → `garraia start` now actually works

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,16 @@ crates/
                         SÓ em `crates/garraia-config/src/auth.rs` (oauth.rs e totp.rs
                         refactorados). `metrics_token` lido via `garraia-telemetry::config`
                         dedicado. Ver `docs/auth-config.md` para matriz de precedência.
+                        Issue #824 (2026-08-17): as duas grafias da passphrase são
+                        aceitas em TODOS os consumidores — cofre lê via
+                        `garraia_security::vault_passphrase_from_env()` (all-caps
+                        canônica > mixed-case deprecated com warning) e
+                        `AuthConfig::from_env` ganha `GARRAIA_VAULT_PASSPHRASE`
+                        como último fallback (`GARRAIA_JWT_SECRET` >
+                        `GarraIA_VAULT_PASSPHRASE` > `GARRAIA_VAULT_PASSPHRASE`).
+                        Leituras da mixed-case fora de auth.rs: presence-only em
+                        check.rs/diagnostics_handler.rs + fallback do cofre em
+                        garraia-security/credentials.rs (fonte única).
                         Fase 3.5 (GAR-395 slice 1 plan 0041 + slice 2 plan 0044 +
                         slice 3 plan 0047) adiciona `rest_v1::uploads` com `POST
                         /v1/uploads` (tus 1.0 Creation) + `HEAD /v1/uploads/{id}`

--- a/crates/garraia-config/src/auth.rs
+++ b/crates/garraia-config/src/auth.rs
@@ -11,8 +11,9 @@
 //!
 //! | Variable | Required | Notes |
 //! |---|---|---|
-//! | `GARRAIA_JWT_SECRET` | yes | ≥32 bytes; **same env var as `mobile_auth.rs` legacy** so both flows share one secret in dev. When absent, `from_env` falls back to `GarraIA_VAULT_PASSPHRASE` (plan 0046 slice 3 — legacy compat). |
-//! | `GarraIA_VAULT_PASSPHRASE` | fallback | Legacy alias accepted by `from_env` when `GARRAIA_JWT_SECRET` is missing. Preserved for zero-breaking-change dev workflows (plan 0046). Prefer `GARRAIA_JWT_SECRET` for new deployments. |
+//! | `GARRAIA_JWT_SECRET` | yes | ≥32 bytes; **same env var as `mobile_auth.rs` legacy** so both flows share one secret in dev. When absent, `from_env` falls back to `GarraIA_VAULT_PASSPHRASE`, then to `GARRAIA_VAULT_PASSPHRASE` (plan 0046 slice 3 + issue #824). |
+//! | `GarraIA_VAULT_PASSPHRASE` | fallback | Legacy mixed-case alias accepted by `from_env` when `GARRAIA_JWT_SECRET` is missing. Preserved for zero-breaking-change dev workflows (plan 0046). Prefer `GARRAIA_JWT_SECRET` for new deployments. |
+//! | `GARRAIA_VAULT_PASSPHRASE` | fallback | Canonical vault passphrase (issue #824). Accepted as the last JWT-secret fallback so exporting only the all-caps spelling no longer 503s `/auth/*`. The mixed-case alias keeps precedence over it to preserve deploys that set both spellings with different values. |
 //! | `GARRAIA_REFRESH_HMAC_SECRET` | yes | ≥32 bytes; **distinct** from `GARRAIA_JWT_SECRET`. |
 //! | `GARRAIA_LOGIN_DATABASE_URL` | yes | Postgres URL connecting as the `garraia_login` BYPASSRLS role. |
 //! | `GARRAIA_SIGNUP_DATABASE_URL` | yes | Postgres URL connecting as the `garraia_signup` BYPASSRLS role. |
@@ -127,9 +128,16 @@ impl AuthConfig {
     /// legacy `GarraIA_VAULT_PASSPHRASE` fallback. The fallback exists
     /// solely to preserve dev workflows that predate GAR-379 —
     /// production deployments SHOULD set `GARRAIA_JWT_SECRET` explicitly.
+    ///
+    /// Issue #824: the canonical all-caps `GARRAIA_VAULT_PASSPHRASE` is
+    /// accepted as the *last* fallback so a casing slip (exporting only
+    /// the vault spelling) no longer leaves `/auth/*` answering 503. The
+    /// mixed-case alias stays ahead of it so deploys that set both
+    /// spellings with different values keep signing with the same secret.
     pub fn from_env() -> Result<Option<Self>, AuthConfigError> {
         let jwt = match std::env::var("GARRAIA_JWT_SECRET")
             .or_else(|_| std::env::var("GarraIA_VAULT_PASSPHRASE"))
+            .or_else(|_| std::env::var(garraia_security::VAULT_PASSPHRASE_ENV))
         {
             Ok(v) => v,
             Err(_) => return Ok(None),
@@ -169,11 +177,13 @@ impl AuthConfig {
     /// Strict env loader for production. Errors on missing or invalid vars.
     ///
     /// Plan 0046 slice 3: `GARRAIA_JWT_SECRET` takes precedence over the
-    /// legacy `GarraIA_VAULT_PASSPHRASE` fallback. When neither is set,
-    /// the error surfaces `GARRAIA_JWT_SECRET` as the canonical name.
+    /// legacy `GarraIA_VAULT_PASSPHRASE` fallback, which in turn precedes
+    /// the canonical `GARRAIA_VAULT_PASSPHRASE` (issue #824). When none is
+    /// set, the error surfaces `GARRAIA_JWT_SECRET` as the canonical name.
     pub fn require_from_env() -> Result<Self, AuthConfigError> {
         let jwt = std::env::var("GARRAIA_JWT_SECRET")
             .or_else(|_| std::env::var("GarraIA_VAULT_PASSPHRASE"))
+            .or_else(|_| std::env::var(garraia_security::VAULT_PASSPHRASE_ENV))
             .map_err(|_| AuthConfigError::MissingEnv("GARRAIA_JWT_SECRET"))?;
         let refresh = std::env::var("GARRAIA_REFRESH_HMAC_SECRET")
             .map_err(|_| AuthConfigError::MissingEnv("GARRAIA_REFRESH_HMAC_SECRET"))?;
@@ -261,9 +271,7 @@ mod tests {
     // lock, snapshots + clears the env vars it cares about, runs the
     // assertion, and restores the original values on exit.
 
-    use std::sync::{LazyLock, Mutex};
-
-    static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+    use crate::ENV_TEST_LOCK as ENV_LOCK;
 
     /// Snapshot of the env vars this test module touches. Used to restore
     /// the outer environment when a test exits so concurrent non-auth
@@ -271,6 +279,7 @@ mod tests {
     struct EnvSnapshot {
         jwt: Option<String>,
         vault: Option<String>,
+        vault_canonical: Option<String>,
         refresh: Option<String>,
         login_db: Option<String>,
         signup_db: Option<String>,
@@ -282,6 +291,7 @@ mod tests {
             Self {
                 jwt: std::env::var("GARRAIA_JWT_SECRET").ok(),
                 vault: std::env::var("GarraIA_VAULT_PASSPHRASE").ok(),
+                vault_canonical: std::env::var("GARRAIA_VAULT_PASSPHRASE").ok(),
                 refresh: std::env::var("GARRAIA_REFRESH_HMAC_SECRET").ok(),
                 login_db: std::env::var("GARRAIA_LOGIN_DATABASE_URL").ok(),
                 signup_db: std::env::var("GARRAIA_SIGNUP_DATABASE_URL").ok(),
@@ -303,6 +313,7 @@ mod tests {
             unsafe {
                 set_or_clear("GARRAIA_JWT_SECRET", self.jwt);
                 set_or_clear("GarraIA_VAULT_PASSPHRASE", self.vault);
+                set_or_clear("GARRAIA_VAULT_PASSPHRASE", self.vault_canonical);
                 set_or_clear("GARRAIA_REFRESH_HMAC_SECRET", self.refresh);
                 set_or_clear("GARRAIA_LOGIN_DATABASE_URL", self.login_db);
                 set_or_clear("GARRAIA_SIGNUP_DATABASE_URL", self.signup_db);
@@ -316,6 +327,7 @@ mod tests {
         unsafe {
             std::env::remove_var("GARRAIA_JWT_SECRET");
             std::env::remove_var("GarraIA_VAULT_PASSPHRASE");
+            std::env::remove_var("GARRAIA_VAULT_PASSPHRASE");
             std::env::remove_var("GARRAIA_REFRESH_HMAC_SECRET");
             std::env::remove_var("GARRAIA_LOGIN_DATABASE_URL");
             std::env::remove_var("GARRAIA_SIGNUP_DATABASE_URL");
@@ -391,7 +403,53 @@ mod tests {
         let cfg = AuthConfig::from_env().expect("should parse");
         assert!(
             cfg.is_none(),
-            "absence of both env vars must return Ok(None), got Some"
+            "absence of all three env vars must return Ok(None), got Some"
+        );
+
+        snapshot.restore();
+    }
+
+    // ── Issue #824: canonical vault passphrase as last JWT fallback ───────
+
+    #[test]
+    fn from_env_accepts_canonical_vault_passphrase_as_last_fallback() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let snapshot = EnvSnapshot::capture();
+        clear_all_auth_env();
+        // SAFETY: ENV_LOCK held.
+        unsafe {
+            std::env::set_var("GARRAIA_VAULT_PASSPHRASE", "C".repeat(32));
+        }
+        set_required_except_jwt();
+
+        let cfg = AuthConfig::from_env()
+            .expect("should parse")
+            .expect("all-caps vault passphrase must be accepted (issue #824)");
+        assert_eq!(cfg.jwt_secret.expose_secret(), "C".repeat(32));
+
+        snapshot.restore();
+    }
+
+    #[test]
+    fn from_env_prefers_legacy_alias_over_canonical_vault_passphrase() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let snapshot = EnvSnapshot::capture();
+        clear_all_auth_env();
+        // SAFETY: ENV_LOCK held.
+        unsafe {
+            std::env::set_var("GarraIA_VAULT_PASSPHRASE", "V".repeat(32));
+            std::env::set_var("GARRAIA_VAULT_PASSPHRASE", "C".repeat(32));
+        }
+        set_required_except_jwt();
+
+        let cfg = AuthConfig::from_env()
+            .expect("should parse")
+            .expect("should be Some");
+        assert_eq!(
+            cfg.jwt_secret.expose_secret(),
+            "V".repeat(32),
+            "mixed-case alias must keep precedence over the all-caps vault \
+             passphrase so pre-#824 deploys keep signing with the same secret"
         );
 
         snapshot.restore();

--- a/crates/garraia-config/src/check.rs
+++ b/crates/garraia-config/src/check.rs
@@ -641,13 +641,16 @@ fn validate_auth(
         );
     }
 
-    // Cross-check: if GARRAIA_JWT_SECRET or GarraIA_VAULT_PASSPHRASE are
-    // present in the process env AND `[auth]` is populated in the file,
-    // emit an Info-ish Warning so operators know the file entry is
-    // non-load-bearing for the secret (secrets are env-only by design
-    // — plan 0046 §5.1). We only check presence, never values.
+    // Cross-check: if any env var able to source the JWT secret is
+    // present AND `[auth]` is populated in the file, emit an Info-ish
+    // Warning so operators know the file entry is non-load-bearing for
+    // the secret (secrets are env-only by design — plan 0046 §5.1).
+    // We only check presence, never values. Since issue #824 the
+    // canonical all-caps vault passphrase also unlocks the auth flow
+    // (last fallback in `AuthConfig::from_env`).
     let jwt_env_set = std::env::var_os("GARRAIA_JWT_SECRET").is_some()
-        || std::env::var_os("GarraIA_VAULT_PASSPHRASE").is_some();
+        || std::env::var_os("GarraIA_VAULT_PASSPHRASE").is_some()
+        || std::env::var_os("GARRAIA_VAULT_PASSPHRASE").is_some();
     // Heuristic for "auth section is populated" — any field that
     // differs from default indicates the operator put a `[auth]` in
     // the file. Comparing against defaults avoids a false positive
@@ -665,14 +668,47 @@ fn validate_auth(
         );
     }
 
-    // Cross-check: if NEITHER env var is set, the gateway will run in
+    // Cross-check: if NO env var is set, the gateway will run in
     // fail-soft mode and /auth/* + /v1/auth/* will answer 503. Surface
     // as a warning so operators see the state clearly in `config check`.
     if !jwt_env_set {
         push_warn(
             findings,
             "auth",
-            "neither GARRAIA_JWT_SECRET nor GarraIA_VAULT_PASSPHRASE is set; /auth/* and /v1/auth/* will respond 503 until one is provided".into(),
+            "none of GARRAIA_JWT_SECRET, GarraIA_VAULT_PASSPHRASE or GARRAIA_VAULT_PASSPHRASE is set; /auth/* and /v1/auth/* will respond 503 until one is provided".into(),
+        );
+    }
+
+    // Issue #824: the mixed-case `GarraIA_VAULT_PASSPHRASE` spelling is
+    // deprecated. It still works everywhere (JWT fallback since plan 0046,
+    // vault fallback since #824), but the near-identical names are a trap,
+    // so nudge operators toward the canonical pair. Presence only — the
+    // value comparison below never reaches any output.
+    let legacy_set = std::env::var_os("GarraIA_VAULT_PASSPHRASE").is_some();
+    let canonical_set = std::env::var_os("GARRAIA_VAULT_PASSPHRASE").is_some();
+    if legacy_set {
+        push_warn(
+            findings,
+            "env.GarraIA_VAULT_PASSPHRASE",
+            "mixed-case GarraIA_VAULT_PASSPHRASE is a deprecated spelling — it still works \
+             (JWT-secret fallback and credential-vault fallback), but prefer GARRAIA_JWT_SECRET \
+             for auth and GARRAIA_VAULT_PASSPHRASE for the vault"
+                .into(),
+        );
+    }
+    if legacy_set
+        && canonical_set
+        && std::env::var("GarraIA_VAULT_PASSPHRASE").ok()
+            != std::env::var("GARRAIA_VAULT_PASSPHRASE").ok()
+    {
+        push_warn(
+            findings,
+            "env.GARRAIA_VAULT_PASSPHRASE",
+            "GARRAIA_VAULT_PASSPHRASE and GarraIA_VAULT_PASSPHRASE are both set with DIFFERENT \
+             values: the credential vault prefers the all-caps spelling, while the JWT-secret \
+             fallback prefers the mixed-case one. If that split is not intentional, keep only \
+             GARRAIA_VAULT_PASSPHRASE (vault) and GARRAIA_JWT_SECRET (auth)"
+                .into(),
         );
     }
 }
@@ -1614,6 +1650,106 @@ mod tests {
                 .any(|f| f.message.contains("does not exist")),
             "without_env should NOT fire MISSING warning: {without_env:?}"
         );
+    }
+
+    // ── Issue #824: vault-passphrase spelling findings ─────────────────────
+    //
+    // Env mutation shares the crate-wide ENV_TEST_LOCK with auth::tests —
+    // both modules touch the same GarraIA_*/GARRAIA_* variables inside one
+    // test binary.
+
+    fn passphrase_env_snapshot() -> (Option<String>, Option<String>) {
+        (
+            std::env::var("GarraIA_VAULT_PASSPHRASE").ok(),
+            std::env::var("GARRAIA_VAULT_PASSPHRASE").ok(),
+        )
+    }
+
+    fn restore_passphrase_env((legacy, canonical): (Option<String>, Option<String>)) {
+        // SAFETY: ENV_TEST_LOCK held by caller.
+        unsafe {
+            match legacy {
+                Some(v) => std::env::set_var("GarraIA_VAULT_PASSPHRASE", v),
+                None => std::env::remove_var("GarraIA_VAULT_PASSPHRASE"),
+            }
+            match canonical {
+                Some(v) => std::env::set_var("GARRAIA_VAULT_PASSPHRASE", v),
+                None => std::env::remove_var("GARRAIA_VAULT_PASSPHRASE"),
+            }
+        }
+    }
+
+    #[test]
+    fn legacy_passphrase_spelling_yields_deprecation_warning() {
+        let _guard = crate::ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let snapshot = passphrase_env_snapshot();
+        // SAFETY: ENV_TEST_LOCK held.
+        unsafe {
+            std::env::set_var("GarraIA_VAULT_PASSPHRASE", "some-legacy-secret-value");
+            std::env::remove_var("GARRAIA_VAULT_PASSPHRASE");
+        }
+
+        let findings = validate(&AppConfig::default());
+        let hit = findings
+            .iter()
+            .find(|f| f.field == "env.GarraIA_VAULT_PASSPHRASE")
+            .expect("mixed-case spelling must produce a deprecation warning");
+        assert!(matches!(hit.severity, Severity::Warning));
+        assert!(hit.message.contains("deprecated"));
+        // Redaction invariant: presence only, never the value.
+        assert!(!hit.message.contains("some-legacy-secret-value"));
+
+        restore_passphrase_env(snapshot);
+    }
+
+    #[test]
+    fn divergent_passphrase_spellings_yield_split_warning() {
+        let _guard = crate::ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let snapshot = passphrase_env_snapshot();
+        // SAFETY: ENV_TEST_LOCK held.
+        unsafe {
+            std::env::set_var("GarraIA_VAULT_PASSPHRASE", "legacy-secret-value");
+            std::env::set_var("GARRAIA_VAULT_PASSPHRASE", "canonical-secret-value");
+        }
+
+        let findings = validate(&AppConfig::default());
+        let hit = findings
+            .iter()
+            .find(|f| f.field == "env.GARRAIA_VAULT_PASSPHRASE")
+            .expect("divergent values across the two spellings must warn");
+        assert!(matches!(hit.severity, Severity::Warning));
+        assert!(hit.message.contains("DIFFERENT"));
+        assert!(!hit.message.contains("legacy-secret-value"));
+        assert!(!hit.message.contains("canonical-secret-value"));
+
+        restore_passphrase_env(snapshot);
+    }
+
+    #[test]
+    fn equal_passphrase_spellings_do_not_warn_about_divergence() {
+        let _guard = crate::ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let snapshot = passphrase_env_snapshot();
+        // SAFETY: ENV_TEST_LOCK held.
+        unsafe {
+            std::env::set_var("GarraIA_VAULT_PASSPHRASE", "same-secret-value");
+            std::env::set_var("GARRAIA_VAULT_PASSPHRASE", "same-secret-value");
+        }
+
+        let findings = validate(&AppConfig::default());
+        assert!(
+            !findings
+                .iter()
+                .any(|f| f.field == "env.GARRAIA_VAULT_PASSPHRASE"),
+            "equal values across spellings must not produce the divergence warning"
+        );
+
+        restore_passphrase_env(snapshot);
     }
 
     #[test]

--- a/crates/garraia-config/src/lib.rs
+++ b/crates/garraia-config/src/lib.rs
@@ -20,3 +20,10 @@ pub use provider_keys::{
     resolve_provider_key_source, vault_present_but_locked,
 };
 pub use watcher::ConfigWatcher;
+
+/// Crate-wide lock serializing unit tests that mutate process-global
+/// environment variables (`auth::tests` and `check::tests` touch the same
+/// `GARRAIA_*`/`GarraIA_*` vars inside one test binary).
+#[cfg(test)]
+pub(crate) static ENV_TEST_LOCK: std::sync::LazyLock<std::sync::Mutex<()>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(()));

--- a/crates/garraia-config/src/provider_keys.rs
+++ b/crates/garraia-config/src/provider_keys.rs
@@ -25,10 +25,12 @@ use crate::loader::ConfigLoader;
 
 /// Environment variable carrying the credential-vault passphrase.
 ///
-/// Note the casing: this is **not** the same variable as the mixed-case
-/// `GarraIA_VAULT_PASSPHRASE` consulted by [`crate::auth`] as a JWT-secret
-/// fallback. The two are genuinely distinct and easy to confuse.
-pub const VAULT_PASSPHRASE_ENV: &str = "GARRAIA_VAULT_PASSPHRASE";
+/// Canonical all-caps spelling, re-exported from `garraia-security` (the
+/// single reader). Since issue #824 the deprecated mixed-case
+/// `GarraIA_VAULT_PASSPHRASE` is accepted as a fallback by every consumer
+/// of the passphrase — vault and JWT-secret alike — so a casing slip no
+/// longer fails silently; the canonical spelling always wins.
+pub const VAULT_PASSPHRASE_ENV: &str = garraia_security::VAULT_PASSPHRASE_ENV;
 
 /// Where a resolved API key came from, or why none was found.
 ///
@@ -114,9 +116,7 @@ pub fn vault_present_but_locked(vault_path: &Path) -> bool {
 }
 
 fn vault_passphrase_available() -> bool {
-    std::env::var(VAULT_PASSPHRASE_ENV)
-        .map(|v| !v.is_empty())
-        .unwrap_or(false)
+    garraia_security::vault_passphrase_from_env().is_some()
 }
 
 /// Resolve an API key, reporting where it came from.

--- a/crates/garraia-gateway/src/diagnostics_handler.rs
+++ b/crates/garraia-gateway/src/diagnostics_handler.rs
@@ -226,9 +226,12 @@ pub async fn diagnostics_handler(State(state): State<SharedState>) -> Json<Diagn
         next_step: None,
     });
 
-    // 8. JWT secret configured (presence only).
+    // 8. JWT secret configured (presence only). Issue #824: the canonical
+    // all-caps vault passphrase is the last fallback in AuthConfig::from_env,
+    // so its presence also unlocks the auth flow.
     let jwt_configured = std::env::var("GARRAIA_JWT_SECRET").is_ok()
-        || std::env::var("GarraIA_VAULT_PASSPHRASE").is_ok();
+        || std::env::var("GarraIA_VAULT_PASSPHRASE").is_ok()
+        || std::env::var("GARRAIA_VAULT_PASSPHRASE").is_ok();
     checks.push(DiagnosticCheck {
         id: "secrets.jwt",
         label: "JWT signing secret",

--- a/crates/garraia-gateway/src/mcp/persistence.rs
+++ b/crates/garraia-gateway/src/mcp/persistence.rs
@@ -251,10 +251,7 @@ impl McpPersistenceService {
             }
         };
 
-        if std::env::var("GARRAIA_VAULT_PASSPHRASE")
-            .unwrap_or_default()
-            .is_empty()
-        {
+        if garraia_security::vault_passphrase_from_env().is_none() {
             let has_secrets = config
                 .mcp_servers
                 .values()

--- a/crates/garraia-gateway/src/state.rs
+++ b/crates/garraia-gateway/src/state.rs
@@ -152,16 +152,18 @@ pub struct AppState {
 /// Plan 0046 (GAR-379 slice 3): sentinel returned by
 /// [`AppState::jwt_signing_secret`] when the gateway is running in
 /// fail-soft mode (dev without `GARRAIA_JWT_SECRET` /
-/// `GarraIA_VAULT_PASSPHRASE`). Handlers convert this to
-/// `RestError::AuthUnconfigured` (`503 Service Unavailable`) — **never**
-/// to a hardcoded fallback secret (plan 0046 §5.2 closes SEC-H-2).
+/// `GarraIA_VAULT_PASSPHRASE` / `GARRAIA_VAULT_PASSPHRASE` — the all-caps
+/// vault passphrase doubles as the last JWT fallback since issue #824).
+/// Handlers convert this to `RestError::AuthUnconfigured`
+/// (`503 Service Unavailable`) — **never** to a hardcoded fallback secret
+/// (plan 0046 §5.2 closes SEC-H-2).
 #[derive(Debug, Clone, Copy)]
 pub struct AuthConfigMissing;
 
 impl std::fmt::Display for AuthConfigMissing {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(
-            "auth not configured: GARRAIA_JWT_SECRET / GarraIA_VAULT_PASSPHRASE absent at bootstrap",
+            "auth not configured: GARRAIA_JWT_SECRET / GarraIA_VAULT_PASSPHRASE / GARRAIA_VAULT_PASSPHRASE absent at bootstrap",
         )
     }
 }

--- a/crates/garraia-security/src/credentials.rs
+++ b/crates/garraia-security/src/credentials.rs
@@ -177,6 +177,38 @@ impl CredentialVault {
     }
 }
 
+/// Canonical environment variable carrying the credential-vault passphrase.
+pub const VAULT_PASSPHRASE_ENV: &str = "GARRAIA_VAULT_PASSPHRASE";
+
+/// Deprecated mixed-case spelling of [`VAULT_PASSPHRASE_ENV`]. Historically it
+/// only fed the JWT-secret fallback in `garraia-config::auth`, so exporting it
+/// with the intent of unlocking the vault failed silently (issue #824). It is
+/// now accepted here as a fallback so a casing slip no longer strands the
+/// operator, but the canonical all-caps spelling always wins.
+pub const VAULT_PASSPHRASE_ENV_LEGACY: &str = "GarraIA_VAULT_PASSPHRASE";
+
+/// Read the vault passphrase from the environment: the canonical
+/// [`VAULT_PASSPHRASE_ENV`] first, then the deprecated mixed-case
+/// [`VAULT_PASSPHRASE_ENV_LEGACY`] with a deprecation warning. Empty values
+/// count as unset on both tiers, matching the key-resolution convention in
+/// `garraia-config::provider_keys` (an empty passphrase cannot open a vault).
+pub fn vault_passphrase_from_env() -> Option<String> {
+    if let Some(v) = std::env::var(VAULT_PASSPHRASE_ENV)
+        .ok()
+        .filter(|v| !v.is_empty())
+    {
+        return Some(v);
+    }
+    let legacy = std::env::var(VAULT_PASSPHRASE_ENV_LEGACY)
+        .ok()
+        .filter(|v| !v.is_empty())?;
+    warn!(
+        "vault passphrase read from deprecated mixed-case {VAULT_PASSPHRASE_ENV_LEGACY}; \
+         prefer the canonical {VAULT_PASSPHRASE_ENV} spelling"
+    );
+    Some(legacy)
+}
+
 /// Try to load a credential from the vault, returning `None` if the vault
 /// doesn't exist or can't be opened (no passphrase prompt in server mode).
 pub fn try_vault_get(vault_path: &Path, key: &str) -> Option<String> {
@@ -184,8 +216,9 @@ pub fn try_vault_get(vault_path: &Path, key: &str) -> Option<String> {
         return None;
     }
     // In server mode we cannot prompt for a passphrase, so try the
-    // environment variable `GARRAIA_VAULT_PASSPHRASE` as a fallback.
-    let passphrase = std::env::var("GARRAIA_VAULT_PASSPHRASE").ok()?;
+    // environment (canonical spelling, then the deprecated mixed-case
+    // alias) as a fallback.
+    let passphrase = vault_passphrase_from_env()?;
     match CredentialVault::open(vault_path, &passphrase) {
         Ok(vault) => vault.get(key).map(|s| s.to_string()),
         Err(e) => {
@@ -200,9 +233,8 @@ pub fn try_vault_get(vault_path: &Path, key: &str) -> Option<String> {
 /// cannot be opened/created. This is intended for best-effort key persistence
 /// at runtime (e.g. when a user adds a provider via the web UI).
 pub fn try_vault_set(vault_path: &Path, key: &str, value: &str) -> bool {
-    let passphrase = match std::env::var("GARRAIA_VAULT_PASSPHRASE") {
-        Ok(p) if !p.is_empty() => p,
-        _ => return false,
+    let Some(passphrase) = vault_passphrase_from_env() else {
+        return false;
     };
 
     let mut vault = if CredentialVault::exists(vault_path) {
@@ -239,9 +271,8 @@ pub fn try_vault_set(vault_path: &Path, key: &str, value: &str) -> bool {
 /// Try to remove all vault credentials whose key starts with `prefix`.
 /// Returns the number of keys removed, or `0` on any error.
 pub fn try_vault_delete_prefix(vault_path: &Path, prefix: &str) -> usize {
-    let passphrase = match std::env::var("GARRAIA_VAULT_PASSPHRASE") {
-        Ok(p) if !p.is_empty() => p,
-        _ => return 0,
+    let Some(passphrase) = vault_passphrase_from_env() else {
+        return 0;
     };
     if !CredentialVault::exists(vault_path) {
         return 0;
@@ -363,6 +394,105 @@ mod tests {
         assert!(vault.remove("key1"));
         assert!(!vault.remove("key1")); // already removed
         assert!(vault.get("key1").is_none());
+
+        let _ = fs::remove_file(&path);
+    }
+
+    // ── Issue #824: passphrase env-var spelling fallback ──────────────────
+    //
+    // These tests mutate the process-global environment, so they serialize
+    // on a shared lock (same pattern as garraia-config::auth::tests) and
+    // snapshot/restore both variables on exit.
+
+    use std::sync::{LazyLock, Mutex};
+
+    static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    struct EnvSnapshot {
+        canonical: Option<String>,
+        legacy: Option<String>,
+    }
+
+    impl EnvSnapshot {
+        fn capture_and_clear() -> Self {
+            let snap = Self {
+                canonical: std::env::var(VAULT_PASSPHRASE_ENV).ok(),
+                legacy: std::env::var(VAULT_PASSPHRASE_ENV_LEGACY).ok(),
+            };
+            // SAFETY: ENV_LOCK held by caller.
+            unsafe {
+                std::env::remove_var(VAULT_PASSPHRASE_ENV);
+                std::env::remove_var(VAULT_PASSPHRASE_ENV_LEGACY);
+            }
+            snap
+        }
+    }
+
+    impl Drop for EnvSnapshot {
+        fn drop(&mut self) {
+            // SAFETY: ENV_LOCK still held while the test unwinds.
+            unsafe {
+                match self.canonical.take() {
+                    Some(v) => std::env::set_var(VAULT_PASSPHRASE_ENV, v),
+                    None => std::env::remove_var(VAULT_PASSPHRASE_ENV),
+                }
+                match self.legacy.take() {
+                    Some(v) => std::env::set_var(VAULT_PASSPHRASE_ENV_LEGACY, v),
+                    None => std::env::remove_var(VAULT_PASSPHRASE_ENV_LEGACY),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn passphrase_env_prefers_canonical_and_falls_back_to_legacy() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _snapshot = EnvSnapshot::capture_and_clear();
+
+        assert_eq!(vault_passphrase_from_env(), None, "unset ⇒ None");
+
+        // SAFETY: ENV_LOCK held.
+        unsafe { std::env::set_var(VAULT_PASSPHRASE_ENV_LEGACY, "legacy-pass") };
+        assert_eq!(
+            vault_passphrase_from_env().as_deref(),
+            Some("legacy-pass"),
+            "mixed-case alias must unlock the vault when canonical is unset"
+        );
+
+        unsafe { std::env::set_var(VAULT_PASSPHRASE_ENV, "canonical-pass") };
+        assert_eq!(
+            vault_passphrase_from_env().as_deref(),
+            Some("canonical-pass"),
+            "canonical spelling must win when both are set"
+        );
+
+        // Empty values count as unset on both tiers.
+        unsafe {
+            std::env::set_var(VAULT_PASSPHRASE_ENV, "");
+            std::env::set_var(VAULT_PASSPHRASE_ENV_LEGACY, "");
+        }
+        assert_eq!(vault_passphrase_from_env(), None, "empty ⇒ None");
+    }
+
+    #[test]
+    fn try_vault_get_accepts_legacy_spelling() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _snapshot = EnvSnapshot::capture_and_clear();
+
+        let path = temp_vault_path("legacy-env");
+        let mut vault = CredentialVault::create(&path, "legacy-pass").unwrap();
+        vault.set("ANTHROPIC_API_KEY", "sk-ant-legacy");
+        vault.save().unwrap();
+
+        // The #824 trap: only the mixed-case spelling exported. Before the
+        // fix this returned None and the provider was skipped at boot.
+        // SAFETY: ENV_LOCK held.
+        unsafe { std::env::set_var(VAULT_PASSPHRASE_ENV_LEGACY, "legacy-pass") };
+        assert_eq!(
+            try_vault_get(&path, "ANTHROPIC_API_KEY").as_deref(),
+            Some("sk-ant-legacy"),
+            "mixed-case-only export must now unlock the vault"
+        );
 
         let _ = fs::remove_file(&path);
     }

--- a/crates/garraia-security/src/lib.rs
+++ b/crates/garraia-security/src/lib.rs
@@ -6,7 +6,8 @@ pub mod validation;
 
 pub use allowlist::{Allowlist, AllowlistMode};
 pub use credentials::{
-    CredentialError, CredentialVault, try_vault_delete_prefix, try_vault_get, try_vault_set,
+    CredentialError, CredentialVault, VAULT_PASSPHRASE_ENV, VAULT_PASSPHRASE_ENV_LEGACY,
+    try_vault_delete_prefix, try_vault_get, try_vault_set, vault_passphrase_from_env,
 };
 pub use pairing::PairingManager;
 pub use redaction::{RedactingWriter, redact_secrets};

--- a/docs/auth-config.md
+++ b/docs/auth-config.md
@@ -28,7 +28,7 @@ signing key material. Only operational, non-secret knobs live in `[auth]`.
 
 | Field | Environment variable | Config file key | Default | Fail mode when missing |
 |---|---|---|---|---|
-| `jwt_secret` | `GARRAIA_JWT_SECRET` *(preferred)* <br> `GarraIA_VAULT_PASSPHRASE` *(legacy fallback)* | ❌ **not accepted** | ❌ | `503 Service Unavailable` from `/auth/*` and `/v1/auth/*` |
+| `jwt_secret` | `GARRAIA_JWT_SECRET` *(preferred)* <br> `GarraIA_VAULT_PASSPHRASE` *(legacy fallback, deprecated)* <br> `GARRAIA_VAULT_PASSPHRASE` *(last fallback — issue #824)* | ❌ **not accepted** | ❌ | `503 Service Unavailable` from `/auth/*` and `/v1/auth/*` |
 | `refresh_hmac_secret` | `GARRAIA_REFRESH_HMAC_SECRET` | ❌ **not accepted** | ❌ | `503` from `/v1/auth/*` refresh flow |
 | `login_database_url` | `GARRAIA_LOGIN_DATABASE_URL` | ❌ **not accepted** | ❌ | `503` (fail-soft) |
 | `signup_database_url` | `GARRAIA_SIGNUP_DATABASE_URL` | ❌ **not accepted** | ❌ | `503` (fail-soft) |
@@ -91,14 +91,29 @@ callback. Must be **≥32 bytes** after UTF-8 decoding.
 openssl rand -hex 32
 ```
 
-### 3.2 `GarraIA_VAULT_PASSPHRASE` *(legacy fallback)*
+### 3.2 `GarraIA_VAULT_PASSPHRASE` *(legacy fallback, deprecated spelling)*
 
 Accepted when `GARRAIA_JWT_SECRET` is unset. Preserved for zero-breaking
 change in dev workflows that predate GAR-379. New deployments should
-prefer `GARRAIA_JWT_SECRET`.
+prefer `GARRAIA_JWT_SECRET`. `garraia config check` emits a deprecation
+warning whenever this mixed-case spelling is present.
 
-**Precedence:** if both are set, `GARRAIA_JWT_SECRET` wins (covered by
-`AuthConfig::from_env` + unit test `from_env_prefers_jwt_secret_over_vault_passphrase`).
+### 3.2.1 `GARRAIA_VAULT_PASSPHRASE` *(last fallback — issue #824)*
+
+The canonical credential-vault passphrase (all-caps) doubles as the
+**last** JWT-secret fallback. Before #824, exporting only this spelling
+left `/auth/*` answering 503 while the near-identical mixed-case alias
+above would have worked — a silent casing trap. The reverse also holds
+now: the credential vault (`garraia-security`) accepts the mixed-case
+alias as a fallback, with a deprecation warning at boot.
+
+**Precedence:** `GARRAIA_JWT_SECRET` > `GarraIA_VAULT_PASSPHRASE` >
+`GARRAIA_VAULT_PASSPHRASE`. The mixed-case alias stays ahead of the
+all-caps spelling so deploys that set both with different values keep
+signing JWTs with the same secret as before #824. Covered by unit tests
+`from_env_prefers_jwt_secret_over_vault_passphrase`,
+`from_env_accepts_canonical_vault_passphrase_as_last_fallback` and
+`from_env_prefers_legacy_alias_over_canonical_vault_passphrase`.
 
 ### 3.3 `GARRAIA_REFRESH_HMAC_SECRET`
 
@@ -165,10 +180,17 @@ verification immediately on upgrade.
 - **Error** when `access_token_ttl_secs` is outside `[60, 86400]`.
 - **Error** when `refresh_token_ttl_secs` is outside `[60, 2_592_000]`
   or smaller than `access_token_ttl_secs`.
-- **Warning** when neither `GARRAIA_JWT_SECRET` nor
-  `GarraIA_VAULT_PASSPHRASE` is set (auth flow will 503).
+- **Warning** when none of `GARRAIA_JWT_SECRET`,
+  `GarraIA_VAULT_PASSPHRASE` or `GARRAIA_VAULT_PASSPHRASE` is set
+  (auth flow will 503).
 - **Warning** when the env secret is set **and** `[auth]` overrides are
   present — non-secret overrides apply but secrets remain env-only.
+- **Warning** (deprecation) whenever the mixed-case
+  `GarraIA_VAULT_PASSPHRASE` spelling is present (issue #824).
+- **Warning** when both passphrase spellings are set with **different**
+  values — the vault prefers the all-caps one while the JWT fallback
+  prefers the mixed-case one (presence/equality only; values are never
+  emitted).
 
 The JSON output of `config check --json` never contains secret values —
 only presence flags (plan 0035 SEC-M-02).
@@ -179,8 +201,9 @@ only presence flags (plan 0035 SEC-M-02).
 
 ### `/auth/login` returns 503 "auth not configured"
 
-Cause: `GARRAIA_JWT_SECRET` and `GarraIA_VAULT_PASSPHRASE` are both
-unset. Either one will unblock the endpoint:
+Cause: `GARRAIA_JWT_SECRET`, `GarraIA_VAULT_PASSPHRASE` and
+`GARRAIA_VAULT_PASSPHRASE` are all unset. Any one will unblock the
+endpoint:
 
 ```bash
 export GARRAIA_JWT_SECRET=$(openssl rand -hex 32)

--- a/plans/0352-vault-passphrase-casing.md
+++ b/plans/0352-vault-passphrase-casing.md
@@ -1,0 +1,81 @@
+# Plan 0352 — Unificar as duas grafias da passphrase do cofre (issue #824)
+
+> **Status:** Implementado em 2026-08-17 (America/New_York).
+> **Origem:** issue #824, levantada durante o plan 0351 / PR #823 e deliberadamente
+> deixada fora daquele escopo (§6 do plan 0351).
+
+## 1. Problema
+
+Duas env vars quase idênticas coexistiam com significados diferentes, e errar a
+caixa falhava em silêncio:
+
+| Variável | Consumidor (antes) | Efeito |
+| --- | --- | --- |
+| `GARRAIA_VAULT_PASSPHRASE` (all-caps) | `garraia-security::try_vault_get/set` | abre o cofre de credenciais |
+| `GarraIA_VAULT_PASSPHRASE` (mixed-case) | `garraia-config::auth::AuthConfig::from_env` | fallback do JWT secret |
+
+Exportar a grafia "errada" não produzia erro: o cofre não abria (provider
+pulado no boot com "no API key" enigmático) ou `/auth/*` respondia 503.
+
+## 2. Decisão (opções 3 + 1 da issue)
+
+Aceitar **ambas as grafias em cada consumidor**, com warnings de detecção —
+zero breaking change:
+
+- **Cofre** (`garraia-security`): nova fonte única
+  `vault_passphrase_from_env()` — prefere `GARRAIA_VAULT_PASSPHRASE`
+  (canônica), cai para `GarraIA_VAULT_PASSPHRASE` com `warn!` de deprecation.
+  Valores vazios contam como ausentes nos dois tiers. Usada por
+  `try_vault_get`, `try_vault_set`, `try_vault_delete_prefix`,
+  `provider_keys::vault_passphrase_available` e pelo early-out de
+  `mcp/persistence.rs::encrypt_to_vault`.
+- **Auth** (`garraia-config::auth`): `GARRAIA_VAULT_PASSPHRASE` vira o
+  **último** fallback do JWT secret. Precedência preservada:
+  `GARRAIA_JWT_SECRET` > `GarraIA_VAULT_PASSPHRASE` >
+  `GARRAIA_VAULT_PASSPHRASE`. A mixed-case fica à frente da all-caps de
+  propósito: deploys que setam as duas grafias com valores diferentes
+  continuam assinando JWT com o mesmo secret de antes.
+- **`garraia config check`**: dois warnings novos —
+  1. deprecation sempre que a mixed-case estiver setada;
+  2. alerta de split quando as duas grafias têm valores **diferentes**
+     (comparação de igualdade apenas; valores nunca aparecem no output).
+  O warning "neither ... is set" passa a citar as três vars aceitas.
+- **Diagnostics** (`/api/diagnostics` check `secrets.jwt`): passa a considerar
+  a all-caps também.
+
+### Fora do escopo (deliberado)
+
+- `admin/shared.rs::derive_encryption_key` NÃO ganhou o fallback mixed-case:
+  faria deploys que só têm a mixed-case setada re-derivarem a chave do admin
+  store (antes caíam no `master.key` gerado), quebrando secrets já
+  criptografados. Fica como está.
+- `settings_handler.rs` `secrets.jwt_secret` continua reportando presença
+  apenas de `GARRAIA_JWT_SECRET` (contrato de UI já era var-específico).
+- Renomear a var de auth (opção 2 da issue) — deprecation primeiro; um slice
+  futuro pode remover a mixed-case após ciclo de aviso.
+
+## 3. Arquivos tocados
+
+- `crates/garraia-security/src/credentials.rs` — consts + helper + 3 call
+  sites + 2 testes novos (lock de env próprio).
+- `crates/garraia-security/src/lib.rs` — re-exports.
+- `crates/garraia-config/src/provider_keys.rs` — const re-apontada +
+  `vault_passphrase_available` via helper.
+- `crates/garraia-config/src/auth.rs` — fallback triplo em `from_env` /
+  `require_from_env` + docs + `EnvSnapshot` cobre all-caps + 2 testes novos.
+- `crates/garraia-config/src/check.rs` — `jwt_env_set` inclui all-caps +
+  2 findings novos + 3 testes novos.
+- `crates/garraia-config/src/lib.rs` — `ENV_TEST_LOCK` crate-wide (auth::tests
+  e check::tests mutam as mesmas vars no mesmo binário).
+- `crates/garraia-gateway/src/{mcp/persistence.rs,diagnostics_handler.rs,state.rs}`.
+- Docs: `docs/auth-config.md`, `.env.example`, `CHANGELOG.md`, `CLAUDE.md`.
+
+## 4. Verificação
+
+- `cargo test -p garraia-security -p garraia-config` — 96 testes verdes,
+  incluindo os 7 novos.
+- `cargo test -p garraia-gateway --lib` — 820 verdes.
+- `cargo clippy -p garraia-security -p garraia-config -p garraia-gateway
+  --all-targets` — limpo.
+- Redaction invariant: os testes novos asseguram que os valores das
+  passphrases nunca aparecem nas mensagens dos findings.


### PR DESCRIPTION
## Descrição

Fecha a armadilha da issue #824: as duas grafias quase idênticas `GARRAIA_VAULT_PASSPHRASE` (cofre de credenciais) e `GarraIA_VAULT_PASSPHRASE` (fallback legacy do JWT secret) coexistiam com significados diferentes, e errar a caixa **falhava em silêncio** — o cofre não abria (provider pulado no boot com "no API key" enigmático) ou `/auth/*` respondia 503.

Implementa as opções **3 + 1** da issue (detecção + aceitar ambas as grafias em cada consumidor), com **zero breaking change**:

- **Cofre** (`garraia-security`): nova fonte única `vault_passphrase_from_env()` — prefere a all-caps canônica, cai para a mixed-case com warning de deprecation no boot; valores vazios contam como ausentes. Usada por `try_vault_get`/`try_vault_set`/`try_vault_delete_prefix`, por `provider_keys::vault_passphrase_available` e pelo early-out de `mcp/persistence.rs::encrypt_to_vault`.
- **Auth** (`garraia-config`): `AuthConfig::from_env`/`require_from_env` ganham `GARRAIA_VAULT_PASSPHRASE` como **último** fallback. Precedência preservada: `GARRAIA_JWT_SECRET` > `GarraIA_VAULT_PASSPHRASE` > `GARRAIA_VAULT_PASSPHRASE` — deploys que setam as duas grafias com valores distintos continuam assinando JWT com o mesmo secret de antes.
- **`garraia config check`**: warning de deprecation quando a mixed-case está setada + alerta quando as duas grafias têm valores **diferentes** (comparação de igualdade apenas; valores nunca aparecem no output — redaction invariant coberto por teste). A mensagem do 503 agora cita as três vars aceitas.
- **Gateway**: check `secrets.jwt` do `/api/diagnostics` considera a all-caps; sentinel `AuthConfigMissing` atualizado.
- **Fora do escopo (deliberado)**: `admin/shared.rs::derive_encryption_key` não ganhou o fallback — re-derivaria a chave do admin store em deploys que só têm a mixed-case setada (breaking silencioso). Ver `plans/0352-vault-passphrase-casing.md` §2.

Docs: `docs/auth-config.md` (matriz de precedência + §3.2/§3.2.1 + troubleshooting), `.env.example`, `CHANGELOG.md`, `CLAUDE.md` (grep invariant), plan 0352.

Closes #824

## Tipo de mudança

- [x] `fix`: Correção de bug

## Classe de Risco

- [x] **Classe C (Alto Risco)**: Alterações em autenticação, criptografia, RLS (Row-Level Security), migrations SQL, endpoints REST públicos, autorização/RBAC.

> Classificado C por tocar o sourcing do JWT secret e do vault passphrase. Não há rota nova, migration nem mudança de RLS — a superfície é a cadeia de fallback de env vars, coberta por testes de precedência.

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo fmt --check` executado e limpo
- [x] `cargo clippy --workspace --exclude garraia-desktop -- -D warnings` sem erros
- [x] `cargo test --workspace --exclude garraia-desktop` passando localmente — exceção: `garraia-workspace --test migration_smoke` exige Docker/testcontainers, indisponível no ambiente local (`Socket not found: /var/run/docker.sock`); crate não é tocado por este diff e o CI cobre com `services: postgres`
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo, API key, token ou credencial commitada
- [x] Nenhuma migração Postgres com operações destrutivas sem estratégia de transição forward-only

### Para alterações de Alto Risco (Classe C)

- [ ] Testes de autorização cross-group/cross-tenant adicionados ou atualizados — **N/A**: nenhuma rota nova nem mudança de autorização; a mudança é na cadeia de fallback de env vars (testes de precedência adicionados em `auth.rs`, `check.rs` e `credentials.rs`)
- [ ] Verificação de políticas RLS `USING` e `WITH CHECK` — **N/A**: nenhuma migration ou política tocada
- [x] Auditoria de eventos de workspace estruturada (sem PII na metadata) — nenhum evento novo; findings do `config check` reportam presença/igualdade, nunca valores (testes `legacy_passphrase_spelling_yields_deprecation_warning` e `divergent_passphrase_spellings_yield_split_warning` asseguram)

## Mudanças na API pública e Schema

- Nenhuma rota nova, nenhuma migration.
- `garraia_security` exporta `vault_passphrase_from_env()`, `VAULT_PASSPHRASE_ENV` e `VAULT_PASSPHRASE_ENV_LEGACY` (aditivo).
- `AuthConfig::from_env`/`require_from_env` aceitam uma env var a mais como fallback (aditivo, precedência antiga preservada).
- Dois findings novos (Warning) no `garraia config check`.

## Como testar

1. `cargo test -p garraia-security -p garraia-config` — inclui os 7 testes novos de precedência/fallback/findings.
2. Reproduzir o cenário da issue: criar um vault com `garraia init`, exportar **apenas** `GarraIA_VAULT_PASSPHRASE` (caixa mista) com a senha correta e subir o gateway — o provider agora resolve a key do cofre (antes: "no API key"), com warning de deprecation no log.
3. Exportar **apenas** `GARRAIA_VAULT_PASSPHRASE` (all-caps, ≥32 bytes) sem `GARRAIA_JWT_SECRET` — `/auth/*` agora emite JWT (antes: 503).
4. `garraia config check` com a mixed-case setada → warning de deprecation; com as duas grafias divergentes → warning de split, sem vazar valores.

## Plano de Rollback

Revert do commit único (`git revert`). Sem migration, sem mudança de formato persistido — o comportamento volta ao anterior (grafias estritas) imediatamente. Tokens emitidos via fallback all-caps deixariam de validar após o revert apenas se o deploy não setar `GARRAIA_JWT_SECRET`/mixed-case com o mesmo valor (mesma janela de expiração de 15 min dos access tokens).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmbMxoDgXHbxLDBF8kBBNm

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmbMxoDgXHbxLDBF8kBBNm)_