### PR TITLE
Upgrade sqlx to 0.9 and enforce SQL safety with AssertSqlSafe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -361,7 +361,16 @@ benches/
 2. **NUNCA** `rm -rf /`, `rm -rf ~` ou fork bombs
 3. **NUNCA** force push para `main`
 4. **NUNCA** usar `unwrap()` em código de produção (apenas em testes)
-5. **NUNCA** concatenar strings em SQL queries — `params!` (rusqlite) ou `sqlx::query!` (Postgres)
+5. **NUNCA** concatenar strings em SQL queries — `params!` (rusqlite) ou `sqlx::query!` (Postgres).
+   Desde o sqlx 0.9 o compilador reforça isso: `sqlx::query()` / `query_as()` / `query_scalar()` /
+   `raw_sql()` só aceitam `&'static str` (trait `SqlSafeStr`), então qualquer `format!()` vira erro
+   `E0277`. **Exceção única e delimitada:** identificador SQL que o Postgres não aceita como bind
+   parameter (nome de tabela/coluna, `ORDER BY` dinâmico, DDL). Nesses casos usar
+   `sqlx::AssertSqlSafe` (note: `sqlx::AssertSqlSafe`, **não** `sqlx::sql_str::AssertSqlSafe`, que
+   não é público) **com comentário de auditoria nomeando a origem fechada do valor**. Não é
+   permitido em `crates/*/src/` — só em alvos de teste; hoje há exatamente 3 usos, todos em
+   `tests/`. Valor de dado continua **sempre** por `.bind()`. Para GUC de RLS, use
+   `SELECT set_config('app.current_group_id', $1, true)` com bind — nunca `SET LOCAL` interpolado.
 6. **NUNCA** expor secrets/PII em logs (`GARRAIA_JWT_SECRET`, `GARRAIA_REFRESH_HMAC_SECRET`, `GARRAIA_METRICS_TOKEN`, `ANTHROPIC_API_KEY`, etc.)
 7. **NUNCA** ignorar erros de compilação do `cargo check`
 8. **SEMPRE** escrever ADR em `docs/adr/NNNN-*.md` antes de decisão arquitetural irreversível (Postgres vs SQLite, vector store, storage backend, etc.) — ver `ROADMAP.md` §3.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2518,7 +2518,7 @@ checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
  "bit-set",
  "cssparser",
- "foldhash 0.2.0",
+ "foldhash",
  "html5ever",
  "precomputed-hash",
  "selectors",
@@ -2660,7 +2660,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "hkdf",
+ "hkdf 0.12.4",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
@@ -2787,17 +2787,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
 dependencies = [
  "version_check",
-]
-
-[[package]]
-name = "etcetera"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
-dependencies = [
- "cfg-if",
- "home",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2940,9 +2929,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2954,12 +2943,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -4138,24 +4121,13 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -4164,7 +4136,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "foldhash 0.2.0",
+ "foldhash",
  "serde",
  "serde_core",
 ]
@@ -4180,11 +4152,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -4218,6 +4190,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
  "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -4748,12 +4729,9 @@ checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "ipnetwork"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
-dependencies = [
- "serde",
-]
+checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
 
 [[package]]
 name = "is-docker"
@@ -5170,10 +5148,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.11.1",
  "libc",
- "plain",
- "redox_syscall 0.8.0",
 ]
 
 [[package]]
@@ -6290,7 +6265,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -6529,12 +6504,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -7157,15 +7126,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.11.1",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7591fa2c6b601dfcfe5f043f65a1c39fcdf50efefcd7f1572e538c1f4b398d"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -8321,7 +8281,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -8399,9 +8359,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -8412,12 +8372,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "cfg-if",
  "chrono",
  "crc",
  "crossbeam-queue",
@@ -8427,13 +8388,12 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.5",
- "hashlink 0.10.0",
+ "hashbrown 0.16.1",
+ "hashlink 0.11.1",
  "indexmap 2.14.0",
  "ipnetwork",
  "log",
  "memchr",
- "once_cell",
  "percent-encoding",
  "rustls",
  "rustls-native-certs",
@@ -8451,9 +8411,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8464,15 +8424,15 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
 dependencies = [
+ "cfg-if",
  "dotenvy",
  "either",
  "heck 0.5.0",
  "hex",
- "once_cell",
  "proc-macro2",
  "quote",
  "serde",
@@ -8483,59 +8443,44 @@ dependencies = [
  "sqlx-postgres",
  "sqlx-sqlite",
  "syn 2.0.117",
+ "thiserror 2.0.20",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "atoi",
- "base64 0.22.1",
  "bitflags 2.11.1",
  "byteorder",
  "bytes",
  "chrono",
  "crc",
- "digest 0.10.7",
+ "digest 0.11.3",
  "dotenvy",
  "either",
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "generic-array",
- "hex",
- "hkdf",
- "hmac 0.12.1",
- "itoa",
  "log",
- "md-5 0.10.6",
- "memchr",
- "once_cell",
  "percent-encoding",
- "rand 0.8.6",
- "rsa",
  "serde",
- "sha1 0.10.6",
- "sha2 0.10.9",
- "smallvec",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "sqlx-core",
- "stringprep",
  "thiserror 2.0.20",
  "tracing",
  "uuid",
- "whoami",
 ]
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64 0.22.1",
@@ -8544,24 +8489,22 @@ dependencies = [
  "chrono",
  "crc",
  "dotenvy",
- "etcetera 0.8.0",
+ "etcetera",
  "futures-channel",
  "futures-core",
  "futures-util",
  "hex",
- "hkdf",
- "hmac 0.12.1",
- "home",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
  "ipnetwork",
  "itoa",
  "log",
- "md-5 0.10.6",
+ "md-5 0.11.0",
  "memchr",
- "once_cell",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -8573,13 +8516,14 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
 dependencies = [
  "atoi",
  "chrono",
  "flume",
+ "form_urlencoded",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -8589,7 +8533,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
- "serde_urlencoded",
  "sqlx-core",
  "thiserror 2.0.20",
  "tracing",
@@ -9399,7 +9342,7 @@ dependencies = [
  "bytes",
  "docker_credential",
  "either",
- "etcetera 0.11.0",
+ "etcetera",
  "ferroid",
  "futures",
  "http 1.4.1",
@@ -10516,12 +10459,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11137,13 +11074,9 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite",
-]
+checksum = "626c4bac6755d76ffc12cb01b2eac751db1996b9e0041de9aa02c8c211ddc82c"
 
 [[package]]
 name = "wiggle"
@@ -11423,15 +11356,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -11479,21 +11403,6 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -11564,12 +11473,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -11588,12 +11491,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -11609,12 +11506,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -11648,12 +11539,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -11669,12 +11554,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -11696,12 +11575,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -11717,12 +11590,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ chrono-tz = "0.10"
 croner = "3"
 # RFC 5545 RRULE expansion for workspace task recurrence.
 rrule = "0.14"
-sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "tls-rustls-ring-native-roots", "postgres", "chrono"] }
+sqlx = { version = "0.9", default-features = false, features = ["runtime-tokio", "tls-rustls-ring-native-roots", "postgres", "chrono"] }
 dotenvy = "0.15"
 url = "2"
 regex = "1"

--- a/crates/garraia-auth/Cargo.toml
+++ b/crates/garraia-auth/Cargo.toml
@@ -21,7 +21,7 @@ test-support = []
 # SQL driver — runtime-only, matches garraia-workspace's feature set so the
 # LoginPool can be built from the same Postgres instance without forcing TLS.
 # `ipnetwork` feature is needed for binding `IpAddr` -> Postgres `inet`.
-sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "postgres", "uuid", "chrono", "ipnetwork"] }
+sqlx = { version = "0.9", default-features = false, features = ["runtime-tokio", "postgres", "uuid", "chrono", "ipnetwork"] }
 # Identifiers
 uuid = { version = "1", features = ["v7", "serde"] }
 # Timestamps

--- a/crates/garraia-auth/tests/rls_matrix.rs
+++ b/crates/garraia-auth/tests/rls_matrix.rs
@@ -22,7 +22,7 @@ use common::harness::Harness;
 use common::matrix::RLS_MATRIX;
 use common::oracle::{classify_count, classify_pg_error, matches_expected};
 use common::tenants::Tenant;
-use sqlx::PgPool;
+use sqlx::{AssertSqlSafe, PgPool};
 use uuid::Uuid;
 
 // ─── Runner ────────────────────────────────────────────────────────────────
@@ -228,8 +228,13 @@ async fn execute_select(
     conn: &mut sqlx::pool::PoolConnection<sqlx::Postgres>,
     table: &str,
 ) -> RlsExpected {
+    // AssertSqlSafe: sqlx 0.9 only accepts `&'static str`, and Postgres does
+    // not allow a bind parameter in identifier position. `table` is
+    // `RlsCase.table`, typed `&'static str` in `common::cases` and populated
+    // exclusively by literals in `common::matrix::RLS_MATRIX` — a closed set,
+    // with no user input reaching this string. Audited 2026-08-29.
     let sql = format!("SELECT count(*) FROM {table}");
-    match sqlx::query_scalar::<_, i64>(&sql)
+    match sqlx::query_scalar::<_, i64>(AssertSqlSafe(sql))
         .fetch_one(&mut **conn)
         .await
     {

--- a/crates/garraia-cli/tests/migrate_workspace_integration.rs
+++ b/crates/garraia-cli/tests/migrate_workspace_integration.rs
@@ -16,8 +16,8 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 use ring::pbkdf2;
 use std::num::NonZeroU32;
 
-use sqlx::PgPool;
 use sqlx::postgres::PgPoolOptions;
+use sqlx::{AssertSqlSafe, PgPool};
 use testcontainers::core::{ImageExt, WaitFor};
 use testcontainers::runners::AsyncRunner;
 use testcontainers::{ContainerAsync, GenericImage};
@@ -116,7 +116,12 @@ async fn apply_migrations(pool: &PgPool) {
             .and_then(|v| v.parse().ok())
             .unwrap_or(0);
         let sql = std::fs::read_to_string(&path).expect("read migration file");
-        sqlx::raw_sql(&sql)
+        // AssertSqlSafe: sqlx 0.9 only accepts `&'static str`, and this SQL is
+        // genuinely dynamic — it is the text of a migration file. `path` comes
+        // from walking `crates/garraia-workspace/migrations/`, i.e. files
+        // versioned in this repository; no user input reaches this string.
+        // Audited 2026-08-29.
+        sqlx::raw_sql(AssertSqlSafe(sql))
             .execute(pool)
             .await
             .unwrap_or_else(|e| panic!("apply migration {name}: {e}"));

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -69,7 +69,7 @@ thiserror = { workspace = true }
 # The handlers need sqlx types (`query_as`, transactions) directly.
 # Feature set mirrors dev-dependencies so prod + test link the
 # same version.
-sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "postgres", "uuid", "chrono", "macros", "derive"] }
+sqlx = { version = "0.9", default-features = false, features = ["runtime-tokio", "postgres", "uuid", "chrono", "macros", "derive"] }
 dirs = "6"
 governor = "0.10"
 tower_governor = "0.8"

--- a/crates/garraia-gateway/tests/rest_v1_message_attachments.rs
+++ b/crates/garraia-gateway/tests/rest_v1_message_attachments.rs
@@ -122,22 +122,18 @@ async fn seed_file(h: &Harness, group_id: Uuid, uploader_id: Uuid, deleted: bool
     let object_key = format!("test/{file_id}/v1/payload.bin");
     let hex64 = "a".repeat(64);
 
-    let deleted_at_expr = if deleted {
-        "'2000-01-01T00:00:00Z'::timestamptz"
-    } else {
-        "NULL"
-    };
-
-    sqlx::query(&format!(
+    sqlx::query(
         "INSERT INTO files \
             (id, group_id, name, size_bytes, mime_type, \
              created_by, created_by_label, deleted_at) \
          VALUES ($1, $2, 'test-file.bin', 1024, 'application/octet-stream', \
-                 $3, 'Test User', {deleted_at_expr})",
-    ))
+                 $3, 'Test User', \
+                 CASE WHEN $4 THEN '2000-01-01T00:00:00Z'::timestamptz ELSE NULL END)",
+    )
     .bind(file_id)
     .bind(group_id)
     .bind(uploader_id)
+    .bind(deleted)
     .execute(&h.admin_pool)
     .await
     .expect("seed files row");

--- a/crates/garraia-gateway/tests/rest_v1_task_attachments.rs
+++ b/crates/garraia-gateway/tests/rest_v1_task_attachments.rs
@@ -124,23 +124,19 @@ async fn seed_file(h: &Harness, group_id: Uuid, uploader_id: Uuid, deleted: bool
     // 64 lowercase hex chars satisfy both checksum_sha256 and integrity_hmac CHECK constraints.
     let hex64 = "a".repeat(64);
 
-    let deleted_at_expr = if deleted {
-        "'2000-01-01T00:00:00Z'::timestamptz"
-    } else {
-        "NULL"
-    };
-
     // files row — no folder (NULL folder_id is fine per migration 003 MATCH SIMPLE FK).
-    sqlx::query(&format!(
+    sqlx::query(
         "INSERT INTO files \
             (id, group_id, name, size_bytes, mime_type, \
              created_by, created_by_label, deleted_at) \
          VALUES ($1, $2, 'test-file.bin', 1024, 'application/octet-stream', \
-                 $3, 'Test User', {deleted_at_expr})",
-    ))
+                 $3, 'Test User', \
+                 CASE WHEN $4 THEN '2000-01-01T00:00:00Z'::timestamptz ELSE NULL END)",
+    )
     .bind(file_id)
     .bind(group_id)
     .bind(uploader_id)
+    .bind(deleted)
     .execute(&h.admin_pool)
     .await
     .expect("seed files row");

--- a/crates/garraia-workspace/Cargo.toml
+++ b/crates/garraia-workspace/Cargo.toml
@@ -22,7 +22,7 @@ rrule = { workspace = true }
 # is ever deployed across a public network, enable `tls-rustls` here and
 # document the change; do NOT silently promote to the workspace root sqlx dep
 # without verifying the TLS feature survives the promotion.
-sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "postgres", "uuid", "chrono", "migrate", "macros", "json"] }
+sqlx = { version = "0.9", default-features = false, features = ["runtime-tokio", "postgres", "uuid", "chrono", "migrate", "macros", "json"] }
 # Identifiers
 uuid = { version = "1", features = ["v7", "serde"] }
 # Timestamps

--- a/crates/garraia-workspace/tests/migration_smoke.rs
+++ b/crates/garraia-workspace/tests/migration_smoke.rs
@@ -10,6 +10,7 @@
 //!      `citext` unique constraint.
 
 use garraia_workspace::{Workspace, WorkspaceConfig};
+use sqlx::AssertSqlSafe;
 use testcontainers::ImageExt;
 use testcontainers::runners::AsyncRunner;
 use testcontainers_modules::postgres::Postgres as PgImage;
@@ -619,17 +620,22 @@ async fn migration_001_applies_and_schema_is_sane() -> anyhow::Result<()> {
         sqlx::query("SET LOCAL ROLE garraia_app")
             .execute(&mut *tx)
             .await?;
+        // `SET LOCAL <guc> = <value>` cannot take a bind parameter, but the
+        // equivalent `set_config(name, value, is_local => true)` can — so the
+        // SQL stays a static literal and the uuid travels as a bound value.
+        // Same pattern the gateway already uses in production (see
+        // `rest_v1/chats.rs`, `uploads_worker.rs`, `tasks_recurrence_worker.rs`).
         if let Some(gid) = group_id {
-            // Dynamic SET LOCAL via format! is intentional: SET LOCAL does
-            // not support parameter binding, and the value is a typed
-            // uuid::Uuid that sqlx already validated — no user input flows
-            // through this path. Safe by construction.
-            let stmt = format!("SET LOCAL app.current_group_id = '{gid}'");
-            sqlx::query(&stmt).execute(&mut *tx).await?;
+            sqlx::query("SELECT set_config('app.current_group_id', $1, true)")
+                .bind(gid.to_string())
+                .execute(&mut *tx)
+                .await?;
         }
         if let Some(uid) = user_id {
-            let stmt = format!("SET LOCAL app.current_user_id = '{uid}'");
-            sqlx::query(&stmt).execute(&mut *tx).await?;
+            sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+                .bind(uid.to_string())
+                .execute(&mut *tx)
+                .await?;
         }
         Ok(tx)
     }
@@ -880,8 +886,15 @@ async fn migration_001_applies_and_schema_is_sane() -> anyhow::Result<()> {
             "files",
             "file_versions",
         ] {
+            // AssertSqlSafe: sqlx 0.9 only accepts `&'static str`, and Postgres
+            // does not allow a bind parameter in identifier position. `table`
+            // comes from the hardcoded compile-time `&[&str]` immediately above
+            // — a closed set of literals, with no user input reaching this
+            // string. Audited 2026-08-29.
             let sql = format!("SELECT count(*) FROM {table}");
-            let count: i64 = sqlx::query_scalar(&sql).fetch_one(&mut *tx).await?;
+            let count: i64 = sqlx::query_scalar(AssertSqlSafe(sql))
+                .fetch_one(&mut *tx)
+                .await?;
             assert_eq!(
                 count, 0,
                 "cenário 3: unset settings must yield 0 rows on `{table}` (fail-closed)"


### PR DESCRIPTION
## Descrição

Atualiza sqlx de 0.8 para 0.9 em todos os crates e refatora queries dinâmicas para usar `AssertSqlSafe` onde necessário, alinhando-se com o novo enforcement de `&'static str` no sqlx 0.9. Também refatora `SET LOCAL` GUC interpolado para usar `set_config()` com bind parameters, eliminando string interpolation em SQL.

**Mudanças principais:**
1. **Upgrade sqlx 0.8 → 0.9** em `Cargo.toml` (workspace root + 4 crates)
2. **Refactor GUC settings** em `migration_smoke.rs`: substitui `SET LOCAL app.current_group_id = '{gid}'` por `SELECT set_config('app.current_group_id', $1, true)` com `.bind()`, eliminando interpolation
3. **Wrap dinâmicas com `AssertSqlSafe`** em 3 locais de teste:
   - `migration_smoke.rs`: `SELECT count(*) FROM {table}` (identifiers hardcoded em array literal)
   - `rls_matrix.rs`: `SELECT count(*) FROM {table}` (identifiers de `RLS_MATRIX` estático)
   - `migrate_workspace_integration.rs`: `sqlx::raw_sql()` com conteúdo de arquivo de migration (versionado no repo)
4. **Refactor seed queries** em `rest_v1_message_attachments.rs` e `rest_v1_task_attachments.rs`: substitui `if deleted { "'2000-01-01T00:00:00Z'::timestamptz" } else { "NULL" }` por `CASE WHEN $4 THEN ... END` com `.bind(deleted)`
5. **Atualiza CLAUDE.md** com regra explícita sobre `AssertSqlSafe`: uso permitido **apenas em testes**, com comentário de auditoria nomeando origem fechada do valor; dados sempre via `.bind()`; `SET LOCAL` nunca interpolado

Closes #<!-- nenhuma issue específica, refactor de segurança proativo -->

## Tipo de mudança

- [ ] `feat`: Nova funcionalidade
- [x] `refactor`: Refatoração sem mudança de comportamento
- [x] `docs`: Documentação apenas
- [x] `chore`: Manutenção (deps, CI, build)
- [x] `sec`: Correção ou hardening de segurança

## Classe de Risco

- [x] **Classe A (Baixo Risco)**: Upgrade de dependência com refactor de segurança em testes; nenhuma mudança em código de produção ou schema.

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo fmt --check` executado e limpo
- [x] `cargo clippy --workspace --exclude garraia-desktop -- -D warnings` sem erros
- [x] `cargo test --workspace --exclude garraia-desktop` passando localmente
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo, API key, token ou credencial commitada
- [x] Nenhuma migração Postgres com operações destrutivas

### Segurança SQL

- [x] Todas as queries dinâmicas em testes auditadas e comentadas
- [x] Identifiers hardcoded em arrays literais (compile-time, não user input)
- [x] Dados sempre via `.bind()`, nunca interpolados
- [x] `SET LOCAL` refatorado para `set_config()` com bind parameter

## Mudanças na API pública e Schema

- Nenhuma mudança na API pública
- Nenhuma mudança em schema Postgres
- Nenhuma mudança em assinatura

https://claude.ai/code/session_018NV7PicTY6Nn1RH1wBcFtQ