### PR TITLE
fix(release,deps): ARM64 via cross moderno + sqlx em rustls; v0.3.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,9 +64,17 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install cross
-        run: cargo install cross
+        # Da git, NÃO de crates.io: o cross 0.2.5 (último release publicado)
+        # usa imagens base Ubuntu 16.04 cujo archive só tem OpenSSL 1.0.2 —
+        # abaixo do mínimo do openssl-sys (>= 1.1.0). As imagens da git são
+        # modernas (>= 20.04) e casam com o pre-build do Cross.toml.
+        run: cargo install cross --git https://github.com/cross-rs/cross --locked
 
       - name: Build with cross
+        # OpenSSL só é necessário no TARGET (reqwest/tungstenite via
+        # native-tls) — instalado pelo pre-build do Cross.toml. O lado HOST
+        # ficou livre de OpenSSL com o sqlx em rustls (proc-macros do sqlx
+        # eram o único consumidor host e quebravam o cross-compile).
         run: cross build --release --target aarch64-unknown-linux-gnu --package garraia
 
       - name: Package binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-08-18
+
+### Fixed
+- **Binário Linux ARM64 de verdade desta vez** — dois defeitos empilhados:
+  (1) o cross 0.2.5 de crates.io usa imagem base Ubuntu 16.04, cujo archive só
+  tem OpenSSL 1.0.2 (abaixo do mínimo ≥ 1.1.0 do openssl-sys) — o release.yml
+  agora instala o cross da git (imagens modernas); (2) o proc-macro do sqlx
+  compilava openssl-sys para o HOST dentro do container e quebrava o
+  cross-compile — resolvido movendo o sqlx para rustls (abaixo). Validado
+  localmente: `cross build --target aarch64-unknown-linux-gnu` produz o ELF
+  aarch64. v0.3.1 saiu com 4 binários (sem regressão vs v0.3.0); esta
+  adiciona o quinto.
+
+### Changed
+- **sqlx: native-tls → rustls (`tls-rustls-ring-native-roots`)** — mantém as
+  CAs do sistema para TLS com Postgres remoto. O sqlx-macros era o único
+  consumidor de OpenSSL no lado host dos builds; reqwest/tungstenite seguem
+  em native-tls (OpenSSL só no target, via `Cross.toml`). Suites de
+  integração do garraia-auth verdes contra pgvector/pg16 real.
+
 ## [0.3.1] - 2026-08-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3146,7 +3146,7 @@ dependencies = [
 
 [[package]]
 name = "garraia"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -3191,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-agents"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -3215,7 +3215,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-auth"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-channels"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -3272,7 +3272,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-common"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-config"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "dirs 6.0.0",
  "garraia-common",
@@ -3307,7 +3307,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-db"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3343,7 +3343,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-embeddings"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "serde",
@@ -3357,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-gateway"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3443,7 +3443,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-learning"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "garraia-common",
  "garraia-skills",
@@ -3457,7 +3457,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-media"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "base64 0.23.1",
  "bytes",
@@ -3475,7 +3475,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-plugins"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3507,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-security"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "base64 0.23.1",
  "garraia-common",
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-skills"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "garraia-common",
  "reqwest 0.12.28",
@@ -3535,7 +3535,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-storage"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3562,7 +3562,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-telemetry"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -3598,7 +3598,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-voice"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3612,7 +3612,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-workspace"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8346,9 +8346,10 @@ dependencies = [
  "ipnetwork",
  "log",
  "memchr",
- "native-tls",
  "once_cell",
  "percent-encoding",
+ "rustls",
+ "rustls-native-certs",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/michelbr84/GarraRUST"
@@ -112,7 +112,7 @@ libc = "0.2"
 
 # Utilities
 chrono = { version = "0.4", features = ["serde"] }
-sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "tls-native-tls", "postgres", "chrono"] }
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "tls-rustls-ring-native-roots", "postgres", "chrono"] }
 dotenvy = "0.15"
 url = "2"
 regex = "1"

--- a/Cross.toml
+++ b/Cross.toml
@@ -6,6 +6,13 @@
 # sqlx-core e tokio-tungstenite, então o link dinâmico precisa dos headers e
 # libs :arm64. Receita canônica do FAQ do cross para OpenSSL cross-compile.
 [target.aarch64-unknown-linux-gnu]
+# libssl-dev do TARGET para linkar reqwest/tokio-tungstenite (native-tls).
+# O lado HOST não precisa de OpenSSL: o sqlx usa rustls (o proc-macro do
+# sqlx era o único consumidor host de openssl-sys e quebrava o cross-compile
+# — ora achando OpenSSL 1.0.2 velho demais, ora linkando a libssl aarch64
+# num .so x86). Requer imagem de cross moderna (base >= 20.04, OpenSSL >=
+# 1.1.1 no archive): instalar cross da git, não o 0.2.5 de crates.io
+# (base 16.04) — ver release.yml.
 pre-build = [
   "dpkg --add-architecture $CROSS_DEB_ARCH",
   "apt-get update && apt-get install --assume-yes libssl-dev:$CROSS_DEB_ARCH"

--- a/crates/garraia-cli/Cargo.toml
+++ b/crates/garraia-cli/Cargo.toml
@@ -47,7 +47,7 @@ rmcp = { workspace = true, features = ["server", "transport-io", "macros"] }
 
 # Plan 0039 — `migrate workspace` deps.
 # Use workspace-pinned versions where available to avoid drift.
-sqlx = { workspace = true, features = ["runtime-tokio-native-tls", "postgres", "uuid", "chrono", "derive"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "postgres", "uuid", "chrono", "derive"] }
 rusqlite = { workspace = true }
 base64 = "0.23"
 secrecy = "0.10"
@@ -68,7 +68,7 @@ tempfile = "3"
 testcontainers = "0.27"
 # Integration tests run as their own bin crates, so they need explicit
 # access to some deps from the test file. Reuse workspace pins.
-sqlx = { workspace = true, features = ["runtime-tokio-native-tls", "postgres", "uuid", "chrono"] }
+sqlx = { workspace = true, features = ["runtime-tokio", "postgres", "uuid", "chrono"] }
 # GAR-603 — env-var precedence test for `garra start --port` mutates
 # process env, so it must serialize against any future env-mutating tests.
 serial_test = { workspace = true }


### PR DESCRIPTION
## Problema

O job **Build Linux ARM64** do Release falhou na v0.3.0 e na v0.3.1 — a release sai sem o binário aarch64 e o `install.sh` quebra nesses hosts. Diagnóstico por builds locais do cross (3 iterações):

1. **v0.3.0**: sem OpenSSL nenhum para o target → `Cross.toml` (mergeado no #842) instalou `libssl-dev:arm64`… 
2. **v0.3.1**: …mas o cross 0.2.5 de crates.io usa imagem **Ubuntu 16.04**, cujo archive só tem OpenSSL **1.0.2** — abaixo do mínimo (≥ 1.1.0) do openssl-sys.
3. Com imagem moderna, apareceu o defeito estrutural: o **proc-macro do sqlx** (host, x86) puxa openssl-sys via native-tls e ora achava o 1.0.2, ora linkava a `libssl` **aarch64** num `.so` x86 (`incompatible with elf64-x86-64`).

## Fix

- `release.yml`: instala **cross da git** (`--locked`) — imagens base modernas.
- **sqlx: `tls-native-tls` → `tls-rustls-ring-native-roots`** — zero OpenSSL no lado host (o sqlx-macros era o único consumidor); CAs do sistema preservadas para Postgres remoto. reqwest/tungstenite seguem em native-tls, com OpenSSL só no target via `Cross.toml`.
- Bump **0.3.2** + CHANGELOG (a v0.3.1 publicou com 4 binários, mesmo conjunto da v0.3.0 — sem regressão; a v0.3.2 adiciona o quinto).

## Validação local

- `cross build --release --target aarch64-unknown-linux-gnu --package garraia` → **ELF aarch64 gerado** (6m49s), exatamente os comandos do workflow.
- `cargo test -p garraia-auth --features test-support` (password_change 6/6 + extractor 7/7) com sqlx-rustls contra pgvector/pg16 real.
- `cargo check -p garraia` limpo.

Pós-merge: tag `v0.3.2` → Release com os 5 binários.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
