### PR TITLE
fix(ci): tag_name explícito no release por workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,6 +282,11 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v3
         with:
+          # Sem tag_name explícito, o softprops usa github.ref — que num
+          # workflow_dispatch a partir de main seria "main", criando release
+          # com tag errada. Com tag_name, o dispatch com input `version`
+          # cria o tag vX.Y.Z no commit do run e a release correta.
+          tag_name: ${{ steps.version.outputs.VERSION }}
           name: Release ${{ steps.version.outputs.VERSION }}
           draft: false
           prerelease: ${{ contains(steps.version.outputs.VERSION, 'alpha') || contains(steps.version.outputs.VERSION, 'beta') || contains(steps.version.outputs.VERSION, 'rc') }}


### PR DESCRIPTION
## Descrição

Sem `tag_name`, o `softprops/action-gh-release` usa `github.ref` — num `workflow_dispatch` a partir de `main`, a release sairia com a tag **`main`** em vez de `vX.Y.Z`. Este PR adiciona `tag_name: ${{ steps.version.outputs.VERSION }}` (5 linhas, sendo 4 de comentário), fazendo o caminho manual criar o tag correto no commit do run.

Motivação imediata: cortar a **v0.3.3** (release-prep já mergeada no #856) por dispatch, já que o ambiente desta sessão não pode pushar tags. De quebra corrige o bug latente do dispatch para sempre.

Pós-merge: disparar `release.yml` com `version=v0.3.3` (cria tag + binários + SHA256) e `deploy.yml` com `tag=v0.3.3` (imagem GHCR — tags criadas via `GITHUB_TOKEN` não re-disparam workflows, então o deploy precisa do dispatch).

## Tipo de mudança

- [x] `fix`: Correção de bug
- [x] `chore`: Manutenção (deps, CI, build)

## Classe de Risco

- [x] **Classe A (Baixo Risco)**: mudança de 1 parâmetro em workflow; caminho de tag-push permanece idêntico (`VERSION` = ref do tag).

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo fmt --check` / clippy / test — n/a (nenhum código Rust tocado)
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo, API key, token ou credencial commitada
- [x] Nenhuma migração Postgres com operações destrutivas sem estratégia de transição forward-only
- [x] YAML validado

## Mudanças na API pública e Schema

- Nenhuma mudança na API pública

## Como testar

1. Merge → Actions → Release → Run workflow com `version=v0.3.3`
2. Verificar: tag `v0.3.3` criado no head do `main`, release com 5 binários + `SHA256SUMS` + per-asset `.sha256`

## Plano de Rollback

Revert do commit; o caminho por push de tag não é afetado.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5Ls6QS5GSvzMd4RQkBkd8)_