### PR TITLE
fix(packaging): .deb volta a carregar LICENSE e README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **`.deb` volta a carregar `LICENSE`/`README.md`.** O `packaging/nfpm.yaml`
+  marcava os docs com `type: doc`, que é um tipo **exclusivo do RPM** no nfpm
+  ("ignored by other packagers") — o `garraia-linux-*.deb` da v0.3.4 saiu só
+  com `/usr/bin/garraia`, sem o aviso MIT que uma redistribuição deve
+  carregar (o `.rpm` e os archives não foram afetados). Removido o
+  `type: doc`: como arquivos comuns, `LICENSE`/`README.md` entram nos dois
+  pacotes; o custo aceito é perder a marcação `%doc` no rpm. Vale a partir
+  da próxima release.
+
 ## [0.3.4] - 2026-08-31
 
 ### Added

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -46,15 +46,16 @@ contents:
       mode: 0755
 
   # MIT exige que o aviso viaje com redistribuições; um pacote é uma
-  # redistribuição. type: doc marca %doc no rpm.
+  # redistribuição. SEM `type: doc` de propósito: esse tipo é exclusivo do
+  # RPM ("ignored by other packagers" — nfpm files.go), e com ele o .deb da
+  # v0.3.4 saiu só com o binário. Como arquivos comuns, LICENSE/README
+  # entram nos DOIS pacotes; perder a marcação %doc do rpm é o custo aceito.
   - src: LICENSE
     dst: /usr/share/doc/garraia/LICENSE
-    type: doc
     file_info:
       mode: 0644
   - src: README.md
     dst: /usr/share/doc/garraia/README.md
-    type: doc
     file_info:
       mode: 0644
 


### PR DESCRIPTION
## Descrição

Follow-up da v0.3.4, achado na verificação pós-publicação: o `garraia-linux-*.deb` saiu **só com `/usr/bin/garraia`**, sem `LICENSE`/`README.md` em `/usr/share/doc/garraia/`. Causa raiz: `packaging/nfpm.yaml` marcava os docs com `type: doc`, que no nfpm é um tipo **exclusivo do RPM** — `files.go` o define como "the type of an RPM doc file which is **ignored by other packagers**". O `.rpm` (que os inclui como `%doc`) e os archives `.tar.gz`/`.zip` não foram afetados.

Fix: remover o `type: doc` — como arquivos comuns, `LICENSE`/`README.md` entram nos **dois** pacotes; o custo aceito é perder a marcação `%doc` no rpm (comentado no yaml). Entrada em `### Fixed` no `[Unreleased]` do CHANGELOG. A release v0.3.4 publicada **não** é alterada (assets publicados não se trocam — runbook §Rollback); o fix vale da v0.3.5 em diante.

## Tipo de mudança

- [x] `fix`: Correção de bug

## Classe de Risco

- [x] **Classe A (Baixo Risco)**: config de empacotamento + CHANGELOG; nenhum código de runtime tocado.

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo fmt --check` executado e limpo (nenhum .rs tocado)
- [x] `cargo clippy --workspace --exclude garraia-desktop -- -D warnings` sem erros (inalterado — nenhum .rs tocado)
- [x] `cargo test --workspace --exclude garraia-desktop` passando localmente (inalterado)
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo, API key, token ou credencial commitada
- [x] Nenhuma migração Postgres com operações destrutivas sem estratégia de transição forward-only

### Para alterações de Alto Risco (Classe C)

- N/A

## Mudanças na API pública e Schema

- Nenhuma mudança na API pública. Conteúdo interno dos pacotes `.deb`/`.rpm` de releases futuras: `.deb` passa a incluir `/usr/share/doc/garraia/{LICENSE,README.md}` (o `.rpm` já incluía); os nomes de assets não mudam (regra 15 intacta).

## Como testar

1. `python3 -c "import yaml; yaml.safe_load(open('packaging/nfpm.yaml'))"` — YAML válido.
2. Evidência da causa raiz: `grep -n 'TypeRPMDoc' files/files.go` no repo do nfpm ("ignored by other packagers").
3. Prova real no próximo release dispatch: `dpkg-deb --contents garraia-linux-x86_64.deb` deve listar `./usr/bin/garraia` **e** `./usr/share/doc/garraia/{LICENSE,README.md}` (o smoke do job `package-linux` já roda `dpkg-deb --contents`).

## Plano de Rollback

- Reverter o commit — volta ao comportamento da v0.3.4 (deb sem docs), sem qualquer efeito em releases já publicadas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7bFFyEBXjpxXk8wurw9Aj

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7bFFyEBXjpxXk8wurw9Aj)_