### PR TITLE
fix(plugins)!: wasmtime 47 → 48, migra API WASI e sobe MSRV para 1.95

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,12 +493,16 @@ jobs:
   # GAR-895: wasmtime 46.0.2 (via wiggle-macro) declara rust-version =
   # "1.94.0" — piso elevado de 1.93 → 1.94 junto com o fix do
   # RUSTSEC-2026-0222 (mesmo padrão do bump anterior).
+  # 2026-08-29 (PR #848): wasmtime 48.0.1 declara rust-version = "1.95.0",
+  # junto com ~60 crates transitivos (cranelift-*, pulley-*, wiggle-*) —
+  # piso elevado de 1.94 → 1.95. Mesmo padrão dos três bumps anteriores:
+  # o piso real é ditado pela árvore do wasmtime, não pelas demais deps.
   # `--locked` garante que o lockfile não é regerado durante o check
   # (qualquer drift falha o build). `garraia-desktop` excluído pelos
   # mesmos motivos do clippy/build (GTK + sidecar Windows ausentes em
   # runners GHA).
   msrv:
-    name: MSRV check (1.94)
+    name: MSRV check (1.95)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -506,12 +510,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Install Rust 1.94
-        # MSRV pin — este @1.94 é o Minimum Supported Rust Version do
+      - name: Install Rust 1.95
+        # MSRV pin — este @1.95 é o Minimum Supported Rust Version do
         # workspace, NÃO uma versão de action a ser bumpada. Ignorado no
         # dependabot.yml (grupo gh-actions-all) para o Dependabot não
         # propor de novo um toolchain inexistente (ex.: @1.100, PR #819).
-        uses: dtolnay/rust-toolchain@1.94
+        uses: dtolnay/rust-toolchain@1.95
 
       # utoipa-swagger-ui 9.0.2 build.rs uses reqwest to download the swagger-ui
       # zip, which intermittently returns a corrupt file ("InvalidArchive: Could not
@@ -532,10 +536,10 @@ jobs:
             -o /tmp/swagger-ui-cache/v5.17.14.zip \
             https://github.com/swagger-api/swagger-ui/archive/refs/tags/v5.17.14.zip
 
-      - name: cargo +1.94 check
+      - name: cargo +1.95 check
         env:
           SWAGGER_UI_DOWNLOAD_URL: file:///tmp/swagger-ui-cache/v5.17.14.zip
-        run: cargo +1.94 check --workspace --exclude garraia-desktop --locked
+        run: cargo +1.95 check --workspace --exclude garraia-desktop --locked
 
   # E2E integration test (GAR-216, GAR-438 / plan 0050 Lote 2)
   e2e:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,9 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "cap-fs-ext"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78e5a3368ae89b7cb68186411452b4b9fac8b41be9c19bf3f47c2d2c8e36e6b"
+checksum = "56ff379b70af8e08307a8f65e7040c7301cb4a572538ade16b4984f0da77847f"
 dependencies = [
  "cap-primitives",
  "cap-std",
@@ -1282,9 +1282,9 @@ dependencies = [
 
 [[package]]
 name = "cap-primitives"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+checksum = "8b5f74729fd2f44701d1a8eb47e906cdb3ccd9ec0f02baad85a744b791940b18"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
@@ -1300,9 +1300,9 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+checksum = "c1ec78e242cfa2cfe276807ac2ecc00315a6c97786977414bcd1c3963b6c91b8"
 dependencies = [
  "cap-primitives",
  "io-extras",
@@ -1719,27 +1719,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.134.3"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d552bd33b7a56dc70aeb1e1c960e51a218fa0db50f23873b500a310379450b2d"
+checksum = "9903e767cc0a95a59950de099a6b1d61e1476f774be1cdfa06d7ccdc9bfae56f"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.134.3"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e80e4c222279e3330f6aa1a256ca77ddf156d4453166a9f09defedc4594dd"
+checksum = "e777252ea3ec9daffa71408fbfe0793ab0a7b7bc3b2cf0f417dd0fa33964b8ef"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.134.3"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "820ce15d4ad3562d613c31a67b6d0434d403e7091a68d1349903842f7d31737e"
+checksum = "7828208a36e6627481cea61bd24c6234e31411d5c58b48e80ca094a1d593b944"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -1747,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.134.3"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61bca563d4b86d285928d9e27f97f27039bb33a0fc524fa130d7d0c106bf8ab3"
+checksum = "a58c8447cc59ef98c49096679f81392ad0acec2224cea2bef52011f5169f9d02"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1758,9 +1758,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.134.3"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709f4b7c0fb57d952658d5b5c07fbdc4149acd7b7f0de9678ae754b9c981949a"
+checksum = "ce520e899df1de583e7b564eafd66760fbc147d72894d2278ddac57a1489fcc0"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1789,9 +1789,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.134.3"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903dc8915af62aad1d9d0f39a5968d33fa80b9aa899ed6f56e47f40ca4512e1e"
+checksum = "8d8ab23e63d78ea6bbda18ae1ed9c958bc1cb88d90fb5e95f5ba62e9c019474b"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1802,24 +1802,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.134.3"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0522d74c227e49f3fd49ab055311486ae4f09083262b66705bed676952491469"
+checksum = "24319a996b1ef40ebf8af69b39c868c790b35a42cfe38edacfd8c9deb75ea712"
 
 [[package]]
 name = "cranelift-control"
-version = "0.134.3"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66560ea1c5cef72e170b18e46d263dba2d3169c9d39e8cafdab2173c6362cc1a"
+checksum = "cf9856d68cc2cefb83229cb2c55b620dd38427555c2fe87d73f8a4421616f628"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.134.3"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ef5b17cc814d27e96b66a5b46da0e4ce2b8ac55a6d478048bb99d04b05526"
+checksum = "e0ec225d6b79c5d61358cb5ea081a1384ec541dbf8c1a8c618d187875af326ad"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1829,9 +1829,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.134.3"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a87e0aaa39dbf70693b348a221e45904111704ee8f9fef140498471005f9842d"
+checksum = "7d3a96a09bd9bd3cf6df2de2ea15d7418f493e946a8eaa1acfe39297a67ed3f3"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.17.1",
@@ -1842,15 +1842,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.134.3"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf79003ebfa1eed5e87f3b84446ad5236f540268289960e14f387dc9b28e40b7"
+checksum = "bd28f593c36afbdc9aa17305c0bb66c39ce0530e1caffcf389fbec053950083e"
 
 [[package]]
 name = "cranelift-native"
-version = "0.134.3"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05bf4f235743c81e67ee4db617c5a4a0b65d58d3f0cfc575ee0f1a4e0cd58273"
+checksum = "2987ca47affc261aa31ac643fb80dd7f8274cebf878003ba9f50cd6ff2c1055f"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1859,9 +1859,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.134.3"
+version = "0.135.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6977c2a71ab1e0d1e62f966b411a498aa04c4dce47d93d52f8a360a06058922"
+checksum = "b7431dd8c9def94aca43b27915dee0d42103d9b13922cfb044febcd975547d68"
 
 [[package]]
 name = "crc"
@@ -6855,9 +6855,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5c8c21ea032e4efbdf2d067dc45171779dbe0c8ecf20ef4a57efa7474f2b0a"
+checksum = "f755d75e0809a4738a3e4880eeeb852fadbe1de5a437505b84f09c381657012a"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -6867,9 +6867,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f10925455d5dde962e3604eade797ba5488644c8ee14a44191e2f2b58980574"
+checksum = "c7e69fa1c4a555946f82e7894a7df88b0e9ee03b4266829b4811467c616ce51d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7214,9 +7214,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
+checksum = "757712e8e61590d6d4f5d563483755538b5aa13467837a3b41cd9832509a7f85"
 dependencies = [
  "allocator-api2",
  "bumpalo",
@@ -10578,9 +10578,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-compose"
-version = "0.252.0"
+version = "0.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59b710751a35d54732a63851cdfacbfb2266b7160ce174faf269d3f4e84e31b"
+checksum = "8fd717357bff09b5f1ea49aea8ed1cd149b0c521823a1cc70bc2ac16b90b651a"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -10588,19 +10588,19 @@ dependencies = [
  "log",
  "petgraph",
  "smallvec",
- "wasm-encoder 0.252.0",
- "wasmparser 0.252.0",
+ "wasm-encoder 0.254.0",
+ "wasmparser 0.254.0",
  "wat",
 ]
 
 [[package]]
 name = "wasm-encoder"
-version = "0.252.0"
+version = "0.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
+checksum = "09480d646178e5fdd12bb06e812d0af9a3a191dbc9cd697fdc86687beade7393"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.252.0",
+ "wasmparser 0.254.0",
 ]
 
 [[package]]
@@ -10611,6 +10611,18 @@ checksum = "ec1492381bfd5ea51c2a99a919b676662559925cb8d7490547ec2e14c1ad3eb1"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.256.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.254.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b01df5f3b4ca7881e843f3bc0fb8a3905d79c68692250dcb8e33e698705ccdb6"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder 0.254.0",
+ "wasmparser 0.254.0",
 ]
 
 [[package]]
@@ -10641,9 +10653,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.252.0"
+version = "0.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
+checksum = "d5769a29f799fbab136aaf65b4fe5384cd7d93fe6fc9ba0dcb6c8382a1f16e27"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.17.1",
@@ -10665,27 +10677,26 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.252.0"
+version = "0.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7142797de29b35ab8dbf15c00f55fda75d409da4c423a8ab8bd6b667a785824b"
+checksum = "64e3ba11e024f504698f87b629b2b66c22a1231758de7607754963f7d198be39"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.252.0",
+ "wasmparser 0.254.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80ca6098e0d4d06886d91d7f2cc3cb6623eb583c4c0ab3c89cbfb6098c8586c"
+checksum = "1bd39f78fe9bc82cee4025ec9d52118269e9a1498016cc60119b14f2e1d86a8d"
 dependencies = [
  "addr2line",
  "async-trait",
  "bitflags 2.11.1",
  "bumpalo",
  "cc",
- "cfg-if",
  "encoding_rs",
  "futures",
  "fxprof-processed-profile",
@@ -10709,8 +10720,8 @@ dependencies = [
  "target-lexicon 0.13.5",
  "tempfile",
  "wasm-compose",
- "wasm-encoder 0.252.0",
- "wasmparser 0.252.0",
+ "wasm-encoder 0.254.0",
+ "wasmparser 0.254.0",
  "wasmtime-environ",
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
@@ -10729,9 +10740,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134f9d136d29c76f6c1b4c9b468e97a2efc38c7d49fd188e39b64870b2fea701"
+checksum = "00c1070d95484d048994ec109cd42c4932ac07e6ee3cc1886fb90c7a18ec29da"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -10751,8 +10762,8 @@ dependencies = [
  "sha2 0.10.9",
  "smallvec",
  "target-lexicon 0.13.5",
- "wasm-encoder 0.252.0",
- "wasmparser 0.252.0",
+ "wasm-encoder 0.254.0",
+ "wasmparser 0.254.0",
  "wasmprinter",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
@@ -10760,9 +10771,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65db2eb1bfc5371a3b4107dbf539d0b93d05016fc29625b1648146b47db02071"
+checksum = "9d447fd40f3e149cda8c0cd808660a1d1de438f3ff28627abb9bcda90dfb4895"
 dependencies = [
  "base64 0.22.1",
  "directories-next",
@@ -10780,9 +10791,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf7b91fed3fc34781d57f9c6654ea2513bf0a99f7b0b0523c00de1e6efebe1c"
+checksum = "f3d2b2f9f89a65bb2277d82fbdd49263d27d8233bc717d750c4b13a23d57721c"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -10795,15 +10806,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc8a678149885cae00289f806fbe74c7863084cf74cace0b8dc73602279400e1"
+checksum = "2c0fe8292115fda08875f29064ae9f7f0b2c1ffbb323146eae538ae34b8a613f"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0092c4b9d070ac5e278b6d0db10f5e71214190f0347ca57502b4692f796321"
+checksum = "821385794cf44baf2967fd2515368429ed2bff9b9b256f62d09a0f1301474fd8"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -10813,11 +10824,10 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6851ebc9e03cab23d9821d2b2505d380bdfe38f35ccec945247b05274d85c98b"
+checksum = "0238b4a52773457ad1b8a1a26be90486e0ca0108cf46b9be16cc1d8d8cabdfa1"
 dependencies = [
- "cfg-if",
  "cranelift-codegen",
  "cranelift-control",
  "cranelift-entity",
@@ -10831,7 +10841,7 @@ dependencies = [
  "smallvec",
  "target-lexicon 0.13.5",
  "thiserror 2.0.20",
- "wasmparser 0.252.0",
+ "wasmparser 0.254.0",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
@@ -10840,12 +10850,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b26da6d5f60d4c438da70bba3553fe810a840533a64156be287dca2081c6991"
+checksum = "596f1d85e06cbf9c9add9c78ea135171c5753264ffe94a83dcc082a1ff49fc9b"
 dependencies = [
  "cc",
- "cfg-if",
  "libc",
  "rustix",
  "wasmtime-environ",
@@ -10855,9 +10864,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed621ba25d7bf78b7edd7b4749abbb27c2e5cdba836c9504a424ee74b6c23149"
+checksum = "365faed74827bb0116785bab5872372df1baaec9ec0003c83bc99ccdc595f689"
 dependencies = [
  "cc",
  "object 0.39.1",
@@ -10867,11 +10876,10 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5684ba160951baad06a725696f3c590e2fb0e8067c2aebee27bf7f9259058e85"
+checksum = "3cce25afd9e7ac4957292a5c6a219951dd0f140b8417e7378a97f50b67c3b96f"
 dependencies = [
- "cfg-if",
  "libc",
  "wasmtime-internal-core",
  "windows-sys 0.61.2",
@@ -10879,11 +10887,10 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112eead527bffa8ff0646a11fb4339a9d52ddd1da2b9a6fce4aff84c815dd94f"
+checksum = "a1fdea09d51e39c774984ca68a7d7486767e5b2935f5e686fa654aabcfc3c42d"
 dependencies = [
- "cfg-if",
  "cranelift-codegen",
  "log",
  "object 0.39.1",
@@ -10892,9 +10899,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "153592e0bed824fc13c6696203fa1bd7bd20eb355316475e39a55f081ef80eca"
+checksum = "97e48a5f514c38c2f74249724cb3501e45548d3311ca9e3881694859fd6ba116"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10903,31 +10910,30 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c456ad6e81e0f46abfeca43687d18ea15e289c395b262ea6e0023e2682e088be"
+checksum = "07429ab53576255be2d298e04b2e1f381e39645465adbaebd69314b5430165c0"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
  "heck 0.5.0",
  "indexmap 2.14.0",
+ "wit-component",
  "wit-parser",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c1cf60cd6a565213af7074b4aad7bb5e110e3c6c6aae54425aa0500a0e15e86"
+checksum = "85dd81ee95792682ea5b279c9ed352f6b8a2cba084c2f8abdb225e6933323fed"
 dependencies = [
  "async-trait",
  "bitflags 2.11.1",
  "bytes",
  "cap-fs-ext",
- "cap-std",
- "cfg-if",
+ "cap-primitives",
  "futures",
- "io-lifetimes 3.0.1",
  "rand 0.10.1",
  "rustix",
  "thiserror 2.0.20",
@@ -10942,9 +10948,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb08e1d7755aaa467ce14080b7b01e33c914a920f6000696f1e42e40ea6387e"
+checksum = "6a557bc8a7232cd079f6b423a9bb385f3ff9148824f3c26c07a028b499fab2bf"
 dependencies = [
  "async-trait",
  "bytes",
@@ -11141,9 +11147,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89091642df051b84a7e00bdff75e985e507f2298384e477cc9310b0ddd79f004"
+checksum = "b871ea219ad85c1e59ee7d013563814e86d2e6aa094d3bc66b7675ec4ca58bb7"
 dependencies = [
  "bitflags 2.11.1",
  "thiserror 2.0.20",
@@ -11155,9 +11161,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12247f46f31bb5e7593947f9bba07317d0c1978e0d02250b979dd08f56f46e9f"
+checksum = "ed981675756e748a4725286a4059c9be006749a8db4120d54e2021d0f167bac3"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -11169,9 +11175,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "47.0.3"
+version = "48.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e556a0880c9506fdcc662b1e226c7ced692f4977fed5b1ed40a3f3f0a48356f2"
+checksum = "7f3927729af874585c58b85710128e40d459a7064bb9aea9b0b420fb5eafd555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11813,10 +11819,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
-name = "wit-parser"
-version = "0.252.0"
+name = "wit-component"
+version = "0.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4266bea110371c620ccf3201c5023676046bc4556e5c7cfb5d500bda5ebc162d"
+checksum = "b0e65bb94c369b3c4741ce3d1d2704b1fec93db7c540df0e521a097e7ceeb5be"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.254.0",
+ "wasm-metadata",
+ "wasmparser 0.254.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.254.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1655131e4f7d3f0cb141f6eca71315ca40eff0f3d4de7cff0a82bacedd8c89b4"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -11828,7 +11853,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-ident",
- "wasmparser 0.252.0",
+ "wasmparser 0.254.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ edition = "2024"
 license = "MIT"
 repository = "https://github.com/michelbr84/GarraRUST"
 description = "A personal AI assistant platform, rewritten in Rust"
-rust-version = "1.94"
+rust-version = "1.95"
 
 [workspace.dependencies]
 # Async runtime
@@ -89,8 +89,14 @@ jsonwebtoken = { version = "11", default-features = false, features = ["rust_cry
 # `wasmtime-wasi` requires `features = ["p1"]` because `WasiCtxBuilder::build_p1`
 # (used by `garraia-plugins/src/runtime.rs`) became feature-gated in v44.
 # `preview1` module was renamed to `p1` in the upstream — handled in runtime.rs.
-wasmtime = "47"
-wasmtime-wasi = { version = "47", features = ["p1"] }
+# 47→48 (PR #848, 2026-08-29): breaking API change — `DirPerms`/`FilePerms`
+# collapsed into `FsPerms`, `preopened_dir` lost an argument, and the
+# `SocketAddrUse` variants were reshaped (`UdpConnect`/`UdpOutgoingDatagram`
+# out, `UdpSend`/`UdpReceive`/`TcpListen`/`TcpAccept` in). Migrated in
+# runtime.rs. This bump is ALSO what forces `rust-version = "1.95"` above:
+# wasmtime 48 and its cranelift/pulley/wiggle tree declare rustc 1.95.0.
+wasmtime = "48"
+wasmtime-wasi = { version = "48", features = ["p1"] }
 
 # Discord
 serenity = { version = "0.12", default-features = false, features = ["client", "gateway", "model", "cache", "native_tls_backend"] }

--- a/crates/garraia-plugins/src/runtime.rs
+++ b/crates/garraia-plugins/src/runtime.rs
@@ -14,13 +14,15 @@ use wasmtime::{Config, Engine, Linker, Module, Store, StoreLimits, StoreLimitsBu
 // only the path changed. `build_p1()` is feature-gated under `features = ["p1"]`
 // declared in the workspace Cargo.toml since wasmtime-wasi 44.
 use wasmtime_wasi::p1::{self, WasiP1Ctx};
-// `DirPerms` / `FilePerms` / `WasiCtxBuilder` remain at the top of the crate
-// (they are shared by both p1 and p2 contexts). `SocketAddrUse` and the
-// `pipe::*` types moved into `wasmtime_wasi::p2::*` in v30+ when WASIp2
-// became the canonical namespace; the names and contracts are unchanged.
+// 2026-08-29 (PR #848, Dependabot): wasmtime-wasi 47 → 48. `DirPerms` and
+// `FilePerms` bitflags were collapsed into a single `FsPerms { ReadOnly,
+// ReadWrite }` enum, and `preopened_dir` lost its fourth argument
+// accordingly. `WasiCtxBuilder` still lives at the crate root (shared by the
+// p1 and p2 contexts). `SocketAddrUse` and the `pipe::*` types moved into
+// `wasmtime_wasi::p2::*` in v30+ when WASIp2 became the canonical namespace.
 use wasmtime_wasi::p2::pipe::{MemoryInputPipe, MemoryOutputPipe};
 use wasmtime_wasi::sockets::SocketAddrUse;
-use wasmtime_wasi::{DirPerms, FilePerms, WasiCtxBuilder};
+use wasmtime_wasi::{FsPerms, WasiCtxBuilder};
 
 pub struct WasmRuntime {
     manifest: PluginManifest,
@@ -115,19 +117,17 @@ impl WasmRuntime {
 
         for (idx, (host_path, writable)) in mounts.into_iter().enumerate() {
             let guest_path = format!("mnt{idx}");
-            let dir_perms = if writable {
-                DirPerms::READ | DirPerms::MUTATE
+            // wasmtime-wasi 48 folded the dir/file bitflag pair into one enum:
+            // `READ` alone is `ReadOnly`, `READ | MUTATE` plus `READ | WRITE`
+            // is `ReadWrite`. Same intent, fewer ways to get it wrong.
+            let fs_perms = if writable {
+                FsPerms::ReadWrite
             } else {
-                DirPerms::READ
-            };
-            let file_perms = if writable {
-                FilePerms::READ | FilePerms::WRITE
-            } else {
-                FilePerms::READ
+                FsPerms::ReadOnly
             };
 
             builder
-                .preopened_dir(&host_path, &guest_path, dir_perms, file_perms)
+                .preopened_dir(&host_path, &guest_path, fs_perms)
                 .map_err(|e| {
                     Error::Plugin(format!(
                         "failed to preopen filesystem path {}: {e}",
@@ -150,14 +150,7 @@ impl WasmRuntime {
         builder.allow_udp(true);
         builder.socket_addr_check(move |addr, reason| {
             let allowed_ips = Arc::clone(&allowed_ips);
-            Box::pin(async move {
-                match reason {
-                    SocketAddrUse::TcpConnect
-                    | SocketAddrUse::UdpConnect
-                    | SocketAddrUse::UdpOutgoingDatagram => allowed_ips.contains(&addr.ip()),
-                    SocketAddrUse::TcpBind | SocketAddrUse::UdpBind => false,
-                }
-            })
+            Box::pin(async move { socket_use_allowed(reason, addr, &allowed_ips) })
         });
 
         Ok(())
@@ -413,9 +406,54 @@ fn resolve_allowlisted_ips(domains: &[String]) -> Result<HashSet<IpAddr>> {
     Ok(ips)
 }
 
+/// Decides whether a sandboxed plugin may use `addr` for `reason`.
+///
+/// The policy is: a plugin may reach out to addresses its manifest
+/// allowlisted, and may never act as a server.
+///
+/// The bind arms deserve an explanation, because the obvious `false` is wrong
+/// on wasmtime-wasi 48. When a guest calls `connect` on a socket it never
+/// bound, v48 asks this check about an *implicit* bind to the wildcard
+/// address before it asks about the connect itself (`sockets/tcp.rs:208` and
+/// `sockets/udp.rs:123` in 48.0.1). Refusing every bind therefore refuses
+/// every outbound connection, turning the allowlist into a silent deny-all.
+/// v47 had no such implicit check, which is why the port is not mechanical.
+///
+/// So we permit exactly the shape wasmtime uses for an implicit bind —
+/// `0.0.0.0:0` or `[::]:0` (`sockets/mod.rs:573-579`) — and keep refusing an
+/// explicit bind to a concrete local address. Listening and accepting, the
+/// operations that actually expose a plugin to the network, stay refused
+/// outright.
+///
+/// The match is deliberately exhaustive with no `_` arm: a variant added by a
+/// future wasmtime should fail the build and force a decision here, rather
+/// than silently inherit network access.
+fn socket_use_allowed(
+    reason: SocketAddrUse,
+    addr: std::net::SocketAddr,
+    allowed_ips: &HashSet<IpAddr>,
+) -> bool {
+    match reason {
+        // Outbound traffic — gated by the manifest allowlist.
+        SocketAddrUse::TcpConnect | SocketAddrUse::UdpSend | SocketAddrUse::UdpReceive => {
+            allowed_ips.contains(&addr.ip())
+        }
+
+        // Implicit bind only (see above); an explicit bind stays refused.
+        SocketAddrUse::TcpBind | SocketAddrUse::UdpBind => {
+            addr.ip().is_unspecified() && addr.port() == 0
+        }
+
+        // A plugin is never a server.
+        SocketAddrUse::TcpListen | SocketAddrUse::TcpAccept => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{is_private_ip, normalize_scoped_path, resolve_allowlisted_ips};
+    use super::{
+        is_private_ip, normalize_scoped_path, resolve_allowlisted_ips, socket_use_allowed,
+    };
     use std::net::IpAddr;
     use std::path::Path;
 
@@ -497,5 +535,104 @@ mod tests {
         assert!(!is_private_ip(
             &"2001:4860:4860::8888".parse::<IpAddr>().unwrap()
         ));
+    }
+
+    // ── socket_use_allowed (wasmtime-wasi 48 policy) ──────────────────────
+    //
+    // These pin the semantics of the 47 → 48 migration. The bind cases are
+    // the ones that matter: on 48 a `connect` on an unbound socket is checked
+    // as an implicit wildcard bind *first*, so a blanket `false` on the bind
+    // arms would silently refuse every outbound connection.
+
+    use super::SocketAddrUse;
+    use std::collections::HashSet;
+    use std::net::SocketAddr;
+
+    fn allowlist() -> HashSet<IpAddr> {
+        let mut set = HashSet::new();
+        set.insert("93.184.216.34".parse::<IpAddr>().unwrap());
+        set
+    }
+
+    fn addr(s: &str) -> SocketAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn outbound_to_allowlisted_ip_is_permitted() {
+        let allowed = allowlist();
+        for reason in [
+            SocketAddrUse::TcpConnect,
+            SocketAddrUse::UdpSend,
+            SocketAddrUse::UdpReceive,
+        ] {
+            assert!(
+                socket_use_allowed(reason, addr("93.184.216.34:443"), &allowed),
+                "allowlisted peer must be reachable"
+            );
+        }
+    }
+
+    #[test]
+    fn outbound_to_unlisted_ip_is_refused() {
+        let allowed = allowlist();
+        for reason in [
+            SocketAddrUse::TcpConnect,
+            SocketAddrUse::UdpSend,
+            SocketAddrUse::UdpReceive,
+        ] {
+            assert!(
+                !socket_use_allowed(reason, addr("1.1.1.1:443"), &allowed),
+                "peer outside the manifest allowlist must be refused"
+            );
+        }
+    }
+
+    #[test]
+    fn implicit_wildcard_bind_is_permitted() {
+        // wasmtime 48 passes SocketAddr::new(UNSPECIFIED, 0) for the implicit
+        // bind it checks before TcpConnect / UdpSend. Refusing this would
+        // break every outbound connection, so it must be allowed.
+        let allowed = allowlist();
+        for reason in [SocketAddrUse::TcpBind, SocketAddrUse::UdpBind] {
+            assert!(
+                socket_use_allowed(reason, addr("0.0.0.0:0"), &allowed),
+                "implicit IPv4 bind precedes every outbound connect"
+            );
+            assert!(
+                socket_use_allowed(reason, addr("[::]:0"), &allowed),
+                "implicit IPv6 bind precedes every outbound connect"
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_bind_to_a_concrete_address_is_refused() {
+        let allowed = allowlist();
+        for reason in [SocketAddrUse::TcpBind, SocketAddrUse::UdpBind] {
+            assert!(
+                !socket_use_allowed(reason, addr("127.0.0.1:8080"), &allowed),
+                "binding a concrete local address is not the implicit form"
+            );
+            // Wildcard IP but a fixed port is still an explicit bind.
+            assert!(
+                !socket_use_allowed(reason, addr("0.0.0.0:8080"), &allowed),
+                "a pinned port means the guest asked for this bind"
+            );
+        }
+    }
+
+    #[test]
+    fn listening_and_accepting_are_always_refused() {
+        let allowed = allowlist();
+        // Even an allowlisted address must not let a plugin serve.
+        for reason in [SocketAddrUse::TcpListen, SocketAddrUse::TcpAccept] {
+            assert!(!socket_use_allowed(
+                reason,
+                addr("93.184.216.34:443"),
+                &allowed
+            ));
+            assert!(!socket_use_allowed(reason, addr("0.0.0.0:0"), &allowed));
+        }
     }
 }


### PR DESCRIPTION
## Descrição

Substitui o [#848](https://github.com/michelbr84/GarraRUST/pull/848) (Dependabot), que estava com 7 jobs vermelhos. São **dois bloqueios independentes** — o segundo não aparece se você ler só o erro de compilação.

### Bloqueio 1 — quebra de API no `wasmtime-wasi` 48

A sugestão do compilador não serve: ele manda trocar só `FilePerms` por `FsPerms` e **manter** `DirPerms`, o que não compilaria.

| v47 | v48 | fonte |
| --- | --- | --- |
| `DirPerms` + `FilePerms` (bitflags) | `FsPerms { ReadOnly, ReadWrite }` | `filesystem.rs:98` |
| `preopened_dir(host, guest, dir, file)` | `preopened_dir(host, guest, FsPerms)` | `ctx.rs:297` |
| `UdpConnect`, `UdpOutgoingDatagram` | `UdpSend`, `UdpReceive` | `sockets/mod.rs:169` |
| — | `TcpListen`, `TcpAccept` (novas) | idem |

O mapeamento de filesystem preserva a intenção atual: `READ` → `ReadOnly`, `READ|MUTATE` + `READ|WRITE` → `ReadWrite`.

### A armadilha na política de rede

Portar o `match` literalmente seria um erro. Na v48, um `connect()` sobre socket não vinculado dispara `check(0.0.0.0:0, TcpBind)` **antes** do `TcpConnect` (`sockets/tcp.rs:198-211`); o mesmo vale para `UdpBind` antes de `UdpSend` (`sockets/udp.rs:115-133`). Na v47 esse check implícito não existia — `p2/host/tcp.rs:54` checava só `TcpConnect`.

Manter `TcpBind => false` transformaria a allowlist de rede num **deny-all silencioso**: toda conexão de saída seria recusada antes de a allowlist ser sequer consultada.

A política agora vive em `socket_use_allowed`, função pura:

- saída (`TcpConnect`/`UdpSend`/`UdpReceive`) filtrada pela allowlist do manifesto;
- bind permitido **apenas** na forma implícita exata que o wasmtime usa — `is_unspecified()` e porta 0 (`sockets/mod.rs:573-579`) — com bind explícito em endereço concreto recusado;
- `TcpListen`/`TcpAccept` sempre recusados: um plugin nunca é servidor;
- `match` exaustivo **sem braço `_`**, para que uma variante futura quebre o build em vez de herdar acesso à rede por omissão.

Verificado empiricamente: `implicit_wildcard_bind_is_permitted` falha com o patch ingênuo e passa com este.

### Bloqueio 2 — MSRV

O job `MSRV check` falhava **antes de qualquer compilação**: `wasmtime@48.0.1 requires rustc 1.95.0`, junto com ~60 crates transitivos (`cranelift-*`, `pulley-*`, `wiggle-*`). Migrar o `runtime.rs` sozinho deixaria esse job vermelho.

Sobe `rust-version` 1.94 → 1.95 e o pin do toolchain no `ci.yml`, seguindo o mesmo padrão dos bumps anteriores (GAR-454 → 1.92, GAR-708 → 1.93, GAR-895 → 1.94): o piso é ditado pela árvore do wasmtime. O stable atual é 1.98.

### Nota honesta de escopo

Sob WASI Preview 1 — que é o que este runtime usa (`WasiP1Ctx`/`build_p1()`) — sockets **não são implementados**: `sock_accept`/`sock_recv`/`sock_send` só emitem `tracing::warn!` (`p1.rs:2652-2684`) e não existe `sock_connect`. Ou seja, `configure_network` é código aspiracional hoje: a armadilha acima é **latente, não ativa**, e não há como validá-la ponta a ponta — só por unit test do predicado. Fazer a allowlist funcionar de verdade exige migrar o runtime de p1 para p2, o que merece issue e ADR próprios.

Closes #848

## Tipo de mudança

- [x] `fix`: Correção de bug
- [x] `chore`: Manutenção (deps, build)
- [x] `sec`: Correção ou hardening de segurança

## Classe de Risco

- [ ] **Classe A (Baixo Risco)**
- [ ] **Classe B (Médio Risco)**
- [x] **Classe C (Alto Risco)**: o diff altera a política de sandbox de rede dos plugins WASM. Não toca autenticação, cripto, RLS, migrations nem endpoints REST.

## Checklist de Segurança e Qualidade

- [x] `cargo fmt --check` executado e limpo
- [x] `cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings` sem erros
- [x] `cargo test --workspace --exclude garraia-desktop` — 2015 testes verdes
- [x] Nenhum `unwrap()` adicionado em código de produção (só em testes)
- [x] Nenhum segredo, API key, token ou credencial commitada
- [x] Nenhuma migração Postgres envolvida

### Alto Risco (Classe C)

- [x] A mudança de política de sandbox tem 5 testes novos, incluindo o que pina a armadilha do bind implícito
- [x] `match` exaustivo garante que variantes futuras falhem o build em vez de conceder acesso

## Mudanças na API pública e Schema

- Nenhuma mudança de API pública nem de schema.
- **Quebra de build:** compilar o workspace passa a exigir `rustc >= 1.95.0`.

## Como testar

1. `cargo +1.95 test -p garraia-plugins` — 18 testes, 5 deles novos sobre a política de socket.
2. Para ver a armadilha: troque as duas linhas do braço de bind por `false` e rode de novo — `implicit_wildcard_bind_is_permitted` falha.
3. `cargo +1.95 check --workspace --exclude garraia-desktop --locked` reproduz o gate MSRV; com `+1.94` ele falha com `requires rustc 1.95.0`, que é a prova de que o bump era necessário.

## Plano de Rollback

`git revert` do commit. Volta wasmtime para 47, o `runtime.rs` para a API antiga e o MSRV para 1.94 — os três juntos, já que são inseparáveis.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZNsL1kjZqhdSgUvhVUZA3)_