### PR TITLE
test(gateway): elimina flake de teardown Tokio no harness compartilhado

### DIFF
--- a/crates/garraia-gateway/tests/common/mod.rs
+++ b/crates/garraia-gateway/tests/common/mod.rs
@@ -116,6 +116,23 @@ impl Harness {
             .clone()
     }
 
+    /// Open a FRESH dedicated superuser connection, bound to the
+    /// caller's own runtime.
+    ///
+    /// Use this instead of `admin_pool` in tests that must be immune
+    /// to the cross-runtime teardown race described on `admin_pool`'s
+    /// `test_before_acquire` comment: a connection opened here has its
+    /// socket registered with the calling test's live IO driver, so it
+    /// can never be a stale handle from an already-shut-down runtime.
+    /// Prefer `admin_pool` for fixture inserts (connection reuse);
+    /// prefer this for one-shot schema introspection.
+    pub async fn admin_conn(&self) -> sqlx::PgConnection {
+        use sqlx::Connection;
+        sqlx::PgConnection::connect(&self.admin_url)
+            .await
+            .expect("fresh admin connection to the harness container")
+    }
+
     async fn boot() -> anyhow::Result<Self> {
         // 1. Divert GARRAIA_CONFIG_DIR to a tempdir BEFORE anything
         //    in the gateway touches `default_config_dir()`. This
@@ -161,8 +178,21 @@ impl Harness {
         //    rationale.
         // admin_pool: sized at 16 for safe headroom when fixtures
         // run concurrently. Acquire timeout kept at sqlx default.
+        //
+        // test_before_acquire: each `#[tokio::test]` runs on its own
+        // runtime, but this pool is shared process-wide — a pooled
+        // connection created inside one test's runtime has its socket
+        // registered with THAT runtime's IO driver. Once that runtime
+        // shuts down, reusing the idle connection from another test
+        // fails with `Io(Custom { .. "A Tokio 1.x context was found,
+        // but it is being shutdown." })` (observed intermittently on
+        // `migration_012_single_owner_idx_predicate_filters_active`).
+        // The pre-acquire ping makes sqlx detect the dead connection,
+        // discard it and open a fresh one on the live runtime instead
+        // of surfacing the teardown error to the test.
         let admin_pool = sqlx::postgres::PgPoolOptions::new()
             .max_connections(16)
+            .test_before_acquire(true)
             .connect(&admin_url)
             .await?;
         sqlx::query("ALTER ROLE garraia_app    WITH LOGIN PASSWORD 'app-pw'")

--- a/crates/garraia-gateway/tests/harness_smoke.rs
+++ b/crates/garraia-gateway/tests/harness_smoke.rs
@@ -62,20 +62,27 @@ async fn harness_boots_and_router_responds_to_openapi_json() {
 /// single-owner slot. Migration 012 amends the predicate so the
 /// DB constraint matches the app-layer last-owner invariant.
 ///
-/// Uses `admin_pool` because `pg_indexes` is a catalog view — visible
-/// regardless of RLS, but requires read access that `garraia_app`
-/// may not have on `pg_indexes` rows for non-public schemas. The
-/// harness's admin pool is the consistent choice for schema
-/// introspection (same pattern as fixture setup).
+/// Uses a superuser connection because `pg_indexes` is a catalog
+/// view — visible regardless of RLS, but requires read access that
+/// `garraia_app` may not have on `pg_indexes` rows for non-public
+/// schemas.
+///
+/// Uses `Harness::admin_conn()` (a fresh dedicated connection) rather
+/// than the shared `admin_pool`: this test flaked intermittently in CI
+/// with `Io(Custom { .. "A Tokio 1.x context was found, but it is
+/// being shutdown." })` when it reused a pooled connection whose
+/// creating `#[tokio::test]` runtime had already shut down. A fresh
+/// connection is bound to THIS test's live runtime by construction.
 #[tokio::test]
 async fn migration_012_single_owner_idx_predicate_filters_active() {
     let h = Harness::get().await;
+    let mut conn = h.admin_conn().await;
 
     let (indexdef,): (String,) = sqlx::query_as(
         "SELECT indexdef FROM pg_indexes \
          WHERE indexname = 'group_members_single_owner_idx'",
     )
-    .fetch_one(&h.admin_pool)
+    .fetch_one(&mut conn)
     .await
     .expect("group_members_single_owner_idx must exist after migration 012");
 


### PR DESCRIPTION
## Descrição

Corrige o flake intermitente do **Security Gate (BOLA & Tenant Isolation)** diagnosticado no PR #862: o teste `migration_012_single_owner_idx_predicate_filters_active` falhava esporadicamente com

```
Io(Custom { kind: Other, error: "A Tokio 1.x context was found, but it is being shutdown." })
```

**Causa raiz:** o `Harness` de integração é um singleton (`OnceCell<Arc<Harness>>`) compartilhado entre funções `#[tokio::test]`, cada uma com runtime Tokio próprio. As conexões do `admin_pool` criadas durante o `boot()` ficam com o socket registrado no IO driver do runtime do **primeiro** teste que rodou; quando esse runtime encerra, um teste posterior que reusa a conexão idle do pool recebe o erro de teardown acima. Evidência: verde na base exata, flip verde→vermelho entre pushes docs-only (#861), e re-run do mesmo commit passando ([diagnóstico completo](https://github.com/michelbr84/GarraRUST/pull/862#issuecomment-5455031018)).

**Fix em duas camadas, ambas exclusivamente em código de teste** (`tests/common/mod.rs` + `tests/harness_smoke.rs`):

1. `admin_pool` ganha `test_before_acquire(true)` — o ping pré-acquire do sqlx detecta a conexão órfã de runtime morto, descarta e abre outra no runtime vivo, em vez de propagar o erro ao teste. Cura o pool inteiro (fixtures inclusas).
2. Novo helper `Harness::admin_conn()` — conexão superuser dedicada, aberta no runtime do próprio teste (imune à race por construção). O teste que flakou passa a usá-lo para a introspecção de `pg_indexes`.

Closes nenhum issue (follow-up registrado no PR #862).

## Tipo de mudança

- [x] `test`: Adição ou correção de testes

## Classe de Risco

- [x] **Classe A (Baixo Risco)**: só código de teste (`tests/`); zero mudanças em código de produção, schema ou API.

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo fmt --check` executado e limpo
- [x] `cargo clippy -p garraia-gateway --features test-helpers --test harness_smoke` sem warnings novos
- [x] Suíte compilada (`cargo test -p garraia-gateway --features test-helpers --test harness_smoke --no-run`); execução real fica com o Security Gate do CI (testcontainers requer Docker, indisponível no ambiente local)
- [x] Nenhum `unwrap()` adicionado em código de produção (o `expect` novo está em teste)
- [x] Nenhum segredo, API key, token ou credencial commitada
- [x] Nenhuma migração Postgres tocada

## Mudanças na API pública e Schema

- Nenhuma mudança na API pública

## Como testar

1. CI: o job **Security Gate (BOLA & Tenant Isolation)** roda `cargo test -p garraia-gateway --features test-helpers`, que exercita `harness_smoke.rs` com o harness real (testcontainer pgvector/pg16).
2. Local (com Docker): `cargo test -p garraia-gateway --features test-helpers --test harness_smoke`.
3. O flake era uma race não-determinística — a validação de regressão é a ausência de novas ocorrências do erro de teardown nos próximos runs do Security Gate.

## Plano de Rollback

Revert do commit — o flake volta ao estado anterior (intermitente, não bloqueante).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5Ls6QS5GSvzMd4RQkBkd8

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5Ls6QS5GSvzMd4RQkBkd8)_