### PR TITLE
sec: fix nonce generation in AES-256-GCM encryption

### DIFF
--- a/crates/garraia-gateway/src/admin/secrets.rs
+++ b/crates/garraia-gateway/src/admin/secrets.rs
@@ -2,8 +2,8 @@ use axum::Json;
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
-use ring::aead::{AES_256_GCM, Aad, LessSafeKey, Nonce, UnboundKey};
-use ring::rand::{SecureRandom, SystemRandom};
+use ring::aead::{AES_256_GCM, Aad, LessSafeKey, NONCE_LEN, Nonce, UnboundKey};
+use ring::rand::SystemRandom;
 
 use super::middleware::{AuthenticatedAdmin, extract_ip};
 use super::rbac::{Action, Resource, check_permission};
@@ -422,20 +422,26 @@ pub(super) fn encrypt_value(plaintext: &[u8], key: &[u8]) -> Result<(Vec<u8>, Ve
         .map_err(|_| "failed to create encryption key".to_string())?;
     let aead_key = LessSafeKey::new(unbound);
 
+    // Nonce straight from the CSPRNG. `ring::rand::generate` hands back the
+    // array already filled, so no zeroed buffer exists in between — the
+    // `vec![0u8; 12]` this replaced was what CodeQL read as a hard-coded
+    // cryptographic value (alert #142), even though `fill` overwrote it on the
+    // next line. Two smaller wins come with it: the length is `NONCE_LEN`
+    // rather than a literal 12, and `assume_unique_for_key` is infallible over
+    // `[u8; NONCE_LEN]`, so there is one fewer error arm.
     let rng = SystemRandom::new();
-    let mut nonce_bytes = vec![0u8; 12];
-    rng.fill(&mut nonce_bytes)
-        .map_err(|_| "failed to generate nonce".to_string())?;
+    let nonce_bytes: [u8; NONCE_LEN] = ring::rand::generate(&rng)
+        .map_err(|_| "failed to generate nonce".to_string())?
+        .expose();
 
-    let nonce =
-        Nonce::try_assume_unique_for_key(&nonce_bytes).map_err(|_| "invalid nonce".to_string())?;
+    let nonce = Nonce::assume_unique_for_key(nonce_bytes);
 
     let mut in_out = plaintext.to_vec();
     aead_key
         .seal_in_place_append_tag(nonce, Aad::empty(), &mut in_out)
         .map_err(|_| "encryption failed".to_string())?;
 
-    Ok((in_out, nonce_bytes))
+    Ok((in_out, nonce_bytes.to_vec()))
 }
 
 pub(super) fn decrypt_value(
@@ -486,5 +492,53 @@ pub(super) fn redact_config_secrets(config: &mut garraia_config::AppConfig) {
                 *val = serde_json::json!("***REDACTED***");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// AES-256 key. Not a credential: a fixed byte pattern is enough to drive
+    /// the AEAD, and the property under test is the *nonce*, not the key.
+    const TEST_KEY: [u8; 32] = [7u8; 32];
+
+    #[test]
+    fn encrypt_decrypt_roundtrip() {
+        let (ciphertext, nonce) =
+            encrypt_value(b"sk-live-roundtrip", &TEST_KEY).expect("encrypt should succeed");
+        let plaintext =
+            decrypt_value(&ciphertext, &nonce, &TEST_KEY).expect("decrypt should succeed");
+        assert_eq!(plaintext, b"sk-live-roundtrip");
+    }
+
+    #[test]
+    fn nonce_has_aead_length() {
+        let (_, nonce) = encrypt_value(b"x", &TEST_KEY).expect("encrypt should succeed");
+        assert_eq!(nonce.len(), NONCE_LEN);
+    }
+
+    /// The assertion that keeps CodeQL alert #142 honest: the nonce is drawn
+    /// per call, so the same plaintext under the same key never encrypts to the
+    /// same bytes. A hard-coded nonce would make both of these equal — and
+    /// reusing a nonce under one AES-GCM key is a real break, not a lint.
+    #[test]
+    fn nonce_is_fresh_per_call() {
+        let (first_ct, first_nonce) = encrypt_value(b"same-plaintext", &TEST_KEY).expect("encrypt");
+        let (second_ct, second_nonce) =
+            encrypt_value(b"same-plaintext", &TEST_KEY).expect("encrypt");
+
+        assert_ne!(first_nonce, second_nonce, "nonce must not repeat");
+        assert_ne!(first_ct, second_ct, "ciphertext must not repeat");
+
+        // Both still decrypt: freshness must not have cost correctness.
+        assert_eq!(
+            decrypt_value(&first_ct, &first_nonce, &TEST_KEY).expect("decrypt first"),
+            b"same-plaintext"
+        );
+        assert_eq!(
+            decrypt_value(&second_ct, &second_nonce, &TEST_KEY).expect("decrypt second"),
+            b"same-plaintext"
+        );
     }
 }


### PR DESCRIPTION
## Descrição

Refactors nonce generation in `encrypt_value()` to use `ring::rand::generate()` directly instead of pre-allocating a zeroed buffer and filling it. This addresses CodeQL alert #142 (hard-coded cryptographic value) by eliminating the intermediate zeroed buffer that existed between allocation and `fill()`.

The alert was technically a **false positive** — `SystemRandom::fill` overwrote the buffer on the very next line, and the AES-256-GCM nonce was already random per operation. It is fixed in code rather than dismissed in `docs/security/codeql-suppressions.md` because the ledger is explicitly the last-resort mechanism (§3, rule 1 `no-bulk-suppression`), and here a legitimate fix exists that removes the literal from the dataflow entirely. The alert closes as `Fixed` instead of `Dismissed`, and the ledger does not grow.

Verified against the **ring 0.17.14** source (crate downloaded, SHA-256 matching `Cargo.lock`): `impl<const N: usize> RandomlyConstructable for [u8; N]` (`rand.rs:75`) covers `[u8; 12]`. In 0.16 the `impl_random_arrays[4 8 16 32 48 64 128 256]` macro omitted 12; 0.17 replaced it with a const-generic blanket impl.

**Key improvements:**
- Nonce is now generated directly from CSPRNG without a zeroed intermediate buffer
- Uses `NONCE_LEN` constant instead of magic literal `12`
- Simplifies error handling: `assume_unique_for_key()` is infallible over `[u8; NONCE_LEN]`, eliminating one error arm
- Adds unit tests to verify nonce freshness and encryption/decryption roundtrip

The change is cryptographically equivalent. The signature `Result<(Vec<u8>, Vec<u8>), String>` is unchanged, so none of the 5 call sites move.

## Tipo de mudança

- [ ] `feat`: Nova funcionalidade
- [x] `sec`: Correção ou hardening de segurança
- [x] `test`: Adição ou correção de testes
- [ ] `refactor`: Refatoração sem mudança de comportamento

## Classe de Risco

- [ ] **Classe A (Baixo Risco)**
- [ ] **Classe B (Médio Risco)**
- [x] **Classe C (Alto Risco)**: Alterações em criptografia

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo fmt --all --check` executado e limpo
- [x] `cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings` sem erros (exit 0)
- [x] `cargo test --workspace --exclude garraia-desktop --no-fail-fast` — **2108 passed, 1 failed, 23 ignored**; ver a ressalva abaixo
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo, API key, token ou credencial commitada
- [x] Nenhuma migração Postgres com operações destrutivas

> **Ressalva sobre a suíte de testes.** A única falha é
> `garraia-workspace --test migration_smoke::migration_001_applies_and_schema_is_sane`,
> e ela é **ambiental, não deste PR**: o erro é
> `failed to initialize a docker client: Socket not found: /var/run/docker.sock`.
> É um teste testcontainers que sobe um Postgres, e o ambiente onde a validação
> rodou não tem Docker. O crate afetado (`garraia-workspace`) não é tocado por
> este diff, que fica inteiro em `garraia-gateway`. O CI, que tem Docker, é a
> autoridade sobre esse teste.
>
> Toolchain: `cargo +1.95` (o default do ambiente era 1.94.1 e o workspace exige
> 1.95 por conta de `garraia-auth` / `garraia-telemetry` / `garraia-workspace`).

### Para alterações de Alto Risco (Classe C)

- [x] Testes de criptografia adicionados (roundtrip, nonce freshness, length validation)
- [x] Nenhuma mudança em RLS ou autorização
- [x] Auditoria de eventos não afetada
- [x] Caminho de decriptação (`decrypt_value`) intocado — segue aceitando `&[u8]` e usando `try_assume_unique_for_key`, então nonces já gravados continuam legíveis

## Mudanças na API pública e Schema

- Nenhuma mudança na API pública
- Nenhuma mudança em schema

## Como testar

```bash
cargo test --package garraia-gateway --lib admin::secrets::tests
```

Três testes novos validam:
1. **`encrypt_decrypt_roundtrip`**: encrypt → decrypt devolve o plaintext
2. **`nonce_has_aead_length`**: o nonce tem exatamente `NONCE_LEN` bytes
3. **`nonce_is_fresh_per_call`**: mesmo plaintext sob a mesma chave produz nonces **e** ciphertexts diferentes a cada chamada — é a asserção que prova que o alerta #142 era falso-positivo, e que continua sendo depois do refactor. Um nonce fixo faria as duas comparações passarem a iguais; reúso de nonce sob uma chave AES-GCM é quebra real, não lint.

Os três ficam sob `#[cfg(test)]`, portanto fora do escopo do CodeQL
(`CODEQL_EXTRACTOR_RUST_OPTION_CARGO_CFG_OVERRIDES: "-test"` em `codeql.yml`) — não criam alerta novo.

## Plano de Rollback

Revert do commit. A mudança é isolada em `encrypt_value()` e não afeta o caminho de decriptação nem qualquer outra operação criptográfica. Nenhuma migração de dados é necessária: o formato do que vai para o banco (ciphertext + nonce de 12 bytes) é idêntico ao anterior, então dados escritos por qualquer uma das versões são legíveis pela outra.

https://claude.ai/code/session_01FbPD96nLw6g5PkdLcaSa8z