### PR TITLE
Potential fix for code scanning alert no. 161: Uncontrolled data used in path expression

### DIFF
--- a/crates/garraia-gateway/src/skins_handler.rs
+++ b/crates/garraia-gateway/src/skins_handler.rs
@@ -156,14 +156,34 @@ pub async fn delete_skin(Path(name): Path<String>) -> impl IntoResponse {
     let dir = skins_dir();
     let file_path = dir.join(format!("{name}.json"));
 
-    if !file_path.is_file() {
+    let canonical_dir = match tokio::fs::canonicalize(&dir).await {
+        Ok(path) => path,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": format!("failed to resolve skins dir: {e}") })),
+            );
+        }
+    };
+
+    let canonical_file = match tokio::fs::canonicalize(&file_path).await {
+        Ok(path) => path,
+        Err(_) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": "skin not found" })),
+            );
+        }
+    };
+
+    if !canonical_file.starts_with(&canonical_dir) {
         return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "error": "skin not found" })),
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "invalid skin path" })),
         );
     }
 
-    match tokio::fs::remove_file(&file_path).await {
+    match tokio::fs::remove_file(&canonical_file).await {
         Ok(_) => (StatusCode::OK, Json(serde_json::json!({ "ok": true }))),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
Potential fix for [https://github.com/michelbr84/GarraRUST/security/code-scanning/161](https://github.com/michelbr84/GarraRUST/security/code-scanning/161)

To fix this safely without changing behavior, keep the existing `validate_skill_name` check and add a directory-containment check in `delete_skin`, mirroring the secure pattern used in `get_skin`:

- Build the candidate path as today.
- Canonicalize both the skins directory and the candidate file path.
- If canonicalization of the file fails, return `404 skin not found`.
- If canonicalized file is not within canonicalized skins directory, return `400` (or reject similarly to invalid name).
- Perform `remove_file` on the canonicalized file path.

This ensures that even if validation logic changes or misses an edge case, deletion cannot escape the configured skins directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
