### PR TITLE
feat(deploy): worker Cloudflare get.garraia.cloud para o instalador (#827)

### DIFF
--- a/deploy/installer-worker/README.md
+++ b/deploy/installer-worker/README.md
@@ -1,0 +1,73 @@
+# garraia-installer — Worker do `get.garraia.cloud`
+
+Cloudflare Worker que serve o `install.sh` do branch `main` com cache no
+edge, eliminando o HTTP 429 por IP do `raw.githubusercontent.com` no
+bootstrap (issue #827; contexto completo no PR #826 §"O que este PR NÃO
+resolve").
+
+```bash
+curl -fsSL https://get.garraia.cloud | sh
+```
+
+## Como funciona
+
+- `GET /` e `GET /install.sh` respondem o conteúdo de
+  `https://raw.githubusercontent.com/michelbr84/GarraRUST/main/install.sh`
+  com `Content-Type: text/x-shellscript; charset=utf-8`.
+- **Cache de edge** (`caches.default`) com TTL de **5 minutos** — o Worker
+  busca o raw raramente e a partir de IPs da Cloudflare; o rate limit por
+  IP do usuário final sai do caminho. Mudanças no `install.sh` propagam em
+  até 5 min (aceite da issue).
+- **Fallback**: se o raw falhar, tenta o mirror jsDelivr antes de responder
+  502 (com os canais alternativos no corpo). Falhas nunca são cacheadas.
+
+## Deploy (runbook)
+
+Pré-requisitos: conta Cloudflare com o DNS de `garraia.cloud` ativo na
+Cloudflare (nameservers apontados) e `wrangler` >= 3 autenticado
+(`wrangler login`).
+
+1. Deploy inicial (fica em `garraia-installer.<subdomínio>.workers.dev`):
+
+   ```bash
+   cd deploy/installer-worker
+   wrangler deploy
+   ```
+
+2. Smoke test no workers.dev (sem cache de edge — esperado; `caches.default`
+   é no-op fora de zona própria):
+
+   ```bash
+   curl -fsS https://garraia-installer.<subdomínio>.workers.dev/ | head -5
+   # Deve imprimir o cabeçalho do install.sh
+   ```
+
+3. Criar o registro DNS: na zona `garraia.cloud`, um registro
+   `get` do tipo `AAAA 100::` (ou `CNAME` placeholder) **com proxy laranja
+   ligado** — a rota do Worker intercepta antes do origin.
+
+4. Descomentar o bloco `routes` no `wrangler.toml` e re-deployar:
+
+   ```bash
+   wrangler deploy
+   ```
+
+5. Aceite (critérios da issue #827):
+
+   ```bash
+   # Em pod Ubuntu novo:
+   curl -fsSL https://get.garraia.cloud | sh
+   # Header de diagnóstico (raw ou jsdelivr + cache HIT/MISS):
+   curl -fsSI https://get.garraia.cloud | grep -i "x-garraia-upstream\|cf-cache-status\|content-type"
+   ```
+
+6. Pós-aceite: atualizar site + `README.md` + `docs/installation.md`
+   anunciando `get.garraia.cloud` como canal primário, mantendo raw /
+   release-CDN / jsDelivr como alternativos. (Deliberadamente **não** feito
+   junto com este código — anunciar a URL antes do DNS + deploy estarem
+   vivos quebraria a instrução para todo mundo.)
+
+## Rollback
+
+`wrangler delete` (ou desativar a rota na dashboard). O one-liner clássico
+via raw/release-CDN/jsDelivr continua funcionando de forma independente.

--- a/deploy/installer-worker/worker.js
+++ b/deploy/installer-worker/worker.js
@@ -1,0 +1,114 @@
+/**
+ * garraia-installer — Cloudflare Worker que serve o `install.sh` em
+ * `https://get.garraia.cloud` (issue #827).
+ *
+ * Por que existe: `raw.githubusercontent.com` aplica rate limit por IP e o
+ * IP de saída de pods cloud (RunPod etc.) é compartilhado — o one-liner do
+ * site morria com HTTP 429 antes de qualquer código do repo executar. Este
+ * Worker busca o script a partir de IPs da Cloudflare e o mantém no cache
+ * de edge, tirando o rate limit por IP do usuário final do caminho.
+ *
+ * Contrato (issue #827 §Proposta):
+ *   - `GET /` e `GET /install.sh` respondem o conteúdo de `install.sh` do
+ *     branch `main`, com `Content-Type: text/x-shellscript; charset=utf-8`.
+ *   - Cache no edge via `caches.default` com TTL curto (5 min) — mudanças
+ *     no `install.sh` propagam em <= CACHE_TTL_SECONDS.
+ *   - Fallback: se o raw responder erro, tenta o mirror jsDelivr (mesmo
+ *     canal alternativo documentado pelo PR #826) antes de desistir.
+ *   - Nunca cacheia falha: upstream indisponível => 502 `no-store` com os
+ *     canais alternativos no corpo, para o operador seguir manualmente.
+ */
+
+const UPSTREAMS = [
+  "https://raw.githubusercontent.com/michelbr84/GarraRUST/main/install.sh",
+  "https://cdn.jsdelivr.net/gh/michelbr84/GarraRUST@main/install.sh",
+];
+
+const CACHE_TTL_SECONDS = 300; // 5 min — aceite da issue: propagação <= TTL
+
+export default {
+  async fetch(request, _env, ctx) {
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return new Response("method not allowed\n", {
+        status: 405,
+        headers: { allow: "GET, HEAD" },
+      });
+    }
+
+    const url = new URL(request.url);
+    if (url.pathname !== "/" && url.pathname !== "/install.sh") {
+      return new Response("not found — use / (ou /install.sh)\n", {
+        status: 404,
+        headers: { "content-type": "text/plain; charset=utf-8" },
+      });
+    }
+
+    // `/` e `/install.sh` compartilham uma única entrada de cache.
+    // NOTA: `caches.default` é no-op em domínios *.workers.dev — o cache de
+    // edge só funciona atrás de zona própria (get.garraia.cloud). Ver README.
+    const cacheKey = new Request(new URL("/install.sh", url.origin), {
+      method: "GET",
+    });
+    const cache = caches.default;
+
+    let response = await cache.match(cacheKey);
+    if (!response) {
+      response = await fetchInstallerFromUpstreams();
+      if (response.ok) {
+        ctx.waitUntil(cache.put(cacheKey, response.clone()));
+      }
+    }
+
+    if (request.method === "HEAD") {
+      return new Response(null, {
+        status: response.status,
+        headers: response.headers,
+      });
+    }
+    return response;
+  },
+};
+
+async function fetchInstallerFromUpstreams() {
+  let lastError = "nenhum upstream tentado";
+
+  for (const upstream of UPSTREAMS) {
+    const host = new URL(upstream).host;
+    try {
+      const res = await fetch(upstream, {
+        headers: { "user-agent": "garraia-installer-worker (+issue #827)" },
+      });
+      if (res.ok) {
+        const body = await res.text();
+        return new Response(body, {
+          status: 200,
+          headers: {
+            "content-type": "text/x-shellscript; charset=utf-8",
+            "cache-control": `public, max-age=${CACHE_TTL_SECONDS}`,
+            "x-content-type-options": "nosniff",
+            // Diagnóstico: de onde veio a cópia cacheada (nunca é segredo).
+            "x-garraia-upstream": host,
+          },
+        });
+      }
+      lastError = `${host} respondeu ${res.status}`;
+    } catch (err) {
+      lastError = `${host} falhou: ${err}`;
+    }
+  }
+
+  return new Response(
+    "instalador GarraIA temporariamente indisponível (" +
+      lastError +
+      ").\nCanais alternativos:\n" +
+      "  curl -fsSL https://github.com/michelbr84/GarraRUST/releases/latest/download/install.sh | sh\n" +
+      "  curl -fsSL https://cdn.jsdelivr.net/gh/michelbr84/GarraRUST@main/install.sh | sh\n",
+    {
+      status: 502,
+      headers: {
+        "content-type": "text/plain; charset=utf-8",
+        "cache-control": "no-store",
+      },
+    },
+  );
+}

--- a/deploy/installer-worker/wrangler.toml
+++ b/deploy/installer-worker/wrangler.toml
@@ -1,0 +1,14 @@
+# garraia-installer — Worker que serve o install.sh em get.garraia.cloud.
+# Deploy: `wrangler deploy` a partir deste diretório (ver README.md).
+
+name = "garraia-installer"
+main = "worker.js"
+compatibility_date = "2026-08-17"
+
+# Ative a rota depois que o DNS de garraia.cloud estiver na Cloudflare
+# (pré-requisito da issue #827). Em *.workers.dev o Worker funciona, mas
+# `caches.default` é no-op — o cache de edge exige zona própria.
+#
+# routes = [
+#   { pattern = "get.garraia.cloud/*", zone_name = "garraia.cloud" },
+# ]

--- a/plans/0353-installer-worker.md
+++ b/plans/0353-installer-worker.md
@@ -1,0 +1,45 @@
+# Plan 0353 — Worker `get.garraia.cloud` para o instalador (issue #827)
+
+> **Status:** código entregue em 2026-08-17 (America/New_York); deploy +
+> DNS ficam com o operador (pré-requisitos externos da issue).
+> **Origem:** issue #827, follow-up do PR #826 ("O que este PR NÃO resolve").
+
+## 1. Problema
+
+O one-liner `curl -fsSL https://raw.githubusercontent.com/.../install.sh | sh`
+morre com HTTP 429 em pods cloud novos: o rate limit do raw é por IP e o IP
+de saída é compartilhado. Acontece antes de qualquer código do repo rodar —
+não é eliminável pelo repositório; o PR #826 apenas mitigou (retries, release
+asset, mirror jsDelivr).
+
+## 2. Entrega
+
+`deploy/installer-worker/` (opção 1 da issue — código vive neste repo):
+
+- `worker.js` — ES module servindo `GET|HEAD /` e `/install.sh`:
+  - upstream primário raw `main`, fallback jsDelivr;
+  - `caches.default` com TTL 300 s (aceite: propagação <= TTL);
+  - `Content-Type: text/x-shellscript; charset=utf-8` + `nosniff` +
+    header de diagnóstico `x-garraia-upstream`;
+  - falha de upstream => 502 `no-store` com canais alternativos no corpo
+    (nunca cacheia falha);
+  - 404 para outros paths, 405 para outros métodos.
+- `wrangler.toml` — rota `get.garraia.cloud/*` comentada até o DNS existir.
+- `README.md` — runbook de deploy em 6 passos + rollback.
+
+## 3. Deliberadamente fora
+
+- **Anunciar a URL** em site/README/docs/installation.md — só depois do
+  deploy + DNS vivos (anunciar antes quebraria a instrução para todos).
+  Passo 6 do runbook.
+- Testes automatizados do Worker no CI — exigiria toolchain node/miniflare
+  nova no pipeline por ~100 linhas de JS sem dependências; validação é o
+  smoke test do runbook. Reavaliar se o Worker crescer.
+
+## 4. Verificação
+
+- Código sem dependências externas; revisão manual + smoke test pós-deploy
+  (runbook §5): `curl -fsSL https://get.garraia.cloud | sh` em pod novo,
+  headers `x-garraia-upstream`/`cf-cache-status`.
+- A issue #827 permanece aberta até o aceite (exige DNS + deploy, fora do
+  alcance do repo).


### PR DESCRIPTION
## Descrição

Entrega o lado-repo da issue #827 (follow-up do PR #826 §"O que este PR NÃO resolve"): o one-liner via `raw.githubusercontent.com` morre com HTTP 429 por IP em pods cloud, antes de qualquer código nosso executar. A solução definitiva é a vanity URL `get.garraia.cloud` com cache no edge.

Novo diretório `deploy/installer-worker/` (opção 1 da issue — código vive neste repo):

- **`worker.js`** — Cloudflare Worker (ES module, zero dependências) servindo `GET|HEAD /` e `/install.sh`:
  - upstream primário: raw do `main`; fallback: mirror jsDelivr (mesmo canal alternativo do PR #826);
  - cache de edge (`caches.default`) com **TTL 5 min** — mudanças no `install.sh` propagam em ≤ TTL (aceite da issue);
  - `Content-Type: text/x-shellscript; charset=utf-8` + `nosniff` + header de diagnóstico `x-garraia-upstream`;
  - upstreams indisponíveis ⇒ **502 `no-store`** com os canais alternativos no corpo (falha nunca é cacheada);
  - 404 para outros paths, 405 para outros métodos.
- **`wrangler.toml`** — rota `get.garraia.cloud/*` comentada até o DNS estar na Cloudflare (pré-requisito externo da issue).
- **`README.md`** — runbook de deploy em 6 passos (deploy → smoke workers.dev → DNS proxied → rota → aceite → anúncio nos docs) + rollback.
- **`plans/0353-installer-worker.md`** — registro da decisão.

**Deliberadamente fora deste PR:** anunciar a URL em site/`README`/`docs/installation.md` — só depois do deploy + DNS vivos (passo 6 do runbook); anunciar antes quebraria a instrução para todo mundo. A issue #827 permanece aberta até o aceite em pod real.

Refs #827

## Tipo de mudança

- [x] `feat`: Nova funcionalidade

## Classe de Risco

- [x] **Classe A (Baixo Risco)**: Documentação, comentários, formatação, bumps de dependências de desenvolvimento sem impacto em tempo de execução.

> Nenhum código do workspace Rust é tocado; o Worker só entra em produção com deploy manual via wrangler (fora do CI).

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo fmt --check` executado e limpo — sem mudanças Rust
- [x] `cargo clippy --workspace --exclude garraia-desktop -- -D warnings` sem erros — sem mudanças Rust (validado no HEAD anterior desta branch base)
- [x] `cargo test --workspace --exclude garraia-desktop` passando localmente — sem mudanças Rust
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo, API key, token ou credencial commitada — o Worker não usa secrets; header de diagnóstico expõe apenas o host do upstream
- [x] Nenhuma migração Postgres com operações destrutivas sem estratégia de transição forward-only — sem migrations

### Para alterações de Alto Risco (Classe C)

- [ ] N/A — mudança Classe A (nenhuma rota do gateway, RLS ou auth tocada)

## Mudanças na API pública e Schema

- Nenhuma mudança na API pública do gateway; nenhum crate tocado.
- Novo artefato de deploy opt-in (`deploy/installer-worker/`), ativado só por `wrangler deploy` manual.

## Como testar

1. `node --check deploy/installer-worker/worker.js` — sintaxe OK.
2. Pós-deploy (runbook §2 e §5): `curl -fsS https://garraia-installer.<subdomínio>.workers.dev/ | head -5` deve imprimir o cabeçalho do `install.sh`; com a rota ativa, `curl -fsSI https://get.garraia.cloud` deve mostrar `content-type: text/x-shellscript`, `x-garraia-upstream` e `cf-cache-status`.
3. Aceite final (issue #827): pod Ubuntu novo → `curl -fsSL https://get.garraia.cloud | sh`.

## Plano de Rollback

`wrangler delete` (ou desativar a rota na dashboard Cloudflare) — o one-liner clássico via raw/release-CDN/jsDelivr continua funcionando de forma independente. No repo, revert do commit único.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmbMxoDgXHbxLDBF8kBBNm

---
_Generated by [Claude Code](https://claude.ai/code/session_01XmbMxoDgXHbxLDBF8kBBNm)_