### PR TITLE
fix(auth,gateway): POST /v1/me/anonymize anonimiza de verdade (plan 0354)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,51 @@ jobs:
           fi
         shell: bash
 
+  # Integração garraia-auth com test-support (plan 0354).
+  #
+  # Os 16 binários de teste de integração do garraia-auth (extractor, matriz
+  # RLS de 81 cenários, signup_flow, sessions_lifecycle, password_change, …)
+  # declaram `required-features = ["test-support"]`, que NÃO é default — o
+  # `cargo test --workspace` do job `test` os pula SILENCIOSAMENTE. Até este
+  # job existir, o único executor era o cargo-mutants semanal (mutants.yml),
+  # cujo vermelho ficou 16 semanas sem leitura e escondeu um bug de produção
+  # no POST /v1/me/anonymize. Regra 10 do CLAUDE.md exige testes de
+  # autorização cross-group no PR path — este job os executa de fato.
+  auth-integration:
+    name: Auth Integration (test-support)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-authint-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-authint-
+            ${{ runner.os }}-cargo-
+
+      - name: Pre-pull Docker image for testcontainers
+        # Mesmo racional do mutants.yml: warm pull ~3-5 s por container em
+        # vez de ~60 s no cold start do pgvector/pg16.
+        run: docker pull pgvector/pgvector:pg16
+
+      - name: Run garraia-auth integration suite
+        run: cargo test -p garraia-auth --features test-support
+
   # Coverage instrumentation (GAR-435 / Q5 of EPIC GAR-430). Linux-only.
   #
   # Generates lcov.info via cargo-llvm-cov, uploads as artifact (14d retention),

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3253,6 +3253,7 @@ dependencies = [
  "secrecy 0.10.3",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2 0.10.9",
  "sqlx",
  "static_assertions",

--- a/crates/garraia-auth/Cargo.toml
+++ b/crates/garraia-auth/Cargo.toml
@@ -86,6 +86,10 @@ password-hash = { version = "0.5", features = ["getrandom"] }
 # Compile-time `LoginPool: !Clone` denial — see GAR-391a security review H-1.
 # Tiny zero-dep crate used only by unit tests.
 static_assertions = "1"
+# Serializa os testes de password_change.rs: cada teste segura uma conexão do
+# LoginPool (max 5) através de hashing lento (Argon2id/PBKDF2 em debug) dentro
+# de tx — 6 testes concorrentes estouram o acquire timeout do pool (plan 0354).
+serial_test = { workspace = true }
 # Integration tests spin their own pgvector container so garraia-auth stays
 # independently testable. Shared fixture optimization deferred to GAR-391c.
 testcontainers = "0.27"

--- a/crates/garraia-auth/src/lib.rs
+++ b/crates/garraia-auth/src/lib.rs
@@ -59,7 +59,7 @@ pub use app_pool::{AppPool, AppPoolConfig};
 
 // Plan 0335 (GAR-876) — self-service password change
 pub mod password;
-pub use password::{PasswordChangeOutcome, anonymize_identity, change_password};
+pub use password::{PasswordChangeOutcome, anon_token, anonymize_identity, change_password};
 
 /// Convenience `Result` alias for crate APIs.
 pub type Result<T> = std::result::Result<T, AuthError>;

--- a/crates/garraia-auth/src/password.rs
+++ b/crates/garraia-auth/src/password.rs
@@ -98,13 +98,22 @@ pub async fn change_password(
     Ok(PasswordChangeOutcome::Success)
 }
 
-/// Anonymise the `user_identities` row for `user_id`.
+/// Anonymise the internal `user_identities` row for `user_id`.
 ///
-/// Replaces `login` with a non-identifiable token (`anon-<8 hex chars>@garraanon.local`)
-/// derived from the user's UUID, making the row impossible to correlate back to a
-/// real email address.  The `password_hash` is left intact — the account status
-/// (`users.status = 'anonymized'`) is the authoritative gate for further logins;
-/// the internal provider hash is irrelevant once status is anonymized.
+/// Replaces `provider_sub` — which for `provider = 'internal'` carries the
+/// user's login email in THIS schema (`create_internal_user` inserts it and
+/// `verify_internal` matches `provider_sub = $email`; there is no `login`
+/// column — migration 001) — with a non-identifiable deterministic token
+/// (`anon-<32 hex>@garraanon.local`).
+///
+/// The token uses the FULL UUID: under UUIDv7 (time-ordered, production ids)
+/// an 8-hex prefix is shared by users created within the same ~65 s window,
+/// and `UNIQUE (provider, provider_sub)` would turn that collision into a
+/// hard error on the second anonymize.
+///
+/// `password_hash` is left intact — the account status
+/// (`users.status = 'anonymized'`) is the authoritative gate for further
+/// logins (`verify_internal` rejects any status != 'active').
 ///
 /// ## Why LoginPool?
 /// `user_identities` is invisible to `garraia_app` under FORCE RLS (CLAUDE.md rule 12).
@@ -112,27 +121,28 @@ pub async fn change_password(
 ///
 /// ## Atomicity
 /// This function runs a single UPDATE — one round-trip, no transaction needed.
-/// The caller (`anonymize_me`) must commit the `users` status update via `app_pool`
-/// independently; the two operations are best-effort sequential (email first, then
-/// status).
-pub async fn anonymize_identity(login_pool: &LoginPool, user_id: Uuid) -> Result<(), AuthError> {
-    let anon_login = format!(
-        "anon-{}@garraanon.local",
-        &user_id.simple().to_string()[..8]
-    );
+/// The caller (`anonymize_me`) anonymises `users.email` + status in its own
+/// `app_pool` transaction; the two commits are sequential, and a failure
+/// between them heals on retry (this UPDATE is idempotent and the status
+/// guard only trips after the app-side commit).
+///
+/// Returns the number of rows updated — 0 when the user has no internal
+/// identity (e.g. a future external-IdP-only account), which is not an error.
+pub async fn anonymize_identity(login_pool: &LoginPool, user_id: Uuid) -> Result<u64, AuthError> {
+    let anon_sub = format!("anon-{}@garraanon.local", user_id.simple());
     let pool = login_pool.pool();
-    sqlx::query(
+    let result = sqlx::query(
         "UPDATE user_identities \
-         SET login = $1 \
+         SET provider_sub = $1 \
          WHERE user_id = $2 AND provider = 'internal'",
     )
-    .bind(&anon_login)
+    .bind(&anon_sub)
     .bind(user_id)
     .execute(pool)
     .await
     .map_err(AuthError::Storage)?;
 
-    Ok(())
+    Ok(result.rows_affected())
 }
 
 #[cfg(test)]
@@ -208,34 +218,47 @@ mod tests {
     }
 
     // ── anonymize_identity helpers ────────────────────────────────────────────
+    // Espelham o formato REAL do token (UUID completo, 32 hex — plan 0354).
+    // O comportamento da função contra Postgres real é coberto pelos testes
+    // de integração em `tests/password_change.rs`.
 
     #[test]
-    fn anon_login_format_is_deterministic() {
+    fn anon_token_format_is_deterministic_full_uuid() {
         let uid = uuid::Uuid::parse_str("12345678-0000-0000-0000-000000000001").unwrap();
-        let anon = format!("anon-{}@garraanon.local", &uid.simple().to_string()[..8]);
-        assert_eq!(anon, "anon-12345678@garraanon.local");
-    }
-
-    #[test]
-    fn anon_login_is_not_valid_email_domain() {
-        let uid = uuid::Uuid::parse_str("abcdef01-0000-0000-0000-000000000001").unwrap();
-        let anon = format!("anon-{}@garraanon.local", &uid.simple().to_string()[..8]);
-        assert!(anon.ends_with("@garraanon.local"));
-        assert!(anon.contains('@'), "must contain exactly one @");
-    }
-
-    #[test]
-    fn anon_login_prefix_is_not_identifiable() {
-        let uid = uuid::Uuid::parse_str("cafebabe-dead-beef-cafe-babe00000001").unwrap();
-        let anon = format!("anon-{}@garraanon.local", &uid.simple().to_string()[..8]);
-        // Must start with 'anon-' prefix (not the bare UUID).
-        assert!(anon.starts_with("anon-"));
-        // Must not expose the full UUID (36-char hyphenated form) in the email.
-        assert!(
-            !anon.contains("cafebabe-dead"),
-            "must not expose full hyphenated UUID in login"
+        let anon = format!("anon-{}@garraanon.local", uid.simple());
+        assert_eq!(
+            anon,
+            "anon-12345678000000000000000000000001@garraanon.local"
         );
-        // The 8-char derived token is the first 8 hex chars of the simple UUID.
-        assert_eq!(&anon[5..13], "cafebabe");
+        // local-part = "anon-" (5) + 32 hex = 37 chars antes do '@'.
+        assert_eq!(anon.find('@'), Some(37));
+    }
+
+    #[test]
+    fn anon_token_is_not_valid_email_domain() {
+        let uid = uuid::Uuid::parse_str("abcdef01-0000-0000-0000-000000000001").unwrap();
+        let anon = format!("anon-{}@garraanon.local", uid.simple());
+        assert!(anon.ends_with("@garraanon.local"));
+        assert_eq!(anon.matches('@').count(), 1, "must contain exactly one @");
+    }
+
+    #[test]
+    fn anon_token_full_uuid_avoids_v7_prefix_collision() {
+        // Sob UUIDv7 os primeiros 32 bits são timestamp — dois usuários criados
+        // na mesma janela de ~65 s compartilham o prefixo de 8 hex. O token usa
+        // o UUID COMPLETO justamente para que os tokens continuem distintos
+        // (users.email e (provider, provider_sub) são UNIQUE).
+        let a = uuid::Uuid::parse_str("cafebabe-0001-7000-8000-000000000001").unwrap();
+        let b = uuid::Uuid::parse_str("cafebabe-0001-7000-8000-000000000002").unwrap();
+        let anon_a = format!("anon-{}@garraanon.local", a.simple());
+        let anon_b = format!("anon-{}@garraanon.local", b.simple());
+        assert_eq!(
+            &anon_a[5..13],
+            &anon_b[5..13],
+            "premissa: mesmo prefixo de 8 hex"
+        );
+        assert_ne!(anon_a, anon_b, "tokens completos devem diferir");
+        // Não expõe a forma hifenizada do UUID.
+        assert!(!anon_a.contains("cafebabe-0001"));
     }
 }

--- a/crates/garraia-auth/src/password.rs
+++ b/crates/garraia-auth/src/password.rs
@@ -98,6 +98,19 @@ pub async fn change_password(
     Ok(PasswordChangeOutcome::Success)
 }
 
+/// Token de anonimização determinístico para `user_id` — a ÚNICA fonte da
+/// fórmula (security review plan 0354 LOW-3: `users.email`,
+/// `user_identities.provider_sub` e `group_invites.invited_email` precisam
+/// receber o MESMO token; duplicar o format em cada sítio dessincroniza
+/// silencioso).
+///
+/// UUID completo (32 hex): sob UUIDv7 um prefixo de 8 hex é compartilhado por
+/// usuários criados na mesma janela de ~65 s, e os UNIQUEs de `users.email` e
+/// `(provider, provider_sub)` transformariam a colisão em erro.
+pub fn anon_token(user_id: Uuid) -> String {
+    format!("anon-{}@garraanon.local", user_id.simple())
+}
+
 /// Anonymise the internal `user_identities` row for `user_id`.
 ///
 /// Replaces `provider_sub` — which for `provider = 'internal'` carries the
@@ -129,7 +142,7 @@ pub async fn change_password(
 /// Returns the number of rows updated — 0 when the user has no internal
 /// identity (e.g. a future external-IdP-only account), which is not an error.
 pub async fn anonymize_identity(login_pool: &LoginPool, user_id: Uuid) -> Result<u64, AuthError> {
-    let anon_sub = format!("anon-{}@garraanon.local", user_id.simple());
+    let anon_sub = anon_token(user_id);
     let pool = login_pool.pool();
     let result = sqlx::query(
         "UPDATE user_identities \

--- a/crates/garraia-auth/tests/password_change.rs
+++ b/crates/garraia-auth/tests/password_change.rs
@@ -1,22 +1,39 @@
 //! Integration tests for `change_password` and `anonymize_identity`
-//! (plan 0347 / GAR-891 — Q6.15).
+//! (plan 0347 / GAR-891 — Q6.15; anonymize fixado no plan 0354).
 //!
 //! # Mutants killed
 //!
-//! * `password.rs:81:8` — `delete !` in `change_password` (shard 2): killed by
+//! * `change_password` `delete !` (shard 2): killed by
 //!   [`change_password_correct_argon2id_returns_success`].
-//! * `password.rs:75:58` — `replace \|\| with &&` in `change_password` (shard 1): killed by
+//! * `change_password` `replace \|\| with &&` (shard 1): killed by
 //!   [`change_password_correct_pbkdf2sha256_returns_success`].
-//! * `password.rs:119:5` — `replace anonymize_identity with Ok(())` (shard 0): killed by
-//!   [`anonymize_identity_updates_login`].
+//! * `anonymize_identity` `replace body with Ok(...)`: killed by
+//!   [`anonymize_identity_replaces_provider_sub`].
+//! * `anonymize_identity` `delete WHERE user_id` clause variants: killed by
+//!   [`anonymize_identity_leaves_other_users_untouched`].
 //!
 //! All tests use the shared `Harness` (one pgvector/pg16 container per binary,
 //! isolation via unique UUIDs per test).
+//!
+//! ## Pools por teste, não o `h.login_pool` compartilhado
+//!
+//! Mesmo dragão documentado em `garraia-gateway/tests/rest_v1_me_authed.rs`:
+//! cada `#[tokio::test]` cria e destrói um runtime tokio próprio, e conexões
+//! sqlx adquiridas num runtime nem sempre voltam ao pool compartilhado do
+//! `Harness` antes de o runtime seguinte tentar adquirir — resultado flaky
+//! "pool timed out while waiting for an open connection" (`#[serial]` sozinho
+//! NÃO resolve; foi testado). Aqui cada teste constrói seu próprio `LoginPool`
+//! via [`fresh_login_pool`], que nasce e morre dentro do runtime do teste.
+//! `#[serial]` continua aplicado só para não empilhar hashing Argon2id/PBKDF2
+//! (CPU-pesado em debug) em runners de CI de 2 cores.
 
 mod common;
 
 use common::harness::Harness;
-use garraia_auth::{PasswordChangeOutcome, anonymize_identity, change_password, hash_argon2id};
+use garraia_auth::{
+    LoginConfig, LoginPool, PasswordChangeOutcome, anonymize_identity, change_password,
+    hash_argon2id,
+};
 use password_hash::{PasswordHasher, SaltString};
 use pbkdf2::Pbkdf2;
 use secrecy::SecretString;
@@ -27,9 +44,25 @@ fn pw(s: &str) -> SecretString {
     SecretString::from(s.to_owned())
 }
 
+/// `LoginPool` dedicado ao teste corrente (ver doc do módulo). Mesma derivação
+/// de URL que o `Harness` usa; 2 conexões bastam para um teste linear.
+async fn fresh_login_pool(h: &Harness) -> anyhow::Result<LoginPool> {
+    let login_url = h
+        .admin_url
+        .replace("postgres:postgres@", "garraia_login:login-pw@");
+    Ok(LoginPool::from_dedicated_config(&LoginConfig {
+        database_url: login_url,
+        max_connections: 2,
+    })
+    .await?)
+}
+
 /// Insert one user + one internal identity via the admin pool.
-/// Returns the new `user_id`. The `login` column is set to `email` so that
-/// `anonymize_identity` tests can detect the change by querying it.
+/// Returns the new `user_id`. `provider_sub` recebe o email lowercase —
+/// espelha o signup real (`create_internal_user`), que insere o email ali,
+/// e o login lookup (`verify_internal`), que casa `provider_sub = $email`.
+/// (Não existe coluna `login` neste schema — migration 001; o seed antigo
+/// que a inseria quebrava o baseline inteiro do cargo-mutants.)
 async fn seed(admin: &sqlx::PgPool, email: &str, password_hash: &str) -> anyhow::Result<Uuid> {
     let row = sqlx::query("INSERT INTO users (email, display_name) VALUES ($1, $2) RETURNING id")
         .bind(email)
@@ -40,12 +73,11 @@ async fn seed(admin: &sqlx::PgPool, email: &str, password_hash: &str) -> anyhow:
 
     sqlx::query(
         "INSERT INTO user_identities \
-         (user_id, provider, provider_sub, login, password_hash) \
-         VALUES ($1, 'internal', $2, $3, $4)",
+         (user_id, provider, provider_sub, password_hash) \
+         VALUES ($1, 'internal', $2, $3)",
     )
     .bind(user_id)
-    .bind(user_id.to_string())
-    .bind(email)
+    .bind(email.to_lowercase())
     .bind(password_hash)
     .execute(admin)
     .await?;
@@ -61,21 +93,18 @@ async fn seed(admin: &sqlx::PgPool, email: &str, password_hash: &str) -> anyhow:
 /// If the `!` were deleted it becomes `if matches { return Ok(WrongPassword); }`,
 /// meaning a CORRECT password returns `WrongPassword`. This test panics in that case.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial_test::serial]
 async fn change_password_correct_argon2id_returns_success() -> anyhow::Result<()> {
     let h = Harness::get().await;
     let admin = sqlx::PgPool::connect(&h.admin_url).await?;
+    let login_pool = fresh_login_pool(&h).await?;
     let email = format!("cp-ok-argon-{}@garraia.test", Uuid::now_v7());
     let correct = pw("correct-horse-battery-staple-42");
     let hash = hash_argon2id(&correct)?;
     let user_id = seed(&admin, &email, &hash).await?;
 
-    let outcome = change_password(
-        &h.login_pool,
-        user_id,
-        &correct,
-        &pw("brand-new-password-99"),
-    )
-    .await?;
+    let outcome =
+        change_password(&login_pool, user_id, &correct, &pw("brand-new-password-99")).await?;
     assert_eq!(
         outcome,
         PasswordChangeOutcome::Success,
@@ -96,9 +125,11 @@ async fn change_password_correct_argon2id_returns_success() -> anyhow::Result<()
 /// (it satisfies the first condition but not the second), causing the function
 /// to fall through to `Err(AuthError::UnknownHashFormat)` instead of `Success`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial_test::serial]
 async fn change_password_correct_pbkdf2sha256_returns_success() -> anyhow::Result<()> {
     let h = Harness::get().await;
     let admin = sqlx::PgPool::connect(&h.admin_url).await?;
+    let login_pool = fresh_login_pool(&h).await?;
     let email = format!("cp-ok-pbkdf2-{}@garraia.test", Uuid::now_v7());
 
     // Build a real PBKDF2-SHA256 PHC string — same pattern as verify_internal.rs.
@@ -120,7 +151,7 @@ async fn change_password_correct_pbkdf2sha256_returns_success() -> anyhow::Resul
 
     let user_id = seed(&admin, &email, &phc).await?;
     let outcome = change_password(
-        &h.login_pool,
+        &login_pool,
         user_id,
         &pw(plaintext_str),
         &pw("new-password-after-upgrade"),
@@ -137,15 +168,17 @@ async fn change_password_correct_pbkdf2sha256_returns_success() -> anyhow::Resul
 
 /// Baseline: wrong password returns `WrongPassword` (anti-enumeration path).
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial_test::serial]
 async fn change_password_wrong_argon2id_returns_wrong_password() -> anyhow::Result<()> {
     let h = Harness::get().await;
     let admin = sqlx::PgPool::connect(&h.admin_url).await?;
+    let login_pool = fresh_login_pool(&h).await?;
     let email = format!("cp-wrong-{}@garraia.test", Uuid::now_v7());
     let real_hash = hash_argon2id(&pw("actual-secret-password"))?;
     let user_id = seed(&admin, &email, &real_hash).await?;
 
     let outcome = change_password(
-        &h.login_pool,
+        &login_pool,
         user_id,
         &pw("definitely-wrong-password"),
         &pw("irrelevant-new-password"),
@@ -161,44 +194,92 @@ async fn change_password_wrong_argon2id_returns_wrong_password() -> anyhow::Resu
 
 // ── anonymize_identity tests ─────────────────────────────────────────────────
 
-/// Kills `password.rs:119:5` — `replace anonymize_identity → Ok(())` mutant.
+/// Kills o mutant `replace anonymize_identity → Ok(...)`.
 ///
-/// If the function body were replaced with `Ok(())`, `user_identities.login`
-/// would remain the original email. This test queries the column directly and
-/// panics if the UPDATE was silently skipped.
+/// Neste schema o email de login mora em `user_identities.provider_sub`
+/// (o signup insere o email ali; `verify_internal` casa `provider_sub = $email`).
+/// Após `anonymize_identity` o token deve ser determinístico com o UUID
+/// COMPLETO (32 hex): um prefixo de 8 hex colidiria entre usuários criados
+/// na mesma janela de ~65 s sob UUIDv7 — e `UNIQUE (provider, provider_sub)`
+/// transformaria a colisão em erro do segundo anonymize.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn anonymize_identity_updates_login() -> anyhow::Result<()> {
+#[serial_test::serial]
+async fn anonymize_identity_replaces_provider_sub() -> anyhow::Result<()> {
     let h = Harness::get().await;
     let admin = sqlx::PgPool::connect(&h.admin_url).await?;
+    let login_pool = fresh_login_pool(&h).await?;
     let email = format!("anon-target-{}@garraia.test", Uuid::now_v7());
     let hash = hash_argon2id(&pw("any-password-for-anon"))?;
     let user_id = seed(&admin, &email, &hash).await?;
 
-    anonymize_identity(&h.login_pool, user_id).await?;
+    let rows = anonymize_identity(&login_pool, user_id).await?;
+    assert_eq!(
+        rows, 1,
+        "exactly the seeded internal identity must be updated"
+    );
 
     let row = sqlx::query(
-        "SELECT login FROM user_identities \
+        "SELECT provider_sub FROM user_identities \
          WHERE user_id = $1 AND provider = 'internal'",
     )
     .bind(user_id)
     .fetch_one(&admin)
     .await?;
-    let new_login: Option<String> = row.try_get("login")?;
-    let new_login = new_login.expect(
-        "login must be non-NULL after anonymize_identity — \
-         fails if `replace with Ok(())` mutant (password.rs:119) is active",
-    );
-    assert!(
-        new_login.starts_with("anon-"),
-        "login must start with 'anon-' after anonymization, got: {new_login}"
-    );
-    assert!(
-        new_login.ends_with("@garraanon.local"),
-        "login must end with '@garraanon.local' after anonymization, got: {new_login}"
+    let new_sub: String = row.try_get("provider_sub")?;
+    let expected = format!("anon-{}@garraanon.local", user_id.simple());
+    assert_eq!(
+        new_sub, expected,
+        "provider_sub must be the deterministic full-UUID anon token"
     );
     assert_ne!(
-        new_login, email,
-        "login must have changed from the original email"
+        new_sub,
+        email.to_lowercase(),
+        "provider_sub must have changed from the original email"
     );
+    Ok(())
+}
+
+/// Kills mutants que degradam a cláusula WHERE (`user_id = $2` /
+/// `provider = 'internal'`): anonimizar o usuário A não pode tocar o B.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial_test::serial]
+async fn anonymize_identity_leaves_other_users_untouched() -> anyhow::Result<()> {
+    let h = Harness::get().await;
+    let admin = sqlx::PgPool::connect(&h.admin_url).await?;
+    let login_pool = fresh_login_pool(&h).await?;
+    let email_a = format!("anon-a-{}@garraia.test", Uuid::now_v7());
+    let email_b = format!("anon-b-{}@garraia.test", Uuid::now_v7());
+    let hash = hash_argon2id(&pw("shared-password-for-pair"))?;
+    let user_a = seed(&admin, &email_a, &hash).await?;
+    let user_b = seed(&admin, &email_b, &hash).await?;
+
+    let rows = anonymize_identity(&login_pool, user_a).await?;
+    assert_eq!(rows, 1, "only user A's identity may be updated");
+
+    let row = sqlx::query(
+        "SELECT provider_sub FROM user_identities \
+         WHERE user_id = $1 AND provider = 'internal'",
+    )
+    .bind(user_b)
+    .fetch_one(&admin)
+    .await?;
+    let sub_b: String = row.try_get("provider_sub")?;
+    assert_eq!(
+        sub_b,
+        email_b.to_lowercase(),
+        "user B's provider_sub must remain the original email"
+    );
+    Ok(())
+}
+
+/// Contrato: usuário sem identidade `internal` (ou inexistente) → 0 linhas,
+/// sem erro. O handler decide o que fazer; a função não inventa falha.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial_test::serial]
+async fn anonymize_identity_returns_zero_for_unknown_user() -> anyhow::Result<()> {
+    let h = Harness::get().await;
+    let login_pool = fresh_login_pool(&h).await?;
+    let rows = anonymize_identity(&login_pool, Uuid::now_v7()).await?;
+    assert_eq!(rows, 0, "unknown user must affect zero rows");
     Ok(())
 }

--- a/crates/garraia-gateway/src/rest_v1/me.rs
+++ b/crates/garraia-gateway/src/rest_v1/me.rs
@@ -80,7 +80,7 @@ use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use chrono::{DateTime, Utc};
 use garraia_auth::{
-    PasswordChangeOutcome, Principal, WorkspaceAuditAction, anonymize_identity,
+    PasswordChangeOutcome, Principal, WorkspaceAuditAction, anon_token, anonymize_identity,
     audit_workspace_event, change_password,
 };
 use password_hash::rand_core::RngCore;
@@ -4212,9 +4212,10 @@ pub async fn export_me(
 /// `POST /v1/me/anonymize` — LGPD art. 12 / GDPR art. 4(5) personal data
 /// anonymisation (plan 0345 / GAR-888, slice 3 of GAR-400; fixed in plan 0354).
 ///
-/// Replaces the caller's email in BOTH places it lives in this schema —
-/// `user_identities.provider_sub` (the login key, via `garraia_login`) and
-/// `users.email` (in the same app-pool transaction as the status flip) —
+/// Replaces the caller's email everywhere it lives in this schema —
+/// `user_identities.provider_sub` (the login key, via `garraia_login`),
+/// `users.email` (in the same app-pool transaction as the status flip) and
+/// `group_invites.invited_email` (pending + historical invites, same tx) —
 /// with a non-identifiable deterministic token
 /// (`anon-<32 hex>@garraanon.local`), and sets `users.display_name` to
 /// `'Usuário Anônimo'` + `users.status` to `'anonymized'`.  All active sessions
@@ -4262,30 +4263,32 @@ pub async fn anonymize_me(
         .await
         .map_err(|e| RestError::Internal(e.into()))?;
 
-    // Guard: FOR UPDATE prevents concurrent double-anonymize.
-    let current_status: Option<String> =
-        sqlx::query_scalar("SELECT status FROM users WHERE id = $1 FOR UPDATE")
+    // Guard: FOR UPDATE prevents concurrent double-anonymize. O email
+    // original é capturado aqui (cast ::text — sqlx não decodifica citext
+    // direto em String) para o wipe de group_invites mais abaixo.
+    let current: Option<(String, String)> =
+        sqlx::query_as("SELECT status, email::text FROM users WHERE id = $1 FOR UPDATE")
             .bind(principal.user_id)
             .fetch_optional(&mut *tx)
             .await
             .map_err(|e| RestError::Internal(e.into()))?;
 
-    match current_status.as_deref() {
+    let original_email = match current {
         None => {
             return Err(RestError::Internal(anyhow::anyhow!(
                 "user row not found for authenticated principal"
             )));
         }
-        Some("deleted") => {
+        Some((status, _)) if status == "deleted" => {
             return Err(RestError::Conflict(
                 "account is already deleted; cannot anonymize".into(),
             ));
         }
-        Some("anonymized") => {
+        Some((status, _)) if status == "anonymized" => {
             return Err(RestError::Conflict("account is already anonymized".into()));
         }
-        _ => {}
-    }
+        Some((_, email)) => email,
+    };
 
     // Step 1: anonymise the login key (user_identities.provider_sub) via
     // login_pool (BYPASSRLS — the table is invisible to garraia_app under
@@ -4302,10 +4305,12 @@ pub async fn anonymize_me(
         .map_err(|e| RestError::Internal(anyhow::anyhow!("anonymize_identity: {e}")))?;
 
     // Step 2 (atomic): anonymise users.email + status + display_name, revoke
-    // sessions, emit audit event. users.email is citext UNIQUE — the token
-    // embeds the full UUID, so it cannot collide across users.
-    // users.updated_at has no trigger (caller responsibility per migration 001).
-    let anon_email = format!("anon-{}@garraanon.local", principal.user_id.simple());
+    // sessions, wipe group_invites, emit audit event. users.email is citext
+    // UNIQUE — the token embeds the full UUID, so it cannot collide across
+    // users. users.updated_at has no trigger (caller responsibility per
+    // migration 001). Fórmula única do token: garraia_auth::anon_token
+    // (security review plan 0354).
+    let anon_email = anon_token(principal.user_id);
     sqlx::query(
         "UPDATE users \
          SET status = 'anonymized', display_name = 'Usuário Anônimo', \
@@ -4326,6 +4331,18 @@ pub async fn anonymize_me(
     .execute(&mut *tx)
     .await
     .map_err(|e| RestError::Internal(e.into()))?;
+
+    // group_invites.invited_email guarda o email PII de convites pendentes e
+    // históricos (security review plan 0354 LOW-2). Sem FORCE RLS nesta
+    // tabela (acesso por token — ver comentário em list_my_invites), então o
+    // UPDATE por email funciona no app_pool. citext = text compara
+    // case-insensitive, cobrindo convites gravados com caixa diferente.
+    sqlx::query("UPDATE group_invites SET invited_email = $2 WHERE invited_email = $1")
+        .bind(&original_email)
+        .bind(&anon_email)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| RestError::Internal(e.into()))?;
 
     audit_workspace_event(
         &mut tx,

--- a/crates/garraia-gateway/src/rest_v1/me.rs
+++ b/crates/garraia-gateway/src/rest_v1/me.rs
@@ -4210,10 +4210,13 @@ pub async fn export_me(
 // ─── POST /v1/me/anonymize ────────────────────────────────────────────────────
 
 /// `POST /v1/me/anonymize` — LGPD art. 12 / GDPR art. 4(5) personal data
-/// anonymisation (plan 0345 / GAR-888, slice 3 of GAR-400).
+/// anonymisation (plan 0345 / GAR-888, slice 3 of GAR-400; fixed in plan 0354).
 ///
-/// Replaces the caller's `user_identities.login` (email) with a non-identifiable
-/// token (`anon-<8 hex chars>@garraanon.local`) and sets `users.display_name` to
+/// Replaces the caller's email in BOTH places it lives in this schema —
+/// `user_identities.provider_sub` (the login key, via `garraia_login`) and
+/// `users.email` (in the same app-pool transaction as the status flip) —
+/// with a non-identifiable deterministic token
+/// (`anon-<32 hex>@garraanon.local`), and sets `users.display_name` to
 /// `'Usuário Anônimo'` + `users.status` to `'anonymized'`.  All active sessions
 /// are revoked atomically in the same transaction. The operation is irreversible.
 ///
@@ -4284,19 +4287,33 @@ pub async fn anonymize_me(
         _ => {}
     }
 
-    // Step 1: anonymise identity (email) via login_pool (BYPASSRLS).
-    // This runs outside the app_pool transaction — best-effort sequential.
-    anonymize_identity(&state.auth.login_pool, principal.user_id)
+    // Step 1: anonymise the login key (user_identities.provider_sub) via
+    // login_pool (BYPASSRLS — the table is invisible to garraia_app under
+    // FORCE RLS). Runs outside the app_pool transaction; a failure between
+    // the two commits heals on endpoint retry (the UPDATE is idempotent and
+    // the 409 status guard only trips after the app-side commit below).
+    // Intencional: o FOR UPDATE de `users` (acima) segue segurado durante
+    // este round-trip — é o que impede um segundo anonymize concorrente de
+    // passar pelo guard de status antes de este fluxo commitar.
+    // 0 rows = user without an internal identity (e.g. future external IdP)
+    // — not an error; users.email is anonymised regardless.
+    let _identity_rows = anonymize_identity(&state.auth.login_pool, principal.user_id)
         .await
         .map_err(|e| RestError::Internal(anyhow::anyhow!("anonymize_identity: {e}")))?;
 
-    // Step 2 (atomic): update users, revoke sessions, emit audit event.
+    // Step 2 (atomic): anonymise users.email + status + display_name, revoke
+    // sessions, emit audit event. users.email is citext UNIQUE — the token
+    // embeds the full UUID, so it cannot collide across users.
+    // users.updated_at has no trigger (caller responsibility per migration 001).
+    let anon_email = format!("anon-{}@garraanon.local", principal.user_id.simple());
     sqlx::query(
         "UPDATE users \
-         SET status = 'anonymized', display_name = 'Usuário Anônimo' \
+         SET status = 'anonymized', display_name = 'Usuário Anônimo', \
+             email = $2, updated_at = now() \
          WHERE id = $1",
     )
     .bind(principal.user_id)
+    .bind(&anon_email)
     .execute(&mut *tx)
     .await
     .map_err(|e| RestError::Internal(e.into()))?;

--- a/plans/0354-anonymize-fix.md
+++ b/plans/0354-anonymize-fix.md
@@ -1,0 +1,71 @@
+# Plan 0354 — Fix do POST /v1/me/anonymize (coluna fantasma + email não anonimizado)
+
+**Data:** 2026-08-18 · **Branch:** `fix/anonymize-users-email` · **Origem:** descoberta colateral
+do cleanup de 2026-08-18 (investigação do Mutation Testing vermelho desde 2026-04-28).
+
+## Problema
+
+`POST /v1/me/anonymize` (LGPD art. 12 / GDPR art. 4(5), plan 0345 / GAR-888) retornava
+**500 em toda chamada**:
+
+1. `garraia_auth::anonymize_identity` fazia `UPDATE user_identities SET login = $1`,
+   mas a coluna `login` **não existe** em nenhuma das 32 migrations deste repo
+   (migration 001 define `provider_sub`; a coluna `login` existe só no schema do
+   repo interno — código portado sem o schema, violação da regra 14 do CLAUDE.md).
+2. Mesmo se a coluna existisse, o handler nunca anonimizava `users.email` — que é
+   onde o email PII mora neste schema (citext UNIQUE), junto com
+   `user_identities.provider_sub` (a chave de login: o signup insere o email ali e
+   `verify_internal` casa `provider_sub = $email`; o comentário da migration 001
+   dizendo "equals users.id::text" está desatualizado vs a implementação).
+3. Bug latente adicional: o token anônimo usava só **8 hex** do UUID. Em produção os
+   ids são UUIDv7 (time-ordered): usuários criados na mesma janela de ~65 s
+   compartilham o prefixo de 32 bits → colisão nos UNIQUEs de `users.email` e
+   `(provider, provider_sub)` → 500 no segundo anonymize.
+
+Por que ninguém viu: os 16 binários de integração do garraia-auth têm
+`required-features = ["test-support"]` e o `cargo test --workspace` do CI de PR os
+**pula silenciosamente**. O único executor era o cargo-mutants semanal
+(mutants.yml), vermelho havia 16 semanas — o `seed()` de `password_change.rs`
+inseria a coluna fantasma e quebrava o baseline inteiro (exit 4) antes de
+qualquer mutação.
+
+## Decisão
+
+- `anonymize_identity` (LoginPool, BYPASSRLS — a tabela é FORCE RLS, invisível ao
+  `garraia_app`, regra 12): anonimiza `user_identities.provider_sub` com token
+  determinístico de **UUID completo** `anon-<32 hex>@garraanon.local`. Retorna
+  `u64` (linhas afetadas; 0 = sem identidade internal, não é erro).
+- Handler `anonymize_me`: anonimiza **também `users.email`** (mesmo token) dentro
+  da transação atômica do app_pool que já flipa `status`/`display_name`/sessions/
+  audit (+ `updated_at = now()`, responsabilidade do caller por schema).
+  `password_hash` fica intacto — `users.status != 'active'` é o gate autoritativo
+  de login (`verify_internal` recusa com caminho constant-time).
+- Seam entre os dois commits (LoginPool e app_pool): sem 2PC; falha entre eles
+  cura com retry do endpoint (o UPDATE do provider_sub é idempotente e o guard
+  409 só dispara após o commit do app-side).
+- **Sem migration nova** — a alternativa (criar a coluna `login`) importaria schema
+  do repo interno sem necessidade.
+
+## Testes
+
+- `password_change.rs`: `seed()` corrigido (sem coluna fantasma; `provider_sub` =
+  email lowercase, espelhando o signup real). Testes novos:
+  `anonymize_identity_replaces_provider_sub` (token exato de 32 hex),
+  `anonymize_identity_leaves_other_users_untouched` (WHERE clause),
+  `anonymize_identity_returns_zero_for_unknown_user` (contrato de 0 linhas).
+- Todos os testes do binário agora são `#[serial_test::serial]`: cada um segura
+  conexão do LoginPool (max 5) através de hashing lento dentro de tx — 6
+  concorrentes estouravam o acquire timeout (flake real observada:
+  "pool timed out while waiting for an open connection").
+- **Gap estrutural fechado:** job novo `auth-integration` no ci.yml roda
+  `cargo test -p garraia-auth --features test-support` no PR path (ubuntu,
+  Docker, pre-pull pgvector/pg16 como no mutants.yml). Não entra nos required
+  checks do ruleset por ora.
+
+## Efeitos esperados
+
+- Endpoint volta a funcionar e a anonimização cobre os dois lugares onde o email
+  vive. Baseline do cargo-mutants destravado → workflow semanal deve voltar a
+  ficar verde no próximo agendamento (conferir domingo).
+- Follow-up fora deste plan: teste HTTP de integração do endpoint no
+  garraia-gateway (hoje não existe suite HTTP para /v1/me/anonymize).


### PR DESCRIPTION
## Problema

`POST /v1/me/anonymize` (LGPD art. 12 / GDPR art. 4(5)) retornava **500 em toda chamada**: `anonymize_identity` fazia `UPDATE user_identities SET login = …`, mas a coluna `login` **não existe** em nenhuma das 32 migrations deste repo (código portado do repo interno sem o schema — regra 14 do CLAUDE.md). E mesmo se existisse, `users.email` — onde o email PII mora — nunca era anonimizado. Detalhes completos em `plans/0354-anonymize-fix.md`.

Ninguém viu por 16 semanas porque os 16 binários de integração do garraia-auth (`required-features = ["test-support"]`) são **pulados silenciosamente** pelo `cargo test --workspace` do CI — o único executor era o cargo-mutants semanal, vermelho desde 2026-04-28 (o `seed()` com a coluna fantasma quebrava o baseline inteiro, exit 4).

## Fix

- **`anonymize_identity`** → anonimiza `user_identities.provider_sub` (a chave de login real: signup insere o email ali; `verify_internal` casa `provider_sub = $email`) via LoginPool/BYPASSRLS. Token determinístico `anon-<32 hex>@garraanon.local` com UUID **completo** — prefixo de 8 hex colide sob UUIDv7 (janela de ~65 s) e os UNIQUEs (`users.email`, `(provider, provider_sub)`) virariam 500 no segundo anonymize. Retorna `rows_affected`.
- **`anonymize_me`** → `users.email` + `updated_at = now()` entram na transação atômica que já flipa status/display_name/sessions/audit. `password_hash` intacto (status ≠ 'active' é o gate autoritativo, caminho constant-time no login).
- **Testes**: seed consertado, 3 testes de integração novos (token exato, isolamento de WHERE, contrato 0-linhas), `LoginPool` dedicado por teste (o pool compartilhado do Harness estranda conexões entre runtimes tokio — mesmo dragão documentado em `rest_v1_me_authed.rs`) + `#[serial]`. 3× runs locais consecutivos verdes.
- **CI**: job novo `auth-integration` executa `cargo test -p garraia-auth --features test-support` no PR path — fecha o gap estrutural (regra 10).

## Validação

- `cargo test -p garraia-auth --features test-support --test password_change` → 6/6, 3 runs consecutivos.
- `cargo test -p garraia-auth --lib` → 76/76.
- fmt + clippy limpos.
- Revisões: code-reviewer ✅ (ajustes aplicados: unit tests do formato antigo atualizados, comentário do lock scope); security-auditor em andamento — findings entram como commit adicional antes do merge.

Efeito esperado pós-merge: baseline do cargo-mutants destravado (workflow semanal volta a ter chance de ficar verde).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
