### PR TITLE
Potential fix for code scanning alert no. 161: Uncontrolled data used in path expression

### DIFF
--- a/crates/garraia-gateway/src/skins_handler.rs
+++ b/crates/garraia-gateway/src/skins_handler.rs
@@ -99,16 +99,41 @@ pub async fn get_skin(Path(name): Path<String>) -> impl IntoResponse {
         return bad_skin_name(&name, e);
     }
     let dir = skins_dir();
-    let file_path = dir.join(format!("{name}.json"));
-
-    if !file_path.is_file() {
+    if let Err(e) = tokio::fs::create_dir_all(&dir).await {
         return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "error": "skin not found" })),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": format!("failed to prepare skins dir: {e}") })),
+        );
+    }
+    let canonical_dir = match tokio::fs::canonicalize(&dir).await {
+        Ok(p) => p,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": format!("failed to resolve skins dir: {e}") })),
+            );
+        }
+    };
+
+    let file_path = dir.join(format!("{name}.json"));
+    let canonical_file = match tokio::fs::canonicalize(&file_path).await {
+        Ok(p) => p,
+        Err(_) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": "skin not found" })),
+            );
+        }
+    };
+
+    if !canonical_file.starts_with(&canonical_dir) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "invalid skin path" })),
         );
     }
 
-    match tokio::fs::read_to_string(&file_path).await {
+    match tokio::fs::read_to_string(&canonical_file).await {
         Ok(contents) => match serde_json::from_str::<Skin>(&contents) {
             Ok(skin) => (StatusCode::OK, Json(serde_json::json!({ "skin": skin }))),
             Err(e) => (


### PR DESCRIPTION
Potential fix for [https://github.com/michelbr84/GarraRUST/security/code-scanning/161](https://github.com/michelbr84/GarraRUST/security/code-scanning/161)

General fix: when user input influences file paths, enforce that the final resolved path remains inside a trusted base directory before any file operation. Keep input validation, but add containment validation as defense in depth.

Best concrete fix here (in `crates/garraia-gateway/src/skins_handler.rs`, inside `get_skin`):
1. Keep `validate_skill_name(&name)` as-is.
2. Ensure the skins directory exists (`tokio::fs::create_dir_all(&dir).await`) so canonicalization can succeed deterministically.
3. Canonicalize the base `dir`.
4. Build `file_path` from the validated name, then canonicalize the candidate path if it exists.
5. If canonicalization succeeds but path is outside canonical base dir, return `400`.
6. If the file doesn’t exist, preserve existing `404` behavior.
7. Read using the canonicalized safe path.

No new dependencies are needed; use `tokio::fs::canonicalize` and existing `axum` response types.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
