### PR TITLE
sec(random): helper de bytes aleatórios e fecha o alerta #43 do ledger

### DIFF
--- a/crates/garraia-gateway/src/admin/shared.rs
+++ b/crates/garraia-gateway/src/admin/shared.rs
@@ -37,7 +37,6 @@ use std::sync::Arc;
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
-use ring::rand::{SecureRandom, SystemRandom};
 use tokio::sync::Mutex;
 use tracing::{info, warn};
 
@@ -87,13 +86,12 @@ struct KdfParams {
 }
 
 impl KdfParams {
-    fn generate(rng: &SystemRandom) -> Result<Self, String> {
-        let mut salt = vec![0u8; KDF_SALT_LEN];
-        rng.fill(&mut salt)
+    fn generate() -> Result<Self, String> {
+        let salt = garraia_security::random_bytes::<KDF_SALT_LEN>()
             .map_err(|_| "failed to generate KDF salt".to_string())?;
         Ok(Self {
             version: KDF_PARAMS_VERSION,
-            salt: BASE64.encode(&salt),
+            salt: BASE64.encode(salt),
             iterations: KDF_ITERATIONS,
         })
     }
@@ -175,21 +173,16 @@ fn admin_passphrase() -> Option<String> {
 /// 3. No passphrase -> the pre-existing random `master.key` file, which was
 ///    never affected by the constant-salt problem.
 fn derive_admin_keys(stored: Option<StoredKdfParams>) -> AdminKeys {
-    let rng = SystemRandom::new();
     match admin_passphrase() {
-        Some(passphrase) => derive_with_passphrase(stored, &passphrase, &rng),
-        None => master_key_file_keys(&rng),
+        Some(passphrase) => derive_with_passphrase(stored, &passphrase),
+        None => master_key_file_keys(),
     }
 }
 
 /// The passphrase-derived half of [`derive_admin_keys`], with the passphrase
 /// passed in rather than read from the environment so it can be driven
 /// deterministically from tests.
-fn derive_with_passphrase(
-    stored: Option<StoredKdfParams>,
-    passphrase: &str,
-    rng: &SystemRandom,
-) -> AdminKeys {
+fn derive_with_passphrase(stored: Option<StoredKdfParams>, passphrase: &str) -> AdminKeys {
     if let Some((_, salt_b64, iterations)) = stored {
         match BASE64
             .decode(&salt_b64)
@@ -216,7 +209,7 @@ fn derive_with_passphrase(
         }
     }
 
-    match KdfParams::generate(rng) {
+    match KdfParams::generate() {
         Ok(params) => match params.salt_bytes() {
             Ok(salt) => {
                 return AdminKeys {
@@ -250,7 +243,7 @@ fn derive_with_passphrase(
 /// No passphrase configured: a random 32-byte key persisted at
 /// `<config_dir>/admin/master.key`. This path never used a salt, so it needs no
 /// migration.
-fn master_key_file_keys(rng: &SystemRandom) -> AdminKeys {
+fn master_key_file_keys() -> AdminKeys {
     let key_path = admin_dir().join("master.key");
 
     if let Ok(data) = std::fs::read(&key_path)
@@ -263,8 +256,12 @@ fn master_key_file_keys(rng: &SystemRandom) -> AdminKeys {
         };
     }
 
-    let mut key = vec![0u8; MASTER_KEY_LEN];
-    rng.fill(&mut key).expect("failed to generate master key");
+    // The `.expect` predates this change: the function returns `AdminKeys`,
+    // not `Result`, so propagating would mean changing the signature and its
+    // callers. Without entropy there is no key to hand back either way.
+    let key = garraia_security::random_bytes::<MASTER_KEY_LEN>()
+        .expect("failed to generate master key")
+        .to_vec();
 
     if let Some(parent) = key_path.parent() {
         let _ = std::fs::create_dir_all(parent);
@@ -404,9 +401,8 @@ mod tests {
 
     #[test]
     fn generated_salts_differ_between_installations() {
-        let rng = SystemRandom::new();
-        let a = KdfParams::generate(&rng).expect("a");
-        let b = KdfParams::generate(&rng).expect("b");
+        let a = KdfParams::generate().expect("a");
+        let b = KdfParams::generate().expect("b");
         assert_ne!(a.salt, b.salt, "two installations must not share a salt");
         assert_eq!(a.salt_bytes().expect("decode").len(), KDF_SALT_LEN);
 
@@ -431,13 +427,12 @@ mod tests {
         // The bug the single-resolution-point design exists to prevent: with no
         // params recorded, each derivation mints a fresh salt. Once they ARE
         // recorded, every later boot must land on the exact same key.
-        let rng = SystemRandom::new();
-        let first = derive_with_passphrase(None, PASS, &rng);
+        let first = derive_with_passphrase(None, PASS);
         assert!(first.migration_pending());
         let recorded = params_of(&first);
 
-        let second = derive_with_passphrase(Some(recorded.clone()), PASS, &rng);
-        let third = derive_with_passphrase(Some(recorded), PASS, &rng);
+        let second = derive_with_passphrase(Some(recorded.clone()), PASS);
+        let third = derive_with_passphrase(Some(recorded), PASS);
         assert_eq!(first.current, second.current);
         assert_eq!(second.current, third.current);
         assert!(!second.migration_pending(), "nothing left to migrate");
@@ -445,14 +440,13 @@ mod tests {
 
     #[test]
     fn unusable_stored_params_fall_back_to_legacy_not_to_a_third_key() {
-        let rng = SystemRandom::new();
         let legacy = pbkdf2_key(LEGACY_KDF_SALT, LEGACY_KDF_ITERATIONS, PASS);
 
         for bad in [
             (1u32, "!!!not base64!!!".to_string(), 600_000u32),
             (1, BASE64.encode([7u8; 32]), 0), // zero iterations
         ] {
-            let keys = derive_with_passphrase(Some(bad), PASS, &rng);
+            let keys = derive_with_passphrase(Some(bad), PASS);
             assert_eq!(
                 keys.current, legacy,
                 "must stay on the key the ciphertexts are under"
@@ -464,7 +458,7 @@ mod tests {
     // ── Forward-only re-key migration ────────────────────────────────────
 
     fn pending_keys(passphrase: &str) -> AdminKeys {
-        derive_with_passphrase(None, passphrase, &SystemRandom::new())
+        derive_with_passphrase(None, passphrase)
     }
 
     #[test]
@@ -500,7 +494,7 @@ mod tests {
         // Params landed in the SAME transaction, so the next boot rederives the
         // very key the ciphertexts are now under.
         let recorded = store.kdf_params().expect("params recorded");
-        let next_boot = derive_with_passphrase(Some(recorded), PASS, &SystemRandom::new());
+        let next_boot = derive_with_passphrase(Some(recorded), PASS);
         assert_eq!(next_boot.current, keys.current);
         assert!(!next_boot.migration_pending());
     }

--- a/crates/garraia-gateway/src/admin/store.rs
+++ b/crates/garraia-gateway/src/admin/store.rs
@@ -1,7 +1,6 @@
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use ring::pbkdf2;
-use ring::rand::{SecureRandom, SystemRandom};
 use rusqlite::{Connection, params};
 use std::num::NonZeroU32;
 use std::path::Path;
@@ -360,8 +359,8 @@ impl AdminStore {
         ip_address: Option<&str>,
         user_agent: Option<&str>,
     ) -> Result<AdminSession, String> {
-        let token = generate_random_token(SESSION_TOKEN_LEN)?;
-        let csrf_token = generate_random_token(CSRF_TOKEN_LEN)?;
+        let token = generate_random_token::<SESSION_TOKEN_LEN>()?;
+        let csrf_token = generate_random_token::<CSRF_TOKEN_LEN>()?;
 
         let expires_at = chrono::Utc::now() + chrono::Duration::seconds(SESSION_DURATION_SECS);
         let expires_str = expires_at.format("%Y-%m-%d %H:%M:%S").to_string();
@@ -934,9 +933,7 @@ pub struct ConfigVersionEntry {
 // ── Password hashing ─────────────────────────────────────────────────
 
 fn hash_password(password: &str) -> Result<(String, String), String> {
-    let rng = SystemRandom::new();
-    let mut salt = vec![0u8; SALT_LEN];
-    rng.fill(&mut salt)
+    let salt = garraia_security::random_bytes::<SALT_LEN>()
         .map_err(|_| "failed to generate salt".to_string())?;
 
     let iterations = NonZeroU32::new(PBKDF2_ITERATIONS).expect("iterations > 0");
@@ -949,7 +946,7 @@ fn hash_password(password: &str) -> Result<(String, String), String> {
         &mut hash,
     );
 
-    Ok((BASE64.encode(&hash), BASE64.encode(&salt)))
+    Ok((BASE64.encode(&hash), BASE64.encode(salt)))
 }
 
 fn verify_password_hash(password: &str, stored_hash: &str, stored_salt: &str) -> bool {
@@ -971,12 +968,10 @@ fn verify_password_hash(password: &str, stored_hash: &str, stored_salt: &str) ->
     .is_ok()
 }
 
-fn generate_random_token(len: usize) -> Result<String, String> {
-    let rng = SystemRandom::new();
-    let mut buf = vec![0u8; len];
-    rng.fill(&mut buf)
+fn generate_random_token<const N: usize>() -> Result<String, String> {
+    let buf = garraia_security::random_bytes::<N>()
         .map_err(|_| "failed to generate random token".to_string())?;
-    Ok(BASE64.encode(&buf))
+    Ok(BASE64.encode(buf))
 }
 
 #[cfg(test)]

--- a/crates/garraia-gateway/src/totp.rs
+++ b/crates/garraia-gateway/src/totp.rs
@@ -63,9 +63,7 @@ pub struct TotpStatusResponse {
 
 /// Generate a cryptographically random TOTP secret (base32 encoded).
 pub fn generate_totp_secret() -> Result<String, String> {
-    let rng = ring::rand::SystemRandom::new();
-    let mut buf = vec![0u8; TOTP_SECRET_BYTES];
-    ring::rand::SecureRandom::fill(&rng, &mut buf)
+    let buf = garraia_security::random_bytes::<TOTP_SECRET_BYTES>()
         .map_err(|_| "failed to generate TOTP secret".to_string())?;
     Ok(base32_encode(&buf))
 }

--- a/crates/garraia-security/src/credentials.rs
+++ b/crates/garraia-security/src/credentials.rs
@@ -1,8 +1,7 @@
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
-use ring::aead::{AES_256_GCM, Aad, LessSafeKey, Nonce, UnboundKey};
+use ring::aead::{AES_256_GCM, Aad, LessSafeKey, NONCE_LEN, Nonce, UnboundKey};
 use ring::pbkdf2;
-use ring::rand::{SecureRandom, SystemRandom};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::num::NonZeroU32;
@@ -11,7 +10,6 @@ use tracing::{info, warn};
 
 const PBKDF2_ITERATIONS: u32 = 600_000;
 const SALT_LEN: usize = 32;
-const NONCE_LEN: usize = 12; // AES-256-GCM nonce
 const KEY_LEN: usize = 32; // 256 bits
 
 /// On-disk representation of the encrypted vault.
@@ -45,10 +43,9 @@ impl CredentialVault {
             return Err(CredentialError::AlreadyExists(path.display().to_string()));
         }
 
-        let rng = SystemRandom::new();
-        let mut salt = vec![0u8; SALT_LEN];
-        rng.fill(&mut salt)
-            .map_err(|_| CredentialError::Crypto("failed to generate salt".into()))?;
+        let salt = crate::random_bytes::<SALT_LEN>()
+            .map_err(|_| CredentialError::Crypto("failed to generate salt".into()))?
+            .to_vec();
 
         let derived_key = derive_key(passphrase, &salt);
 
@@ -136,14 +133,15 @@ impl CredentialVault {
         let plaintext = serde_json::to_vec(&self.entries)
             .map_err(|e| CredentialError::Format(format!("failed to serialize vault: {e}")))?;
 
-        let rng = SystemRandom::new();
-        let mut nonce_bytes = vec![0u8; NONCE_LEN];
-        rng.fill(&mut nonce_bytes)
+        let nonce_bytes = crate::random_bytes::<NONCE_LEN>()
             .map_err(|_| CredentialError::Crypto("failed to generate nonce".into()))?;
 
         let key = make_aead_key(&self.derived_key)?;
-        let nonce = Nonce::try_assume_unique_for_key(&nonce_bytes)
-            .map_err(|_| CredentialError::Crypto("invalid nonce length".into()))?;
+        // `random_bytes` returns `[u8; NONCE_LEN]`, so the length is
+        // guaranteed by the type and this cannot fail. `open` above keeps the
+        // fallible variant: there the nonce is decoded from the vault file and
+        // its length is only known at runtime.
+        let nonce = Nonce::assume_unique_for_key(nonce_bytes);
 
         let mut in_out = plaintext;
         key.seal_in_place_append_tag(nonce, Aad::empty(), &mut in_out)
@@ -151,7 +149,7 @@ impl CredentialVault {
 
         let vault_file = VaultFile {
             salt: BASE64.encode(&self.salt),
-            nonce: BASE64.encode(&nonce_bytes),
+            nonce: BASE64.encode(nonce_bytes),
             ciphertext: BASE64.encode(&in_out),
         };
 

--- a/crates/garraia-security/src/lib.rs
+++ b/crates/garraia-security/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod allowlist;
 pub mod credentials;
 pub mod pairing;
+pub mod random;
 pub mod redaction;
 pub mod validation;
 
@@ -10,5 +11,6 @@ pub use credentials::{
     try_vault_delete_prefix, try_vault_get, try_vault_set, vault_passphrase_from_env,
 };
 pub use pairing::PairingManager;
+pub use random::{RandomError, random_bytes};
 pub use redaction::{RedactingMakeWriter, RedactingWriter, redact_secrets};
 pub use validation::InputValidator;

--- a/crates/garraia-security/src/random.rs
+++ b/crates/garraia-security/src/random.rs
@@ -1,0 +1,87 @@
+//! Bytes from the system CSPRNG, with no zeroed buffer in between.
+//!
+//! Before this module, every site that needed a salt, nonce, key or token
+//! reimplemented the same idiom:
+//!
+//! ```ignore
+//! let rng = SystemRandom::new();
+//! let mut buf = vec![0u8; N];
+//! rng.fill(&mut buf).map_err(|_| "...")?;
+//! ```
+//!
+//! There were seven copies of it in production code, and the shape is exactly
+//! what CodeQL reads as `rust/hard-coded-cryptographic-value`: a short-lived
+//! buffer of zeros exists, and the analysis does not follow the `fill` on the
+//! next line. That is where alert #142 (AES-256-GCM nonce in
+//! `admin/secrets.rs`) and #43 (PBKDF2 salt in `credentials.rs`) came from —
+//! the first fixed in code, the second dismissed in the ledger as a false
+//! positive.
+//!
+//! [`random_bytes`] closes the whole class: `ring::rand::generate` returns the
+//! array **already filled**, so no buffer of zeros ever exists in our source.
+//! The length comes from the type, which also removes the chance of handing
+//! `fill` a mismatched length.
+
+use ring::rand::SystemRandom;
+
+/// The system CSPRNG could not produce bytes.
+///
+/// `ring` exposes no cause detail (`ring::error::Unspecified` is opaque by
+/// design), so neither does this error. Callers map it onto their own error
+/// type with whatever message makes sense in their context.
+#[derive(Debug, thiserror::Error)]
+#[error("failed to generate random bytes")]
+pub struct RandomError;
+
+/// `N` cryptographically random bytes from the system CSPRNG.
+///
+/// The length is a type parameter, so callers write `random_bytes::<32>()` or
+/// let inference take it from the binding.
+///
+/// ```
+/// use garraia_security::random_bytes;
+///
+/// let salt: [u8; 32] = random_bytes()?;
+/// let nonce = random_bytes::<12>()?;
+/// assert_ne!(salt[..12], nonce[..]);
+/// # Ok::<(), garraia_security::RandomError>(())
+/// ```
+pub fn random_bytes<const N: usize>() -> Result<[u8; N], RandomError> {
+    let rng = SystemRandom::new();
+    // `generate` hands back a `Random<[u8; N]>` that is already filled;
+    // `expose` consumes it. No `vec![0u8; N]` exists between allocation and
+    // fill, which is the whole point of this helper.
+    ring::rand::generate::<[u8; N]>(&rng)
+        .map(|random| random.expose())
+        .map_err(|_| RandomError)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_the_requested_length() {
+        let a: [u8; 12] = random_bytes().expect("rng");
+        let b: [u8; 32] = random_bytes().expect("rng");
+        assert_eq!(a.len(), 12);
+        assert_eq!(b.len(), 32);
+    }
+
+    #[test]
+    fn successive_calls_differ() {
+        // Two 32-byte draws colliding has probability 2^-256; what this test
+        // actually catches is a stuck generator handing back the same buffer.
+        let a: [u8; 32] = random_bytes().expect("rng");
+        let b: [u8; 32] = random_bytes().expect("rng");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn output_is_not_all_zeros() {
+        // Direct regression for the shape that motivated the module: if this
+        // ever goes back to returning the zeroed buffer unfilled, it fails here.
+        let bytes: [u8; 32] = random_bytes().expect("rng");
+        assert!(bytes.iter().any(|&b| b != 0));
+    }
+}

--- a/docs/security/codeql-suppressions.json
+++ b/docs/security/codeql-suppressions.json
@@ -45,18 +45,6 @@
       "ledger_md_anchor": "alert-42"
     },
     {
-      "alert_number": 43,
-      "rule_id": "rust/hard-coded-cryptographic-value",
-      "path": "crates/garraia-security/src/credentials.rs",
-      "line": 49,
-      "sink_snippet": "let mut salt = vec![0u8; SALT_LEN];",
-      "disposition": "dismissed-false-positive",
-      "dismissed_reason": "false_positive",
-      "justification": "vec![0u8; SALT_LEN] is a buffer initializer immediately overwritten by ring::SystemRandom::fill on the next line (credentials.rs:50). The ring API requires a &mut [u8] backing slice; the zero literal never becomes a real salt. CodeQL flags the 0u8 literal pattern but the dataflow proves the bytes are replaced before any cryptographic use. Empirical-proof anchor for GAR-491 mechanism.",
-      "gar_ref": "GAR-491",
-      "ledger_md_anchor": "alert-43"
-    },
-    {
       "alert_number": 44,
       "rule_id": "rust/hard-coded-cryptographic-value",
       "path": "crates/garraia-security/src/validation.rs",
@@ -360,7 +348,7 @@
       "alert_number": 165,
       "rule_id": "rust/hard-coded-cryptographic-value",
       "path": "crates/garraia-gateway/src/admin/shared.rs",
-      "line": 68,
+      "line": 67,
       "sink_snippet": "const LEGACY_KDF_SALT: &[u8] = b\"garraia-admin-secrets-v1\";",
       "disposition": "dismissed-wont-fix",
       "dismissed_reason": "wont_fix",

--- a/docs/security/codeql-suppressions.md
+++ b/docs/security/codeql-suppressions.md
@@ -17,6 +17,16 @@
 > (entradas com mais de 90 dias devem ser revisitadas; alertas que não existem
 > mais no Security tab devem ser removidos do ledger).
 >
+> Removida em 2026-08-30 a entrada do alerta **#43** (`credentials.rs:49`,
+> `rust/hard-coded-cryptographic-value`): o padrão que a justificava —
+> `let mut salt = vec![0u8; SALT_LEN];` seguido de `rng.fill` — deixou de
+> existir. O site passou a usar `garraia_security::random_bytes`, que devolve
+> o array já preenchido pelo CSPRNG e nunca materializa um buffer de zeros.
+> É o mesmo desfecho do alerta #142 e a preferência declarada em §3: correção
+> em código, não supressão. O ledger cai de 30 para 29 entradas. A §5 continua
+> narrando o experimento empírico que usou o #43 como alvo — é registro
+> histórico, e por isso a referência lá virou texto simples.
+>
 > Estado do re-audit em 2026-08-29: a **metade mecânica** está feita e provada —
 > as 23 entradas ainda casam `rule_id`/`path`/`linha` (§5.2). A **metade de
 > julgamento** — cada justificativa ainda procede? o guard citado ainda está na
@@ -80,7 +90,7 @@ cobertura de extração de 118 para 422 arquivos):
 
 **A entrada nova desta leva já está registrada**: alerta
 [#165](#alert-165), o salt PBKDF2 legado em
-`crates/garraia-gateway/src/admin/shared.rs:68` (`LEGACY_KDF_SALT`). O salt
+`crates/garraia-gateway/src/admin/shared.rs:67` (`LEGACY_KDF_SALT`). O salt
 constante deixou de ser usado para derivar qualquer chave nova — agora é
 aleatório por instalação, com 600k iterações — mas a constante permanece no
 fonte porque a migração forward-only precisa dela para decifrar os segredos já
@@ -212,7 +222,6 @@ esperar alguém reparar no Security tab.
 | <a id="alert-40"></a>[#40](https://github.com/michelbr84/GarraRUST/security/code-scanning/40) | `rust/hard-coded-cryptographic-value` | `crates/garraia-gateway/src/mobile_auth.rs:738` | dismissed-used-in-tests | `used_in_tests` | Test fixture em `#[tokio::test] argon2id_register_and_login_roundtrip`. Literal salt `""` é placeholder do path PHC Argon2id (que embute seu próprio salt); coluna legacy não-usada. | GAR-491 |
 | <a id="alert-41"></a>[#41](https://github.com/michelbr84/GarraRUST/security/code-scanning/41) | `rust/hard-coded-cryptographic-value` | `crates/garraia-gateway/src/mobile_auth.rs:749` | dismissed-used-in-tests | `used_in_tests` | Test fixture em `#[tokio::test] argon2id_register_and_login_roundtrip` — branch negativo, password `"nope"` deve retornar false. Input intencionalmente inválido para coverage. | GAR-491 |
 | <a id="alert-42"></a>[#42](https://github.com/michelbr84/GarraRUST/security/code-scanning/42) | `rust/hard-coded-cryptographic-value` | `crates/garraia-gateway/src/mobile_auth.rs:870` | dismissed-used-in-tests | `used_in_tests` | Test fixture em `#[tokio::test] second_login_after_upgrade_still_works`. `"seq-password-xyz"` exercita o PBKDF2 → Argon2id lazy-upgrade transactional path; nunca persistido. | GAR-491 |
-| <a id="alert-43"></a>[#43](https://github.com/michelbr84/GarraRUST/security/code-scanning/43) | `rust/hard-coded-cryptographic-value` | `crates/garraia-security/src/credentials.rs:49` | dismissed-false-positive | `false_positive` | `vec![0u8; SALT_LEN]` é buffer initializer imediatamente sobrescrito por `ring::SystemRandom::fill` na linha 50. API do `ring` exige `&mut [u8]` como backing; literal `0u8` nunca vira salt real. **Anchor da empirical proof do mecanismo.** | GAR-491 |
 | <a id="alert-44"></a>[#44](https://github.com/michelbr84/GarraRUST/security/code-scanning/44) | `rust/hard-coded-cryptographic-value` | `crates/garraia-security/src/validation.rs:233` | dismissed-used-in-tests | `used_in_tests` | Test fixture em `#[test] validate_password_length`. Literal `"short"` intencionalmente abaixo do mínimo para asserir `Err`. Negative-path coverage. | GAR-491 |
 | <a id="alert-45"></a>[#45](https://github.com/michelbr84/GarraRUST/security/code-scanning/45) | `rust/hard-coded-cryptographic-value` | `crates/garraia-security/src/validation.rs:234` | dismissed-used-in-tests | `used_in_tests` | Test fixture em `#[test] validate_password_length`. Literal `"validpass123"` intencionalmente acima do mínimo para asserir `Ok`. Positive-path coverage. | GAR-491 |
 | <a id="alert-149"></a>[#149](https://github.com/michelbr84/GarraRUST/security/code-scanning/149) | `rust/path-injection` | `crates/garraia-gateway/src/skins_handler.rs:84` | dismissed-false-positive | `false_positive` | GAR-490 PR A (PR [#111](https://github.com/michelbr84/GarraRUST/pull/111), squash `613510d`): `create_skin` guards `body.name` via [`validate_skill_name`](../../crates/garraia-gateway/src/path_validation.rs) at line 60 before `tokio::fs::create_dir_all` / `tokio::fs::write`. Charset `[A-Za-z0-9-]{1,128}` ASCII-only. CodeQL Rust pack does not model the helper as a sanitizer. Regression: `tests/skins_test.rs::create_skin_with_path_traversal_returns_400` + `create_skin_with_dot_in_name_returns_400` + `create_skin_rejects_underscore_per_project_convention`. | GAR-490 |
@@ -238,7 +247,7 @@ esperar alguém reparar no Security tab.
 | <a id="alert-144"></a>[#144](https://github.com/michelbr84/GarraRUST/security/code-scanning/144) | `rust/cleartext-transmission` | `crates/garraia-channels/src/signal/mod.rs:279` | dismissed-false-positive | `false_positive` | **Triagem 2026-08-30.** O sink (`:279` neste PR, `:272` no alerta vivo, que foi emitido contra a main antes de este PR deslocar o arquivo) esta **dentro** de `connect()`, depois do guard: `connect()` chama `ensure_url_vetted()?` antes de qualquer IO, e o `?` aborta se a URL for recusada. O `config` e clonado **antes** do `tokio::spawn` e `SignalConfig` nao tem mutabilidade interior, entao a URL do loop e o mesmo valor imutavel ja validado. CodeQL nao liga o clone a validacao anterior. Auditado por `security-auditor`. Contraste com o **#143**, mesma regra e mesmo arquivo, que **nao** entrou neste ledger: era codigo morto (`receive_messages`, `#[allow(dead_code)]`, zero call sites) e foi **removido**, fechando como `Fixed`. | GAR-491 |
 | <a id="alert-145"></a>[#145](https://github.com/michelbr84/GarraRUST/security/code-scanning/145) | `rust/cleartext-transmission` | `crates/garraia-channels/src/whatsapp/api.rs:48` | dismissed-false-positive | `false_positive` | **Wave 3 — cleartext.** O destino e HTTPS: `const GRAPH_API_BASE: &str = "https://graph.facebook.com/v21.0"` ([whatsapp/api.rs:5](../../crates/garraia-channels/src/whatsapp/api.rs)), entao `.bearer_auth(token)` sai sempre sobre TLS. O esquema e constante de compilacao e nenhum caminho de config o altera. CodeQL nao dobra a const dentro do `format!` e trata o esquema como desconhecido. | GAR-491 |
 | <a id="alert-146"></a>[#146](https://github.com/michelbr84/GarraRUST/security/code-scanning/146) | `rust/cleartext-transmission` | `crates/garraia-channels/src/whatsapp/api.rs:79` | dismissed-false-positive | `false_positive` | **Wave 3 — cleartext.** Identico ao [#145](#alert-145), em `mark_as_read`. Contraste deliberado com os alertas 143/144 do canal Signal: mesmo rule, mas **nao** eram falso-positivo — la a URL base vinha da config do operador e admitia `http://` remoto, e foi corrigida em codigo (guard `vet_signal_cli_url`). | GAR-491 |
-| <a id="alert-165"></a>[#165](https://github.com/michelbr84/GarraRUST/security/code-scanning/165) | `rust/hard-coded-cryptographic-value` | `crates/garraia-gateway/src/admin/shared.rs:68` | dismissed-wont-fix | `wont_fix` | `LEGACY_KDF_SALT`. **Não é falso-positivo nem fixture** — o CodeQL está certo, é um salt PBKDF2 constante. Permanece deliberadamente porque a migração forward-only do PR [#869](https://github.com/michelbr84/GarraRUST/pull/869) precisa dele para decifrar **uma última vez** os segredos de instalações anteriores a 2026-08-29, antes de re-cifrá-los sob a chave derivada do salt aleatório por instalação. Nenhuma chave nova é derivada dele: `derive_with_passphrase` só o usa no arm de migração pendente e no fallback de parâmetros ilegíveis. Os parâmetros novos vivem na tabela `kdf_params` do `admin.db`, gravados na mesma transação que re-cifra os segredos. Só sai quando não houver mais instalações por migrar. ✅ Número reconferido na `main` em 2026-08-29 (squash `a47d3c3`): o dry-run casou `rule_id`/`path`/`line` sem `exit 2`, então 165 sobreviveu ao squash. Dispensado no mesmo dia — ver §5.2. | PR-869 |
+| <a id="alert-165"></a>[#165](https://github.com/michelbr84/GarraRUST/security/code-scanning/165) | `rust/hard-coded-cryptographic-value` | `crates/garraia-gateway/src/admin/shared.rs:67` | dismissed-wont-fix | `wont_fix` | `LEGACY_KDF_SALT`. **Não é falso-positivo nem fixture** — o CodeQL está certo, é um salt PBKDF2 constante. Permanece deliberadamente porque a migração forward-only do PR [#869](https://github.com/michelbr84/GarraRUST/pull/869) precisa dele para decifrar **uma última vez** os segredos de instalações anteriores a 2026-08-29, antes de re-cifrá-los sob a chave derivada do salt aleatório por instalação. Nenhuma chave nova é derivada dele: `derive_with_passphrase` só o usa no arm de migração pendente e no fallback de parâmetros ilegíveis. Os parâmetros novos vivem na tabela `kdf_params` do `admin.db`, gravados na mesma transação que re-cifra os segredos. Só sai quando não houver mais instalações por migrar. ✅ Número reconferido na `main` em 2026-08-29 (squash `a47d3c3`): o dry-run casou `rule_id`/`path`/`line` sem `exit 2`, então 165 sobreviveu ao squash. Dispensado no mesmo dia — ver §5.2. | PR-869 |
 
 **Total**: 30 entries (6 from GAR-491 Wave 2 + 16 from GAR-490 Wave 1 PR A +
 1 from PR [#869](https://github.com/michelbr84/GarraRUST/pull/869) + 5 from
@@ -324,7 +333,7 @@ no mesmo repositório; o `state=dismissed` não é resetado quando o workflow
 
 **Procedure**:
 
-1. Aplicar dismissal apenas no alerta [#43](#alert-43) (`credentials.rs:49`,
+1. Aplicar dismissal apenas no alerta #43 (`credentials.rs:49`,
    `dismissed_reason=false_positive`) na branch
    `security/gar-491-codeql-suppressions-2026-05-01`.
 2. Imediato: `gh api repos/michelbr84/GarraRUST/code-scanning/alerts/43 --jq


### PR DESCRIPTION
## Descrição

Sete sites de produção reimplementavam o mesmo idioma para obter salt, nonce, chave ou token:

```rust
let rng = SystemRandom::new();
let mut buf = vec[0u8; N];
rng.fill(&mut buf).map_err(|_| "...")?;
```

Essa forma é exatamente a que o CodeQL lê como `rust/hard-coded-cryptographic-value`: existe um buffer de zeros de vida curta e a análise não acompanha o `fill` da linha seguinte. Foi assim que nasceram **dois** alertas — o #142 (nonce AES-256-GCM em `admin/secrets.rs`) e o **#43** (salt PBKDF2 em `credentials.rs`). O primeiro foi corrigido em código no PR #880; o segundo foi dispensado no ledger como falso-positivo.

O novo `garraia_security::random_bytes::<N>()` fecha a classe inteira: `ring::rand::generate` devolve o array **já preenchido**, então nenhum buffer de zeros chega a existir no nosso fonte. O comprimento vem do tipo, o que também elimina a chance de passar um tamanho errado para o `fill`.

Uma única assinatura basta porque **todos os sete sites usam tamanho constante** — inclusive os dois call sites de `generate_random_token`, que passa a ser const-genérico.

### O ledger encolhe: 30 → 29

A entrada **#43** sai. O padrão que a justificava deixou de existir, e correção em código é a preferência declarada em `codeql-suppressions.md` §3 — o ledger é último recurso. Mesmo desfecho do #142.

Isso também reduz a superfície do re-audit pendente na issue #886, que precisa revisar o mérito de cada entrada uma a uma.

## Tipo de mudança

- [ ] `feat`: Nova funcionalidade
- [ ] `fix`: Correção de bug
- [x] `refactor`: Refatoração sem mudança de comportamento
- [x] `sec`: Correção ou hardening de segurança

## Classe de Risco

- [ ] **Classe A (Baixo Risco)**
- [ ] **Classe B (Médio Risco)**
- [x] **Classe C (Alto Risco)**: toca derivação de chave, geração de salt/nonce e o cofre de credenciais.

## Sites migrados

| Arquivo | Buffer |
|---|---|
| `garraia-security/src/credentials.rs:49` | salt do cofre — **é o alerta #43** |
| `garraia-security/src/credentials.rs:140` | nonce AES-256-GCM |
| `garraia-gateway/src/totp.rs:67` | segredo TOTP |
| `garraia-gateway/src/admin/store.rs:938` | salt de senha do admin |
| `garraia-gateway/src/admin/store.rs:976` | `generate_random_token` (vira `<const N>`) |
| `garraia-gateway/src/admin/shared.rs:91` | salt do KDF por instalação |
| `garraia-gateway/src/admin/shared.rs:266` | master key do arquivo |

### Deliberadamente NÃO migrados

- **Buffers de saída de `pbkdf2::derive`** (`credentials.rs:311`, `admin/store.rs:943`, `admin/shared.rs:131`, `mobile_auth.rs:465`). Mesma forma sintática, semântica diferente: recebem resultado determinístico, não bytes aleatórios.
- **`local_fs.rs:155`** — buffer de I/O de 64 KiB, nada de cripto.
- **Fixtures de teste**: `migrate_workspace.rs:1383,1435`, `migrate_workspace_integration.rs:166,169`, `uploads.rs:1542`, e `legacy_hash_password_for_tests` (`#[cfg(any(test, feature = "test-helpers"))]`).

## Efeitos colaterais, todos consequência direta da migração

1. **`credentials.rs::save` usa `Nonce::assume_unique_for_key`**, infalível sobre `[u8; NONCE_LEN]`, em vez da variante checada — um arm de erro a menos. O `open` **mantém** a variante falível: lá o nonce vem decodificado do arquivo do cofre, com comprimento só conhecido em runtime. Essa distinção está comentada no código.
2. **O `const NONCE_LEN` local vira o do `ring`**, tornando o acoplamento explícito em vez de um `12` que podia derivar.
3. **`KdfParams::generate`, `derive_with_passphrase` e `master_key_file_keys` deixam de receber `&SystemRandom`** — `random_bytes` cria o próprio handle, e parâmetro sem uso falha sob `-D warnings`. Isso explica por que o diff de `shared.rs` é maior que os outros: são os call sites de teste acompanhando a assinatura.

## O gate de âncoras pegou uma deriva minha

A remoção do `use ring::rand::{...}` deslocou as linhas de `shared.rs` em 1, e a entrada **#165** (`LEGACY_KDF_SALT`) passou a apontar para o statement errado. O `check-ledger-anchors.py` — o job que o PR #882 adicionou — reprovou na primeira execução local.

Reapontada de `:68` para `:67`: **mesmo sink, mesmo `sink_snippet`**, só a linha andou. É exatamente o reaponte legítimo que o script descreve, não uma edição de `sink_snippet` para calar o check.

## Checklist de Segurança e Qualidade

- [x] `cargo fmt --all --check` limpo
- [x] `cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings` limpo
- [ ] `cargo test --workspace --exclude garraia-desktop` — **não concluído neste sandbox**: o build completo estoura a cota de disco da sessão (falha de link por `No space left on device`, não erro de código). Rodei os crates afetados; o CI cobre o resto.
- [x] `cargo test -p garraia-security -p garraia-gateway --lib` → **840 + 30 passed, 0 failed**
- [x] Doc test de `random_bytes` verde
- [x] `bash scripts/security/codeql-reapply-dismissals.sh --check-md` → `ok: ledger MD/JSON in sync (29 entries)`
- [x] `python3 scripts/security/check-ledger-anchors.py` → `ok: 29 entradas`
- [x] Nenhum `unwrap()` novo em produção
- [x] Nenhum segredo commitado
- [x] Nenhuma migração Postgres

> **Sobre o `.expect` em `master_key_file_keys`**: é pré-existente e continua. A função devolve `AdminKeys`, não `Result`, então propagar mudaria a assinatura e os chamadores — maior que este PR. Anotei o motivo em comentário no código. Sem entropia não há chave para devolver de qualquer forma.

## Mudanças na API pública e Schema

- **Nova API pública** em `garraia-security`: `random_bytes<const N>()` e `RandomError`, exportados em `lib.rs`. Adição pura, nada removido.
- Nenhuma rota REST, campo de config ou migration.

## Como testar

```bash
cargo test -p garraia-security --lib          # inclui os 3 testes novos do helper
cargo test -p garraia-security --doc          # o exemplo do rustdoc é executável
cargo test -p garraia-gateway --lib admin::shared   # 8 testes de KDF
bash scripts/security/codeql-reapply-dismissals.sh --check-md
python3 scripts/security/check-ledger-anchors.py
```

Para confirmar que nenhum site de RNG sobrou em produção:

```bash
grep -rn 'vec!\[0u8;' crates/ --include=*.rs
```

Os que aparecem devem ser só os quatro da lista "NÃO migrados" acima — todos de teste ou não-cripto.

Três testes novos no helper, sendo `output_is_not_all_zeros` a regressão direta da forma que motivou o módulo: se algum dia voltar a devolver buffer zerado sem preencher, falha ali.

## Plano de Rollback

Revert do commit. Os sete sites voltam ao idioma anterior e o alerta #43 volta a precisar de entrada no ledger — ou seja, o rollback reabre a supressão que este PR eliminou. Prefira corrigir para frente.

## Contexto

Primeiro de três PRs sequenciais dos follow-ups que sobraram do trabalho de CodeQL (PRs #880, #881, #883, que fecharam com 0 alertas abertos). Os próximos:

2. Extrair `signal/api.rs` seguindo a convenção já estabelecida por `whatsapp/api.rs` e `slack/api.rs` — o Signal é o único canal de POST manual que reescreve o corpo do envio dentro do `tokio::spawn`.
3. O re-audit de mérito do ledger (issue #886), incluindo dar dente à regra dos 90 dias: `audit_expiration` hoje **não é lido por nenhum código** do repositório.

Um quarto item que eu havia registrado — "downgrade silencioso" em `admin/shared.rs` — foi **descartado após investigação**: os três caminhos de fallback emitem `warn!` desde o PR #869 e há teste dedicado. A caracterização estava errada.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FbPD96nLw6g5PkdLcaSa8z)_