### PR TITLE
docs(claude): adiciona skill steward para dirigir PR até o verde

### DIFF
--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: steward
+description: Guia específica do GarraRUST para dirigir um PR até o verde — quais falhas de CI são ambientais, quais são suas, e o que validar antes de empurrar. Lida ao reagir a eventos de CI ou de review num PR.
+---
+
+# Steward — dirigindo um PR do GarraRUST até o verde
+
+Esta skill é lida **no momento em que um PR seu fica vermelho ou recebe
+review**. Ela não repete o `CLAUDE.md` (convenções de código, regras absolutas,
+estrutura de crates) — vá lá para isso. Aqui está só o que morde nesse momento
+específico, e que já custou ciclos de CI reais.
+
+Ela **não** autoriza aprovar nem mergear PR, e não sobrepõe nenhuma regra
+"nunca" da política de PR do harness (pular/desabilitar teste, reescrever
+histórico de branch alheia, commit vazio para chacoalhar CI).
+
+---
+
+## 1. Antes de qualquer push
+
+O `Format Check` é **bloqueante** e é o erro mais barato e mais frequente:
+
+```bash
+cargo fmt --all && cargo fmt --all -- --check
+```
+
+Rode isso **sempre**, mesmo em mudança que "só mexe em comentário". `cargo
+check`, `clippy` e `test` passando **não** implicam fmt limpo — o rustfmt
+reflui `params!`, `assert!`, `match` longos e reordena blocos `use`, e nada
+disso aparece nas outras ferramentas.
+
+> Caso real: PR #861 foi para o CI com 21 de 22 checks verdes e o único
+> vermelho era fmt — 19 blocos em 8 arquivos, todos cosméticos. Um ciclo
+> inteiro de CI (~25 min) perdido.
+
+Depois, o mais próximo possível do que o CI roda:
+
+```bash
+cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings
+cargo test  --workspace --exclude garraia-desktop
+```
+
+`garraia-desktop` é excluído em **todos** os jobs (clippy, build, test, msrv) —
+faltam libs GTK e o sidecar Windows nos runners. Não tente "consertar" isso.
+
+---
+
+## 2. Falhas que NÃO são suas
+
+Antes de investigar como defeito, descarte estas. Todas aparecem como falha
+legítima e não são.
+
+### `migration_smoke` — "failed to initialize a docker client"
+
+```
+Error: failed to initialize a docker client: Socket not found: /var/run/docker.sock
+```
+
+Os testes de `garraia-workspace` (e os de integração de `garraia-auth` /
+`garraia-gateway`) usam testcontainers. **O container de dev não tem Docker.**
+Nos runners Linux do GitHub tem, e lá passam — inclusive aplicando todas as
+migrations via `sqlx::migrate!` em Postgres real. Se falhar só localmente com
+essa mensagem, é ambiente. Diga isso explicitamente em vez de alegar que
+validou.
+
+### `utoipa-swagger-ui` — build script falha localmente
+
+O `build.rs` baixa um zip do GitHub, e o proxy de egresso desta sessão bloqueia
+o domínio; o "zip" gravado é uma página de erro JSON de 378 bytes. O `ci.yml`
+já contorna pré-baixando com curl.
+
+Para destravar localmente, **não apague o cache cegamente** (`find target -name
+'v5.17.14.zip' -delete` remove também cópias válidas de builds anteriores —
+erro já cometido). Gere o arquivo a partir do clone da tag:
+
+```bash
+git clone --depth 1 --branch v5.17.14 https://github.com/swagger-api/swagger-ui /tmp/swui
+git -C /tmp/swui archive --format=zip --prefix=swagger-ui-5.17.14/ HEAD -o /tmp/v5.17.14.zip
+export SWAGGER_UI_DOWNLOAD_URL="file:///tmp/v5.17.14.zip"
+```
+
+### "No space left on device" disfarçado de erro de compilação
+
+`target/` chega a ~26 GB e o disco da sessão é uma cota fixa — `df` engana
+(mostra "Avail" baixo com "Used" baixo). Sintoma típico: vários `could not
+compile X` sem erro de tipo algum, e no meio um `error 28`. Cure com
+`target/debug/incremental` primeiro (metade do peso), `cargo clean` se
+necessário. **Commite e empurre antes de limpar**, para que um estouro não leve
+o trabalho junto.
+
+### Quality Ratchet reclamando de arquivos grandes
+
+O baseline está congelado em 2026-05-05 e a `main` andou muito desde então.
+As regressões de `max_file_lines` / `files_over_*` quase sempre são **deriva do
+baseline, não suas**. Confirme antes de agir:
+
+```bash
+git diff --name-only origin/main..HEAD          # o arquivo apontado está aqui?
+git show origin/main:<arquivo> | wc -l          # já tinha esse tamanho na main?
+```
+
+O modo é `report-only` (exit 0) e o check fica verde. **Nunca** edite
+`.quality/baseline.json` à mão — é fraude; use `freeze-baseline.py`.
+
+### CodeQL agregado em `neutral`
+
+O check-run agregado "CodeQL" às vezes fecha como `neutral` enquanto os três
+`Analyze (rust|actions|javascript-typescript)` fecham `success`. `neutral` não
+é falha e não bloqueia. Olhe os três individuais.
+
+---
+
+## 3. Bump do wasmtime: o piso de MSRV vem junto
+
+Já aconteceu **quatro vezes** (1.92, 1.93, 1.94, 1.95). Um PR do Dependabot que
+sobe `wasmtime` costuma trazer **dois** bloqueios independentes, e o segundo
+não aparece se você ler só o erro de compilação:
+
+1. quebra de API em `crates/garraia-plugins/src/runtime.rs`;
+2. `MSRV check` falhando **antes de compilar**, porque a árvore
+   `wasmtime`/`cranelift-*`/`pulley-*`/`wiggle-*` declara um `rust-version`
+   novo.
+
+Corrigir só o código deixa o job de MSRV vermelho. Subir o piso toca
+`Cargo.toml` (`rust-version`) **e** o `ci.yml` (nome do job, `dtolnay/rust-
+toolchain@X.YZ`, e as duas invocações `cargo +X.YZ`). Prove nos dois sentidos:
+o novo piso passa `--locked`, o antigo ainda recusa.
+
+Não confie na sugestão do compilador em migração de API do `wasmtime-wasi`: no
+bump 47→48 ele mandava trocar só `FilePerms` por `FsPerms` e **manter**
+`DirPerms`, o que não compilaria.
+
+---
+
+## 4. Auto-merge está armado neste repositório
+
+Ele dispara assim que os checks **obrigatórios** passam — o que pode ser
+**antes** de todos os checks terminarem, e antes de você chamar merge.
+
+Consequências práticas:
+
+- **Nunca afirme que você mergeou** sem conferir `merged_at` e `merged_by`.
+  Uma chamada de merge sobre PR já mergeado retorna "successfully merged" de
+  forma idempotente, e o `commit_title` que você passou é ignorado.
+- Por isso, **arrume o título do PR antes de ele ficar verde**. O squash herda
+  o título do PR, e o auto-merge usa o valor em cache. Um título autogerado
+  (`Claude/foo-bar-abc123`) vira assunto de commit na `main`, fora de
+  Conventional Commits — e corrigir depois exigiria reescrever a `main`, o que
+  é proibido.
+
+---
+
+## 5. O CI não roda em branch solta
+
+`ci.yml` dispara em `push` para `main`/`develop`/`master` e em `pull_request`
+para esses alvos. Empurrar uma branch **não** roda nada: sem PR aberto, não há
+validação de CI. Planeje isso — e não peça para o usuário "esperar o CI" de uma
+branch que não tem PR.
+
+---
+
+## 6. Ao reagir a um review
+
+Achado de bot é relatório de defeito: verifique e corrija se for pequeno e
+local. Se os achados pararem de convergir (cada correção gera um novo), pare de
+empurrar e levante o assunto uma vez, dizendo o que continua sinalizado.
+
+Pedido grande de revisor humano em PR que não é seu → responda com a proposta,
+não empurre nem resolva a thread.
+
+Mudança que toca segurança, auth, storage, RLS, secrets ou CI crítico: o
+`CLAUDE.md` manda acionar os agents `security-auditor` e `code-reviewer` antes
+de seguir.

--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,15 @@ Thumbs.db
 # locally by /max-power tooling; bodies drift from the canonical tracked
 # skills/*.md flat layout. Promotion to canonical layout pending a per-skill
 # diff review (rastreado em Linear, vide CLAUDE.md §Skills disponíveis).
-.claude/skills/
+# Nota: usa `/*` em vez de `/` porque o git não reinclui nada dentro de um
+# diretório excluído — sem isso a negação abaixo é silenciosamente ignorada.
+.claude/skills/*
+# Exceção: `steward/` é escrito à mão, NÃO gerado pelo /max-power — a razão da
+# ignora acima (corpos divergindo do canônico `skills/*.md`) não se aplica a
+# ele, porque não existe contraparte plana. Precisa ser versionado porque o
+# harness que dirige PR lê essa guia de `.claude/skills/steward/SKILL.md` na
+# branch remota; num arquivo ignorado, nenhuma outra sessão a enxerga.
+!.claude/skills/steward/
 # .claude/settings.json, hooks/, agents/ SÃO commitados (config do projeto)
 
 # Git worktrees — isolated workspaces used by parallel agent execution

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -395,6 +395,7 @@ O projeto utiliza [Superpowers](https://github.com/obra/superpowers) como framew
 | `/generate-docs` | Gera documentação automática |
 | `/code-review` | Revisão de código inline |
 | `/git-assist` | Ajuda com git workflow |
+| `steward` | Guia para dirigir PR até o verde — quais falhas de CI são ambientais e quais são suas. Não é slash command: é lida automaticamente por um agente ao reagir a evento de CI/review num PR. |
 
 ## Agents disponíveis
 


### PR DESCRIPTION
## Descrição

Não havia nada dizendo a um agente que dirige PR quais armadilhas de CI são **deste** repositório. O `.claude/commands/quality-babysit.md` cobre só o loop do Quality Ratchet, não CI de PR.

A skill é lida no momento em que um PR fica vermelho ou recebe review. Ela não repete o `CLAUDE.md` — registra só o que morde nesse momento, e cada item veio de um ciclo de CI realmente perdido:

| Armadilha | Custo real |
|---|---|
| `cargo fmt --all` é gate bloqueante | PR #861 foi ao CI com 21 de 22 checks verdes; o único vermelho era fmt. `check`/`clippy`/`test` verdes **não** implicam fmt limpo |
| `migration_smoke` exige Docker | Falha local que parece defeito e é ambiente (o container de dev não tem `/var/run/docker.sock`) |
| Zip do `utoipa-swagger-ui` bloqueado pelo proxy | Build local quebra; apagar o cache cegamente remove também cópias válidas |
| `target/` chega a ~26 GB | ENOSPC se disfarça de vários `could not compile X` sem erro de tipo |
| Bump de wasmtime traz **dois** bloqueios | Quebra de API **e** piso de MSRV novo — já aconteceu 4× (1.92 → 1.93 → 1.94 → 1.95) |
| Auto-merge armado | Dispara quando os checks *obrigatórios* passam, possivelmente antes de todos terminarem — e antes da sua chamada de merge |
| Baseline do Quality Ratchet de 2026-05-05 | As regressões de tamanho de arquivo quase sempre são deriva, não suas |
| `ci.yml` não roda em branch solta | Sem PR aberto não há validação nenhuma |

## Sobre a exceção no `.gitignore`

`.claude/skills/` é ignorado **de propósito** — o comentário existente explica que é layout gerado pelo `/max-power`, cujos corpos divergem do canônico `skills/*.md`. Confirmei: nenhuma das 15 skills locais está versionada.

Essa razão **não se aplica** à `steward`: ela é escrita à mão e não tem contraparte plana. E precisa ser versionada porque o harness lê essa guia de `.claude/skills/steward/SKILL.md` **na branch remota** — num arquivo ignorado, nenhuma outra sessão a enxerga, o que anularia o propósito.

Daí a exceção cirúrgica. Dois detalhes:

- A regra virou `.claude/skills/*` (com `*`) porque **o git não reinclui nada dentro de um diretório excluído** — com `/` a negação é silenciosamente ignorada. Cometi exatamente esse erro na primeira tentativa e o `git status` o revelou.
- Verificado que as outras 15 skills seguem ignoradas (`pre-commit`, `review-pr`, `tdd-loop`, `garra-cli-operator` testadas com `git check-ignore`).

Colocar em `skills/steward.md` não resolveria: o harness não olha lá.

## Tipo de mudança

- [x] `docs`: Documentação apenas
- [x] `chore`: Manutenção

## Classe de Risco

- [x] **Classe A (Baixo Risco)**: documentação e uma regra de `.gitignore`. Nenhum código de runtime, nenhuma dependência, nenhum schema.
- [ ] **Classe B (Médio Risco)**
- [ ] **Classe C (Alto Risco)**

## Checklist de Segurança e Qualidade

- [x] Nenhum segredo, API key, token ou credencial commitada
- [x] Nenhum código Rust tocado — `fmt`/`clippy`/`test` não se aplicam a este diff
- [x] Nenhuma migração Postgres envolvida

## Mudanças na API pública e Schema

- Nenhuma. Só `.claude/skills/steward/SKILL.md` (novo), `.gitignore` e uma linha na tabela de skills do `CLAUDE.md`.

## Como testar

1. `git check-ignore -v .claude/skills/steward/SKILL.md` — não deve mais casar.
2. `git check-ignore -q .claude/skills/pre-commit/SKILL.md` — deve seguir casando (as demais continuam locais).
3. Ler a skill e conferir contra os comentários do `ci.yml`: as exclusões de `garraia-desktop`, o contorno do swagger-ui (`ci.yml:218-226`) e o histórico de pisos de MSRV (`ci.yml:483-499`) batem com o que ela descreve.

## Plano de Rollback

`git revert` do commit. Remove a skill e restaura a regra original do `.gitignore` — sem efeito sobre build, CI ou runtime.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZNsL1kjZqhdSgUvhVUZA3)_