### PR TITLE
docs(wiki): versiona o wiki em wiki/ + workflow de sync automático

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,48 @@
+# Publica a pasta wiki/ no GitHub Wiki (GarraRUST.wiki).
+#
+# Por quê: o wiki passa a ser versionado e revisável por PR neste repo;
+# este workflow é o único caminho de escrita (edições manuais no wiki
+# seriam sobrescritas no próximo sync — edite wiki/ via PR).
+#
+# O GITHUB_TOKEN com contents:write tem acesso de push ao repo .wiki.
+name: Wiki sync
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "wiki/**"
+      - ".github/workflows/wiki-sync.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Publish wiki
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.wiki.git" /tmp/wiki
+          # --delete: wiki/ é a fonte de verdade completa (todas as páginas
+          # existentes estão versionadas aqui, changelogs incluídos).
+          rsync -a --delete --exclude .git wiki/ /tmp/wiki/
+          cd /tmp/wiki
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Wiki já está em dia — nada a publicar."
+            exit 0
+          fi
+          git commit -m "docs(wiki): sync de ${GITHUB_SHA::7}"
+          git push

--- a/wiki/Arquitetura-e-ADRs.md
+++ b/wiki/Arquitetura-e-ADRs.md
@@ -1,0 +1,26 @@
+# Arquitetura e ADRs
+
+## Visão geral
+
+- [Architecture Overview](https://github.com/michelbr84/GarraRUST/blob/main/docs/architecture.md) — estrutura do workspace (22 crates), fluxo do runtime, pipeline de voz, multi-agente, memória, segurança, hot-reload
+- [Referência da API REST do gateway](https://github.com/michelbr84/GarraRUST/blob/main/docs/src/api-reference.md) · [OpenAPI da API mobile](https://github.com/michelbr84/GarraRUST/blob/main/docs/mobile-api-v1.yaml)
+- [Sistema de memória](https://github.com/michelbr84/GarraRUST/blob/main/docs/memory.md) · [Benchmarks](https://github.com/michelbr84/GarraRUST/blob/main/docs/src/benchmarks.md)
+
+## ADRs — Architectural Decision Records
+
+Decisões irreversíveis são registradas antes de implementar ([índice](https://github.com/michelbr84/GarraRUST/blob/main/docs/adr/README.md)). Todas **accepted**:
+
+| # | Decisão | Data |
+|---|---|---|
+| [0001](https://github.com/michelbr84/GarraRUST/blob/main/docs/adr/0001-local-inference-backend.md) | Backend de inferência local (candle vs mistral.rs vs llama.cpp) | 2026-04-21 |
+| [0002](https://github.com/michelbr84/GarraRUST/blob/main/docs/adr/0002-vector-store.md) | Vector store (pgvector vs lancedb vs qdrant) | 2026-04-21 |
+| [0003](https://github.com/michelbr84/GarraRUST/blob/main/docs/adr/0003-database-for-workspace.md) | Postgres para o Group Workspace | 2026-04-13 |
+| [0004](https://github.com/michelbr84/GarraRUST/blob/main/docs/adr/0004-object-storage.md) | Object storage S3-compatible (MinIO default) | 2026-04-21 |
+| [0005](https://github.com/michelbr84/GarraRUST/blob/main/docs/adr/0005-identity-provider.md) | Identity Provider (BYPASSRLS + Argon2id + JWT HS256) | 2026-04-13 |
+| [0006](https://github.com/michelbr84/GarraRUST/blob/main/docs/adr/0006-search-strategy.md) | Estratégia de busca (Postgres FTS → Tantivy → Meilisearch) | 2026-04-21 |
+| [0007](https://github.com/michelbr84/GarraRUST/blob/main/docs/adr/0007-desktop-frontend.md) | Frontend desktop (HTML vanilla → SolidJS) | 2026-04-21 |
+| [0008](https://github.com/michelbr84/GarraRUST/blob/main/docs/adr/0008-doc-collaboration.md) | Colaboração em docs (single-editor → y-crdt) | 2026-04-21 |
+| [0009](https://github.com/michelbr84/GarraRUST/blob/main/docs/adr/0009-web-console-design-system.md) | Design system "Garra Glass" do Web Console (zero CDN) | 2026-05-13 |
+| [0010](https://github.com/michelbr84/GarraRUST/blob/main/docs/adr/0010-garra-learning-agent.md) | Garra Learning Agent (manual de operações auto-evolutivo) | 2026-05-17 |
+| [0011](https://github.com/michelbr84/GarraRUST/blob/main/docs/adr/0011-garra-max-power.md) | GarraMaxPower — modo agent-advanced nativo | 2026-05-24 |
+| [0012](https://github.com/michelbr84/GarraRUST/blob/main/docs/adr/0012-garra-persona.md) | Persona amistosa do Garra (tom de voz padrão) | 2026-06-01 |

--- a/wiki/Changelog-Semana-19.md
+++ b/wiki/Changelog-Semana-19.md
@@ -1,0 +1,62 @@
+# GarraIA Changelog — Semana 19 (4 mai – 10 mai 2026)
+
+## TL;DR
+
+A camada REST `/v1` do Group Workspace saiu do papel. **7 endpoints novos** sobre o pool RLS-enforced (`garraia_app`), todos no mesmo padrão arquitetural: `Principal` extractor + `RequirePermission` + `set_config` parameterized + `FORCE RLS` no banco. A fundação foi a migração de `format!("SET LOCAL …")` para `SELECT set_config($1, $2, true)` (GAR-508 + GAR-511), que fechou 20 ocorrências de SQL-injection-estrutural e desbloqueou os slices.
+
+Onda paralela de hardening: 5 PRs de XSS no front (escapeHtml + DOMPurify) — todos os assets HTML/JS do gateway agora escapam dado vindo do servidor.
+
+## Group Workspace REST API — Fase 3.4
+
+### Chats
+
+- **GAR-506** — `POST/GET /v1/groups/{group_id}/chats` (slice 1, criação e listagem de canais por grupo).
+- **GAR-507** — `POST/GET /v1/chats/{chat_id}/messages` (slice 2, envio + listagem com cursor `?after=<uuid>&limit=<n>`).
+- **GAR-509** — `POST /v1/messages/{message_id}/threads` (slice 3, promove mensagem em thread root via `message_threads`).
+
+### Memory
+
+- **GAR-514** — `GET/POST/DELETE /v1/memory` (slice 1) com `scope_type ∈ {user, group, chat}` + `scope_id`. Plano 0062. Reusa pgvector HNSW da migration 003.
+
+### Tasks (Notion-like Tier 1)
+
+- **GAR-516** — `GET/POST/PATCH/DELETE` para `task-lists` e `tasks` (slice 1). Plano 0066, PR #145.
+- **GAR-518** — `GET /v1/groups/{group_id}/tasks/{task_id}` + task-list `PATCH/DELETE` idempotente (slice 2). Plano 0068, PR #150.
+- **GAR-520** — `task_comments` API (slice 3): `POST/GET/DELETE` em `/v1/groups/{group_id}/tasks/{task_id}/comments` com soft-delete e cursor. Schema migration 006 com FORCE RLS via JOIN policy `task_comments_through_tasks`.
+
+### Fundação parameterized SQL
+
+- **GAR-508** — replaced `format!("SET LOCAL app.current_X_id = '{val}'")` por `SELECT set_config('app.current_X_id', $1, true)` em 19 ocorrências (`rest_v1/{groups,invites,chats,messages,uploads}.rs`).
+- **GAR-511** — cobriu a 20ª ocorrência em `uploads_worker.rs` fora do escopo de GAR-508.
+
+## Security hardening — XSS wave (epic GAR-486)
+
+- **GAR-510** — `admin.html` ganhou `escapeHtml` + 3 sinks corrigidos (channel rows + log viewer).
+- **GAR-512** — `webchat.html` 4 sinks `innerHTML` agora wrapped em `escapeHtml`.
+- **GAR-515** — `webchat.html` adopta DOMPurify para sanitizar `marked.parse()` em 2 sinks streaming + `escapeHtml(langLabel)`. SRI hash adicionado ao DOMPurify CDN.
+- **GAR-517** — Criado módulo ES `assets/utils.js` com `escapeHtml`/`escapeAttr` shared, aplicado em `api.js` (5 sinks), `mcpView.js` e `memoryView.js`. PR #144.
+- **GAR-519** — `modeSidebar.js` 7 sinks (`mode.name`/`description`/`id`) wrapped. Custom modes têm campos user-controlled, então XSS via mode persistia para todos os clientes do gateway.
+
+## Outros movimentos
+
+- **GAR-505** — Mutation Testing run 2026-05-04: triagem dos 6 mutantes missed + 3 timeouts. Workflow `mutants.yml` continua sem `continue-on-error` (fix forward).
+- **GAR-513** — followup de GAR-437 acompanhando carve-outs RUSTSEC (glib/lru/rand) até 2026-07-31.
+- **GAR-521** — Health & Security Routine 2026-05-05: todas as superfícies green, sem ação requerida.
+- **GAR-503** — removido fallback dead-code `CARGO_BIN_EXE_garraia` dos integration tests.
+
+## O que isso destrava
+
+Com a camada `/v1` em pé sobre `set_config` parameterized + `garraia_app` pool, o caminho para a Fase 3.5 (deeper Notion-like — tasks subscriptions, activity feed, doc blocks) está livre. O próximo épico (GAR-396) já tem os primitivos REST que precisava.
+
+## Métricas da semana
+
+- 7 endpoints REST `/v1` novos (3 chat + 1 memory + 3 tasks).
+- 20 ocorrências de SQL-injection-estrutural fechadas via parameterized SQL.
+- 19 sinks XSS fechados em 5 assets do gateway.
+- 24 issues fechadas no Linear (state=completed) team GAR-RUST.
+
+## Links
+
+- README: https://github.com/michelbr84/GarraRUST/blob/main/README.md
+- Linear team GAR: https://linear.app/chatgpt25/team/GAR/all
+- ROADMAP: https://github.com/michelbr84/GarraRUST/blob/main/ROADMAP.md

--- a/wiki/Changelog-Semana-20.md
+++ b/wiki/Changelog-Semana-20.md
@@ -1,0 +1,44 @@
+# GarraIA Changelog — Semana 20 (11/05 a 17/05)
+
+## Destaques
+
+A semana 20 foi a semana em que a **superfície REST /v1 da Fase 3 (Group Workspace) fechou**. A Files API completou os 9 slices entre `GET /v1/groups/{group_id}/files` (slice 1) e `POST /v1/groups/{group_id}/files` (slice 9, upload direto). Em paralelo, Tasks ganhou `task_attachments` com migration 017 e RLS FORCE via JOIN policy, e Groups ganhou members + invites read endpoints. A CLI ganhou fix do default OpenRouter model.
+
+Em uma linha: **`/v1/{files,tasks,groups,memory,chats}` está virtualmente completo — falta apenas a suite cross-group authz (GAR-391d) para fechar o epic GAR-391 e liberar Fase 3 beta.**
+
+## Files API — 9 slices completos
+
+- **[GAR-555](https://linear.app/chatgpt25/issue/GAR-555)** — slice 1: `GET /v1/groups/{group_id}/files` + `GET /v1/groups/{group_id}/folders` + `DELETE /v1/files/{file_id}` (soft-delete). Cursor keyset pagination, RLS FORCE via `set_config('app.current_group_id', $1, true)`.
+- **[GAR-562](https://linear.app/chatgpt25/issue/GAR-562)** — slice 5: `POST /v1/groups/{group_id}/folders` + `DELETE /v1/groups/{group_id}/folders/{folder_id}` (soft-delete). Plan 0092.
+- **[GAR-564](https://linear.app/chatgpt25/issue/GAR-564)** — slice 6: `GET /v1/files/{file_id}/download` — streaming binário com `Content-Type` + `Content-Disposition: attachment`. Plan 0093.
+- **[GAR-567](https://linear.app/chatgpt25/issue/GAR-567)** — slice 7: `POST /v1/groups/{group_id}/files/{file_id}/versions` — uploads de nova versão. Plan 0094.
+- **[GAR-569](https://linear.app/chatgpt25/issue/GAR-569)** — slice 8: `GET /v1/groups/{group_id}/files/{file_id}/versions` — list paginado (newest first). Plan 0095.
+- **[GAR-577](https://linear.app/chatgpt25/issue/GAR-577)** — slice 9: `POST /v1/groups/{group_id}/files` — direct file upload (criação). Plan 0099, PR #264, commit `725cf54`.
+
+## Task attachments — superfície + schema
+
+- **[GAR-572](https://linear.app/chatgpt25/issue/GAR-572)** — migration 017 (`task_attachments` table com PK `task_id+file_id`, `group_id` denormalizada, `attached_by ON DELETE SET NULL`, `attached_by_label` cache para LGPD erasure survival). Dois novos audit variants: `TaskFileAttached` / `TaskFileDetached`. FORCE RLS via JOIN policy sobre `tasks`. Três endpoints: `POST/GET/DELETE /v1/groups/{group_id}/tasks/{task_id}/attachments`. Plan 0096.
+
+## Groups API — slice 2 fechou
+
+- **[GAR-574](https://linear.app/chatgpt25/issue/GAR-574)** — `GET /v1/groups/{id}/members` + `GET /v1/groups/{id}/invites` com cursor pagination + filtros (`role`, `status`). Qualquer membro ativo pode ler. Plan 0097.
+
+## CLI
+
+- **[GAR-576](https://linear.app/chatgpt25/issue/GAR-576)** — `garra chat --provider openrouter` agora respeita o `config.llm["openrouter"].model` em vez de hardcodar `openrouter/auto`. Fix do autodetect chain `Ollama → Anthropic → OpenAI → OpenRouter` que era sequestrado por `OPENAI_API_KEY` stale no `.env` da cwd.
+
+## Health & Security
+
+- **[GAR-575](https://linear.app/chatgpt25/issue/GAR-575)** + **[GAR-578](https://linear.app/chatgpt25/issue/GAR-578)** — health-routine 2026-05-11 (2 runs, all surfaces green). Dependabot baseline: 8 open (2 HIGH, 2 MEDIUM, 4 LOW), todos tracked.
+
+## Próximos passos
+
+- **GAR-391d** — suite cross-group authz via HTTP (≥100 cenários) — fecha o epic GAR-391 e libera a Fase 3 para beta.
+- Endpoints `/v1/me` e `/v1/groups/{id}/storage-usage` (cota por grupo).
+- Mobile (Flutter): integrar a Files API completa no upload flow do app, validar resumable uploads com rede flaky.
+
+---
+
+Repositório: https://github.com/michelbr84/GarraRUST
+Roadmap: https://github.com/michelbr84/GarraRUST/blob/main/ROADMAP.md
+Linear: https://linear.app/chatgpt25/team/GAR/all

--- a/wiki/Changelog-Semana-21.md
+++ b/wiki/Changelog-Semana-21.md
@@ -1,0 +1,36 @@
+# GarraIA Changelog — Semana 21 (18/05 a 24/05)
+
+## Destaques
+
+A semana 21 é a semana de **fechamento do epic GAR-391** (Identity + RBAC + RLS + cross-group authz HTTP). Com a superfície REST /v1 da Fase 3.4 fechada na semana 20 (Files/Tasks/Groups/Memory/Chats), o GAR-391d (≥100 cenários cross-group authz via HTTP) finalmente destrava — ele estava bloqueado pela ausência desses endpoints. Em paralelo, os endpoints `/v1/me` e `/v1/groups/{id}/storage-usage` entram em curso como "últimos detalhes" antes do beta da Fase 3.
+
+Em uma linha: **as 4 camadas de prova de tenant isolation (auth, RBAC, RLS SQL, cross-group HTTP) fecham nesta semana → Fase 3 pronta para beta.**
+
+## Cross-group authz via HTTP (GAR-391d)
+
+- **[GAR-391d](https://linear.app/chatgpt25/issue/GAR-391d)** — suite end-to-end de cross-group authz via HTTP, ≥100 cenários. Cada cenário sobe Postgres real via testcontainers (~7s), autentica via `/v1/auth/login` real, monta JWT real, faz request HTTP real contra recurso de outro grupo. Asserção: status `403 Forbidden` em todos os pares `(usuário do grupo A, recurso do grupo B)`. Cobertura matricial sobre `/v1/{files,tasks,groups,memory,chats}`. Fecha o epic GAR-391.
+
+## Endpoints finais da Fase 3 (REST /v1)
+
+- **`/v1/me`** — endpoint canônico do usuário autenticado: id, email, roles agregadas por grupo, `last_login_at`, `hash_upgraded_at` (transparência sobre o estado do lazy upgrade Argon2id).
+- **`/v1/groups/{id}/storage-usage`** — cota de storage por grupo, agregado de `files` + `file_versions`. Útil para enforcement futuro de quota (Fase 3.5) e para o app mobile mostrar gauge de uso.
+
+## Mobile (Flutter)
+
+- Integração da Files API completa no upload flow do app Garra Cloud Alpha. Validação de resumable uploads em rede mobile flaky (Brasil, 4G), com retry inteligente sobre TUS 1.0.
+
+## Health & Security
+
+- Health-routine semanal — verificação de todas as surfaces (gateway, mobile, mcp, voice). Dependabot rotation conforme calendário SRE.
+
+## Próximos passos (Fase 3 → beta)
+
+- Fechado GAR-391d → epic GAR-391 fecha → Fase 3 entra em beta candidate.
+- Fase 3.5 (quota enforcement, billing rails opcional, plan limits).
+- Documentação pública de migração: como subir um GarraIA self-hosted para um time brasileiro, com checklist LGPD.
+
+---
+
+Repositório: https://github.com/michelbr84/GarraRUST
+Roadmap: https://github.com/michelbr84/GarraRUST/blob/main/ROADMAP.md
+Linear: https://linear.app/chatgpt25/team/GAR/all

--- a/wiki/Configuracao.md
+++ b/wiki/Configuracao.md
@@ -1,0 +1,31 @@
+# Configuração
+
+Duas fontes: o arquivo **`config.yml`** (`~/.garraia/config.yml`, com hot-reload — editar aplica sem reiniciar) e **variáveis de ambiente** para secrets. Referências canônicas:
+
+- [`docs/configuration.md`](https://github.com/michelbr84/GarraRUST/blob/main/docs/configuration.md) — referência completa do `config.yml`
+- [`.env.example`](https://github.com/michelbr84/GarraRUST/blob/main/.env.example) — todas as variáveis, comentadas, em 18 seções
+- [`docs/auth-config.md`](https://github.com/michelbr84/GarraRUST/blob/main/docs/auth-config.md) — **matriz de precedência de auth** (leia antes de configurar JWT)
+- [`mcp.json.example`](https://github.com/michelbr84/GarraRUST/blob/main/mcp.json.example) — servidores MCP
+- [`.garraignore`](https://github.com/michelbr84/GarraRUST/blob/main/README.md#configura%C3%A7%C3%A3o) — padrões de exclusão de arquivos
+
+## Mapa rápido do `.env.example`
+
+| Quero configurar… | Seção |
+|---|---|
+| Provedor LLM | LLM Provider API Keys (pelo menos uma) |
+| Login/JWT do gateway | Auth (JWT + refresh + mobile) — ver nota abaixo |
+| Cofre de credenciais | Vault Encryption (AES-256-GCM) |
+| Telegram/Discord/etc. | Channel Tokens |
+| Porta/host do gateway | Gateway Configuration |
+| Voz (STT/TTS) | Voice |
+| Busca na web | Web Search (`BRAVE_API_KEY`) |
+| Postgres multi-tenant | Database + Group Workspace (Fase 3) |
+| Uploads/S3 | Object Storage (Fase 3.5) |
+| Métricas/tracing | Observabilidade |
+| Embeddings/RAG | Embeddings + RAG/Memória de longo prazo |
+
+## Notas que evitam dor de cabeça
+
+- **`GARRAIA_JWT_SECRET` é env-only e fail-closed**: sem ele, os endpoints de auth respondem **503** de propósito (nunca há fallback inseguro).
+- Precedência de secrets: `GARRAIA_JWT_SECRET` > `GarraIA_VAULT_PASSPHRASE` (grafia mista, deprecated) > `GARRAIA_VAULT_PASSPHRASE` — as duas grafias da passphrase são aceitas em todos os consumidores (issue #824).
+- Valide tudo com `garra config check` (exit 0 ok · 2 warnings em `--strict` · 65 config inválida). O relatório aponta a fonte efetiva de cada valor e **nunca imprime secrets** (só `*_set: true`).

--- a/wiki/Contribuir-Roadmap-e-FAQ.md
+++ b/wiki/Contribuir-Roadmap-e-FAQ.md
@@ -1,0 +1,31 @@
+# Contribuir, Roadmap e FAQ
+
+## Contribuir
+
+Guia completo: [CONTRIBUTING.md](https://github.com/michelbr84/GarraRUST/blob/main/CONTRIBUTING.md) — pré-requisitos (Rust 1.94+, FFmpeg 6.x, Node 20+), setup, convenções (Conventional Commits) e processo de PR. Antes de abrir PR, rode `garra verify` (fmt + clippy + test + gitleaks). Issues para começar: [good first issue](https://github.com/michelbr84/GarraRUST/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22). Decisões arquiteturais exigem [ADR](https://github.com/michelbr84/GarraRUST/blob/main/docs/adr/README.md) antes do código.
+
+## Roadmap AAA (7 fases)
+
+Fonte de verdade: [ROADMAP.md](https://github.com/michelbr84/GarraRUST/blob/main/ROADMAP.md) (com [TODO.md](https://github.com/michelbr84/GarraRUST/blob/main/TODO.md) como backlog curto).
+
+1. Fundações de Core & Inferência
+2. Performance, Memória de Longo Prazo & MCP Ecosystem
+3. Group Workspace (multi-tenant família/equipe)
+4. Experiência Multi-Plataforma AAA
+5. Qualidade, Segurança, Compliance & Polishing
+6. Lançamento, Observabilidade SRE & GA
+7. Pós-GA & Evolução (contínuo)
+
+## FAQ
+
+**O instalador falhou com HTTP 429.** Rate-limit do `raw.githubusercontent.com`. Use o espelho: `curl -fsSL https://github.com/michelbr84/GarraRUST/releases/latest/download/install.sh | sh`.
+
+**`garra update` devolve 404.** Instalações anteriores à v0.2.1 não têm o canal de update — reinstale com o one-liner do instalador.
+
+**Existe binário para ARM64?** Sim, Linux ARM64 a partir da **v0.3.2**.
+
+**Endpoints de auth respondem 503.** Comportamento fail-closed proposital: falta `GARRAIA_JWT_SECRET` no ambiente. Ver [docs/auth-config.md](https://github.com/michelbr84/GarraRUST/blob/main/docs/auth-config.md).
+
+**`GarraIA_VAULT_PASSPHRASE` ou `GARRAIA_VAULT_PASSPHRASE`?** As duas grafias funcionam em todos os consumidores; a all-caps é a canônica e a mista está deprecated com warning (issue #824).
+
+**O que significam os exit codes de `garra config check` / `garra verify`?** `config check`: 0 ok, 2 warnings (com `--strict`), 65 configuração inválida. `verify`: 0 ok, 2 falha em alguma etapa.

--- a/wiki/Guias-de-Integracao.md
+++ b/wiki/Guias-de-Integracao.md
@@ -1,0 +1,38 @@
+# Guias de Integração
+
+Índice curado dos guias versionados no repo, por eixo.
+
+## Canais de chat
+
+- [Visão geral dos 11 canais](https://github.com/michelbr84/GarraRUST/blob/main/docs/channels.md)
+- [Conectar bot do Telegram (passo a passo)](https://github.com/michelbr84/GarraRUST/blob/main/docs/src/guides/connect-telegram.md)
+- [iMessage (macOS)](https://github.com/michelbr84/GarraRUST/blob/main/docs/src/channels/imessage.md)
+
+## Provedores LLM
+
+- [Os 15 provedores e como configurar](https://github.com/michelbr84/GarraRUST/blob/main/docs/src/providers.md)
+- [LM Studio / Ollama (modelos locais)](https://github.com/michelbr84/GarraRUST/blob/main/docs/src/guides/add-lm-studio.md)
+
+## Voz (STT/TTS)
+
+- [Voice Mode: Whisper + Chatterbox/Hibiki, pipeline completo](https://github.com/michelbr84/GarraRUST/blob/main/docs/voice.md) — ativar com `garra start --with-voice`
+
+## MCP (Model Context Protocol)
+
+- [Configurar servidores MCP (stdio + HTTP)](https://github.com/michelbr84/GarraRUST/blob/main/docs/src/mcp.md) (versão mais completa; há um resumo em [docs/mcp.md](https://github.com/michelbr84/GarraRUST/blob/main/docs/mcp.md))
+- [GarraIA como servidor MCP: `garra mcp-server`](https://github.com/michelbr84/GarraRUST/blob/main/docs/cli-mcp-server.md)
+
+## IDE / VS Code
+
+- [Gateway OpenAI-compatible no VS Code](https://github.com/michelbr84/GarraRUST/blob/main/docs/vscode/setup.md)
+- [Templates para Continue.dev](https://github.com/michelbr84/GarraRUST/blob/main/docs/src/continue-modes.md)
+
+## Plugins WASM
+
+- [Visão geral do sistema de plugins](https://github.com/michelbr84/GarraRUST/blob/main/docs/src/plugins.md)
+- [Tutorial: criar um plugin (Rust → WASM)](https://github.com/michelbr84/GarraRUST/blob/main/docs/src/guides/create-plugin.md)
+- [Referência do Plugin SDK](https://github.com/michelbr84/GarraRUST/blob/main/docs/src/guides/plugin-sdk.md)
+
+## Ferramentas do agente
+
+- [Tools embutidas](https://github.com/michelbr84/GarraRUST/blob/main/docs/src/tools.md) · [Modos de execução](https://github.com/michelbr84/GarraRUST/blob/main/docs/src/modes.md) · [Sistema de memória](https://github.com/michelbr84/GarraRUST/blob/main/docs/memory.md)

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,29 @@
+# GarraIA — Wiki
+
+Bem-vindo à wiki pública do **GarraIA** — framework de agentes de IA em Rust, **100% local**, open source (MIT). Binário único de ~16 MB, ~13 MB de RAM em idle, com memória vetorial, modo de voz e 11 canais de chat (Telegram, Discord, Slack, WhatsApp, iMessage e mais) — seus dados nunca saem da sua máquina.
+
+- **Repositório:** https://github.com/michelbr84/GarraRUST
+- **Site:** https://garraia.org
+- **Releases:** https://github.com/michelbr84/GarraRUST/releases
+
+## Escolha seu caminho
+
+| Quero… | Comece por |
+|---|---|
+| Instalar e rodar em 5 minutos | [Instalação e Primeiros Passos](Instalacao-e-Primeiros-Passos) |
+| Conhecer os comandos do CLI | [Referência da CLI](Referencia-da-CLI) |
+| Configurar provedores, canais e secrets | [Configuração](Configuracao) |
+| Conectar Telegram, voz, MCP, VS Code, plugins | [Guias de Integração](Guias-de-Integracao) |
+| Entender como funciona por dentro | [Arquitetura e ADRs](Arquitetura-e-ADRs) |
+| Operar com segurança / reportar vulnerabilidade | [Segurança e Operação](Seguranca-e-Operacao) |
+| Contribuir ou ver o roadmap | [Contribuir, Roadmap e FAQ](Contribuir-Roadmap-e-FAQ) |
+
+> Esta wiki é a **porta de entrada**: o conteúdo técnico canônico vive versionado em [`docs/`](https://github.com/michelbr84/GarraRUST/tree/main/docs) e no [README](https://github.com/michelbr84/GarraRUST/blob/main/README.md).
+
+## Changelogs
+
+- [Semana 21 (18/05 – 24/05)](Changelog-Semana-21)
+- [Semana 20 (11/05 – 17/05)](Changelog-Semana-20)
+- [Semana 19 (04/05 – 10/05)](Changelog-Semana-19)
+
+Histórico completo de versões: [CHANGELOG.md](https://github.com/michelbr84/GarraRUST/blob/main/CHANGELOG.md) (última release: v0.3.2).

--- a/wiki/Instalacao-e-Primeiros-Passos.md
+++ b/wiki/Instalacao-e-Primeiros-Passos.md
@@ -1,0 +1,53 @@
+# Instalação e Primeiros Passos
+
+## Instalação em 1 comando (Linux / macOS)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/michelbr84/GarraRUST/main/install.sh | sh
+```
+
+O script baixa o binário da release mais recente (verificado por SHA-256 via `SHA256SUMS`), roda `garra init` (wizard de provedor LLM + cofre criptografado de credenciais) e `garra start`.
+
+Variáveis úteis do instalador:
+
+| Variável | Efeito |
+|---|---|
+| `GARRAIA_SKIP_INIT=1` | pula o wizard `garra init` |
+| `GARRAIA_SKIP_START=1` | instala sem iniciar o agente |
+| `GARRAIA_BOOTSTRAP_LOCAL=1` | usa artefatos locais em vez de baixar |
+
+Se o `raw.githubusercontent.com` devolver HTTP 429 (rate-limit), use o espelho da release:
+
+```bash
+curl -fsSL https://github.com/michelbr84/GarraRUST/releases/latest/download/install.sh | sh
+```
+
+**Windows:** baixe o binário na [página de releases](https://github.com/michelbr84/GarraRUST/releases). Binários pré-compilados: Linux (x86_64 e ARM64 a partir da v0.3.2), macOS e Windows.
+
+## Primeiros passos
+
+```bash
+garra init      # escolhe o provedor LLM e grava a chave no cofre AES-256-GCM
+garra start     # inicia o agente (use --daemon para segundo plano, --with-voice para voz)
+garra ask "resuma este arquivo" # pergunta única, sem chat interativo
+garra status    # verifica se está rodando
+```
+
+## Atualização e rollback
+
+```bash
+garra update    # auto-atualização com verificação SHA-256
+garra rollback  # volta para a versão anterior
+```
+
+> `garra update` retorna 404 em instalações anteriores à v0.2.1 — nesse caso, reinstale com o one-liner acima.
+
+## Build a partir do código-fonte
+
+```bash
+git clone https://github.com/michelbr84/GarraRUST.git && cd GarraRUST
+cargo build --release -p garraia          # requer Rust 1.94+
+cargo build --release -p garraia --features plugins   # com suporte a plugins WASM
+```
+
+Para o app desktop (Tauri, Windows MSI) e detalhes por plataforma, veja o guia completo: [docs/installation.md](https://github.com/michelbr84/GarraRUST/blob/main/docs/installation.md) · [Início Rápido do README](https://github.com/michelbr84/GarraRUST/blob/main/README.md#in%C3%ADcio-r%C3%A1pido) · [Deploy com Docker](https://github.com/michelbr84/GarraRUST/blob/main/docs/deployment.md).

--- a/wiki/Referencia-da-CLI.md
+++ b/wiki/Referencia-da-CLI.md
@@ -1,0 +1,27 @@
+# Referência da CLI
+
+O binário `garraia` (alias `garra`) concentra toda a operação. Fonte: [`crates/garraia-cli/src/main.rs`](https://github.com/michelbr84/GarraRUST/blob/main/crates/garraia-cli/src/main.rs).
+
+## Comandos
+
+| Comando | O que faz |
+|---|---|
+| `garra init` | Wizard interativo: provedor LLM, chave no cofre criptografado |
+| `garra start` | Inicia o agente (`--daemon`, `--with-voice`, `--host`, `--port`) |
+| `garra stop` / `restart` / `status` | Controle do processo |
+| `garra chat` | Chat interativo no terminal |
+| `garra ask "<pergunta>"` | Pergunta única, com `--json` e exit codes — [docs/cli-ask.md](https://github.com/michelbr84/GarraRUST/blob/main/docs/cli-ask.md) |
+| `garra mcp-server` | Expõe `garra_ask` como servidor MCP stdio (Claude Desktop/Code) — [docs/cli-mcp-server.md](https://github.com/michelbr84/GarraRUST/blob/main/docs/cli-mcp-server.md) |
+| `garra channel list` · `channel status <nome>` | Canais de chat configurados |
+| `garra plugin list/install/remove/watch` | Plugins WASM (feature `plugins`) |
+| `garra skill list/install/remove` | Skills do agente |
+| `garra mcp list/inspect/resources/prompts` | Servidores MCP conectados |
+| `garra migrate openclaw` | Importa dados do OpenClaw |
+| `garra migrate workspace` | SQLite → Postgres multi-tenant (Group Workspace) |
+| `garra config check [--json] [--strict]` | Valida a configuração; exit codes 0 / 2 / 65 |
+| `garra glob test` | Testa padrões glob/ignore (`--mode bash`, `--debug-regex`, `--json`) — [semântica](https://github.com/michelbr84/GarraRUST/blob/main/docs/src/glob-semantics.md) |
+| `garra update` / `rollback` | Auto-atualização com SHA-256 / volta versão |
+| `garra verify` | Pipeline local: fmt, clippy, test, flutter analyze, gitleaks (exit 0/2) |
+| `garra max-power` | Modo agent-advanced nativo (ADR 0011) |
+
+Para flags completas de qualquer comando: `garra <comando> --help`.

--- a/wiki/Seguranca-e-Operacao.md
+++ b/wiki/Seguranca-e-Operacao.md
@@ -1,0 +1,27 @@
+# Segurança e Operação
+
+## Reportar vulnerabilidade
+
+**Não abra issue pública.** Reporte de forma privada via [GitHub Security Advisories](https://github.com/michelbr84/GarraRUST/security/advisories/new) ou **security@garraia.org**. Política completa e o que incluir no reporte: [SECURITY.md](https://github.com/michelbr84/GarraRUST/blob/main/SECURITY.md).
+
+## Modelo de segurança
+
+- [Visão geral](https://github.com/michelbr84/GarraRUST/blob/main/docs/security.md) — cofre AES-256-GCM, allowlists por canal, pareamento, bind em localhost por padrão
+- [Arquitetura security-first](https://github.com/michelbr84/GarraRUST/blob/main/docs/src/security/architecture.md) · [Superfícies de ataque de agentes de IA](https://github.com/michelbr84/GarraRUST/blob/main/docs/src/security/attack-surfaces.md) · [Checklist prático](https://github.com/michelbr84/GarraRUST/blob/main/docs/src/security/checklist.md)
+- [Threat model STRIDE](https://github.com/michelbr84/GarraRUST/blob/main/docs/security/threat-model.md) · [Decisões de hardening](https://github.com/michelbr84/GarraRUST/blob/main/docs/security/hardening-decisions.md)
+
+## Runbooks
+
+| Situação | Runbook |
+|---|---|
+| Segredo vazou num commit | [secret-scanning-runbook.md](https://github.com/michelbr84/GarraRUST/blob/main/docs/security/secret-scanning-runbook.md) |
+| Incidente com dados pessoais (ANPD/GDPR, 72h) | [compliance/incident-response.md](https://github.com/michelbr84/GarraRUST/blob/main/docs/compliance/incident-response.md) |
+| Operação em produção | [production-runbook.md](https://github.com/michelbr84/GarraRUST/blob/main/docs/src/production-runbook.md) |
+| CodeQL (setup + supressões) | [codeql-setup.md](https://github.com/michelbr84/GarraRUST/blob/main/docs/security/codeql-setup.md) · [codeql-suppressions.md](https://github.com/michelbr84/GarraRUST/blob/main/docs/security/codeql-suppressions.md) |
+| Proteção da branch main | [protect-main-ruleset.md](https://github.com/michelbr84/GarraRUST/blob/main/docs/security/protect-main-ruleset.md) |
+
+## Compliance e observabilidade
+
+- [DPIA — LGPD/GDPR](https://github.com/michelbr84/GarraRUST/blob/main/docs/compliance/dpia.md)
+- [Telemetria (OpenTelemetry + Prometheus)](https://github.com/michelbr84/GarraRUST/blob/main/docs/telemetry.md)
+- [Deploy: Docker](https://github.com/michelbr84/GarraRUST/blob/main/docs/deployment.md) · [Runpod serverless](https://github.com/michelbr84/GarraRUST/blob/main/docs/deployment-runpod.md)

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,17 @@
+**[🏠 Home](Home)**
+
+**Usar o GarraIA**
+- [Instalação e Primeiros Passos](Instalacao-e-Primeiros-Passos)
+- [Referência da CLI](Referencia-da-CLI)
+- [Configuração](Configuracao)
+- [Guias de Integração](Guias-de-Integracao)
+
+**Projeto**
+- [Arquitetura e ADRs](Arquitetura-e-ADRs)
+- [Segurança e Operação](Seguranca-e-Operacao)
+- [Contribuir, Roadmap e FAQ](Contribuir-Roadmap-e-FAQ)
+
+**Changelogs**
+- [Semana 21](Changelog-Semana-21)
+- [Semana 20](Changelog-Semana-20)
+- [Semana 19](Changelog-Semana-19)


### PR DESCRIPTION
## Descrição

Entrega a expansão do [GitHub Wiki](https://github.com/michelbr84/GarraRUST/wiki) de forma versionada e automatizada:

- **`wiki/`** passa a ser a fonte de verdade do wiki: Home expandida (com "escolha seu caminho"), 7 páginas novas — **Instalação e Primeiros Passos**, **Referência da CLI** (tabela dos 19 comandos; maior gap de doc do repo), **Configuração** (mapa do `.env.example` + auth), **Guias de Integração**, **Arquitetura e ADRs** (índice dos 12), **Segurança e Operação** (runbooks) e **Contribuir, Roadmap e FAQ** — mais `_Sidebar` e os 3 changelogs semanais existentes preservados. As páginas são porta de entrada: conteúdo técnico linka os docs versionados em `main`, sem duplicar.
- **`.github/workflows/wiki-sync.yml`** publica `wiki/**` no repo `GarraRUST.wiki` via `GITHUB_TOKEN` a cada push no `main` (e por `workflow_dispatch`). O wiki vira revisável por PR; edições manuais diretas no wiki são sobrescritas no sync seguinte (documentado no cabeçalho do workflow).

Contexto: o push direto ao `.wiki.git` não é possível a partir das sessões do Claude Code (o proxy de credenciais não cobre repos wiki), e o GitHub não tem API de wiki — o workflow resolve os dois problemas de forma permanente.

## Tipo de mudança

- [x] `docs`: Documentação apenas
- [x] `chore`: Manutenção (deps, CI, build)

## Classe de Risco

- [x] **Classe A (Baixo Risco)**: Documentação, comentários, formatação, bumps de dependências de desenvolvimento sem impacto em tempo de execução.

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo fmt --check` executado e limpo (nenhum código Rust tocado)
- [x] `cargo clippy` — n/a (nenhum código Rust tocado)
- [x] `cargo test` — n/a (nenhum código Rust tocado)
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo, API key, token ou credencial commitada (workflow usa apenas o `GITHUB_TOKEN` efêmero do Actions)
- [x] Nenhuma migração Postgres com operações destrutivas sem estratégia de transição forward-only

## Mudanças na API pública e Schema

- Nenhuma mudança na API pública

## Como testar

1. Merge → o workflow "Wiki sync" dispara pelo path filter e publica as páginas.
2. Conferir https://github.com/michelbr84/GarraRUST/wiki — Home nova + sidebar + 7 páginas.
3. Re-execução manual disponível em Actions → Wiki sync → Run workflow.

## Plano de Rollback

Revert do commit; para restaurar o conteúdo anterior do wiki, `git revert` na pasta `wiki/` e novo push no `main` (o sync republica o estado revertido).

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5Ls6QS5GSvzMd4RQkBkd8)_