### PR TITLE
chore(release): v0.3.1 — LGPD anonymize, binário ARM64, deps e CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-08-18
+
 ### Fixed
+- **`POST /v1/me/anonymize` funciona pela primeira vez** (plan 0354, PR #843) —
+  o endpoint LGPD/GDPR retornava 500 em toda chamada: o código atualizava uma
+  coluna `user_identities.login` que não existe neste schema. A anonimização
+  agora cobre os três lugares onde o email vive — `user_identities.provider_sub`
+  (chave de login), `users.email` e `group_invites.invited_email` — com token
+  determinístico `anon-<uuid-32-hex>@garraanon.local` (UUID completo: o prefixo
+  de 8 hex colidia sob UUIDv7). Revisado por security-auditor, sem blockers.
+- **Release Linux ARM64 volta ao ar** (PR #842) — o build `cross` aarch64
+  falhava por falta de OpenSSL do target e a v0.3.0 saiu sem o binário
+  linux-aarch64. `Cross.toml` novo instala `libssl-dev:$CROSS_DEB_ARCH` no
+  container de build; esta é a primeira release com os 5 binários.
+- **h2 0.4.16** (PR #842) — RUSTSEC-2026-0258.
 - **Vault-passphrase casing trap eliminated** (issue #824) — the two
   near-identical env vars `GARRAIA_VAULT_PASSPHRASE` (credential vault) and
   `GarraIA_VAULT_PASSPHRASE` (legacy JWT-secret fallback) no longer fail
@@ -21,6 +35,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   check` gains two warnings: a deprecation notice whenever the mixed-case
   spelling is set, and a split-values alert when both spellings are set with
   different values (presence/equality only — values are never emitted).
+
+### Changed
+- **Dependências consolidadas** (PR #844, cleanup 2026-08-18): serial_test
+  4.0.1, base64 0.23, jsonwebtoken 11.0.0, validator 0.21, itertools 0.15,
+  uuid 1.24.1, tauri 2.11.5 e **wasmtime + wasmtime-wasi 47.0.3** — o par
+  agora também viaja junto no dependabot via grupo dedicado (PR #842).
+
+### CI
+- Jobs `e2e`/`playwright` ganham `timeout-minutes` (PR #842) — dois runs de 6h
+  em 2026-08-17, travados no download do Chromium, motivaram o teto.
+- Job novo `auth-integration` (PR #843): os 16 binários de integração do
+  garraia-auth (matriz RLS incluída) agora rodam em todo PR — antes eram
+  pulados silenciosamente pelo `cargo test --workspace` e só o cargo-mutants
+  semanal os executava.
 
 ## [0.3.0] - 2026-08-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3146,7 +3146,7 @@ dependencies = [
 
 [[package]]
 name = "garraia"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -3191,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-agents"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -3215,7 +3215,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-auth"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-channels"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -3272,7 +3272,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-common"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-config"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "dirs 6.0.0",
  "garraia-common",
@@ -3307,7 +3307,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-db"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3343,7 +3343,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-embeddings"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "serde",
@@ -3357,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-gateway"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-learning"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "garraia-common",
  "garraia-skills",
@@ -3457,7 +3457,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-media"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64 0.23.1",
  "bytes",
@@ -3475,7 +3475,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-plugins"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3507,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-security"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64 0.23.1",
  "garraia-common",
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-skills"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "garraia-common",
  "reqwest 0.12.28",
@@ -3535,7 +3535,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-storage"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3562,7 +3562,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-telemetry"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3598,7 +3598,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-voice"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3612,7 +3612,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-workspace"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/michelbr84/GarraRUST"


### PR DESCRIPTION
## Resumo

Fase final do cleanup de 2026-08-18: bump 0.3.0 → 0.3.1 (workspace `Cargo.toml` + re-stamp do lockfile) e CHANGELOG da release, cobrindo:

- Fix do `POST /v1/me/anonymize` (LGPD) — PR #843
- `Cross.toml` para o build Linux ARM64 (a v0.3.0 saiu **sem** o binário aarch64) — PR #842
- h2 0.4.16 (RUSTSEC-2026-0258) — PR #842
- Deps consolidadas incl. wasmtime 47 — PR #844
- Timeouts de CI + job `auth-integration` — PRs #842/#843

Após o merge: tag `v0.3.1` dispara Release + Deploy; o install.sh passa a entregar a versão nova (hoje está preso na v0.3.0 sem binário ARM64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
