### PR TITLE
chore: migrate rmcp 1.7 → 2.2, align model types with MCP spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,17 @@ jobs:
         # scripts/build-installer.ps1.
         run: cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings
 
+      - name: Run clippy (mcp-http)
+        # A feature `mcp-http` é OFF por default em toda a árvore, então o
+        # step acima NUNCA compila `McpManager::connect_http` nem o transporte
+        # Streamable HTTP do rmcp — nenhum job passava `--features mcp-http`
+        # ou `--all-features`. Plan 0358: o bump rmcp 1.7 -> 2.2 quebrou
+        # exatamente esse caminho (o rmcp 2.2.0 declara `sse-stream = "0.2"`
+        # mas usa `SseStream::from_bytes_stream`, que só existe a partir da
+        # 0.2.4), e nada no CI teria pegado. Este step fecha o buraco.
+        # `garraia` é o nome do pacote em `crates/garraia-cli/`.
+        run: cargo clippy -p garraia --features mcp-http --all-targets -- -D warnings
+
   # Supply-chain gate: license allow-list + crate bans + registry source bans
   # + RustSec advisories. Uses deny.toml at the repo root. Runs in parallel
   # with clippy. Now invokes the `cargo-deny-action` default `command: check`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   writer → reader → xref → content stream → extração. Verde na 0.42 e na 0.44.
 
 ### Changed
+- **`rmcp` 1.7 → 2.2**, alinhando os tipos de modelo à spec MCP 2025-11-25
+  (upstream `rust-sdk#927`). O SDK dissolveu duas camadas: `Content`
+  (`= Annotated<RawContent>`) e o próprio `RawContent` viraram o enum achatado
+  `ContentBlock`, e `PromptMessageRole`/`PromptMessageContent` viraram
+  `Role`/`ContentBlock`. Migrados os três call sites — a ponte de tools MCP, o
+  formatador de prompts e o servidor `garra mcp-server`. O **formato de wire não
+  mudou**: o handshake real continua emitindo `{"type":"text","text":…}`, e o
+  transcript de evidência em `docs/integrations/hermes-mcp.md` foi regravado a
+  partir de uma execução de verdade contra a 2.2.0. Detalhes em `plans/0358`.
+- `sse-stream` 0.2.3 → 0.2.5 no lock. O rmcp 2.2.0 declara `sse-stream = "0.2"`
+  mas usa `SseStream::from_bytes_stream`, que só existe a partir da 0.2.4 —
+  under-specification upstream que quebrava o build com `--features mcp-http`.
 - **Modelo Ollama padrão passa a ser `qwen3.8:latest`** (resolve para
   `qwen3.8:27b` — Q4_K_M, ~18 GB, 262 144 tokens de contexto, visão +
   tools), no lugar de `llama3.1`. Atualizado no provider, na CLI, no wizard,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7377,9 +7377,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.7.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7404,9 +7404,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.7.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -8551,9 +8551,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
 dependencies = [
  "bytes",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,12 @@ teloxide = { version = "0.17", default-features = false, features = ["rustls", "
 tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
 
 # MCP (Model Context Protocol)
-rmcp = { version = "1.7" }
+# 2.2 alinha os tipos de modelo à spec MCP 2025-11-25 (upstream rust-sdk#927):
+# `Annotated<RawContent>`/`RawContent`/`Content` viraram o enum achatado
+# `ContentBlock`, e `PromptMessageRole`/`PromptMessageContent` viraram
+# `Role`/`ContentBlock`. Migração em plans/0358. O salto para 3.x segue
+# adiado (tracker interno #163).
+rmcp = { version = "2.2" }
 
 # System / OS interop
 libc = "0.2"

--- a/TODO.md
+++ b/TODO.md
@@ -27,9 +27,10 @@ curtos para a próxima sessão autônoma.
   (`required-features`). Promover a required check: tracker interno #164.
 - **Deps consolidadas** (PR #844): jsonwebtoken 11, validator 0.21, base64
   0.23, serial_test 4, itertools 0.15, uuid/tauri, e **wasmtime 47 em par**
-  (grupo dependabot novo evita o par quebrado). rmcp segue adiado com
-  `@dependabot ignore` → tracker interno #163; lopdf destravado em 2026-08-29
-  (0.42→0.44 com a feature `time` off, plan 0356). h2 0.4.16 (RUSTSEC-2026-0258).
+  (grupo dependabot novo evita o par quebrado). lopdf destravado em 2026-08-29
+  (0.42→0.44 com a feature `time` off, plan 0356) e **rmcp destravado no
+  mesmo dia** (1.7→2.2, `ContentBlock`, plan 0358) — do #163 resta só o salto
+  3.x. h2 0.4.16 (RUSTSEC-2026-0258).
 - **CI higiene** (PR #842): `timeout-minutes` em e2e/playwright (2 runs de 6h
   presos no download do Chromium em 2026-08-17), `Cross.toml` para o build
   ARM64.
@@ -256,8 +257,13 @@ curtos para a próxima sessão autônoma.
    pela primeira vez** após o fix do baseline no plan 0354).
 2. Promover `Auth Integration (test-support)` a required check do ruleset após
    ~1 semana sem flakes (tracker interno #164).
-3. Retomar o upgrade adiado do rmcp 1.7→3.x quando houver janela (tracker
-   interno #163). lopdf 0.44 entregue em 2026-08-29 (plan 0356) — a feature
+3. Retomar o salto **rmcp 2.2→3.x** quando houver janela (tracker interno
+   #163). O degrau 1.7→2.2 foi entregue em 2026-08-29 (plan 0358); o 3.x mantém
+   `ContentBlock`/`Role`/`PromptMessage` e as features que usamos, mas adiciona
+   módulos novos (`mrtr`, `request_state`, `service/client/`, `mcp_headers`)
+   ainda não auditados. O `@dependabot ignore` de rmcp foi aplicado por
+   comentário em PR, não pelo `.github/dependabot.yml` — mergear o 2.2 **não** o
+   limpa sozinho. lopdf 0.44 entregue em 2026-08-29 (plan 0356) — a feature
    `time` fica desligada até um release > 0.44.0 trazer o fix do upstream #518.
 4. Re-triage do RUSTSEC-2026-0253 (`lru` via aws-sdk-s3) até 2026-11-14
    (tracker interno #162).

--- a/crates/garraia-agents/src/mcp/manager.rs
+++ b/crates/garraia-agents/src/mcp/manager.rs
@@ -761,12 +761,18 @@ impl McpManager {
             .messages
             .into_iter()
             .map(|m| {
+                // rmcp 2.2 (spec MCP 2025-11-25) dissolveu os enums específicos
+                // de prompt: `PromptMessageRole` virou o `Role` compartilhado e
+                // `PromptMessageContent` virou o `ContentBlock` unificado.
+                // `Role` é intencionalmente exaustivo (User/Assistant), então
+                // não leva braço curinga; `ContentBlock` é `#[non_exhaustive]`
+                // e leva.
                 let role = match m.role {
-                    rmcp::model::PromptMessageRole::User => "user",
-                    rmcp::model::PromptMessageRole::Assistant => "assistant",
+                    rmcp::model::Role::User => "user",
+                    rmcp::model::Role::Assistant => "assistant",
                 };
                 let text = match m.content {
-                    rmcp::model::PromptMessageContent::Text { text } => text,
+                    rmcp::model::ContentBlock::Text(text_content) => text_content.text,
                     _ => "(non-text content)".to_string(),
                 };
                 format!("[{role}] {text}")

--- a/crates/garraia-agents/src/mcp/tool_bridge.rs
+++ b/crates/garraia-agents/src/mcp/tool_bridge.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use garraia_common::{Error, Result};
-use rmcp::model::{CallToolRequestParams, RawContent};
+use rmcp::model::{CallToolRequestParams, ContentBlock};
 use serde_json::Value;
 use tracing::info;
 
@@ -137,12 +137,17 @@ impl Tool for McpTool {
                 ))
             })?;
 
-        // Converte conteúdos retornados pelo MCP em texto único
+        // Converte conteúdos retornados pelo MCP em texto único.
+        //
+        // rmcp 2.2 removeu a camada `Annotated<RawContent>` (o campo `.raw`) em
+        // favor do enum achatado `ContentBlock`, alinhado à spec MCP
+        // 2025-11-25. O braço `_` é obrigatório: `ContentBlock` é
+        // `#[non_exhaustive]` e ganha variantes novas a cada revisão da spec.
         let mut partes_texto = Vec::new();
         for content in &resultado.content {
-            match &content.raw {
-                RawContent::Text(text_content) => {
-                    partes_texto.push(text_content.text.to_string());
+            match content {
+                ContentBlock::Text(text_content) => {
+                    partes_texto.push(text_content.text.clone());
                 }
                 _ => {
                     // Conteúdo não textual recebe placeholder

--- a/crates/garraia-cli/src/mcp_server.rs
+++ b/crates/garraia-cli/src/mcp_server.rs
@@ -1,7 +1,7 @@
 //! GAR-583 — MCP server exposing `garra ask` as a stdio tool.
 //!
 //! Implements the `Model Context Protocol` (MCP) `ServerHandler` trait
-//! from `rmcp 1.6` and exposes a single tool — `garra_ask` — that calls
+//! from `rmcp 2.2` and exposes a single tool — `garra_ask` — that calls
 //! [`crate::ask::ask_oneshot`] **in-process** (no subprocess spawn, no
 //! shell). Designed for Claude Desktop, Claude Code, and any MCP host
 //! that speaks stdio JSON-RPC.
@@ -22,7 +22,7 @@ use anyhow::Result;
 use garraia_config::AppConfig;
 use rmcp::ErrorData as McpError;
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, Content, ListToolsResult, PaginatedRequestParams,
+    CallToolRequestParams, CallToolResult, ContentBlock, ListToolsResult, PaginatedRequestParams,
     ServerCapabilities, ServerInfo, Tool,
 };
 use rmcp::service::RequestContext;
@@ -307,15 +307,15 @@ impl GarraToolHandler {
 
 impl ServerHandler for GarraToolHandler {
     /// GAR-585 — advertise the `tools` capability in the `initialize`
-    /// handshake. Without this override, `rmcp 1.6`'s default `get_info`
+    /// handshake. Without this override, rmcp's default `get_info`
     /// returns `ServerInfo::default()` whose `capabilities` field is
     /// empty (`{}`); MCP hosts (Claude Code's `/mcp` panel, Claude
     /// Desktop) read that as "no tools" and never call `tools/list`,
     /// leaving `garra_ask` invisible to the model even though the
     /// `list_tools` handler below is wired correctly.
     ///
-    /// Mirrors the canonical example in `rmcp-1.6.0/tests/common/
-    /// calculator.rs` (`enable_tools()` flips `tools` to
+    /// Mirrors the canonical example in `rmcp`'s own
+    /// `tests/common/calculator.rs` (`enable_tools()` flips `tools` to
     /// `Some(ToolsCapability::default())`). No other capabilities are
     /// enabled here on purpose — see `get_info_advertises_only_tools_capability`.
     fn get_info(&self) -> ServerInfo {
@@ -394,7 +394,10 @@ impl ServerHandler for GarraToolHandler {
                 "{\"schema\":\"garra.ask.v1\",\"ok\":false,\"error\":{\"kind\":\"io\",\"message\":\"json serialization failed\"}}",
             )
         });
-        let content = vec![Content::text(text)];
+        // rmcp 2.2 removeu o alias `Content` (era `Annotated<RawContent>`); o
+        // tipo agora é o enum achatado `ContentBlock`, que `CallToolResult::
+        // success`/`error` recebem como `Vec<ContentBlock>`.
+        let content = vec![ContentBlock::text(text)];
         if outcome.is_ok() {
             Ok(CallToolResult::success(content))
         } else {

--- a/docs/integrations/hermes-mcp.md
+++ b/docs/integrations/hermes-mcp.md
@@ -54,13 +54,13 @@ build; produção permanece sem o caminho keyless.
 
 Transcript de `initialize → tools/list → tools/call` contra o binário
 com `dev-echo-provider` (evidência colada do teste executado em
-2026-08-28):
+2026-08-29, já contra o rmcp 2.2 — ver plan 0358):
 
 ```text
 >>> {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25",
      "capabilities":{},"clientInfo":{"name":"hermes-e2e-test","version":"1.0.0"}}}
 <<< {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-11-25",
-     "capabilities":{"tools":{}},"serverInfo":{"name":"rmcp","version":"1.7.0"}}}
+     "capabilities":{"tools":{}},"serverInfo":{"name":"rmcp","version":"2.2.0"}}}
 >>> {"jsonrpc":"2.0","method":"notifications/initialized"}
 >>> {"jsonrpc":"2.0","id":2,"method":"tools/list"}
 <<< ... tools: ["garra_ask"], provider enum: ["ollama","anthropic","openai","openrouter","echo"] ...

--- a/plans/0358-rmcp-220-content-block-migration.md
+++ b/plans/0358-rmcp-220-content-block-migration.md
@@ -1,0 +1,190 @@
+# Plan 0358 — rmcp 1.7 → 2.2 (`ContentBlock` e o fim do `Annotated<RawContent>`)
+
+**Status:** 🚧 Em revisão
+**Branch:** `claude/rmcp-2-2-0-migration-iz08vr`
+**Origem:** Dependabot PR #853 (`dependabot/cargo/rmcp-2.2.0`), 9 jobs de CI vermelhos
+**Data:** 2026-08-29 (America/New_York)
+
+## Goal
+
+Destravar o bump do `rmcp`, adiado desde o PR #844 com `@dependabot ignore`
+(tracker interno #163), migrando o código para a API alinhada à spec MCP
+2025-11-25.
+
+## Root cause
+
+A 2.2.0 traz *"[breaking] align model types with MCP 2025-11-25 spec"*
+(upstream `modelcontextprotocol/rust-sdk#927`). A mudança dissolve duas camadas
+de indireção. Na 1.7 o conteúdo era embrulhado:
+
+```rust
+pub struct Annotated<T: AnnotateAble> { #[serde(flatten)] pub raw: T, pub annotations: ... }
+pub type Content = Annotated<RawContent>;          // model/content.rs:161
+pub enum RawContent { Text(RawTextContent), ... }  // model/content.rs:153
+```
+
+Na 2.2 tudo virou um enum achatado, com `annotations` embutido em cada struct:
+
+```rust
+#[non_exhaustive]
+pub enum ContentBlock { Text(TextContent), Image, Audio, Resource, ResourceLink }
+pub struct TextContent { pub text: String, pub meta: ..., pub annotations: ... }
+pub struct PromptMessage { pub role: Role, pub content: ContentBlock }
+```
+
+`rg 'RawContent|AnnotateAble|\bAnnotated\b|PromptMessageRole|PromptMessageContent'`
+no source da 2.2.0 retorna **zero hits**: a família `Raw*`, o wrapper
+`Annotated<T>`, o alias `Content` e os dois enums específicos de prompt foram
+todos removidos.
+
+Importante: **o formato de wire não mudou** — o handshake continua emitindo
+`{"type":"text","text":...}`. A quebra é exclusivamente na superfície de tipos
+Rust.
+
+## Fix
+
+Seis edições de código em três arquivos, mais o manifesto. Verificado símbolo a
+símbolo contra os `.crate` de 1.7.0 e 2.2.0 baixados do crates.io (docs.rs está
+bloqueado pelo proxy de egress desta sessão).
+
+| Local | De | Para |
+|---|---|---|
+| `tool_bridge.rs:6` | `use rmcp::model::{CallToolRequestParams, RawContent}` | `…, ContentBlock}` |
+| `tool_bridge.rs:143-144` | `match &content.raw { RawContent::Text(tc) =>` | `match content { ContentBlock::Text(tc) =>` |
+| `tool_bridge.rs:145` | `tc.text.to_string()` | `tc.text.clone()` (o campo é `String`; o `match` liga `&TextContent`) |
+| `manager.rs:770-771` | `PromptMessageRole::{User,Assistant}` | `Role::{User,Assistant}` |
+| `manager.rs:775` | `PromptMessageContent::Text { text } => text` | `ContentBlock::Text(tc) => tc.text` |
+| `mcp_server.rs:25,397` | `Content` / `Content::text(…)` | `ContentBlock` / `ContentBlock::text(…)` |
+
+O braço `_` continua obrigatório nos dois `match` de `ContentBlock`: o enum é
+`#[non_exhaustive]`. Já `Role` é `#[expect(clippy::exhaustive_enums)]`, então o
+match de 2 braços compila sem curinga.
+
+**Não** seguir a sugestão do compilador (`rmcp::model::PromptMessage::User`):
+`PromptMessage` virou struct, não enum.
+
+### A quebra que o CI não mostrou
+
+O log do `Build Check` do #853 lista 5 erros, todos em `garraia-agents`, e
+então aborta (*"build failed, waiting for other jobs to finish"*) — **sem
+nunca compilar o `garraia-cli`**. `mcp_server.rs` importa `rmcp::model::Content`
+(:25) e chama `Content::text` (:397), ambos removidos na 2.2. Corrigir apenas os
+5 erros reportados produziria uma segunda rodada de CI vermelho.
+
+### O buraco de CI que este plan fecha
+
+`mcp-http` é OFF por default em toda a árvore e **nenhum** job do CI passava
+`--features mcp-http` ou `--all-features` — logo `McpManager::connect_http` e o
+transporte Streamable HTTP nunca eram compilados. O bump quebrou exatamente esse
+caminho, e de um jeito que nenhum grep no nosso código acharia:
+
+```
+error[E0599]: no associated function named `from_bytes_stream` found for struct `SseStream<B>`
+  --> rmcp-2.2.0/src/transport/common/reqwest/streamable_http_client.rs:87
+```
+
+O rmcp 2.2.0 declara `sse-stream = "0.2"` mas usa `SseStream::from_bytes_stream`,
+que só existe a partir da **0.2.4** — under-specification upstream. Nosso lock
+carregava `0.2.3` da resolução antiga. Resolvido com `cargo update -p sse-stream`
+(0.2.3 → 0.2.5, semver-compatível), e o step novo de clippy no `ci.yml` impede a
+regressão.
+
+## Verificado como NÃO precisando de mudança
+
+Levantado explicitamente para evitar churn defensivo:
+
+- **`ServerCapabilities`** — os 8 campos (`experimental`, `extensions`, `logging`,
+  `completions`, `prompts`, `resources`, `tools`, `tasks`) são idênticos entre
+  1.7 e 2.2, então `get_info_advertises_only_tools_capability` segue válido.
+- **`ListToolsResult { tools, next_cursor, meta }`** — a macro `paginated_result!`
+  marca `#[expect(clippy::exhaustive_structs)]`, **não** `#[non_exhaustive]`; o
+  struct literal em `mcp_server.rs:330` compila. É o único struct literal de tipo
+  rmcp no repo inteiro.
+- **`Resource` / `Prompt` / `PromptArgument`** — deixaram de ser `Annotated<RawX>`
+  e viraram structs achatados, mas com nomes e tipos de campo idênticos. Como
+  `Annotated<T>` fazia `Deref<Target = T>`, os acessos em `manager.rs` (`r.uri
+  .to_string()`, `.description.as_deref()`, `a.required.unwrap_or(false)`)
+  compilam nas duas versões.
+- **`ResourceContents::TextResourceContents { text, .. }`** — variantes e campos
+  idênticos; virou `#[non_exhaustive]`, e o braço `_ => None` já existia.
+- **Nomes de features** — `client`, `server`, `macros`, `transport-child-process`,
+  `transport-io`, `transport-streamable-http-client-reqwest` inalterados: nenhum
+  `Cargo.toml` de crate muda.
+- **Split reqwest 0.12/0.13** — a 2.2 continua em `reqwest 0.13.2`, igual à 1.7.
+  O gap de DNS-pinning documentado em `manager.rs:44-58` **permanece correto** e
+  não foi editado.
+- **Versão de protocolo** — `ProtocolVersion::LATEST` é `2025-11-25` nas duas
+  versões e o client não valida a versão do servidor, então o fixture
+  `fake_mcp_server.py` (`2025-06-18`) segue funcionando sem alteração.
+
+## Cobertura de runtime
+
+`crates/garraia-agents/tests/mcp_lifecycle.rs::tool_survives_reconnect` é o único
+teste que exercita o caminho de decode alterado de ponta a ponta — ele afirma
+que a saída da tool contém `"pong"`, o que só acontece se o braço
+`ContentBlock::Text` extrair o texto. Verde.
+
+Além disso, o handshake completo foi executado de verdade contra o binário
+recompilado (`initialize → tools/list → tools/call`, provider `echo` keyless), e
+o transcript em `docs/integrations/hermes-mcp.md` foi atualizado com a saída
+real — `"serverInfo":{"name":"rmcp","version":"2.2.0"}` — em vez de editado à
+mão.
+
+## Out of scope
+
+- Salto para **rmcp 3.1.4** (tracker interno #163 segue aberto). O 3.x mantém
+  `ContentBlock`/`Role`/`PromptMessage` e todas as features que usamos, mas
+  adiciona módulos novos (`mrtr`, `request_state`, `service/client/`,
+  `mcp_headers`) cujas breaking changes não foram auditadas aqui.
+- Cobertura de teste para o handler `call_tool` de `mcp_server.rs` (:337-403),
+  que hoje tem zero — só os helpers têm.
+
+## File structure
+
+| Arquivo | Mudança |
+|---|---|
+| `crates/garraia-agents/src/mcp/tool_bridge.rs` | import + loop de decode |
+| `crates/garraia-agents/src/mcp/manager.rs` | `Role` + `ContentBlock` em `get_prompt` |
+| `crates/garraia-cli/src/mcp_server.rs` | import + `ContentBlock::text` + prosa "rmcp 1.6" desatualizada |
+| `Cargo.toml` | `rmcp = { version = "2.2" }` + comentário de justificativa |
+| `Cargo.lock` | `rmcp`/`rmcp-macros` 1.7.0→2.2.0, `sse-stream` 0.2.3→0.2.5 |
+| `.github/workflows/ci.yml` | step novo `Run clippy (mcp-http)` no job `clippy` |
+| `docs/integrations/hermes-mcp.md` | transcript real do handshake contra a 2.2.0 |
+| `CHANGELOG.md` | `[Unreleased]` → Changed |
+| `TODO.md` | rmcp sai da lista de upgrades adiados |
+| `plans/README.md` | linha de índice 0358 |
+
+O diff do `Cargo.lock` fica restrito a 3 pacotes — `rmcp`, `rmcp-macros`,
+`sse-stream`.
+
+## Acceptance criteria
+
+- [x] `cargo check -p garraia-agents --features mcp` limpo (os 5 erros do #853 somem)
+- [x] `cargo check -p garraia` limpo (a 6ª quebra latente, que o CI nunca alcançou)
+- [x] `cargo check -p garraia --features mcp-http` limpo (caminho sem cobertura de CI)
+- [x] `cargo test -p garraia-agents --test mcp_lifecycle` — 3/3, incl. `tool_survives_reconnect`
+- [x] `cargo test -p garraia --bin garra mcp_server` — 32/32, incl. os dois `audit_…` que varrem o próprio source
+- [x] `cargo fmt --check --all` limpo
+- [x] `cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings` limpo
+- [x] `cargo clippy -p garraia --features mcp-http --all-targets -- -D warnings` limpo
+- [x] Handshake MCP real (`initialize → tools/list → tools/call`) verde contra a 2.2.0
+
+## Risk register
+
+| Risco | Prob. | Mitigação |
+|---|---|---|
+| Comentário de migração citar string proibida e quebrar os testes `audit_…` de `mcp_server.rs`, que fazem `include_str!` do próprio arquivo | Média — é uma armadilha não óbvia | Comentários redigidos sem as strings da lista; 32/32 verdes |
+| `mcp-http` quebrar sem ninguém ver | **Materializou-se** (E0599 do `sse-stream`) | `cargo update -p sse-stream` + step novo no `ci.yml` |
+| Alguma variante nova de `ContentBlock` cair no placeholder silenciosamente | Baixa | Comportamento idêntico ao anterior — o `_` já existia na 1.7 |
+| `Role` ganhar variante e quebrar o match de 2 braços | Baixa | É `#[expect(clippy::exhaustive_enums)]` upstream, intencionalmente exaustivo |
+
+Rollback: nada aqui toca config, migrations, schema ou API pública. `git revert`
+simples restaura `rmcp = "1.7"` e o código antigo.
+
+## Cross-references
+
+- Dependabot PR #853 (rmcp 2.2.0) — superseded por este trabalho
+- Upstream `modelcontextprotocol/rust-sdk#927` (align model types with MCP 2025-11-25)
+- plan 0356 (lopdf 0.42 → 0.44) — precedente direto de bump com compat fix
+- plans 0102 / 0103 / 0104 (GAR-583 / 585 / 587) — descrevem a API rmcp 1.6 em prosa
+- TODO.md — tracker interno #163 (rmcp), agora reduzido ao salto 3.x

--- a/plans/README.md
+++ b/plans/README.md
@@ -368,3 +368,4 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0355 | [Robustez sempre-online: ciclo de vida MCP + recorrência](0355-recurrence-and-mcp-lifecycle.md) | plan 0355 (origem) | ✅ Entregue 2026-08-29 (ADR 0013) |
 | 0356 | [lopdf 0.42 → 0.44 com a feature `time` desligada (E0599 do BorrowedFormatItem)](0356-lopdf-044-time-feature-off.md) | Dependabot PR #851 / upstream lopdf#518 | 🚧 Em revisão (2026-08-29) |
 | 0357 | [Padrão `qwen3.8`, `garraia --model <tag>` e preparo para `ollama launch`](0357-ollama-defaults-and-launch.md) | pedido direto | ✅ Entregue 2026-08-29 |
+| 0358 | [rmcp 1.7 → 2.2 (`ContentBlock` e o fim do `Annotated<RawContent>`)](0358-rmcp-220-content-block-migration.md) | Dependabot PR #853 / upstream rust-sdk#927 | 🚧 Em revisão (2026-08-29) |


### PR DESCRIPTION
## Descrição

Destravar o bump do `rmcp` de 1.7 para 2.2, migrando o código para a API alinhada à spec MCP 2025-11-25 (upstream `modelcontextprotocol/rust-sdk#927`). A 2.2 dissolve duas camadas de indireção: `Annotated<RawContent>` e `RawContent` viraram o enum achatado `ContentBlock`, e `PromptMessageRole`/`PromptMessageContent` viraram `Role`/`ContentBlock`.

**Importante:** o formato de wire não mudou — o handshake continua emitindo `{"type":"text","text":…}`. A quebra é exclusivamente na superfície de tipos Rust.

Closes #853 (Dependabot PR rmcp 2.2.0)

## Tipo de mudança

- [x] `chore`: Manutenção (deps, CI, build)

## Classe de Risco

- [x] **Classe B (Médio Risco)**: Atualização de dependência em produção, refatoração interna sem alteração de schema ou API pública.

## Mudanças na API pública e Schema

- Nenhuma mudança na API pública
- Nenhuma mudança em schema ou migrations

## Detalhes técnicos

### Seis edições de código em três arquivos

| Local | De | Para |
|---|---|---|
| `tool_bridge.rs:6` | `use rmcp::model::{CallToolRequestParams, RawContent}` | `…, ContentBlock}` |
| `tool_bridge.rs:143-144` | `match &content.raw { RawContent::Text(tc) =>` | `match content { ContentBlock::Text(tc) =>` |
| `tool_bridge.rs:145` | `tc.text.to_string()` | `tc.text.clone()` |
| `manager.rs:770-771` | `PromptMessageRole::{User,Assistant}` | `Role::{User,Assistant}` |
| `manager.rs:775` | `PromptMessageContent::Text { text } => text` | `ContentBlock::Text(tc) => tc.text` |
| `mcp_server.rs:25,397` | `Content` / `Content::text(…)` | `ContentBlock` / `ContentBlock::text(…)` |

### Buraco de CI fechado

O `mcp-http` é OFF por default em toda a árvore e nenhum job do CI passava `--features mcp-http` — logo `McpManager::connect_http` nunca era compilado. O bump quebrou exatamente esse caminho: rmcp 2.2.0 declara `sse-stream = "0.2"` mas usa `SseStream::from_bytes_stream`, que só existe a partir da 0.2.4 (under-specification upstream). Resolvido com `cargo update -p sse-stream` (0.2.3 → 0.2.5) e novo step de clippy no `ci.yml` que passa `--features mcp-http`.

### Verificado como NÃO precisando de mudança

- **`ServerCapabilities`** — 8 campos idênticos entre 1.7 e 2.2
- **`ListToolsResult`** — struct literal em `mcp_server.rs:330` compila nas duas versões
- **`Resource` / `Prompt` / `PromptArgument`** — nomes e tipos de campo idênticos; acessos via `Deref` funcionam nas duas
- **`ResourceContents`** — variantes e campos idênticos
- **Nomes de features** — `client`, `server`, `macros`, `transport-*` inalterados
- **Split reqwest 0.12/0.13** — 2.2 continua em 0.13.2
- **Vers

https://claude.ai/code/session_01VN3ZZqHvomtqVGXiS5dJw9