### PR TITLE
chore(release): v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.5] - 2026-09-01
+
 ### Added
 - **Garra Desktop para Linux (`.deb` + AppImage).** Novo job best-effort
   `build-linux-desktop` no `release.yml` (e gate de PR `build-linux-bundles`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3187,7 +3187,7 @@ dependencies = [
 
 [[package]]
 name = "garraia"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -3233,7 +3233,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-agents"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-auth"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-channels"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "axum",
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-common"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-config"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "dirs 6.0.0",
  "garraia-common",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-db"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-desktop"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "serde",
  "serde_json",
@@ -3391,7 +3391,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-embeddings"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "serde",
@@ -3405,7 +3405,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-gateway"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3491,7 +3491,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-learning"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "garraia-common",
  "garraia-skills",
@@ -3505,7 +3505,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-media"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "base64 0.23.1",
  "bytes",
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-plugins"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3555,7 +3555,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-security"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "base64 0.23.1",
  "garraia-common",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-skills"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "garraia-common",
  "reqwest 0.12.28",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-storage"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3611,7 +3611,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-telemetry"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -3647,7 +3647,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-voice"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3661,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-workspace"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/michelbr84/GarraRUST"


### PR DESCRIPTION
## Descrição

PR de preparação da **Release v0.3.5**, seguindo o runbook `docs/releasing.md` §1:

1. Bump da versão do workspace `0.3.4 → 0.3.5` em `Cargo.toml` (`[workspace.package]`).
2. `Cargo.lock` regenerado via `cargo check` (19 crates do workspace acompanham; nunca editado à mão).
3. `CHANGELOG.md`: conteúdo de `## [Unreleased]` movido para `## [0.3.5] - 2026-09-01` (data narrativa em horário da Flórida); `[Unreleased]` volta vazio.

O que a v0.3.5 entrega (mergeado em #899 + #897): papagaio de volta (sprite commitado + guarda `assert-ui-assets`), **Garra Chat Bar**, streaming no `/ws/parrot`, **pacotes Linux do Garra Desktop** (`garraia-desktop-linux-x86_64.deb`/`.AppImage`) e o `.deb` da CLI voltando a carregar `LICENSE`/`README`.

Após o merge: Actions → Release → Run workflow em `main` com `version=v0.3.5` (caminho usado nas v0.3.3/v0.3.4), e em seguida Deploy com `tag=v0.3.5` (runbook §2/§4.6).

## Tipo de mudança

- [x] `chore`: Manutenção (deps, CI, build)

## Classe de Risco

- [x] **Classe A (Baixo Risco)**: bump de versão + CHANGELOG; nenhum código de runtime alterado.

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo fmt --check` executado e limpo (nenhum .rs tocado)
- [x] `cargo clippy --workspace --exclude garraia-desktop -- -D warnings` sem erros no merge base (main verde); este PR não toca código
- [x] `cargo test --workspace --exclude garraia-desktop` — main verde; este PR não toca código
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo, API key, token ou credencial commitada
- [x] Nenhuma migração Postgres com operações destrutivas sem estratégia de transição forward-only

## Mudanças na API pública e Schema

- Nenhuma mudança na API pública (somente número de versão reportado por `--version`/`/api/health`).

## Como testar

1. `grep 'version = "0.3.5"' Cargo.toml` e `git diff` do lock mostra só os membros do workspace.
2. Pós-release: `garra update` a partir da v0.3.4 encontra e instala a v0.3.5 (runbook §4.3).

## Plano de Rollback

Release ruim: apagar a Release e o tag (`git push origin :refs/tags/v0.3.5`), corrigir via PR e cortar v0.3.6 — nunca reutilizar tag publicado (runbook §Rollback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2Gt7QTupapWy6uKpbhV3D

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2Gt7QTupapWy6uKpbhV3D)_