### PR TITLE
docs(security): hardening do gateway + capacidades MCP com política

### DIFF
--- a/config.hardened.example.yml
+++ b/config.hardened.example.yml
@@ -1,0 +1,71 @@
+# GarraIA — config de referência ENDURECIDO
+# Guia completo: docs/hardening-gateway.md
+# Valide após copiar/editar:  garra config check
+#
+# Copie para ~/.garraia/config.yml (ou $XDG_CONFIG_HOME/garraia/config.yml)
+# e proteja o arquivo:  chmod 0600 config.yml
+
+gateway:
+  # Perfil A (recomendado): só a própria máquina alcança o gateway.
+  # Para expor na rede (Perfil B), veja docs/hardening-gateway.md §1 —
+  # api_key + session_tokens_required + allowed_origins são OBRIGATÓRIOS.
+  host: "127.0.0.1"
+  port: 3888
+
+  # Auth do gateway (opt-in hoje; ligue mesmo em loopback se a máquina é
+  # compartilhada). Valor LITERAL — gere com: openssl rand -hex 32
+  # api_key: "TROQUE-POR-TOKEN-FORTE"
+  session_tokens_required: true
+  session_ttl_secs: 86400      # validade do token de sessão (1 dia)
+  session_idle_secs: 3600      # corte por inatividade (1h)
+
+  # CORS: vazio = allow-all (dev). Em produção, liste as origens.
+  allowed_origins: []
+
+  rate_limit:
+    per_second: 1
+    burst_size: 60
+
+  # TLS embutido exige build com --features tls (fora dos binários
+  # release atuais) — em produção prefira reverse proxy com TLS.
+  # tls_cert_path: "/etc/garraia/cert.pem"
+  # tls_key_path: "/etc/garraia/key.pem"
+
+llm:
+  # Provider local sem chave (troque pelo seu; chaves de cloud provider:
+  # prefira o cofre via `garra init` + GARRAIA_VAULT_PASSPHRASE).
+  ollama-local:
+    provider: ollama
+    model: llama3.1
+    base_url: "http://localhost:11434"
+
+agent:
+  default_provider: ollama-local
+  # Tier "arriscado" do safety_gate passa a exigir confirmação humana
+  # (o tier "perigoso" é bloqueado SEMPRE, com ou sem esta flag):
+  tool_confirmation_enabled: true
+  max_tool_calls: 50
+
+# Servidores MCP com política (escopo mínimo + limites + allowlist).
+# Receitas completas: docs/integrations/mcp-capacidades.md
+mcp:
+  filesystem:
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "/caminho/restrito"]
+    memory_limit_mb: 512
+    max_restarts: 5
+    restart_delay_secs: 5
+    # Só leitura — corte as tools de escrita do servidor:
+    allowed_tools:
+      - read_file
+      - read_multiple_files
+      - list_directory
+      - search_files
+      - get_file_info
+      - directory_tree
+
+# Lembretes de ambiente (ver .env.example):
+#   GARRAIA_VAULT_PASSPHRASE  — sem ela, secrets de MCP caem em plaintext
+#   GARRAIA_JWT_SECRET        — obrigatório para auth v1 em produção
+#   GARRAIA_METRICS_BIND=127.0.0.1:9464 (+ TOKEN/ALLOW se expor métricas)
+#   HOST                      — CUIDADO: sobrescreve gateway.host (containers)

--- a/docs/hardening-gateway.md
+++ b/docs/hardening-gateway.md
@@ -1,0 +1,161 @@
+# Hardening do Gateway — ferramentas de execução com política de segurança
+
+> As ferramentas de execução do GarraIA (`bash`, `file_read`, `file_write`,
+> `web_fetch`, `schedule_heartbeat`) **já vêm ativas por padrão** — não há
+> flag para "ligá-las". O que existe, e este guia cobre, é a **política em
+> volta delas**: quem alcança o gateway, o que exige confirmação, o que é
+> bloqueado sempre, e como adicionar novas capacidades (via MCP) sem abrir
+> a máquina.
+
+Complementa (não substitui): [docs/security.md](security.md),
+[checklist de segurança](src/security/checklist.md) e
+[.env.example](../.env.example).
+
+## 1. Os dois perfis de exposição
+
+### Perfil A — loopback (default, recomendado)
+
+```yaml
+gateway:
+  host: "127.0.0.1"   # default do binário — só a própria máquina alcança
+  port: 3888
+```
+
+Com bind em loopback, a superfície de rede é zero para terceiros. Os
+canais de mensageria (Telegram/Discord/…) continuam funcionando — eles
+fazem *egress* para as APIs dos provedores; ninguém precisa alcançar a
+sua porta 3888. **Se você não tem um motivo concreto para expor o
+gateway, este perfil encerra o assunto.**
+
+Atenção: a env var `HOST` sobrescreve o bind (runtimes de container
+costumam setar `HOST=0.0.0.0`). Se o seu gateway apareceu em `0.0.0.0`
+sem você pedir, procure por essa variável no ambiente.
+
+### Perfil B — exposto na rede (`0.0.0.0`) — requisitos mínimos
+
+Um gateway exposto sem autenticação é **execução remota de comandos
+aberta**: qualquer um que alcance a porta usa o tool `bash`. Se precisa
+expor, TODOS os itens abaixo são obrigatórios, não opcionais:
+
+```yaml
+gateway:
+  host: "0.0.0.0"
+  port: 3888
+  # Valor LITERAL no arquivo (não há interpolação de env no config —
+  # gere com `openssl rand -hex 32` e proteja o arquivo com chmod 0600):
+  api_key: "<token-forte-aqui>"
+  session_tokens_required: true   # exige token de sessão nas rotas /api/*
+  session_ttl_secs: 86400         # validade do token (1 dia)
+  session_idle_secs: 3600         # corte por inatividade (1h)
+  allowed_origins:                # vazio = allow-all; liste explicitamente
+    - "https://seu-dominio.exemplo"
+  rate_limit:
+    per_second: 1
+    burst_size: 60
+```
+
+- **TLS**: os binários release atuais **não** incluem a feature `tls`
+  (compilável com `--features tls` a partir do código). O caminho
+  suportado hoje é um **reverse proxy com TLS** (Caddy/nginx/Traefik) na
+  frente do gateway em loopback — ou seja, muitas vezes o Perfil A + um
+  proxy exposto resolve melhor que `0.0.0.0` direto.
+- **Métricas**: mantenha `GARRAIA_METRICS_BIND=127.0.0.1:9464` e use
+  `GARRAIA_METRICS_TOKEN`/`GARRAIA_METRICS_ALLOW` se precisar raspar de
+  fora (ver `.env.example`).
+- Verifique com `garra config check` após editar — ele valida o schema e
+  reporta a precedência efetiva.
+
+## 2. Confirmação humana para comandos arriscados
+
+O tool `bash` tem **dois tiers** de proteção
+(`crates/garraia-common/src/safety_gate.rs`):
+
+| Tier | Config | Exemplos | Comportamento |
+|---|---|---|---|
+| **DENY_LIST** (perigoso) | sempre ativo, sem opt-out | `rm -rf /`, fork bomb, `mkfs`, `dd if=`, `shutdown`, `git push --force origin main`, `curl … \| sh` | **Bloqueado sempre**, mesmo com confirmação desligada |
+| **CONFIRM_LIST** (arriscado) | `agent.tool_confirmation_enabled: true` | `rm -r`, `git reset --hard`, `drop table`, `truncate`, `kill`, `taskkill` | Pausa e pede "sim"/"yes" **apenas se a flag estiver ligada** |
+
+O default é `false` — o hard-block continua valendo, mas comandos
+"arriscados" executam sem perguntar. Para um agente com `bash` em
+máquina pessoal, ligue:
+
+```yaml
+agent:
+  tool_confirmation_enabled: true
+  max_tool_calls: 50   # teto de chamadas de tool por tarefa
+```
+
+## 3. Restringir tools por contexto: modos (ToolPolicy)
+
+Cada modo de execução carrega uma allow/deny-list de tools
+(`crates/garraia-runtime/src/mode.rs`) — este é o mecanismo legítimo
+para "menos poder por padrão":
+
+| Modo | Tools permitidas |
+|---|---|
+| `ask` (default nos messengers) | nenhuma — só conversa |
+| `search` | `file_read`, `repo_search` (bash read-only) |
+| `review` | `file_read`, `git_diff` |
+| `edit` | `file_read`, `file_write` (sem bash) |
+| `code` | `file_read`, `file_write`, `bash` |
+| `debug` | `file_read`, `bash`, `repo_search` (sem write) |
+| `auto` / `orchestrator` | sem restrição de lista |
+
+Precedência: header `X-Agent-Mode` > comando `/mode` > default do canal
+(Telegram/Discord/WhatsApp → `ask`; web/API → `auto`) > `ask`. Na
+prática: **nos canais de chat o agente nasce sem tools** e só ganha
+poder quando alguém pede um modo explicitamente — mantenha assim; evite
+fixar `code`/`auto` como modo permanente em canal público.
+
+## 4. Quem pode falar com o agente: allowlist + pareamento
+
+Usuários desconhecidos nos canais precisam de código de pareamento
+(deny-by-default). O arquivo é **único e global** —
+`<config_dir>/allowlist.json` (ex.: `~/.garraia/allowlist.json` ou
+`~/.config/garraia/allowlist.json`) — e vale para **todos** os canais:
+um usuário aprovado no Telegram também está aprovado no Discord. O
+primeiro usuário a parear vira `owner`. Revise a lista periodicamente
+(`/users` no chat).
+
+## 5. Secrets: cofre para MCP e chaves de provider
+
+- Exporte `GARRAIA_VAULT_PASSPHRASE` no ambiente do gateway. Com ela,
+  env vars sensíveis dos servidores MCP (`key`, `token`, `secret`,
+  `password`, `auth`, `credential`, `pass` no nome) são movidas para o
+  cofre AES-256-GCM no primeiro save e o `mcp.json` guarda apenas
+  referências `vault:mcp.<server>.<KEY>`. **Sem a passphrase, caem em
+  plaintext com warning.**
+- O default do wizard `garra init` para chaves de provider é
+  `config.yml` (modo 0600). Escolha a opção do cofre no wizard e
+  mantenha a passphrase exportada a cada start para ter criptografia em
+  repouso.
+
+## 6. Adicionando capacidades via MCP — com política
+
+Novas capacidades (navegar em browser real, banco de dados, filesystem
+com escopo) entram como **servidores MCP**, cada um atrás da mesma
+política. Receitas prontas e regras por servidor (`allowed_tools`,
+`memory_limit_mb`, secrets via vault) em
+[docs/integrations/mcp-capacidades.md](integrations/mcp-capacidades.md).
+
+Regra de ouro: **não** adicione um segundo shell via MCP — o `bash`
+nativo já existe e passa pelo safety_gate; um shell MCP contornaria os
+dois tiers.
+
+## 7. Config de referência endurecido
+
+Arquivo completo comentado, validado com `garra config check`:
+[`config.hardened.example.yml`](../config.hardened.example.yml).
+
+## Limitações conhecidas (honestas)
+
+1. `gateway.api_key` só aceita valor literal no arquivo — não há
+   interpolação de env no config (a linha `GARRAIA_API_KEY` do
+   `.env.example` é aspiracional; suportá-la de verdade é follow-up).
+2. Auth do gateway local é **opt-in** hoje (`api_key`/
+   `session_tokens_required` desligados por default) — endurecer esse
+   default está no roadmap.
+3. "Controle de aplicativos" (GUI/automação de apps) não existe como
+   tool — ver a nota em mcp-capacidades.md.
+4. TLS embutido exige build com `--features tls`; binários release
+   atuais servem HTTP puro (use reverse proxy).

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ Welcome to the GarraIA documentation. GarraIA is a secure, lightweight open-sour
 - [Voice Mode](./voice.md)
 - [Memory System](./memory.md)
 - [Security](./security.md)
+- [Gateway Hardening & Execution Tools](./hardening-gateway.md)
 - [Continue Integration](./src/continue-modes.md)
 
 ## Features

--- a/docs/integrations/mcp-capacidades.md
+++ b/docs/integrations/mcp-capacidades.md
@@ -1,0 +1,123 @@
+# Capacidades extras via MCP — receitas com política de segurança
+
+> Complemento de [docs/hardening-gateway.md](../hardening-gateway.md).
+> As tools nativas (`bash`, `file_read`, `file_write`, `web_fetch`,
+> `repo_search`, `git_diff`, agendamento) já cobrem o essencial de um
+> agente de terminal. Capacidades ALÉM disso entram como **servidores
+> MCP** — cada um com escopo mínimo, limites de recurso e secrets no
+> cofre.
+
+## Onde configurar
+
+Servidores MCP vivem em `<config_dir>/mcp.json` (formato compatível com
+Claude Desktop, chaves em camelCase) **ou** na seção `mcp:` do
+`config.yml` (snake_case, com o extra `allowed_tools`). Campos de
+política disponíveis:
+
+| Campo (`mcp.json`) | Campo (`config.yml`) | Efeito |
+|---|---|---|
+| `memoryLimitMb` | `memory_limit_mb` | cap de memória virtual do processo (Unix) |
+| `maxRestarts` / `restartDelaySecs` | `max_restarts` / `restart_delay_secs` | política de restart com backoff |
+| `timeoutSecs` | `timeout` | timeout de inicialização |
+| — | `allowed_tools` | **allowlist de tools do servidor** (vazio = todas) |
+| `env` com valores sensíveis | idem | viram `vault:mcp.<server>.<KEY>` quando `GARRAIA_VAULT_PASSPHRASE` está setada |
+
+## Receita 1 — Filesystem com escopo restrito
+
+O provisionamento automático aponta o server `filesystem` para o `$HOME`
+inteiro. Restrinja ao(s) diretório(s) que o agente realmente precisa:
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/home/voce/projetos"],
+      "memoryLimitMb": 512
+    }
+  }
+}
+```
+
+E, se quiser só leitura, corte as tools de escrita na seção `mcp:` do
+`config.yml`:
+
+```yaml
+mcp:
+  filesystem:
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-filesystem", "/home/voce/projetos"]
+    memory_limit_mb: 512
+    allowed_tools: ["read_file", "read_multiple_files", "list_directory", "search_files", "get_file_info", "directory_tree"]
+```
+
+## Receita 2 — Navegação web real (browser)
+
+O `web_fetch` nativo baixa páginas; para interação real (JS, cliques,
+screenshots) use um MCP de browser:
+
+```json
+{
+  "mcpServers": {
+    "browser": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-puppeteer"],
+      "memoryLimitMb": 1024,
+      "timeoutSecs": 60
+    }
+  }
+}
+```
+
+Política recomendada: browser dá exfiltração bidirecional (o agente lê
+E envia dados a qualquer site). Use com `tool_confirmation_enabled: true`
+e prefira modos restritos nos canais públicos.
+
+## Receita 3 — Banco de dados (Postgres) com credencial no cofre
+
+```json
+{
+  "mcpServers": {
+    "postgres": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-postgres"],
+      "env": {
+        "DATABASE_URL": "postgres://usuario:senha@localhost:5432/app"
+      },
+      "memoryLimitMb": 512
+    }
+  }
+}
+```
+
+Com `GARRAIA_VAULT_PASSPHRASE` exportada, no primeiro save o valor de
+`DATABASE_URL` (nome contém pattern sensível? não — atenção: a detecção
+cobre nomes com `key/token/secret/password/auth/credential/pass`; um
+env chamado `DATABASE_URL` **não** é movido ao cofre automaticamente.
+Prefira nomeá-lo `DB_PASSWORD` + montar a URL no server, ou aceite que
+a URL fica no `mcp.json` e proteja o arquivo com `chmod 0600`). Use um
+usuário de banco **read-only** para o agente sempre que possível.
+
+## Receita 4 — "Controle de aplicativos" (estado honesto)
+
+Não existe tool nativa para controlar aplicativos GUI. Os caminhos
+reais, todos com implicações fortes de segurança:
+
+1. **MCP dedicado por SO** — ex.: um server de automação (AppleScript no
+   macOS, `xdotool`/AT-SPI no Linux, UIA no Windows). Nenhum vem
+   embutido; ao adotar um de terceiros, revise o código antes (ele roda
+   com os seus privilégios) e aplique `allowed_tools` + confirmação.
+2. **Plugin WASM** (`--features plugins`) — sandbox com caps de memória
+   e deadline, mas exige escrever o plugin.
+3. Não usar o `bash` como atalho para isso em canal público — modos
+   `ask`/`search` existem exatamente para esse contexto.
+
+## Checklist ao adicionar QUALQUER servidor MCP
+
+- [ ] Escopo mínimo (diretório, banco, credencial read-only)
+- [ ] `memoryLimitMb` definido
+- [ ] `allowed_tools` no `config.yml` quando o servidor expõe mais do que você quer
+- [ ] Secrets com nome sensível (para irem ao cofre) + `GARRAIA_VAULT_PASSPHRASE` setada
+- [ ] `tool_confirmation_enabled: true` no `agent`
+- [ ] `garra mcp list` / `garra mcp inspect <nome>` para conferir o que ficou exposto
+- [ ] Nunca um segundo shell via MCP (contorna o safety_gate do `bash` nativo)

--- a/wiki/Seguranca-e-Operacao.md
+++ b/wiki/Seguranca-e-Operacao.md
@@ -7,6 +7,7 @@
 ## Modelo de segurança
 
 - [Visão geral](https://github.com/michelbr84/GarraRUST/blob/main/docs/security.md) — cofre AES-256-GCM, allowlists por canal, pareamento, bind em localhost por padrão
+- [Hardening do gateway + ferramentas de execução](https://github.com/michelbr84/GarraRUST/blob/main/docs/hardening-gateway.md) — perfis loopback/exposto, confirmação de comandos (safety_gate), modos/ToolPolicy, MCP com política ([receitas](https://github.com/michelbr84/GarraRUST/blob/main/docs/integrations/mcp-capacidades.md)) e [config de referência](https://github.com/michelbr84/GarraRUST/blob/main/config.hardened.example.yml)
 - [Arquitetura security-first](https://github.com/michelbr84/GarraRUST/blob/main/docs/src/security/architecture.md) · [Superfícies de ataque de agentes de IA](https://github.com/michelbr84/GarraRUST/blob/main/docs/src/security/attack-surfaces.md) · [Checklist prático](https://github.com/michelbr84/GarraRUST/blob/main/docs/src/security/checklist.md)
 - [Threat model STRIDE](https://github.com/michelbr84/GarraRUST/blob/main/docs/security/threat-model.md) · [Decisões de hardening](https://github.com/michelbr84/GarraRUST/blob/main/docs/security/hardening-decisions.md)
 


### PR DESCRIPTION
## Descrição

As ferramentas de execução (`bash`, `file_read`, `file_write`, `web_fetch`, `schedule_heartbeat`) já são ativas por default — o que faltava era documentar a **política em volta delas** e o caminho seguro para novas capacidades:

- **`docs/hardening-gateway.md`** (novo): perfis loopback vs `0.0.0.0` (requisitos mínimos para expor: `api_key` literal + `session_tokens_required: true` + `allowed_origins` + rate limit; TLS honesto — feature `tls` fora dos binários release → reverse proxy); os **2 tiers do safety_gate** (DENY_LIST sempre bloqueada; CONFIRM_LIST só age com `tool_confirmation_enabled: true`); modos/ToolPolicy por canal; allowlist global de usuários; cofre para secrets de MCP; caveats reais (env `HOST` sobrescreve bind; **não há interpolação de env no config** — a linha `GARRAIA_API_KEY` do `.env.example` é aspiracional, follow-up sugerido).
- **`docs/integrations/mcp-capacidades.md`** (novo): receitas MCP com política — filesystem com root restrito e read-only via `allowed_tools`, browser (com aviso de exfiltração), Postgres com nota precisa sobre a detecção de chave sensível do vault (`DATABASE_URL` NÃO vai ao cofre automaticamente), estado honesto de "controle de aplicativos" (não existe tool; caminhos possíveis), checklist, e a regra: **nunca um segundo shell via MCP** (contornaria o safety_gate).
- **`config.hardened.example.yml`** (novo, raiz): referência comentada com os nomes exatos do schema — **validada com o binário real**: `GARRAIA_CONFIG_DIR=<tmp> garra config check` → exit 0 (único warning é o esperado de env de auth, documentado no arquivo).
- Links em `docs/index.md` e `wiki/Seguranca-e-Operacao.md` (wiki sincroniza no merge).

## Tipo de mudança

- [x] `docs`: Documentação apenas

## Classe de Risco

- [x] **Classe A (Baixo Risco)**: docs + example YAML; zero código Rust tocado.

## Checklist de Segurança e Qualidade

- [x] Nenhum segredo commitado (example usa placeholders)
- [x] YAML validado (`yaml.safe_load` + `garra config check` exit 0)
- [x] Links relativos verificados (0 quebrados)
- [x] Nenhuma migração tocada

## Como testar

```bash
T=$(mktemp -d); cp config.hardened.example.yml "$T/config.yml"
GARRAIA_CONFIG_DIR="$T" garra config check   # exit 0
```

## Plano de Rollback

Revert do commit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5Ls6QS5GSvzMd4RQkBkd8)_