### PR TITLE
docs(install): promove garraia.org/install.sh como URL principal

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,13 @@ cargo build --release -p garraia
 <summary>Install via script (Linux, macOS) — uses published release binaries</summary>
 
 ```bash
-curl -fsSL https://github.com/michelbr84/GarraRUST/releases/latest/download/install.sh | sh
+curl -fsSL https://garraia.org/install.sh | sh
 ```
+
+Mirrors (same script, auto-synced): GitHub release CDN
+`https://github.com/michelbr84/GarraRUST/releases/latest/download/install.sh`
+(most robust against IP rate limits) and
+`https://raw.githubusercontent.com/michelbr84/GarraRUST/main/install.sh`.
 
 The installer downloads the binary for your platform, verifies it against
 the release's `SHA256SUMS`, then chains into init and start. Note: the

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -116,15 +116,16 @@ cargo build --release -p garraia-desktop
 <summary>Instalar via script (Linux, macOS) — usa binários publicados no release</summary>
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/michelbr84/GarraRUST/main/install.sh | sh
+curl -fsSL https://garraia.org/install.sh | sh
 ```
 
-> Se o `raw.githubusercontent.com` responder **HTTP 429** (rate limit por IP —
-> comum em pods cloud com IP de saída compartilhado), o mesmo script está
-> publicado em dois canais alternativos:
+> O mesmo script (sincronizado automaticamente) está publicado em canais
+> alternativos — o release CDN é o mais robusto contra rate limit por IP
+> (429 em pods cloud com IP de saída compartilhado):
 >
 > ```bash
 > curl -fsSL https://github.com/michelbr84/GarraRUST/releases/latest/download/install.sh | sh
+> curl -fsSL https://raw.githubusercontent.com/michelbr84/GarraRUST/main/install.sh | sh
 > curl -fsSL https://cdn.jsdelivr.net/gh/michelbr84/GarraRUST@main/install.sh | sh
 > ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,18 +13,19 @@ This guide covers installing GarraIA on various platforms.
 ### Linux/macOS
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/michelbr84/GarraRUST/main/install.sh | sh
+curl -fsSL https://garraia.org/install.sh | sh
 ```
 
-The same script is published through two alternative channels, useful when
-`raw.githubusercontent.com` answers **HTTP 429** (per-IP rate limit — common on
-cloud pods whose egress IP is shared by many users):
+The same script (auto-synced) is published through alternative channels —
+the release CDN is the most robust against per-IP rate limits (**HTTP 429**
+is common on cloud pods whose egress IP is shared by many users):
 
 ```bash
 # Official mirror — GitHub release CDN (no aggressive per-IP limits):
 curl -fsSL https://github.com/michelbr84/GarraRUST/releases/latest/download/install.sh | sh
 
-# Community CDN mirror of the repository's main branch:
+# Repository main branch (raw) and community CDN mirror:
+curl -fsSL https://raw.githubusercontent.com/michelbr84/GarraRUST/main/install.sh | sh
 curl -fsSL https://cdn.jsdelivr.net/gh/michelbr84/GarraRUST@main/install.sh | sh
 ```
 

--- a/wiki/Instalacao-e-Primeiros-Passos.md
+++ b/wiki/Instalacao-e-Primeiros-Passos.md
@@ -3,7 +3,7 @@
 ## Instalação em 1 comando (Linux / macOS)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/michelbr84/GarraRUST/main/install.sh | sh
+curl -fsSL https://garraia.org/install.sh | sh
 ```
 
 O script baixa o binário da release mais recente (verificado por SHA-256 via `SHA256SUMS`), roda `garra init` (wizard de provedor LLM + cofre criptografado de credenciais) e `garra start`.
@@ -16,10 +16,11 @@ Variáveis úteis do instalador:
 | `GARRAIA_SKIP_START=1` | instala sem iniciar o agente |
 | `GARRAIA_BOOTSTRAP_LOCAL=1` | usa artefatos locais em vez de baixar |
 
-Se o `raw.githubusercontent.com` devolver HTTP 429 (rate-limit), use o espelho da release:
+Espelhos do mesmo script (sincronizados automaticamente):
 
 ```bash
 curl -fsSL https://github.com/michelbr84/GarraRUST/releases/latest/download/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/michelbr84/GarraRUST/main/install.sh | sh
 ```
 
 **Windows:** baixe o binário na [página de releases](https://github.com/michelbr84/GarraRUST/releases). Binários pré-compilados: Linux (x86_64 e ARM64 a partir da v0.3.2), macOS e Windows.


### PR DESCRIPTION
## Descrição

`https://garraia.org/install.sh` agora serve o instalador (arquivo estático no repo do site — [garraia-74c335d5#3](https://github.com/michelbr84/garraia-74c335d5/pull/3), com sync diário a partir deste repo e verificação live no CI, [já confirmada verde](https://github.com/michelbr84/garraia-74c335d5/actions/runs/33178336440)). Este PR promove a URL amigável nos docs:

- `README.md` (EN) e `README.pt-BR.md`: one-liner de instalação passa a ser `curl -fsSL https://garraia.org/install.sh | sh`; release CDN, raw e jsDelivr documentados como espelhos (release CDN segue sendo o mais robusto contra 429).
- `wiki/Instalacao-e-Primeiros-Passos.md` (sincroniza para o Wiki no merge) e `docs/installation.md`: idem.

## Tipo de mudança

- [x] `docs`: Documentação apenas

## Classe de Risco

- [x] **Classe A (Baixo Risco)**: só texto de documentação.

## Checklist de Segurança e Qualidade

- [x] Nenhum código tocado; nenhum segredo; nenhuma migração
- [x] URL live verificada contra o script canônico (run do sync no repo do site)

## Como testar

```bash
curl -fsSL https://garraia.org/install.sh | head -3   # deve começar com #!/bin/sh
```

## Plano de Rollback

Revert do commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5Ls6QS5GSvzMd4RQkBkd8)_