### PR TITLE
docs: reconcilia README, ROADMAP e TODO com main na v0.3.5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,10 +35,10 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    # dtolnay/rust-toolchain@1.94 no ci.yml é o pin de MSRV do workspace,
+    # dtolnay/rust-toolchain@1.95 no ci.yml é o pin de MSRV do workspace,
     # não uma versão de action — o Dependabot tentava "bumpar" para um
     # toolchain Rust inexistente (@1.100, PR #819) e quebrava o job
-    # "MSRV check (1.94)". Bump de MSRV é decisão manual (ci.yml + Cargo.toml
+    # "MSRV check (1.95)". Bump de MSRV é decisão manual (ci.yml + Cargo.toml
     # rust-version + Dockerfile juntos).
     ignore:
       - dependency-name: "dtolnay/rust-toolchain"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   limitado — mesma lição do `stream_turn` do `garra chat`).
 
 ### Changed
+- **`garraia-auth` migra para argon2 0.6 + pbkdf2 0.13 + password-hash 0.6.1**
+  (GAR-669 slice 3, fecha o alerta Dependabot #430); PHC parsing do `build.rs`
+  ajustado, sem mudança de formato de hash. *(Registrado retroativamente em
+  2026-09-02.)*
 - **Quick Chat evolui para a Chat Bar.** A janelinha centrada do `Ctrl+Space`
   (`quick-chat.html`/`quick_chat.rs`) foi substituída pela barra; o atalho e o
   item da bandeja agora alternam a barra. O cliente WebSocket que estava
@@ -51,6 +55,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `ui/ws.js` (uma cópia a menos, e a terceira nunca nasceu).
 
 ### Fixed
+- **CI e instaladores**: `install-endpoints.yml` sobrevive a `errexit` e imprime
+  o código HTTP de cada sonda (#892); `tests/install_ps1/platform.ps1` em ASCII
+  puro para o PSScriptAnalyzer; `set -euo pipefail` no `Get version` do
+  `package-linux`. *(Registrado retroativamente em 2026-09-02.)*
 - **O papagaio do Garra Desktop voltou a aparecer.** O sprite
   `crates/garraia-desktop/ui/assets/parrot-sprite.png` estava no `.gitignore`
   ("binário grande" — na verdade 32KB) e nenhum build de CI executava o
@@ -87,6 +95,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [0.3.4] - 2026-08-31
 
 ### Added
+- **`garra agents setup|status|link|rollback|web`** (plan 0360): front-end do
+  AgentDeck que provisiona GarraIA, OpenClaw, Hermes e Claude Code com um mesmo
+  provedor+modelo; e **`POST /v1/messages`**, shim Anthropic-compatible no
+  gateway para o Claude Code apontar para o Garra
+  ([ADR 0014](docs/adr/0014-anthropic-messages-shim.md)). *(Registrado
+  retroativamente em 2026-09-02.)*
+- **`garra chat` ganha indicador de atividade** (spinner que nunca esconde o
+  cursor, fallback ASCII) e `Ctrl+C` passa a cancelar o turno em vez de matar
+  o processo (#884). *(Retroativo.)*
+- **Interop Hermes ↔ Garra via MCP** (#859) e workflow
+  `codeql-apply-dismissals.yml` (#871). *(Retroativo.)*
 - **Instalador de uma linha para Windows.** Novo `install.ps1`, irmão do
   `install.sh` e em paridade de comportamento com ele:
   `irm https://garraia.org/install.ps1 | iex` detecta a plataforma, resolve a
@@ -219,6 +238,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   job lista cada arquivo de teste explicitamente).
 
 ### Changed
+- **Breaking: MSRV 1.94 → 1.95** — wasmtime 47 → 48 migra a API WASI e exige
+  rustc 1.95 (#865); `ci.yml` ganha o job `MSRV check (1.95)`. *(Retroativo.)*
+- **sqlx 0.9** (#868): `SqlSafeStr` enforçado pelo compilador — `sqlx::query*()`
+  só aceita `&'static str`; `AssertSqlSafe` restrito a alvos de teste (regra 5
+  do CLAUDE.md). *(Retroativo.)*
 - **`rmcp` 1.7 → 2.2**, alinhando os tipos de modelo à spec MCP 2025-11-25
   (upstream `rust-sdk#927`). O SDK dissolveu duas camadas: `Content`
   (`= Annotated<RawContent>`) e o próprio `RawContent` viraram o enum achatado
@@ -271,6 +295,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   no lock; reavaliar quando o serenity suportar reqwest 0.13.
 
 ### Security
+- **Guard SSRF centralizado** em `garraia_common::ssrf` (`vet_url` +
+  `pinned_client`): toda requisição HTTP de saída cuja URL vem de request,
+  config editável ou tool call de LLM passa pelo guard (#869, #883, #889; regra
+  14 do CLAUDE.md). *(Retroativo.)*
 - **RUSTSEC-2026-0192 fechado estruturalmente** — na 0.44 o `ttf-parser` passou a ser
   opcional atrás da feature `font_embedding`, que não usamos (nem `FontData` nem
   `add_font`). O `ttf-parser 0.25.1` (não mantido, sem upgrade seguro) saiu do

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@
 
 ## Protocolo de início de sessão
 
-1. Leia `.garra-estado.md` para contexto da sessão anterior
+1. Leia `TODO.md` (backlog operacional) e, se existir, `.garra-estado.md` (handoff local gerado por `garra max-power`; gitignored, ausente em clone novo)
 2. Verifique `git status` e `git log --oneline -5`
 3. Consulte a memória em `.claude/` se o contexto for relevante
 
@@ -122,10 +122,10 @@ crates/
                         denied). Oracle SQLSTATE distingue InsufficientPrivilege
                         (42501 grant) / PermissionDenied (42501 WITH CHECK) /
                         RlsFilteredZero (USING) / RowsVisible (any positive). GAR-391d
-                        (app-layer cross-group via HTTP) DEFERIDO para plan 0014 /
-                        Fase 3.4 — endpoints REST /v1/{chats,messages,memory,tasks,
-                        groups,me} ainda não existem em garraia-gateway (verificado
-                        empiricamente 2026-04-14). Epic GAR-391 continua aberto.
+                        (app-layer cross-group via HTTP) entregue via plan 0014 em
+                        `crates/garraia-gateway/tests/authz_http_matrix.rs` (50 cenários
+                        sobre /v1/me, /v1/groups, /v1/groups/{id}). Epic GAR-391 fechado
+                        em 2026-04-15.
                         Decisão: docs/adr/0005-identity-provider.md (com Amendment 2026-04-13).
   garraia-channels/   — Telegram, Discord, Slack, WhatsApp, iMessage
   garraia-db/         — SQLite (rusqlite), SessionStore, CRUD (dev/CLI single-user).
@@ -156,8 +156,9 @@ crates/
   garraia-telemetry/  — ✅ OpenTelemetry + Prometheus baseline (GAR-384) — feature-gated
   garraia-workspace/  — ✅ Postgres 16 + pgvector multi-tenant — Fase 3 schema COMPLETO
                         (GAR-407 + GAR-386 + GAR-388 + GAR-389 + GAR-408 + GAR-390 + 391a/b/c
-                        + GAR-387 + GAR-395). 29 tabelas em 14 migrations, 22 sob FORCE RLS, 7 tenant-root
-                        sob app-layer:
+                        + GAR-387 + GAR-395). 37 tabelas em 33 migrations (a lista abaixo cobre as 14
+                        iniciais), 32 sob FORCE RLS e 5 fora dela (users, roles,
+                        permissions, role_permissions, group_invites):
                         • 001 users/groups/identities/sessions/api_keys/invites (tenant roots)
                         • 002 RBAC roles/permissions/63 role_permissions + audit_events + single-owner idx
                         • 003 folders/files/file_versions (GAR-387) — compound FK + object_key UNIQUE
@@ -189,10 +190,11 @@ crates/
                         funcional + 17 unit tests, `versioning.rs`, `skill_override.rs`,
                         `lib.rs`) + tipos `Skill`/`SkillScope`/`SkillSource` + frontmatter
                         `LearningSkillFrontmatter` com `score`/`locked`/`critical_paths_touched`/
-                        `fail_count`. Sub-componentes restantes ainda Backlog em
-                        GAR-643..GAR-651 (miner, generator, registry full, retriever via
-                        garraia-embeddings, evaluator, auto-updater PR flow, versioning
-                        git-backed, override CLI/UI). Separação rígida: memória
+                        `fail_count`. Sub-componentes GAR-643..GAR-651 entregues em
+                        2026-05-18..20 (9/10: miner, generator, registry, evaluator,
+                        auto-updater, safety gates, versioning git-backed, Web UI);
+                        GAR-646 Retriever segue stub até a Fase 2.1 (garraia-embeddings)
+                        e o CLI de override (`skill_override.rs`) também. Separação rígida: memória
                         (`workspace.memory_items`) ≠ skill (`learning.skills`) ≠ log
                         (`telemetry.traces`) ≠ manual distribuível (`garraia-skills` crate).
                         Nunca copiar código do Hermes Agent — Hermes é referência conceitual
@@ -201,7 +203,9 @@ crates/
   garraia-runtime/    — runtime helpers
   garraia-common/     — tipos + erros compartilhados
   garraia-glob/       — glob matching utilitário
-  garraia-desktop/    — Tauri v2 app (Windows MSI, overlay)
+  garraia-desktop/    — Tauri v2 app: bandeja + overlay do papagaio + Chat Bar
+                        (Ctrl+Space); MSI/NSIS no Windows e .deb/AppImage no Linux
+                        (v0.3.5), CLI como sidecar `binaries/garraia`
   garraia-gateway/    — Plan 0046 (GAR-379 slice 3, 2026-04-22) remove hardcoded
                         fallback inseguro `garraia-insecure-default-jwt-secret-change-me`
                         de `mobile_auth.rs` e introduz sentinel `AuthConfigMissing`
@@ -516,8 +520,8 @@ python3 -m pytest scripts/quality/tests/
 
 - @imports `.claude/agents/` para agentes especializados
 - @imports `skills/` para workflows reutilizáveis
-- @imports `.garra-estado.md` para estado da sessão anterior
+- @imports `TODO.md` (backlog operacional) e `.garra-estado.md` (handoff local, gitignored) para estado da sessão anterior
 - @imports `ROADMAP.md` — plano AAA em 7 fases, fonte de verdade do planejamento
 - @imports `deep-research-report.md` — base arquitetural da Fase 3 (Group Workspace multi-tenant)
-- @imports `docs/adr/` — decisões arquiteturais. **Accepted:** 0003 (Postgres para Group Workspace). **Proposed/blocked:** 0001, 0002, 0004-0008. Ver `docs/adr/README.md` para o índice.
+- @imports `docs/adr/` — decisões arquiteturais: 15 ADRs (0001-0015), todas **Accepted**. Ver `docs/adr/README.md` para o índice.
 - Tracking: tracker interno (o Linear foi descontinuado em 2026-08-18 — não criar/consultar issues lá; IDs `GAR-xxx` permanecem como registro histórico de entregas)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Ao participar deste projeto, você concorda em ser respeitoso, inclusivo e const
 
 | Ferramenta | Versão mínima | Instalação |
 |------------|---------------|------------|
-| Rust | 1.94 | `rustup update stable` |
+| Rust | 1.95 | `rustup update stable` |
 | Git | qualquer | [git-scm.com](https://git-scm.com) |
 | FFmpeg | 6.x | `apt install ffmpeg` / `brew install ffmpeg` |
 | Node.js (opcional) | 20+ | Para rodar servidores MCP de teste |
@@ -221,9 +221,9 @@ Abra o PR no GitHub apontando para `main`. Preencha o template completamente.
 
 ## Encontrando algo para trabalhar
 
-- [Good first issues](https://github.com/michelbr84/GarraRUST/issues?q=label%3Agood-first-issue+is%3Aopen)
+- [Good first issues](https://github.com/michelbr84/GarraRUST/issues?q=label%3A%22good+first+issue%22+is%3Aopen)
 - [Help wanted](https://github.com/michelbr84/GarraRUST/issues?q=label%3Ahelp-wanted+is%3Aopen)
-- [Roadmap no Linear](https://linear.app/chatgpt25/project/garraia-complete-roadmap-2026-ac242025/overview)
+- [ROADMAP.md](ROADMAP.md) (visão por fase) e [TODO.md](TODO.md) (fila operacional)
 
 Comente em uma issue antes de começar a trabalhar para evitar esforço duplicado.
 
@@ -231,7 +231,7 @@ Comente em uma issue antes de começar a trabalhar para evitar esforço duplicad
 
 ## Acompanhamento e milestones
 
-Planejamento de releases e ciclos vive no [Linear (time GAR)](https://linear.app/chatgpt25/team/GAR/projects), não em GitHub milestones. Por design, **milestones do GitHub não são utilizados** neste repositório — a ferramenta de prioridade, sequenciamento e alocação por ciclo é o Linear.
+Planejamento de releases e ciclos vive no `ROADMAP.md` (visão por fase) e no `TODO.md` (fila operacional), com um tracker interno para sequenciamento — o Linear foi descontinuado em 2026-08-18 e os IDs `GAR-xxx` que aparecem em planos e ADRs são históricos. Por design, **milestones do GitHub não são utilizados** neste repositório.
 
 GitHub Issues neste repositório serve a três propósitos restritos:
 
@@ -239,7 +239,7 @@ GitHub Issues neste repositório serve a três propósitos restritos:
 2. Issues de automação geradas por workflows (ex.: `garra-routine-trigger.yml`, rotuladas com `automation` + `garra-routine`).
 3. Discussões pontuais que precisem de threading público.
 
-Trabalho interno ativo (slices, planos, refactors, dependências) é rastreado em Linear e correlacionado com PRs por título / branch (`feat(...): GAR-XXX — ...`). Se você for um colaborador externo procurando saber o que está em andamento, prefira o link do Linear acima ou o `ROADMAP.md` na raiz do repositório.
+Trabalho interno ativo (slices, planos, refactors, dependências) é rastreado em `plans/` (um plano por slice; índice em `plans/README.md`) e correlacionado com PRs por título / branch. Se você for um colaborador externo procurando saber o que está em andamento, prefira o `ROADMAP.md` e o `TODO.md` na raiz do repositório.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@
   <a href="https://github.com/michelbr84/GarraRUST/actions/workflows/cargo-audit.yml"><img src="https://github.com/michelbr84/GarraRUST/actions/workflows/cargo-audit.yml/badge.svg?branch=main" alt="Security Audit"></a>
   <a href="https://github.com/michelbr84/GarraRUST/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
   <a href="https://github.com/michelbr84/GarraRUST/stargazers"><img src="https://img.shields.io/github/stars/michelbr84/GarraRUST" alt="Stars"></a>
-  <a href="https://github.com/michelbr84/GarraRUST/issues?q=label%3Agood-first-issue+is%3Aopen"><img src="https://img.shields.io/github/issues/michelbr84/GarraRUST/good-first-issue?color=7057ff&label=good%20first%20issues" alt="Good First Issues"></a>
+  <a href="https://github.com/michelbr84/GarraRUST/issues?q=label%3A%22good+first+issue%22+is%3Aopen"><img src="https://img.shields.io/github/issues/michelbr84/GarraRUST/good%20first%20issue?color=7057ff&label=good%20first%20issues" alt="Good First Issues"></a>
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/rust-1.94%2B-orange?logo=rust" alt="Rust">
+  <img src="https://img.shields.io/badge/rust-1.95%2B-orange?logo=rust" alt="Rust">
   <img src="https://img.shields.io/badge/crates-22-green" alt="Crates">
   <img src="https://img.shields.io/badge/channels-5%20wired-purple" alt="Channels">
   <img src="https://img.shields.io/badge/LLM%20providers-15-red" alt="Providers">
@@ -57,7 +57,9 @@ If a number has no committed measurement behind it, it does not appear here.
 **Local-first.** All state — conversations, memory, config, credentials —
 is stored on your machine, and there is no telemetry or analytics
 phone-home. Your prompts go only to the LLM provider you configure; run
-[Ollama](https://ollama.com) for a fully offline, zero-egress setup.
+[Ollama](https://ollama.com) for a fully offline setup (set
+`GARRAIA_NO_UPDATE_CHECK=1` to also silence the once-a-day release check
+against the GitHub API — the only other outbound call `garra start` makes).
 
 ## 🐾 Meet Garra
 
@@ -77,7 +79,7 @@ tone in any language. See [ADR 0012](docs/adr/0012-garra-persona.md).
 ## Quick Start
 
 ```bash
-# Requires Rust 1.94+ (matches the MSRV declared in Cargo.toml)
+# Requires Rust 1.95+ (matches the MSRV declared in Cargo.toml)
 cargo build --release -p garraia
 
 # Interactive setup — pick your LLM provider; optionally store API keys
@@ -107,10 +109,12 @@ cargo build --release -p garraia
 curl -fsSL https://garraia.org/install.sh | sh
 ```
 
-Mirrors (same script, auto-synced): GitHub release CDN
+Mirrors of the same script: GitHub release CDN
 `https://github.com/michelbr84/GarraRUST/releases/latest/download/install.sh`
-(most robust against IP rate limits) and
-`https://raw.githubusercontent.com/michelbr84/GarraRUST/main/install.sh`.
+(most robust against IP rate limits; a snapshot taken at each release),
+`https://raw.githubusercontent.com/michelbr84/GarraRUST/main/install.sh` and
+`https://cdn.jsdelivr.net/gh/michelbr84/GarraRUST@main/install.sh` (both
+track `main`).
 
 The installer downloads the binary for your platform, verifies it against
 the release's `SHA256SUMS`, then chains into init and start. Note: the
@@ -133,7 +137,8 @@ In TTY-less contexts (Docker build, CI) the installer prints next steps
 and exits 0 instead of blocking.
 
 Releases ship 6 prebuilt CLI binaries: Linux x86_64/aarch64,
-macOS x86_64/aarch64, Windows x86_64/aarch64 — each also as a `.tar.gz`
+macOS x86_64/aarch64, Windows x86_64/aarch64 (the three aarch64 builds
+are best-effort) — each also as a `.tar.gz`
 (`.zip` on Windows) containing the binary named plainly `garraia`,
 plus `LICENSE` and `README.md`. From `v0.3.4` they also carry Linux
 packages — `garraia-linux-{x86_64,aarch64}.deb`/`.rpm` and a portable
@@ -144,6 +149,15 @@ assets by exact name. The Linux binaries are built against glibc 2.35,
 so they need Ubuntu 22.04+ / Debian 12+; older distros and musl-based
 systems (Alpine) have to build from source. The installer checks
 this before downloading.
+
+Separately from the CLI, the **Garra Desktop** app (a Tauri tray app with
+the parrot overlay and the Chat Bar on `Ctrl+Space`, bundling the CLI as a
+sidecar) is published best-effort as
+`garraia-desktop-windows-x86_64.msi` / `-setup.exe` (from `v0.3.4`) and
+`garraia-desktop-linux-x86_64.deb` / `.AppImage` (from `v0.3.5`). Do not
+confuse the two AppImages: `garraia-linux-x86_64.AppImage` is the
+terminal CLI only. See [docs/installation.md](docs/installation.md)
+§"Garra Desktop on Linux".
 
 </details>
 
@@ -175,8 +189,10 @@ landed after the `v0.3.3` tag. See [`docs/installation.md`](docs/installation.md
 
 Flags mirror the shell installer (`-SkipSetup`, `-SkipInit`, `-SkipStart`,
 `-NoLocal`, `-Version <tag>`, `-InstallDir <dir>`, `-NoModifyPath`, `-Help`),
-each an alias for the matching `GARRAIA_*` environment variable; an env var set
-by the caller wins over its flag.
+each paired with a `GARRAIA_*` environment variable. `GARRAIA_VERSION` and
+`GARRAIA_INSTALL_DIR` set by the caller win over `-Version`/`-InstallDir`;
+for the on/off switches, env var and flag are OR-ed — either one enables
+the behaviour.
 
 On Windows ARM64 the installer picks the native
 `garraia-windows-aarch64.exe` (published from `v0.3.4`, best-effort);
@@ -208,10 +224,17 @@ checksum), and swaps the executable atomically.
 <details>
 <summary>Build the desktop app (Tauri)</summary>
 
+Prebuilt bundles are on the Releases page (see above); build from source
+only if you need to. `scripts/build-desktop-linux.sh` (Linux: `.deb` +
+AppImage, prerequisites listed in its header) and
+`scripts/build-installer.ps1` (Windows: MSI + NSIS) wrap these steps:
+
 ```bash
 cargo build --release -p garraia
+mkdir -p crates/garraia-desktop/src-tauri/binaries
 cp target/release/garra crates/garraia-desktop/src-tauri/binaries/garraia-$(rustc -vV | grep host | cut -d' ' -f2)
-cargo build --release -p garraia-desktop
+cargo tauri build --manifest-path crates/garraia-desktop/src-tauri/Cargo.toml
+# `cargo build --release -p garraia-desktop` gives the bare binary, no bundle
 ```
 
 </details>
@@ -270,13 +293,13 @@ with per-claim evidence in `results/`:
 |---|---|---|---|
 | Chat channels | 5 wired end-to-end (Telegram, Discord, Slack, WhatsApp, iMessage·macOS) + web chat + OpenAI-compatible API; 6 more implemented in-crate, not yet wired | 27 bundled channel plugins | ~40 adapters (default build bundles 6) |
 | LLM providers | 15 built-in (Anthropic, OpenAI, Ollama native + 12 OpenAI-compatible presets); 100+ models via OpenRouter; any endpoint via `base_url` | plugin providers | multiple, feature-gated |
-| MCP | client: stdio (default build) + Streamable HTTP (`mcp-http` feature) | client: stdio/SSE/Streamable HTTP; also serves MCP | client: stdio/http/sse, per-agent fail-closed scoping |
+| MCP | client: stdio (default build) + Streamable HTTP (`mcp-http` feature); also serves MCP over stdio (`garra mcp-server`, one `garra_ask` tool) | client: stdio/SSE/Streamable HTTP; also serves MCP | client: stdio/http/sse, per-agent fail-closed scoping |
 | Memory | SQLite + local vector search (sqlite-vec) + LLM fact extraction, auto-injected into context | Markdown files + SQLite FTS5/vector | sqlite/postgres/qdrant backends |
 | Config hot reload | file watch — most settings apply live (channels/providers wire at boot) | file watch (hybrid mode) | explicit reload endpoint only |
 | Scheduling | one-shot heartbeats (up to 30 days ahead) **and** cron recurrence with IANA timezones, delivered to the originating channel; retries failed runs with backoff | full cron + automations | cron + SOP engine |
-| Multi-tenant group workspace | in active development — Postgres 16 + pgvector, 37 tables across 32 migrations with FORCE Row-Level Security on tenant data ([Phase 3](ROADMAP.md)) | explicit non-goal (single trusted operator) | no |
+| Multi-tenant group workspace | in active development — Postgres 16 + pgvector, 37 tables across 33 migrations, 32 of them under FORCE Row-Level Security ([Phase 3](ROADMAP.md)) | explicit non-goal (single trusted operator) | no |
 | Native PT-BR assistant persona | yes — first-class, default | no | no |
-| Prebuilt binaries + self-update | 5 targets, SHA-256-verified atomic self-update | npm package (needs Node runtime) | 10 targets, SLSA provenance |
+| Prebuilt binaries + self-update | 6 targets (3 x86_64 required, 3 aarch64 best-effort), SHA-256-verified atomic self-update | npm package (needs Node runtime) | 10 targets, SLSA provenance |
 
 **Where the others win, honestly:** OpenClaw has the broadest channel and
 plugin ecosystem (27 channels, 150+ extensions) plus a mature cron system,
@@ -303,9 +326,14 @@ fallback on 429/5xx with exponential backoff and a circuit breaker.
 Wired end-to-end today: **Telegram** (streaming, MarkdownV2, bot
 commands, pairing), **Discord** (slash commands, sessions), **Slack**
 (Socket Mode), **WhatsApp** (Meta Cloud API webhooks), **iMessage**
-(macOS, chat.db polling + AppleScript). Also: web chat console and an
+(macOS, chat.db polling + AppleScript). Also: web chat console, an
 **OpenAI-compatible API** (`/v1/chat/completions`) for VS Code
-(Continue et al.) sharing the same session history. Six more channel
+(Continue et al.) sharing the same session history, and an
+**Anthropic-compatible `POST /v1/messages`** shim so Claude Code can point
+at the gateway ([ADR 0014](docs/adr/0014-anthropic-messages-shim.md)).
+`garra agents setup|status|link|rollback|web` provisions GarraIA,
+OpenClaw, Hermes and Claude Code with one provider + model via AgentDeck.
+Six more channel
 implementations (Google Chat, Teams, Matrix, LINE, IRC, Signal) exist in
 `garraia-channels` and await gateway wiring — tracked on the
 [roadmap](ROADMAP.md).
@@ -322,15 +350,18 @@ deterministic auto-routing.
 ### Voice
 
 STT via Whisper (local whisper.cpp or OpenAI API); TTS via Chatterbox
-(GPU, multilingual), Hibiki, ElevenLabs, Kokoro, or OpenAI TTS;
+(GPU, multilingual), Hibiki, or any OpenAI-compatible `/v1/audio/speech`
+endpoint (LM Studio) — ElevenLabs and Kokoro adapters exist in
+`garraia-channels::voice_channel` but are not wired to the gateway yet;
 `garra start --with-voice`; automatic audio replies on Telegram; format
 conversion via ffmpeg.
 
 ### MCP (Model Context Protocol)
 
 Connect any MCP server: stdio for local processes (default build), plus
-Streamable HTTP for remote ones behind the `mcp-http` feature (config
-accepts `http`/`sse`/`streamable-http` values — all served by the
+Streamable HTTP for remote ones behind the `mcp-http` feature (in
+`config.yml`/`mcp.json` use `transport: stdio` or `transport: http`; the
+admin API additionally accepts `sse`/`streamableHttp`, all mapped to the
 Streamable HTTP client; legacy SSE-only servers are not supported, and
 the prebuilt binaries currently ship stdio-only). Tools appear
 namespaced (`server.tool`); MCP prompts become slash commands
@@ -372,7 +403,7 @@ headers (`X-AI-Model`, `X-AI-Provider`) on every response.
 <config-dir>/                # ~/.config/garraia by default (see Configuration)
 ├── memoria/fatos.json      # LLM-extracted facts
 ├── data/memory.db          # SQLite + vector search (sqlite-vec)
-├── data/sessions.db        # persistent conversation sessions
+├── data/sessions.db        # persistent conversation sessions (today under ~/.garraia/data/ unless `data_dir` is set)
 └── credentials/vault.json  # AES-256-GCM encrypted credentials
 ```
 
@@ -386,11 +417,12 @@ CLI is on the roadmap).
 ```yaml
 memory:
   enabled: true
-  auto_extract: true
+  embedding_provider: ollama-embed   # key of the `embeddings` entry below
 embeddings:
-  provider: ollama
-  model: nomic-embed-text
-  base_url: "http://localhost:11434"
+  ollama-embed:
+    provider: ollama
+    model: nomic-embed-text
+    base_url: "http://localhost:11434"
 ```
 
 ## Security
@@ -421,7 +453,8 @@ the comparison section above for the evidence trail).
 - **Two auth stacks, stated plainly** — Auth v1 (`/v1/auth/*`): 15-minute
   HS256 access tokens + opaque HMAC-signed refresh tokens, Argon2id
   hashing with PBKDF2 lazy upgrade. Legacy mobile endpoints (`/auth/*`):
-  30-day JWTs, PBKDF2 — being migrated to v1.
+  30-day JWTs, Argon2id (legacy PBKDF2 rows upgraded on first login) —
+  being migrated to v1.
 - **Risky-command confirmation** — opt-in `tool_confirmation_enabled`
   pauses before destructive bash (`rm -r`, `git reset --hard`, …).
 - **MCP process resource limits** — optional per-server virtual-memory
@@ -434,8 +467,11 @@ the comparison section above for the evidence trail).
   keyword screen for common prompt-injection phrases on chat channels and
   the WebSocket. It is a heuristic, not a guarantee — treat prompt
   injection as unsolved, like every framework should.
-- **TLS (source builds)** — compile with `--features tls` and point
-  `tls_cert_path`/`tls_key_path` at your certs (e.g. issued via
+- **TLS (source builds)** — compile with
+  `cargo build -p garraia --features garraia-gateway/tls` (the feature
+  lives on the gateway crate; the `garraia` binary has no `tls`
+  passthrough yet) and point `tls_cert_path`/`tls_key_path` at your certs
+  (e.g. issued via
   certbot/Let's Encrypt). No built-in ACME client. Honest caveats: the
   prebuilt release binaries do **not** include the TLS feature today, and
   with certs configured but the feature absent the gateway logs a warning
@@ -451,7 +487,7 @@ garra migrate openclaw            # --dry-run to preview, --source <dir> for cus
 
 Imports your skills and channel configurations. Credential files are
 detected and listed but **not copied** — re-enter API keys via
-`garra init` so they land in the encrypted vault.
+`garra init` (pick the vault option there to store them encrypted).
 
 ## Configuration
 
@@ -489,8 +525,7 @@ agent:
   summarize_threshold: 40
 
 memory:
-  enabled: true
-  auto_extract: true
+  enabled: true   # embeddings + `embedding_provider`: see "Memory and self-learning"
 ```
 
 Run `garra config check` to validate the effective configuration with
@@ -510,7 +545,7 @@ crates/
 ├── garraia-agents/     # LLM providers, tools, MCP client, agent runtime
 ├── garraia-channels/   # Telegram, Discord, Slack, WhatsApp, iMessage (+6 pending wiring)
 ├── garraia-auth/       # Auth v1: Argon2id, JWT HS256, RBAC, RLS-backed identity
-├── garraia-workspace/  # Postgres 16 + pgvector multi-tenant (FORCE RLS, 29 tables)
+├── garraia-workspace/  # Postgres 16 + pgvector multi-tenant (37 tables / 33 migrations, 32 under FORCE RLS)
 ├── garraia-security/   # Credential vault, allowlists, pairing, validation
 ├── garraia-db/         # SQLite memory, vector search, sessions
 ├── garraia-config/     # YAML/TOML config, hot reload, `config check`
@@ -534,14 +569,17 @@ deep in **Phase 3: Group Workspace**, a multi-tenant family/team space
 with FORCE Row-Level Security. Recent milestones: auth v1 (Argon2id +
 15-min JWTs + refresh tokens), the 37-table RLS schema, tus resumable
 uploads, object storage (local + S3), OpenTelemetry baseline, the Garra
-Learning agent, and this benchmark harness.
+Learning agent, this benchmark harness, and the v0.3.x distribution wave
+(Aug–Sep 2026): `install.sh`/`install.ps1`, Linux `.deb`/`.rpm`/AppImage,
+native Windows ARM64, `garra agents setup` with the Anthropic-compatible
+`/v1/messages` shim, and Garra Desktop for Linux with the Chat Bar.
 
 ## Contributing
 
 GarraIA is MIT-licensed open source. Join the
 [Discord](https://discord.gg/aEXGq5cS), check
 [CONTRIBUTING.md](CONTRIBUTING.md), and filter by
-[`good-first-issue`](https://github.com/michelbr84/GarraRUST/issues?q=label%3Agood-first-issue+is%3Aopen).
+[`good first issue`](https://github.com/michelbr84/GarraRUST/issues?q=label%3A%22good+first+issue%22+is%3Aopen).
 Support channels are listed in [SUPPORT.md](SUPPORT.md); security reports
 go through [SECURITY.md](SECURITY.md).
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -19,11 +19,11 @@
   <a href="https://github.com/michelbr84/GarraRUST/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="Licença: MIT"></a>
   <a href="https://github.com/michelbr84/GarraRUST/stargazers"><img src="https://img.shields.io/github/stars/michelbr84/GarraRUST" alt="Estrelas"></a>
   <a href="https://github.com/michelbr84/GarraRUST/issues"><img src="https://img.shields.io/github/issues/michelbr84/GarraRUST" alt="Issues"></a>
-  <a href="https://github.com/michelbr84/GarraRUST/issues?q=label%3Agood-first-issue+is%3Aopen"><img src="https://img.shields.io/github/issues/michelbr84/GarraRUST/good-first-issue?color=7057ff&label=good%20first%20issues" alt="Boas Primeiras Issues"></a>
+  <a href="https://github.com/michelbr84/GarraRUST/issues?q=label%3A%22good+first+issue%22+is%3Aopen"><img src="https://img.shields.io/github/issues/michelbr84/GarraRUST/good%20first%20issue?color=7057ff&label=good%20first%20issues" alt="Boas Primeiras Issues"></a>
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/rust-1.94%2B-orange?logo=rust" alt="Rust">
+  <img src="https://img.shields.io/badge/rust-1.95%2B-orange?logo=rust" alt="Rust">
   <img src="https://img.shields.io/badge/license-MIT-blue" alt="License">
   <img src="https://img.shields.io/badge/crates-22-green" alt="Crates">
   <img src="https://img.shields.io/badge/channels-5%20wired-purple" alt="Channels">
@@ -73,7 +73,7 @@ Nota de sincronizacao (2026-05-24): a decisao GarraMaxPower esta formalizada em 
 ## Início Rápido
 
 ```bash
-# Requer Rust 1.94+ (alinhado com MSRV declarado em Cargo.toml — GAR-895)
+# Requer Rust 1.95+ (alinhado com MSRV declarado em Cargo.toml)
 cargo build --release -p garraia
 
 # Configuração interativa - escolha seu provedor de LLM; opcionalmente
@@ -103,11 +103,13 @@ O app desktop requer que o binário CLI já esteja compilado como sidecar:
 # 1. Compilar o CLI primeiro
 cargo build --release -p garraia
 
-# 2. Copiar para o diretório de sidecar esperado pelo Tauri
+# 2. Copiar para o diretório de sidecar esperado pelo Tauri (gitignored — crie antes)
+mkdir -p crates/garraia-desktop/src-tauri/binaries
 cp target/release/garra crates/garraia-desktop/src-tauri/binaries/garraia-$(rustc -vV | grep host | cut -d' ' -f2)
 
-# 3. Compilar o desktop
-cargo build --release -p garraia-desktop
+# 3. Gerar o bundle (`cargo build --release -p garraia-desktop` dá só o binário, sem instalador)
+cargo tauri build --manifest-path crates/garraia-desktop/src-tauri/Cargo.toml
+# Linux: ./scripts/build-desktop-linux.sh (.deb + AppImage) · Windows: .\scripts\build-installer.ps1 (MSI + NSIS)
 ```
 
 </details>
@@ -151,7 +153,11 @@ Em contextos sem TTY real (docker build, CI puro), o instalador imprime os "Next
 > `LICENSE` e `README.md`. A partir da `v0.3.4`, as releases trazem também
 > **pacotes Linux** — `garraia-linux-{x86_64,aarch64}.deb`/`.rpm` e um
 > `garraia-linux-x86_64.AppImage` portátil (todos best-effort; ver
-> [`docs/installation.md`](docs/installation.md)). Os binários crus continuam
+> [`docs/installation.md`](docs/installation.md)). Desde a `v0.3.5` sai também o
+> **Garra Desktop** para Linux — `garraia-desktop-linux-x86_64.deb`/`.AppImage`
+> (app de bandeja com o papagaio e a Chat Bar, CLI como sidecar) — ao lado dos
+> `.msi`/`-setup.exe` do Windows; não confunda com o AppImage da CLI, que é só
+> terminal. Os binários crus continuam
 > publicados sem alteração — o `garra update` e os dois instaladores resolvem
 > assets por nome exato, então eles são superfície de compatibilidade e não
 > serão renomeados nem removidos.
@@ -238,7 +244,7 @@ garraia rollback
 
 </details>
 
-As releases atuais (v0.3.4+) publicam 6 binários CLI (Linux x86_64/aarch64, macOS x86_64/aarch64, Windows x86_64/aarch64) com seus archives, pacotes Linux (`.deb`/`.rpm`/AppImage) e os instaladores desktop do Windows (`.msi` + `-setup.exe`, de volta ao pipeline desde 2026-08-30) — os formatos além dos binários x86_64 são best-effort. O `.apk` mobile (Android) foi publicado até a v0.2.1. Tudo nas [Versões do GitHub](https://github.com/michelbr84/GarraRUST/releases).
+As releases atuais (v0.3.4+) publicam 6 binários CLI (Linux x86_64/aarch64, macOS x86_64/aarch64, Windows x86_64/aarch64) com seus archives, pacotes Linux (`.deb`/`.rpm`/AppImage) e os instaladores desktop do Windows (`.msi` + `-setup.exe`, de volta ao pipeline desde 2026-08-30) — os formatos além dos binários x86_64 são best-effort. O `.apk` mobile (Android) foi publicado até a v0.2.1. Tudo nas [Versões do GitHub](https://github.com/michelbr84/GarraRUST/releases). Desde a v0.3.5, também o Garra Desktop para Linux (`garraia-desktop-linux-x86_64.deb` / `.AppImage`).
 
 ## Por que GarraIA?
 
@@ -261,7 +267,7 @@ segurança usa checkouts de inspeção pinados por commit (OpenClaw
 | **Credenciais em repouso** | Cofre AES-256-GCM disponível, **opt-in** — default do wizard é `config.yml` (0600) | Sem criptografia em repouso (docs deles) — permissões POSIX; SecretRefs/1Password opt-in | ChaCha20-Poly1305 **por default** (única postura cifrada por default das três); chave no mesmo disco; refs 1Password opt-in |
 | **Auth default do gateway** | Canais deny-by-default (pareamento); API local aberta no loopback, token opt-in | Token exigido out-of-the-box (fail-closed) | Pareamento exigido por default; bind público só avisa |
 | **Bind default** | 127.0.0.1 | loopback | 127.0.0.1 |
-| **Dependências** | 1.061 crates (Cargo.lock) | 66 deps diretas de produção (~377 no fechamento) | 1.265 crates (Cargo.lock) |
+| **Dependências** | 1.061 crates (Cargo.lock) | 66 deps diretas de produção (300 pacotes resolvidos no `npm install -g` da run medida) | 1.265 crates (Cargo.lock) |
 | **Canais** | 5 ligados fim-a-fim (+6 implementados no crate, sem wiring) | 27 plugins bundled | ~40 adapters (6 no build default) |
 | **Provedores de LLM** | 15 built-in (100+ modelos via OpenRouter) | via plugins | vários, feature-gated |
 | **Agendamento** | Tarefas one-shot persistidas **e** recorrência cron com timezone IANA | Cron/automations completo | Cron + SOP engine |
@@ -311,6 +317,7 @@ cenário — corrigimos a tabela, não o resultado.
 - **WhatsApp** - webhooks da Meta Cloud API, lista de permissões/pareamento
 - **iMessage** - nativo macOS via polling de chat.db, grupos de chat, envio via AppleScript ([guia de configuração](docs/src/channels/imessage.md))
 - **VS Code** - via API OpenAI-compatible, integrado ao mesmo histórico de conversas
+- **Claude Code** - via shim Anthropic-compatible `POST /v1/messages` ([ADR 0014](docs/adr/0014-anthropic-messages-shim.md)); `garra agents setup|status|link|rollback|web` provisiona GarraIA, OpenClaw, Hermes e Claude Code com um mesmo provedor+modelo via AgentDeck
 
 Implementados no crate `garraia-channels`, **aguardando wiring no
 gateway** (acompanhe no [ROADMAP](ROADMAP.md)): Google Chat, Microsoft
@@ -337,7 +344,7 @@ Além dos comandos embutidos, qualquer servidor MCP que exponha **prompts** via 
 ### Voice Mode (STT/TTS) com Múltiplos Providers
 
 - **STT Providers** - Whisper local (whisper.cpp) e OpenAI Whisper API com dual-endpoint
-- **TTS Providers** - Chatterbox (GPU, multilíngue), Hibiki, ElevenLabs, Kokoro, OpenAI TTS API
+- **TTS Providers** - Chatterbox (GPU, multilíngue), Hibiki ou qualquer endpoint OpenAI-compatible `/v1/audio/speech` (LM Studio); adapters ElevenLabs/Kokoro existem em `garraia-channels::voice_channel`, ainda sem wiring no gateway
 - **Síntese multilíngue** - pt, en, es, fr, de, it, hi via GPU local
 - **Endpoint REST** - `POST /api/tts` para síntese sob demanda
 - **Ativação** - `garra start --with-voice` habilita o modo de voz
@@ -437,7 +444,7 @@ O GarraIA mantém **histórico unificado** entre todos os canais:
 
 - Conecte qualquer servidor compatível com MCP (sistema de arquivos, GitHub, bancos de dados, busca na web)
 - Ferramentas aparecem como ferramentas nativas do agente com nomes namespaced (`server.tool`)
-- Configure em `config.yml` ou `~/.garraia/mcp.json` (compatível com Claude Desktop)
+- Configure em `config.yml` ou `~/.config/garraia/mcp.json` (compatível com Claude Desktop)
 - CLI: `garra mcp list`, `garra mcp inspect <name>`
 
 ### Modos de Execução (Agent Modes)
@@ -575,7 +582,7 @@ Consulte a [documentação completa de integração com Continue](docs/src/conti
 ### Skills
 
 - Defina skills de agente como arquivos Markdown (SKILL.md) com frontmatter YAML
-- Auto-descoberta de `~/.garraia/skills/` - injetado no prompt do sistema
+- Auto-descoberta de `~/.config/garraia/skills/` - injetado no prompt do sistema
 - CLI: `garra skill list`, `garra skill install <url>`, `garra skill remove <name>`
 
 ### MCP Tool Integration com Marketplace
@@ -596,7 +603,7 @@ Consulte a [documentação completa de integração com Continue](docs/src/conti
 ### Skills Editor com CRUD
 
 - Defina skills de agente como arquivos Markdown (SKILL.md) com frontmatter YAML
-- Auto-descoberta de `~/.garraia/skills/`
+- Auto-descoberta de `~/.config/garraia/skills/`
 - **Editor visual** na WebChat UI para criar/editar skills
 - CLI: `garra skill list`, `garra skill install <url>`, `garra skill remove <name>`
 - CRUD completo via API REST (`GET/POST/PATCH/DELETE /api/skills`)
@@ -617,7 +624,7 @@ Consulte a [documentação completa de integração com Continue](docs/src/conti
 
 ### TLS/HTTPS (builds de fonte)
 
-- **Suporte TLS** - compile com `--features tls` e aponte `tls_cert_path`/`tls_key_path` para seus certificados (ex.: emitidos via certbot/Let's Encrypt). Não há cliente ACME embutido. Caveats honestos: os binários release atuais **não** incluem a feature TLS, e com certs configurados mas sem a feature o gateway loga warning e serve HTTP puro — ambos itens de hardening no roadmap. Para produção, recomenda-se reverse proxy com TLS na frente do bind loopback.
+- **Suporte TLS** - compile com `cargo build -p garraia --features garraia-gateway/tls` (a feature vive no crate do gateway; o binário ainda não tem passthrough `tls`) e aponte `tls_cert_path`/`tls_key_path` para seus certificados (ex.: emitidos via certbot/Let's Encrypt). Não há cliente ACME embutido. Caveats honestos: os binários release atuais **não** incluem a feature TLS, e com certs configurados mas sem a feature o gateway loga warning e serve HTTP puro — ambos itens de hardening no roadmap. Para produção, recomenda-se reverse proxy com TLS na frente do bind loopback.
 - **Binding seguro** - `127.0.0.1` por padrao, `0.0.0.0` com TLS para producao
 
 ### Health Checks Centralizados
@@ -675,7 +682,7 @@ O GarraIA possui um sistema completo de memória que permite ao agente aprender 
 ### Sistema de Memória Completo
 
 ```text
-~/.garraia/
+~/.config/garraia/
 ├── memoria/
 │   ├── fatos.json          # Facts extraídos pelo LLM
 │   └── embeddings/         # Embeddings vetoriais locais
@@ -707,14 +714,14 @@ O GarraIA aprende automaticamente das conversas usando um extrator LLM dedicado:
 ```yaml
 memory:
   enabled: true
-  auto_extract: true        # Extrai fatos automaticamente
-  extraction_interval: 5    # Intervalo em minutos
-  max_facts: 100           # Máximo de fatos armazenados
-  
+  embedding_provider: ollama-embed   # chave da entrada em `embeddings` abaixo
+  # a extração de fatos roda em todo turno (não há knob `auto_extract`)
+
 embeddings:
-  provider: ollama          # ou "openai", "cohere"
-  model: nomic-embed-text  # Modelo de embedding local
-  base_url: "http://localhost:11434"
+  ollama-embed:
+    provider: ollama          # ou "openai", "cohere"
+    model: nomic-embed-text   # Modelo de embedding local
+    base_url: "http://localhost:11434"
 ```
 
 ### Embeddings Locais com Ollama
@@ -744,7 +751,7 @@ subcomando `garra memory` na CLI está no roadmap.
 
 O GarraIA foi desenvolvido para os requisitos de segurança de agentes de IA que ficam sempre ativos, acessam dados privados e se comunicam externamente.
 
-- **Cofre de credenciais criptografadas (opt-in)** - AES-256-GCM em `~/.garraia/credentials/vault.json`, chave derivada via PBKDF2-HMAC-SHA256 (600k iterações) de `GARRAIA_VAULT_PASSPHRASE`. Dito com clareza: o default recomendado do wizard `garra init` grava as chaves de provider em `config.yml` (modo 0600, texto puro); escolha a opção do cofre e exporte a passphrase a cada start para ter criptografia em repouso. Tornar o cofre o default está no roadmap.
+- **Cofre de credenciais criptografadas (opt-in)** - AES-256-GCM em `~/.config/garraia/credentials/vault.json`, chave derivada via PBKDF2-HMAC-SHA256 (600k iterações) de `GARRAIA_VAULT_PASSPHRASE`. Dito com clareza: o default recomendado do wizard `garra init` grava as chaves de provider em `config.yml` (modo 0600, texto puro); escolha a opção do cofre e exporte a passphrase a cada start para ter criptografia em repouso. Tornar o cofre o default está no roadmap.
 - **Tokens MCP protegidos por vault** - Variáveis de ambiente sensíveis dos servidores MCP (`API_KEY`, `TOKEN`, `SECRET`, etc.) são automaticamente movidas para o vault no primeiro `save`. O `mcp.json` armazena apenas referências `vault:mcp.<server>.<key>`. Sem `GARRAIA_VAULT_PASSPHRASE`, salva em plaintext com aviso — nunca quebra o boot.
 - **Tokens de sessão criptograficamente seguros** - Cada sessão WebSocket recebe um token de 256 bits (URL-safe base64). Suportados via cookie `garraia_session` (HttpOnly, SameSite=Strict), header `Authorization: Bearer` ou `X-Session-Key`. TTL e idle-timeout configuráveis. Rotação automática no resume.
 - **Canais deny-by-default** - Usuários desconhecidos nos canais de mensageria precisam apresentar código de pareamento. A API local (WS/HTTP) faz bind em `127.0.0.1` e é aberta por default — habilite `gateway.api_key` e/ou `session_tokens_required: true` para exigir auth nela (endurecer esse default está no roadmap).
@@ -777,7 +784,7 @@ Use `--dry-run` para visualizar as alterações antes de confirmar. Use `--sourc
 
 ## Configuração
 
-O GarraIA procura configuração em `~/.garraia/config.yml`:
+O GarraIA procura `config.yml` no diretório de config, resolvido como `$GARRAIA_CONFIG_DIR` → `~/.config/garraia` (padrão em instalações novas) → `~/.garraia` (legado, só quando o diretório XDG não existe). `garraia config check` mostra qual está ativo:
 
 ```yaml
 gateway:
@@ -843,13 +850,13 @@ agent:
 
 memory:
   enabled: true
-  auto_extract: true
-  extraction_interval: 5
+  embedding_provider: ollama-embed
 
 embeddings:
-  provider: ollama
-  model: nomic-embed-text
-  base_url: "http://localhost:11434"
+  ollama-embed:
+    provider: ollama
+    model: nomic-embed-text
+    base_url: "http://localhost:11434"
 
 # Servidores MCP para ferramentas externas
 mcp:
@@ -914,7 +921,7 @@ crates/
 ├── garraia-config/     # Carregamento YAML/TOML, hot-reload, config MCP
 ├── garraia-channels/   # Discord, Telegram, Slack, WhatsApp, iMessage
 ├── garraia-agents/     # Provedores de LLM, ferramentas, cliente MCP, runtime do agente
-├── garraia-auth/       # ✅ verify path real + extractor + endpoints + RLS matrix (GAR-391a/b/c + GAR-392) — IdentityProvider trait, InternalProvider, LoginPool/SignupPool BYPASSRLS newtypes, JWT HS256 (15min) + refresh HMAC, Argon2id+PBKDF2 dual-verify, Role/Action enums + fn can() (110-case test), Principal extractor + RequirePermission, RedactedStorageError. Migration 008/010 (login/signup roles). GAR-392 RLS matrix ✅ (plan 0013 path C, 81 cenários × 3 dedicated roles × 10 FORCE RLS tables). GAR-391d (app-layer cross-group matrix via HTTP) deferido ao plan 0014 — aguarda endpoints REST /v1/{chats,messages,memory,tasks,groups,me} da Fase 3.4; epic GAR-391 permanece aberto.
+├── garraia-auth/       # ✅ verify path real + extractor + endpoints + RLS matrix (GAR-391a/b/c + GAR-392) — IdentityProvider trait, InternalProvider, LoginPool/SignupPool BYPASSRLS newtypes, JWT HS256 (15min) + refresh HMAC, Argon2id+PBKDF2 dual-verify, Role/Action enums + fn can() (110-case test), Principal extractor + RequirePermission, RedactedStorageError. Migration 008/010 (login/signup roles). GAR-392 RLS matrix ✅ (plan 0013 path C, 81 cenários × 3 dedicated roles × 10 FORCE RLS tables). GAR-391d (matriz cross-group via HTTP, plan 0014) entregue em `crates/garraia-gateway/tests/authz_http_matrix.rs` (50 cenários); epic GAR-391 fechado em 2026-04-15.
 ├── garraia-voice/      # Pipeline de voz: Whisper STT → LLM → Chatterbox/Hibiki TTS
 ├── garraia-tools/      # Trait Tool + ToolRegistry, execução com timeout
 ├── garraia-runtime/    # Executor com máquina de estados, meta-controller, gerenciador de turn
@@ -926,11 +933,11 @@ crates/
 ├── garraia-skills/     # Parser de SKILL.md, scanner, instalador
 ├── garraia-common/     # Tipos compartilhados, erros, utilitários
 ├── garraia-telemetry/  # ✅ OpenTelemetry + Prometheus baseline (GAR-384) — feature-gated
-├── garraia-workspace/  # ✅ Postgres 16 + pgvector multi-tenant — Fase 3 (37 tabelas em 32 migrations, FORCE RLS nos dados de tenant)
+├── garraia-workspace/  # ✅ Postgres 16 + pgvector multi-tenant — Fase 3 (37 tabelas em 33 migrations, 32 sob FORCE RLS)
 ├── garraia-embeddings/ # Traits EmbeddingProvider/VectorStore + DeterministicProvider (Fase 2.1)
 ├── garraia-learning/   # Garra Learning Agent — miner/generator/safety gate/versioning (Fase 1.4)
 ├── garraia-storage/    # ObjectStore: LocalFs + S3 (SSE-S3, HMAC integrity, presigned URLs)
-└── garraia-desktop/    # Assistente desktop Clippy-style (Tauri v2) — overlay transparente, hotkey Alt+G, sprite animado
+└── garraia-desktop/    # Assistente desktop Clippy-style (Tauri v2) — overlay do papagaio (Alt+G), Chat Bar (Ctrl+Space), bandeja; MSI/NSIS no Windows e .deb/AppImage no Linux (v0.3.5)
 ```
 
 Além dos crates Rust, o repositório inclui o app mobile:
@@ -1029,7 +1036,7 @@ O GarraIA suporta múltiplos agentes com roteamento inteligente:
 O GarraIA implementa o protocolo MCP com:
 
 - **Transporte stdio** - Servidores MCP locais (processo filho)
-- **Transporte Streamable HTTP** - Servidores MCP remotos (`mcp-http` feature). A config aceita `http`/`sse`/`streamable-http` como valores, todos servidos pelo cliente Streamable HTTP — servidores legados SSE-only não são suportados
+- **Transporte Streamable HTTP** - Servidores MCP remotos (`mcp-http` feature). No `config.yml`/`mcp.json` use `transport: stdio` ou `transport: http`; a admin API aceita também `sse`/`streamableHttp`, todos servidos pelo cliente Streamable HTTP — servidores legados SSE-only não são suportados
 - **Tool Bridging** - Ferramentas aparecem como `server.tool` namespaced
 - **Resource API** - Arquivos, prompts, e custom resources
 - **Health Monitor** - Auto-reconexão com verificação periódica (30s)
@@ -1037,7 +1044,7 @@ O GarraIA implementa o protocolo MCP com:
 - **Diagnostic API** - `GET /api/mcp/tools` lista todas as tools ativas no AgentRuntime (built-ins + MCP); `GET /api/mcp/health` retorna status por servidor com contagem de tools e indicador `all_connected | partial | all_disconnected`
 - **CLI Commands** - `garraia mcp list`, `mcp inspect`, `mcp resources`, `mcp prompts`
 
-Configure em `config.yml` ou `~/.garraia/mcp.json` (compatível com Claude Desktop). Veja `mcp.json.example` para referência de formato sem tokens.
+Configure em `config.yml` ou `~/.config/garraia/mcp.json` (compatível com Claude Desktop). Veja `mcp.json.example` para referência de formato sem tokens.
 
 | Componente | Status |
 |-----------|--------|
@@ -1072,7 +1079,7 @@ Configure em `config.yml` ou `~/.garraia/mcp.json` (compatível com Claude Deskt
 | Skills Editor CRUD (API + WebChat UI) | ✅ Funcionando |
 | OAuth2/OIDC + TOTP 2FA | ✅ Funcionando |
 | EU AI Act Compliance (X-AI-Model headers) | ✅ Funcionando |
-| TLS/HTTPS (`--features tls`; fora dos binários release atuais) | ✅ Funcionando |
+| TLS/HTTPS (`--features garraia-gateway/tls`; fora dos binários release atuais) | ✅ Funcionando |
 | Processamento de mídia (PDF, imagens) | ✅ Funcionando |
 | Garra Cloud Alpha — app mobile Flutter (Android/iOS) | ✅ Funcionando |
 | Mobile Auth (register/login/me, JWT, PBKDF2) | ✅ Funcionando |
@@ -1080,8 +1087,7 @@ Configure em `config.yml` ou `~/.garraia/mcp.json` (compatível com Claude Deskt
 
 ## Testes Automatizados
 
-O GarraIA utiliza o **TestSprite MCP** para geração e execução automatizada de testes da API do backend.
-Os testes validam os contratos REST e o comportamento do sistema de forma contínua, garantindo estabilidade durante refatorações.
+CI no GitHub Actions (`ci.yml` e irmãos): fmt, clippy `-D warnings`, testes unitários e de integração (incluindo a matriz RLS de 81 cenários do `garraia-auth` contra Postgres real e a matriz HTTP de 50 cenários do gateway), cobertura (cargo-llvm-cov), cargo-audit/deny, gitleaks, e2e + Playwright, CodeQL e `cargo-mutants` semanal. Ver `docs/contributing.md` e `tests/`.
 
 ## Contribuindo
 
@@ -1099,11 +1105,11 @@ Acompanhe as próximas entregas em [`ROADMAP.md`](ROADMAP.md) — o planejamento
 6. **Fase 6 — Lançamento & SRE** — Helm, Terraform, SLOs, runbooks, beta → GA.
 7. **Fase 7 — Pós-GA & Evolução** — Multi-região, federation, marketplace, voice, vision, enterprise.
 
-Marcos já entregues incluem Core Hardening, Voice E2E, Commands Registry, Admin Console, Garra Desktop overlay (Tauri v2 GAR-303..316), Garra Cloud Alpha (Flutter mobile GAR-334..345), bootstrap dos 7 projects AAA (GAR-371..410), **GAR-384 — OpenTelemetry + Prometheus baseline** via o novo crate `garraia-telemetry` (Jaeger + Prometheus + Grafana via `ops/compose.otel.yml`, feature flag opt-out, PII redaction by design), **GAR-373 — ADR 0003 Database para Group Workspace** que fixa **PostgreSQL 16 + pgvector + pg_trgm** como backend multi-tenant da Fase 3 (benchmark empírico no PoC `benches/database-poc/` — removido em 2026-08-16 após estabilização, números preservados no ADR 0003 — provando 124x vantagem em ANN HNSW e validando RLS cross-group com FORCE ROW LEVEL SECURITY), **GAR-407 — garraia-workspace bootstrap** que materializa a migration 001 (users, user_identities, sessions, api_keys, groups, group_members, group_invites + pgcrypto/citext) com smoke test testcontainers verde em ~7s e `Workspace` handle PII-safe, **GAR-386 — Migration 002 RBAC + audit_events** que adiciona 5 roles × 22 permissions × 63 role_permissions seedados estaticamente, `audit_events` sem FK (sobrevive CASCADE para LGPD erasure demonstrável) e partial unique index `group_members_single_owner_idx`, **GAR-388 — Migration 004 chats + messages + FTS** que adiciona `chats`, `chat_members`, `messages` (com `body_tsv tsvector GENERATED STORED` + GIN index + compound FK `(chat_id, group_id)` contra cross-group drift) e `message_threads`, e o **schema set completo da Fase 3** através de **GAR-389** (memory_items + memory_embeddings com pgvector HNSW cosseno), **GAR-408** (Row-Level Security FORCE em 10 tabelas com NULLIF fail-closed + prova empírica de FORCE via ownership transfer scopeguard-safe + hard blocker documentado para GAR-391 login flow) e **GAR-390** (8 tabelas do módulo Tasks Tier 1 Notion-like — listas/tasks/subtasks/assignees/labels/comments/subscriptions/activity — com RLS FORCE embutido na própria migration e erasure survival via `created_by_label`/`author_label`/`actor_label` cached). **Atualização 2026-04-13:** GAR-391c shipped — Axum `Principal` extractor + `RequirePermission(Action)` + `Role`/`Action` enums + `fn can()` central com 110-case table-driven test + endpoints `/v1/auth/{login,refresh,logout,signup}` wired no `AppState` real (feature flag `auth-v1` removida) + `garraia_signup NOLOGIN BYPASSRLS` role + `SignupPool` newtype + `RedactedStorageError` wrapper + `AuthConfig` em `garraia-config` + métricas Prometheus baseline + **migration 010** com `GRANT SELECT ON sessions TO garraia_login` (Gap A), `GRANT SELECT ON group_members TO garraia_login` (Gap C), e role `garraia_signup` separado (Gap B). Próximo: GAR-392 / 391d (suite cross-group authz ≥100 cenários) fecha o epic GAR-391.
+Marcos já entregues incluem Core Hardening, Voice E2E, Commands Registry, Admin Console, Garra Desktop overlay (Tauri v2 GAR-303..316), Garra Cloud Alpha (Flutter mobile GAR-334..345), bootstrap dos 7 projects AAA (GAR-371..410), **GAR-384 — OpenTelemetry + Prometheus baseline** via o novo crate `garraia-telemetry` (Jaeger + Prometheus + Grafana via `ops/compose.otel.yml`, feature flag opt-out, PII redaction by design), **GAR-373 — ADR 0003 Database para Group Workspace** que fixa **PostgreSQL 16 + pgvector + pg_trgm** como backend multi-tenant da Fase 3 (benchmark empírico no PoC `benches/database-poc/` — removido em 2026-08-16 após estabilização, números preservados no ADR 0003 — provando 124x vantagem em ANN HNSW e validando RLS cross-group com FORCE ROW LEVEL SECURITY), **GAR-407 — garraia-workspace bootstrap** que materializa a migration 001 (users, user_identities, sessions, api_keys, groups, group_members, group_invites + pgcrypto/citext) com smoke test testcontainers verde em ~7s e `Workspace` handle PII-safe, **GAR-386 — Migration 002 RBAC + audit_events** que adiciona 5 roles × 22 permissions × 63 role_permissions seedados estaticamente, `audit_events` sem FK (sobrevive CASCADE para LGPD erasure demonstrável) e partial unique index `group_members_single_owner_idx`, **GAR-388 — Migration 004 chats + messages + FTS** que adiciona `chats`, `chat_members`, `messages` (com `body_tsv tsvector GENERATED STORED` + GIN index + compound FK `(chat_id, group_id)` contra cross-group drift) e `message_threads`, e o **schema set completo da Fase 3** através de **GAR-389** (memory_items + memory_embeddings com pgvector HNSW cosseno), **GAR-408** (Row-Level Security FORCE em 10 tabelas com NULLIF fail-closed + prova empírica de FORCE via ownership transfer scopeguard-safe + hard blocker documentado para GAR-391 login flow) e **GAR-390** (8 tabelas do módulo Tasks Tier 1 Notion-like — listas/tasks/subtasks/assignees/labels/comments/subscriptions/activity — com RLS FORCE embutido na própria migration e erasure survival via `created_by_label`/`author_label`/`actor_label` cached). **Atualização 2026-04-13:** GAR-391c shipped — Axum `Principal` extractor + `RequirePermission(Action)` + `Role`/`Action` enums + `fn can()` central com 110-case table-driven test + endpoints `/v1/auth/{login,refresh,logout,signup}` wired no `AppState` real (feature flag `auth-v1` removida) + `garraia_signup NOLOGIN BYPASSRLS` role + `SignupPool` newtype + `RedactedStorageError` wrapper + `AuthConfig` em `garraia-config` + métricas Prometheus baseline + **migration 010** com `GRANT SELECT ON sessions TO garraia_login` (Gap A), `GRANT SELECT ON group_members TO garraia_login` (Gap C), e role `garraia_signup` separado (Gap B). GAR-392 (matriz RLS, 81 cenários) e GAR-391d (matriz HTTP, 50 cenários) fecharam o epic GAR-391 em 2026-04-15. Desde então: tus uploads + object storage (GAR-395/394), Web Console "Garra Glass" (ADR 0009), Garra Learning Agent (ADR 0010, 9/10), benchmark harness (`benches/agent-framework-comparison/`), e a onda de distribuição v0.3.x (ago–set/2026): `install.sh`/`install.ps1`, pacotes Linux `.deb`/`.rpm`/AppImage, Windows ARM64 nativo, `garra agents setup` + shim `/v1/messages` (ADR 0014), Garra Desktop para Linux com a Chat Bar.
 
-A Fase 3.3 destravou em 2026-04-13 com **GAR-375 — ADR 0005 Identity Provider** (BYPASSRLS dedicated role + Argon2id RFC 9106 + HS256 JWT + lazy upgrade dual-verify PBKDF2→Argon2id, trait `IdentityProvider` shape congelada) e **GAR-391a — `garraia-auth` skeleton** (crate skeleton + migration 008 criando `garraia_login NOLOGIN BYPASSRLS` com 4 GRANTs exatos do ADR 0005 + `LoginPool` newtype com `current_user` validation + `static_assertions::assert_not_impl_all!(LoginPool: Clone)` + smoke tests integration). Migration 009 (prereq estrutural de GAR-391b) adicionou `user_identities.hash_upgraded_at` para o lazy upgrade transacional. Próximo: **GAR-391b** (`verify_credential` real impl + audit + JWT issuance + endpoint `/v1/auth/login` sob feature flag).
+A Fase 3.3 destravou em 2026-04-13 com **GAR-375 — ADR 0005 Identity Provider** (BYPASSRLS dedicated role + Argon2id RFC 9106 + HS256 JWT + lazy upgrade dual-verify PBKDF2→Argon2id, trait `IdentityProvider` shape congelada) e **GAR-391a — `garraia-auth` skeleton** (crate skeleton + migration 008 criando `garraia_login NOLOGIN BYPASSRLS` com 4 GRANTs exatos do ADR 0005 + `LoginPool` newtype com `current_user` validation + `static_assertions::assert_not_impl_all!(LoginPool: Clone)` + smoke tests integration). Migration 009 (prereq estrutural de GAR-391b) adicionou `user_identities.hash_upgraded_at` para o lazy upgrade transacional. GAR-391b (`verify_credential` real + audit + JWT + `/v1/auth/login`) e GAR-391c foram entregues em 2026-04-13 — ver a linha do `garraia-auth` acima.
 
-Filtre por [`good-first-issue`](https://github.com/michelbr84/GarraRUST/issues?q=label%3Agood-first-issue+is%3Aopen) no GitHub para encontrar um lugar para começar.
+Filtre por [`good first issue`](https://github.com/michelbr84/GarraRUST/issues?q=label%3A%22good+first+issue%22+is%3Aopen) no GitHub para encontrar um lugar para começar.
 
 ## Licença
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Roadmap unificado do ecossistema GarraIA (CLI, Gateway, Desktop, Mobile, Agents, Channels, Voice) rumo ao padrão **AAA**. Funde o plano de inferência local + workflows agenticos com a nova direção de produto **Group Workspace** (família/equipe multi-tenant) derivada de `deep-research-report.md`.
 >
-> **Última atualização:** 2026-08-31 (local America/New_York) — **release v0.3.4** (plan 0361 + ADR 0015): primeira release a exercitar a matriz do plan 0359 (archives, MSI/NSIS, `install.ps1`) e a estrear **pacotes Linux `.deb`/`.rpm` (nfpm) + AppImage x86_64 (appimagetool)** no job best-effort `package-linux`, **binário nativo Windows ARM64** (`garraia-windows-aarch64.exe` + `.zip`, job `build-windows-aarch64`) com `garra update` e `install.ps1` resolvendo o asset novo, suíte `tests/install_ps1/platform.ps1` e casos mixed de checksum nos dois instaladores. Restam DMG notarizado e AppImage aarch64 (§4.1). Anterior (2026-08-18): cleanup total do repo (0 issues, 0 PRs, só `main`): releases **v0.3.1** e **v0.3.2** (5 binários — `garraia-linux-aarch64` pela primeira vez; cross da git + sqlx→rustls, PR #846); fix crítico LGPD no `POST /v1/me/anonymize` (plan 0354, PR #843 — retornava 500 desde junho) + job CI `auth-integration` rodando a matriz RLS em todo PR; deps consolidadas incl. wasmtime 47 (PR #844); timeouts e2e/playwright + grupo dependabot wasmtime + Cross.toml (PR #842); h2 0.4.16 (RUSTSEC-2026-0258). **Linear descontinuado — planejamento interno migrou para o tracker interno; trigger de issues da garra-routine desativado.** Anterior (2026-05-24): docs/backlog sync: `TODO.md` criado como fila operacional obrigatória, GAR-493/ADR 0011 ✅ **Done** via PR [#492](https://github.com/michelbr84/GarraRUST/pull/492) (`95618d3`), `plans/README.md` sincronizado, e checklist GAR-603 reconciliada com evidência já presente em `Dockerfile`, `router.rs` e `docs/deployment-runpod.md`; smoke Docker/Runpod real permanece pendente. GarraMaxPower sincronizado: GAR-498 Skills MVP ✅ **Done** (PR [#488](https://github.com/michelbr84/GarraRUST/pull/488) `c65e099`), GAR-499 Agent Team MVP ✅ **Done** (PR [#490](https://github.com/michelbr84/GarraRUST/pull/490) `7e45ec5`). GAR-695 health run 23 docs ✅ **Done** via PRs [#493](https://github.com/michelbr84/GarraRUST/pull/493) / [#494](https://github.com/michelbr84/GarraRUST/pull/494). Anterior: GAR-679 SSE rate-limit per user ✅ **Done** (plan 0163); GAR-680 Audit-log of SSE chat subscriptions ✅ **Done** (PR [#463](https://github.com/michelbr84/GarraRUST/pull/463) `a972947`); GAR-496 Repo workflow seguro ✅ **Done** (PR #455 `1b7f04c`); GAR-495 ✅ **Done** (PR #453 `e5a2a08`); GAR-669 Slice 2 + GAR-500 Auto Dream ✅; GAR-372 embeddings scaffoldado; ADR 0010 Accepted + `garraia-learning`.
+> **Última atualização:** 2026-09-01 (local America/New_York) — **release v0.3.5** (plan 0362 + Amendment do ADR 0015): **Garra Desktop para Linux** (`garraia-desktop-linux-x86_64.deb`/`.AppImage` via bundler Tauri, job best-effort `build-linux-desktop`; o `.deb` declara `Provides/Conflicts/Replaces: garraia` porque instala o sidecar em `/usr/bin/garraia`), **Garra Chat Bar** (barra flutuante `Ctrl+Space` que substitui o quick-chat e compartilha a sessão `parrot-desktop` com o papagaio), streaming de chunks no `/ws/parrot`, sprite do papagaio commitado + guarda `assert-ui-assets` no CI, migração argon2 0.6 / pbkdf2 0.13 / password-hash 0.6.1 (GAR-669 slice 3). Anterior (2026-08-31): **release v0.3.4** (plan 0361 + ADR 0015): primeira release a exercitar a matriz do plan 0359 (archives, MSI/NSIS, `install.ps1`) e a estrear **pacotes Linux `.deb`/`.rpm` (nfpm) + AppImage x86_64 (appimagetool)** no job best-effort `package-linux`, **binário nativo Windows ARM64** (`garraia-windows-aarch64.exe` + `.zip`, job `build-windows-aarch64`) com `garra update` e `install.ps1` resolvendo o asset novo, suíte `tests/install_ps1/platform.ps1` e casos mixed de checksum nos dois instaladores. Restam DMG notarizado e AppImage aarch64 (§4.1). Ainda em 2026-08-30: plan 0360 / ADR 0014 — `garra agents setup|status|link|rollback|web` (front-end do AgentDeck) + shim Anthropic-compatible `POST /v1/messages` para o Claude Code apontar para o gateway. Anterior (2026-08-18): cleanup total do repo (0 issues, 0 PRs, só `main`): releases **v0.3.1** e **v0.3.2** (5 binários — `garraia-linux-aarch64` pela primeira vez; cross da git + sqlx→rustls, PR #846); fix crítico LGPD no `POST /v1/me/anonymize` (plan 0354, PR #843 — retornava 500 desde junho) + job CI `auth-integration` rodando a matriz RLS em todo PR; deps consolidadas incl. wasmtime 47 (PR #844; depois 48 + MSRV 1.95 no PR #865, 2026-08-28); timeouts e2e/playwright + grupo dependabot wasmtime + Cross.toml (PR #842); h2 0.4.16 (RUSTSEC-2026-0258). **Linear descontinuado — planejamento interno migrou para o tracker interno; trigger de issues da garra-routine desativado.** Anterior (2026-05-24): docs/backlog sync: `TODO.md` criado como fila operacional obrigatória, GAR-493/ADR 0011 ✅ **Done** via PR [#492](https://github.com/michelbr84/GarraRUST/pull/492) (`95618d3`), `plans/README.md` sincronizado, e checklist GAR-603 reconciliada com evidência já presente em `Dockerfile`, `router.rs` e `docs/deployment-runpod.md`; smoke Docker/Runpod real permanece pendente. GarraMaxPower sincronizado: GAR-498 Skills MVP ✅ **Done** (PR [#488](https://github.com/michelbr84/GarraRUST/pull/488) `c65e099`), GAR-499 Agent Team MVP ✅ **Done** (PR [#490](https://github.com/michelbr84/GarraRUST/pull/490) `7e45ec5`). GAR-695 health run 23 docs ✅ **Done** via PRs [#493](https://github.com/michelbr84/GarraRUST/pull/493) / [#494](https://github.com/michelbr84/GarraRUST/pull/494). Anterior: GAR-679 SSE rate-limit per user ✅ **Done** (plan 0163); GAR-680 Audit-log of SSE chat subscriptions ✅ **Done** (PR [#463](https://github.com/michelbr84/GarraRUST/pull/463) `a972947`); GAR-496 Repo workflow seguro ✅ **Done** (PR #455 `1b7f04c`); GAR-495 ✅ **Done** (PR #453 `e5a2a08`); GAR-669 Slice 2 + GAR-500 Auto Dream ✅; GAR-372 embeddings scaffoldado; ADR 0010 Accepted + `garraia-learning`.
 > **Owner:** @michelbr84
 > **Tracking:** tracker interno desde 2026-08-18 (histórico no Linear, time `GAR` — IDs preservados neste doc)
 > **Branch base:** `main`
@@ -44,7 +44,7 @@
 - `garraia-channels`: adapters Telegram/Discord/Slack/WhatsApp/iMessage.
 - `garraia-voice`: STT Whisper (dual endpoint) + TTS (Chatterbox/ElevenLabs/Kokoro stubs).
 - Mobile (Flutter): auth JWT + chat + mascote — roda no emulator Android.
-- Desktop (Tauri v2): scaffold + sidecar Windows MSI/NSIS, publicado pelo job best-effort `build-windows-installer` (`release.yml`) desde 2026-08-30. Sem assinatura de codigo (SmartScreen avisa) e sem auto-updater funcional -- ver `docs/releasing.md`.
+- Desktop (Tauri v2): overlay do papagaio + bandeja + hotkeys + notificações/diálogos nativos + Chat Bar (`Ctrl+Space`, v0.3.5), com a CLI como sidecar. Instaladores Windows MSI/NSIS (job best-effort `build-windows-installer`, desde 2026-08-30) e Linux `.deb`/AppImage x86_64 (job `build-linux-desktop`, v0.3.5 em 2026-09-01). Sem assinatura de codigo (SmartScreen avisa), sem DMG, e com `tauri-plugin-updater` ligado mas inerte (nenhum workflow publica `latest.json`) -- ver `docs/releasing.md`.
 
 **O que ainda é stub, frágil ou ausente (snapshot 2026-04-13 — mantido como
 registro histórico; a verificação empírica de 2026-05-18 abaixo classifica
@@ -72,22 +72,23 @@ mapeada ao seu estado atual com pointer de evidência. Quando o status é
 
 | # | Reivindicação §1 | Status hoje | Evidência |
 |---|---|---|---|
-| 1 | Sem Postgres (só SQLite) | ✅ **Done** | `crates/garraia-workspace/migrations/` tem 19 migrations, 29 tabelas, RLS FORCE, BYPASSRLS roles dedicados (`garraia_login` / `garraia_signup` / `garraia_app`). ADR 0003 Accepted 2026-04-13. |
+| 1 | Sem Postgres (só SQLite) | ✅ **Done** | `crates/garraia-workspace/migrations/` tem 33 migrations, 37 tabelas (32 sob FORCE RLS), roles BYPASSRLS dedicados (`garraia_login` / `garraia_signup`) + role de app `garraia_app` sujeito a FORCE RLS. ADR 0003 Accepted 2026-04-13. |
 | 2 | Sem object storage | ✅ **Done** | `crates/garraia-storage/{local_fs,s3_compat}.rs` (GAR-394) + tus 1.0 ledger em `tus_uploads` (migration 014, GAR-395 mergeado em `96f5c03`). ADR 0004 Accepted. |
 | 3 | Sem grupos/membros/RBAC | ✅ **Done** | Migrations 001 (users/groups), 002 (63 role_permissions + RBAC table-driven), 011-013, 018 (RLS FORCE em groups+members). Matriz de 81 cenários cross-tenant (GAR-392). |
 | 4 | Sem embeddings locais nem busca vetorial | ⚠️ **Parcial → scaffold em 2026-05-18** | Trait surface + types entregues hoje via PR #396 (GAR-372, plan 0145). `PgVectorStore` real sobre `sqlx` contra `memory_embeddings` (migration 005 já tem `vector(768)` + HNSW cosine) é o próximo slice. Modelo real (mxbai) também é slice futuro. |
 | 5 | Sem OpenTelemetry, sem métricas | ✅ **Done (baseline)** | `crates/garraia-telemetry/src/{config,layers,metrics,tracer,redact}.rs` — GAR-384, feature-gated, PII-safe via `redact.rs`. |
-| 6 | CredentialVault não é fonte única | ✅ **Done** | GAR-410 mergeado em 2026-05-17. Secrets agora lidos via `garraia-config::auth` + `garraia-telemetry::config` dedicados; grep verifica que `std::env::var("GARRAIA_JWT_SECRET")` e `GarraIA_VAULT_PASSPHRASE` aparecem só nesses módulos. |
-| 7 | Mobile Android com Gradle/SDK desatualizados | ✅ **Done** | `app/build.gradle.kts` usa `flutter.compileSdkVersion`/`minSdkVersion` (delegado ao Flutter SDK); JDK 23; AndroidX habilitado. `applicationId` + `namespace` migrados de `com.example.garraia_mobile` (template default Flutter) para `org.garraia.mobile` em 2026-05-18 (reverse-DNS de `garraia.org`, alinhado ao binário CLI `garraia` e ao `install.sh`). |
-| 8 | Desktop UI apenas WebView básico | ⚠️ **Parcial** | Web Console "Garra Glass" (ADR 0009, 10 PRs #330-341, 2026-05-14) entregue como `webchat.html` servido pelo gateway — Dashboard, Chat, Providers, Channels, Sessions, Settings (schema-driven dry-run), Diagnostics (12 checks), Logs, Themes/Skins. O **shell desktop Tauri** (`crates/garraia-desktop/src-tauri/`) continua um wrapper WebView que carrega esse mesmo HTML; UI nativa rich (notifications, file picker hooks, system tray menu items) ainda backlog. |
-| 9 | MCP em sandbox WASM | ✅ **Done (baseline)** | `crates/garraia-plugins/src/{loader,manifest,runtime,sdk,traits}.rs` em `wasmtime 44.0.1` (RUSTSEC closed PR #108). Features avançadas (capability tokens, resource limits per-plugin) na Fase 2.2. |
+| 6 | CredentialVault não é fonte única | ⚠️ **Parcial** | Leitura de secrets centralizada em 2026-05-17 (plan 0046): valores lidos só em `garraia-config::auth` + `garraia-telemetry::config` (leituras presence-only em `settings_handler`/`diagnostics_handler`/`check.rs`). O CredentialVault **final** (GAR-410: fonte única do gateway + rotação + master key argon2id) segue adiado — o gateway ainda não consome o cofre e `garraia-security` não tem rotação. Ver §5.1 e `TODO.md`. |
+| 7 | Mobile Android com Gradle/SDK desatualizados | ✅ **Done** | `app/build.gradle.kts` usa `flutter.compileSdkVersion`/`minSdkVersion` (delegado ao Flutter SDK); gradle 8.14, AGP 8.11.1, Java 17 (source/target/jvmTarget); AndroidX habilitado. `applicationId` + `namespace` migrados de `com.example.garraia_mobile` (template default Flutter) para `org.garraia.mobile` em 2026-05-18 (reverse-DNS de `garraia.org`, alinhado ao binário CLI `garraia` e ao `install.sh`). |
+| 8 | Desktop UI apenas WebView básico | ⚠️ **Parcial** | Web Console "Garra Glass" (ADR 0009, 10 PRs #330-341, 2026-05-14) entregue como `webchat.html` servido pelo gateway — Dashboard, Chat, Providers, Channels, Sessions, Settings (schema-driven dry-run), Diagnostics (12 checks), Logs, Themes/Skins. O **shell desktop Tauri** (`crates/garraia-desktop/src-tauri/`) hoje tem UI própria: overlay do papagaio (`index.html`), bandeja com 9 itens (`tray.rs`), hotkeys `Alt+G`/`Ctrl+Space` (`hotkey.rs`), notificações + diálogos nativos (`commands.rs`) e a Chat Bar (`chat_bar.rs`, v0.3.5). Pendente: assinatura de código, auto-updater alimentado, DMG, always-on-top no Wayland. |
+| 9 | MCP em sandbox WASM | ✅ **Done (baseline)** | `crates/garraia-plugins/src/{loader,manifest,runtime,sdk,traits}.rs` em `wasmtime 48.0.1` (44.0.1 fechou o RUSTSEC no PR #108; 47→48 + MSRV 1.95 no PR #865, 2026-08-28). Features avançadas (capability tokens, resource limits per-plugin) na Fase 2.2. |
 | 10 | Sem wizard, `.env.example` é caminho oficial | ✅ **Done** | `crates/garraia-cli/src/wizard/` + subcomando `garraia init` (PR #348, plan 0126) + `curl \| sh` installer wizard (PR #350, plan 0127). Cobre Linux/macOS x86_64+aarch64 via `curl \| sh` e Windows via `irm \| iex` (`install.ps1`, 2026-08-30). O MSI do desktop e publicado a parte, best-effort. |
-| 11 | Cobertura de testes baixa | 🔁 **Em curso** | Mutation testing 90.78% killed em `garraia-auth` (GAR-436 + PR #94). AI Quality Ratchet PR-1 em report-only (plan 0064, `scripts/quality/`). Coverage job em CI (`Coverage (cargo-llvm-cov)`) ativo. Sub-issues Q6.1-Q6.9 + GAR-505 ainda fechando mutation gaps. |
+| 11 | Cobertura de testes baixa | 🔁 **Em curso** | Mutation testing 90.78% killed em `garraia-auth` (GAR-436 + PR #94). AI Quality Ratchet PR-1 em report-only (plan 0064, `scripts/quality/`). Coverage job em CI (`Coverage (cargo-llvm-cov)`) ativo. Sub-issues Q6 restantes ainda fechando mutation gaps (GAR-505 fechou em 2026-05-04); `cargo-mutants` semanal verde desde 2026-08-24. |
 
 **Sumário:** dos 11 itens listados em §1 como "stub, frágil ou ausente" em
 2026-04-13, **7 estão ✅ Done** em `main`, **3 estão ⚠️ Parciais** (embeddings com
-scaffold real entregue 2026-05-18, falta `PgVectorStore` + modelo real; Android
-applicationId; Desktop Tauri native UI), e **1 está 🔁 em curso** (cobertura de
+scaffold real entregue 2026-05-18, falta `PgVectorStore` + modelo real;
+CredentialVault final — GAR-410; Desktop Tauri — UI própria entregue, faltam
+assinatura/updater/DMG), e **1 está 🔁 em curso** (cobertura de
 testes, sem fim explícito — Quality Ratchet é o sistema permanente).
 
 A lista original em §1 acima é mantida como registro histórico do estado em
@@ -108,7 +109,7 @@ seções de fase ao longo deste documento.
 
 ### Sprint **Green Security Baseline 2026-04-30** (umbrella GAR-486)
 
-Sub-issues 1-3 ✅ done implicitamente em `main@7fc838b`. Sub-issues 4-5 em andamento.
+Sub-issues 1-3 ✅ done implicitamente em `main@7fc838b`. Sub-issues 4-5 fechadas em 2026-05-04 (ver "Status do umbrella" abaixo).
 
 | PR | Commit | Conteúdo |
 |----|--------|----------|
@@ -125,14 +126,14 @@ Sub-issues 1-3 ✅ done implicitamente em `main@7fc838b`. Sub-issues 4-5 em anda
 - Dependabot alerts: **20 → 7** — todos os 7 residuais com Linear ownership em [`docs/security/dependabot-status.md`](docs/security/dependabot-status.md)
 - CodeQL total open: **90** (medição da Phase 0 desta sessão, advanced setup já em main) → **84** após os 6 dismissals do GAR-491. O description original do GAR-486 mencionava "~90 → 71" como projeção do efeito do `paths-ignore`, mas a medição direta via `gh api ... code-scanning/alerts | length` retornou 90 alertas open antes de qualquer triagem ativa nesta sessão. Triagem ativa só começou via GAR-491 (Wave 2) e levou o total para 84. GAR-490 (Wave 1) ataca os 16 path-injection + 8 sql-injection restantes na sessão futura.
 - GitHub-native CodeQL default setup: `configured` → `not-configured` (advanced setup é canonical)
-- `continue-on-error: true` em workflows: 4 removidos no Lote 2 (PR #64, GAR-438) + 1 no Lote 4 (PR sobre Playwright `data-testid`); restante intencional (1 RUSTSEC residual)
+- `continue-on-error: true` em workflows: 4 removidos no Lote 2 (PR #64, GAR-438) + 1 no Lote 4 (PR sobre Playwright `data-testid`); o último (RUSTSEC) virou gate bloqueante no plan 0053 (GAR-453) — hoje **0** `continue-on-error` ativos nos workflows (jobs best-effort da release usam `needs` fora do `if`)
 
-### CodeQL triage **ainda em aberto** (registro da sessão de triagem; GAR-490 Wave 1 pendente)
+### CodeQL triage (registro histórico da sessão de 2026-05-01 — fechado em 2026-05-04)
 
-Sub-issues 4 e 5 de GAR-486 estão em execução agora:
+Sub-issues 4 e 5 de GAR-486 (estado em 2026-05-01; ambas mergeadas em 2026-05-04):
 
-- **GAR-491 — CodeQL Wave 2 (fixtures + suppression convention)** — sub-issue 5/5, **In Progress** desde 2026-05-01, PR [#109](https://github.com/michelbr84/GarraRUST/pull/109) draft. Estabelece a convenção de suppression para Rust CodeQL via REST API dismissal + ledger versionado em [`docs/security/codeql-suppressions.md`](docs/security/codeql-suppressions.md) + [`docs/security/codeql-suppressions.json`](docs/security/codeql-suppressions.json) + script [`scripts/security/codeql-reapply-dismissals.sh`](scripts/security/codeql-reapply-dismissals.sh) com fail-closed validation (rule_id/path/line). 6 alertas em escopo, 21 deferidos para `GAR-491.1`.
-- **GAR-490 — CodeQL Wave 1 (production paths)** — sub-issue 4/5, **Backlog**, bloqueada por GAR-491. 16 path-injection (`skills_handler.rs`, `skins_handler.rs`) + 8 sql-injection (`rest_v1/groups.rs`, `rest_v1/invites.rs`). Plano de ataque: helper `validate_skill_name` em handlers + integração de `garraia_storage::sanitise_key` em `skins_handler.rs` (single-segment) + experimento `SELECT set_config('app.current_user_id', $1, true)` substituindo `SET LOCAL ... format!()` antes de qualquer dismissal.
+- **GAR-491 — CodeQL Wave 2 (fixtures + suppression convention)** — sub-issue 5/5, ✅ mergeada em 2026-05-01 via PR [#109](https://github.com/michelbr84/GarraRUST/pull/109). Estabelece a convenção de suppression para Rust CodeQL via REST API dismissal + ledger versionado em [`docs/security/codeql-suppressions.md`](docs/security/codeql-suppressions.md) + [`docs/security/codeql-suppressions.json`](docs/security/codeql-suppressions.json) + script [`scripts/security/codeql-reapply-dismissals.sh`](scripts/security/codeql-reapply-dismissals.sh) com fail-closed validation (rule_id/path/line). 6 alertas em escopo, 21 deferidos para `GAR-491.1`.
+- **GAR-490 — CodeQL Wave 1 (production paths)** — sub-issue 4/5, ✅ mergeada em 2026-05-04 via PR #112 (o experimento `SELECT set_config(...)` abaixo virou o padrão em `rest_v1/groups.rs`). 16 path-injection (`skills_handler.rs`, `skins_handler.rs`) + 8 sql-injection (`rest_v1/groups.rs`, `rest_v1/invites.rs`). Plano de ataque: helper `validate_skill_name` em handlers + integração de `garraia_storage::sanitise_key` em `skins_handler.rs` (single-segment) + experimento `SELECT set_config('app.current_user_id', $1, true)` substituindo `SET LOCAL ... format!()` antes de qualquer dismissal.
 
 **Decisão central documentada**: Rust CodeQL ainda **não suporta** comentários inline `// codeql[rule]: ...` em 2026 ([github/codeql#21638](https://github.com/github/codeql/issues/21637) aberto). `paths-ignore` global não serve porque os testes do GarraRUST são INLINE (`#[cfg(test)] mod tests {}`) dentro de produção. Mecanismo escolhido: ledger versionado + REST dismissal por alerta + script fail-closed. **Sem fallback global**: se a empirical proof falhar, abort + nova decisão (sem `query-filters: exclude` por rule-id). Ver [`docs/security/codeql-suppressions.md`](docs/security/codeql-suppressions.md) §3-§6.
 
@@ -140,7 +141,7 @@ Sub-issues 4 e 5 de GAR-486 estão em execução agora:
 
 - **GAR-436 (mutation testing baseline)** ✅ — `cargo-mutants` pilot em `garraia-auth`. Run inicial 85% killed (19 missed). PR [#94](https://github.com/michelbr84/GarraRUST/pull/94) appended run `25116031135`: **85.04% → 90.78% killed (+5.74 p.p.)**.
 - **GAR-463 Q6.1** ✅ — kill 5 critical mutation bypasses em `garraia-auth/src/hashing.rs` + `lib.rs` (PR #92).
-- **GAR-468 Q6.6** ✅ — kill 3 Debug-redaction mutation bypasses em `garraia-auth` (PR [#96](https://github.com/michelbr84/GarraRUST/pull/96)). **Memória local**: rodar Q6 sub-issues 6.1-6.7 ainda pendentes (`project_next_session_q6_queue`).
+- **GAR-468 Q6.6** ✅ — kill 3 Debug-redaction mutation bypasses em `garraia-auth` (PR [#96](https://github.com/michelbr84/GarraRUST/pull/96)). **Memória local**: fila Q6 (`project_next_session_q6_queue`) consumida — 6.1/6.3/6.5/6.6/6.7/6.8 fechadas.
 - **GAR-469 Q6.7** ✅ — `mutants.yml` timeout bumped 90 → 150 min (PR #93).
 - **GAR-481 Q6.8** ✅ — workflows migrated to **Node 24** (`actions/{checkout,setup-node,upload-artifact,download-artifact,cache}` v4 → latest, deprecation pre-announce 2026-Q3) (PR [#95](https://github.com/michelbr84/GarraRUST/pull/95)).
 
@@ -148,11 +149,11 @@ Sub-issues 4 e 5 de GAR-486 estão em execução agora:
 
 - **GAR-438 (Lote 2)** ✅ (PR [#64](https://github.com/michelbr84/GarraRUST/pull/64), `1828625`) — fix `e2e` + `playwright` jobs que tentavam executar `./target/release/garraia-gateway` (binário inexistente — `garraia-gateway` é biblioteca). Substituído por `cargo build --bin garraia --release` + `services: postgres:16.8-alpine` + envs de auth via `::add-mask::`. 4 de 7 `continue-on-error: true` removidos.
 - **GAR-443 (Lote 4)** ✅ — Playwright admin specs migrados para `getByTestId(...)` ancorados em `data-testid` estáveis (`admin.html`). Convenção: especificações Playwright do admin DEVEM preferir `data-testid` em vez de `placeholder*=` ou `getByRole(button,{name})`.
-- **GitHub Actions annotations follow-up (2026-05-03)** — CI voltou a ficar verde após PR [#113](https://github.com/michelbr84/GarraRUST/pull/113), mas os jobs `Analyze (javascript-typescript)` e `Analyze (rust)` ainda emitem 2 annotations não-bloqueantes: (a) `github/codeql-action/init@v3` + `analyze@v3` rodam em Node.js 20 (forced switch 2026-06-02, removido em 2026-09-16) — escopo expandido em GAR-482 (Q6.9 third-party Node 24 readiness); (b) CodeQL Action v3 será deprecated em dezembro de 2026 — rastreado em GAR-502 (chore migrate v3 → v4). Manutenção preventiva de CI/runtime, **não** alerta CodeQL real (esses ficam em GAR-490 / GAR-491) e **não** bloqueia o merge verde atual.
+- **GitHub Actions annotations follow-up (2026-05-03)** — CI voltou a ficar verde após PR [#113](https://github.com/michelbr84/GarraRUST/pull/113), mas os jobs `Analyze (javascript-typescript)` e `Analyze (rust)` ainda emitem 2 annotations não-bloqueantes: (a) `github/codeql-action/init@v3` + `analyze@v3` rodam em Node.js 20 (forced switch 2026-06-02, removido em 2026-09-16) — escopo expandido em GAR-482 (Q6.9 third-party Node 24 readiness); (b) CodeQL Action v3 será deprecated em dezembro de 2026 — rastreado em GAR-502 (chore migrate v3 → v4). **Resolvido:** `codeql.yml` já roda `codeql-action/init@v4` + `analyze@v4` (GAR-502 ✅). Manutenção preventiva de CI/runtime, **não** alerta CodeQL real (esses ficam em GAR-490 / GAR-491) e **não** bloqueia o merge verde atual.
 - **CARGO_BIN_EXE_garraia removal** (GAR-503) ✅ — fallback dead-code removido de `crates/garraia-cli/tests/migrate_workspace_integration.rs` (plan [`0060`](plans/0060-gar-503-cargo-bin-exe-cleanup.md), PR [#132](https://github.com/michelbr84/GarraRUST/pull/132) `750fb50`, 2026-05-05). `git grep CARGO_BIN_EXE_garraia` agora retorna 0 hits.
-- **Benchmark evidence run** (GAR-504) — primeira execução real de `benches/agent-framework-comparison/run.sh --all` em droplet DigitalOcean 1 vCPU / 1 GB para repor a tabela do `README.md` (PR [#117](https://github.com/michelbr84/GarraRUST/pull/117) §"Open follow-ups"). **Bloqueado** por requerer provisionamento de infra externa.
+- **Benchmark evidence run** (GAR-504) — primeira execução real de `benches/agent-framework-comparison/run.sh --all` em droplet DigitalOcean 1 vCPU / 1 GB para repor a tabela do `README.md` (PR [#117](https://github.com/michelbr84/GarraRUST/pull/117) §"Open follow-ups"). **Parcial**: o run em VM x86_64 está versionado em `results/2026-08-28-vm/` e alimenta a tabela do README; o run de referência no droplet 1 vCPU / 1 GB segue pendente.
 - **Mutation Testing 2026-05-04 missed mutants** (GAR-505) ✅ — triagem dos 6 NEW missed mutants em `jwt.rs` / `storage_redacted.rs` / `app_pool.rs` + 3 timeouts (run [25307117776](https://github.com/michelbr84/GarraRUST/actions/runs/25307117776)) entregue via PR [#119](https://github.com/michelbr84/GarraRUST/pull/119) / PR [#120](https://github.com/michelbr84/GarraRUST/pull/120), 2026-05-04. Sub-issue de GAR-436.
-- **AI Quality Ratchet PR-1** (epic novo, plan [`0064`](plans/0064-quality-ratchet-pr1.md), 2026-05-05) — scaffold do sistema de catraca de qualidade. PR-1 entrega `.quality/{baseline,README,thresholds}`, `scripts/quality/{collect-metrics.sh, compare.py, freeze-baseline.py, parse-{llvm-cov,cargo-audit,clippy}.py + tests/}`, `.github/workflows/quality-ratchet.yml` em modo report-only via flag `compare.py --mode report-only` (zero `continue-on-error`), `.claude/commands/quality-babysit.md` em modo manual-only, e `CODEOWNERS` como camada inicial de visibilidade. **Out of scope deste PR**: duplicação (PR-3), promoção a bloqueante (PR-4 com aprovação explícita), branch protection (sempre com aprovação explícita). Plan-mãe com filosofia + 5 ajustes do owner: `~/.claude/plans/voc-est-no-projeto-buzzing-volcano.md` (não versionado). Issue TBD após merge (tracker interno).
+- **AI Quality Ratchet PR-1** (epic novo, plan [`0064`](plans/0064-quality-ratchet-pr1.md), 2026-05-05) — scaffold do sistema de catraca de qualidade. PR-1 entrega `.quality/{baseline,README,thresholds}`, `scripts/quality/{collect-metrics.sh, compare.py, freeze-baseline.py, parse-{llvm-cov,cargo-audit,clippy}.py + tests/}`, `.github/workflows/quality-ratchet.yml` em modo report-only via flag `compare.py --mode report-only` (zero `continue-on-error`), `.claude/commands/quality-babysit.md` em modo manual-only, e `CODEOWNERS` como camada inicial de visibilidade. **Out of scope deste PR**: duplicação (PR-3), promoção a bloqueante (PR-4 com aprovação explícita), branch protection (sempre com aprovação explícita). Plan-mãe com filosofia + 5 ajustes do owner: `~/.claude/plans/voc-est-no-projeto-buzzing-volcano.md` (não versionado). ✅ mergeado; sem issue (tracker interno).
 
 ### Status do umbrella GAR-486
 
@@ -180,14 +181,14 @@ foram corrigidos no mesmo PR:
 
 Workspace version bumped `0.2.0 → 0.2.1` em `Cargo.toml`, `crates/garraia-desktop/src-tauri/Cargo.toml` e `tauri.conf.json` para fechar o gap de versão sem reuso de tag. Linear: GAR-619 (criada nesta sessão).
 
-### Sprint **Web Console Garra Glass** (2026-05-14) — `web_chat.html` redesenhado de ponta-a-ponta
+### Sprint **Web Console Garra Glass** (2026-05-14) — `webchat.html` redesenhado de ponta-a-ponta
 
-10 PRs sequenciais (#330–#341) entregando o Web Console multi-page completo com design system "Garra Glass" (ADR 0009, plan 0116). Stack: HTML + CSS custom properties `--garra-*` + JS vanilla, zero CDN para Bootstrap/AdminLTE/Animate.css — todos os ícones SVG inline. Páginas: Dashboard, Chat, Providers & Models, Channels, Sessions, Settings Registry (schema-driven dry-run), Diagnostics (12 checks), Logs (filter/search/export), Themes & Skins (4 presets). Novos endpoints REST (todos `/api/*`, auth-free, secret-free via `configured: bool` em vez de `value`): `/api/health` (Dashboard schema com `version`, `uptime_secs`, `active_sessions`, `provider`, `model`, `channels`, `warnings`, back-compat `checks`), `/api/capabilities`, `/api/channels`, `POST /api/providers/test`, `PATCH /api/providers/default`, `/api/settings/{schema,effective}`, `PATCH /api/settings` (validate + audit + dry-run; persistência TOML em plan 0121a), `/api/diagnostics`. Plans: 0116a, 0116b, 0117–0123. Issues Linear: GAR-607, GAR-612…GAR-618, GAR-623.
+10 PRs sequenciais (#330–#341) entregando o Web Console multi-page completo com design system "Garra Glass" (ADR 0009, plan 0116). Stack: HTML + CSS custom properties `--garra-*` + JS vanilla, zero CDN para Bootstrap/AdminLTE/Animate.css — todos os ícones SVG inline. Páginas: Dashboard, Chat, Providers & Models, Channels, Sessions, Settings Registry (schema-driven dry-run), Diagnostics (12 checks), Logs (filter/search/export), Themes & Skins (4 presets). Novos endpoints REST (todos `/api/*`, auth-free, secret-free via `configured: bool` em vez de `value`): `/api/health` (Dashboard schema com `version`, `uptime_secs`, `active_sessions`, `provider`, `model`, `channels`, `warnings`, back-compat `checks`), `/api/capabilities`, `/api/channels`, `POST /api/providers/test`, `PATCH /api/providers/default`, `/api/settings/{schema,effective}`, `PATCH /api/settings` (validate + audit + dry-run; persistência TOML em plan 0121a), `/api/diagnostics`. Plans: 0116a, 0116b, 0117–0123. Issues (histórico Linear): GAR-607, GAR-612…GAR-618, GAR-623.
 
 ### Sprint **Onboarding zero-friction** (2026-05-14..15)
 
-- **PR-A — `garraia init` env-aware bootstrap** (plan 0126, PR #348 `6a2279e`, 2026-05-14): subcomando `garraia init` que detecta config existente, oferece wizard interativo + flags `--yes`/`--non-interactive` para CI, materializa `.garraia/config.toml` + `.env` placeholder. Issue: TBD (tracker interno).
-- **PR-B — `curl \| sh` installer wizard** (plan 0127, PR #350 `bfddf78`, 2026-05-15): `install.sh` ganhou bootstrap wizard de uma linha (`curl -fsSL https://garraia.org/install.sh | sh`) que detecta plataforma, baixa binário correto, roda `garraia init --yes`, sobe `garraia start` em foreground. Cobre Linux/macOS x86_64 + aarch64. Issue: TBD (tracker interno).
+- **PR-A — `garraia init` env-aware bootstrap** (plan 0126, PR #348 `6a2279e`, 2026-05-14): subcomando `garraia init` que detecta config existente, oferece wizard interativo + flags `--yes`/`--non-interactive` para CI, materializa `config.yml` no diretório de config (estratégias FirstWrite/Backup/MergeUpdate em `wizard/config_writer.rs`).
+- **PR-B — `curl \| sh` installer wizard** (plan 0127, PR #350 `bfddf78`, 2026-05-15): `install.sh` ganhou bootstrap wizard de uma linha (`curl -fsSL https://garraia.org/install.sh | sh`) que detecta plataforma, baixa binário correto, roda `garraia init` interativo (ou pula com `GARRAIA_SKIP_INIT=1`), depois `exec garraia start`. Cobre Linux/macOS x86_64 + aarch64.
 
 ### Sprint **Q9 admin/handlers.rs modularização** (2026-05-15..16, 6 PRs)
 
@@ -236,21 +237,21 @@ Continuação do padrão Q9 agora em `crates/garraia-gateway/src/rest_v1/tasks.r
 
 ### Sprint **Garra Learning Agent — épico criado** (2026-05-17, esta sessão)
 
-Nova iniciativa estratégica §1.4 + ADR 0010 Proposed + plan 0138 + épico Linear `GAR-641` com 10 sub-issues criados (ver §1.4 e ADR para detalhes). Sem implementação ainda — apenas planejamento + arquitetura.
+Nova iniciativa estratégica §1.4 + ADR 0010 Proposed + plan 0138 + épico Linear `GAR-641` com 10 sub-issues criados (ver §1.4 e ADR para detalhes). Sem implementação ainda — apenas planejamento + arquitetura *(superado em 2026-05-20: 9/10 sub-issues Done, ver §1.4)*.
 
 ### Sprint **Garra Learning Agent — scaffold GAR-642** (2026-05-18)
 
 Primeira implementação real do Learning Agent epic. Plan [0144](plans/0144-gar-642-learning-agent-scaffold.md):
 
 - ADR 0010 promovido **Proposed → Accepted**.
-- Novo crate `crates/garraia-learning/` adicionado ao workspace (19 → 20 crates ativos).
+- Novo crate `crates/garraia-learning/` adicionado ao workspace (19 → 20 crates ativos; 22 hoje).
 - `safety.rs` **funcional**: 5 SafetyDenial variants + 17 unit tests verdes (DangerousCommand, CriticalPath, ScoreTooLow, AntiFlapDeprecated, PiiDetected).
 - 8 módulos stub: miner, generator, registry, retriever, evaluator, updater, versioning, skill_override — todos retornam `Err(Error::Other("... não implementado"))`.
 - Issue: GAR-642 ✅ Done.
 
 ### `garraia update` / CLI helpers / Runpod compatibility
 
-- **GAR-603 Runpod Load Balancer Serverless compat** ✅ — PR [#327](https://github.com/michelbr84/GarraRUST/pull/327) `cdebe9a`, 2026-05-13. Container HTTP server mode + `GET /ping` health + `PORT`/`HOST` env honor; `PORT_HEALTH` documentado como igual a `PORT` até haver listener separado. Ver §6.1.1.
+- **GAR-603 Runpod Load Balancer Serverless compat** ⚠️ Parcial — código/docs via PR [#327](https://github.com/michelbr84/GarraRUST/pull/327) `cdebe9a`, 2026-05-13: container HTTP server mode + `GET /ping` health + `PORT`/`HOST` env honor; `PORT_HEALTH` documentado como igual a `PORT` até haver listener separado. Smoke Docker local e smoke público Runpod ainda pendentes — ver §6.1.1 e `TODO.md`.
 - **GAR-604 DM creation via `POST /v1/groups/{id}/chats`** ✅ — PR [#324](https://github.com/michelbr84/GarraRUST/pull/324) `4ce9d75`, 2026-05-14.
 - **GAR-605 CodeQL `actions` language matrix re-add** ✅ — PR [#323](https://github.com/michelbr84/GarraRUST/pull/323) `f6698c7`, 2026-05-14. Fecha 17 alertas Medium stale.
 - **CI concurrency cancel-superseded** ✅ — PR [#311](https://github.com/michelbr84/GarraRUST/pull/311) `10f637b` + PR [#316](https://github.com/michelbr84/GarraRUST/pull/316) `f57af85`. Canonical `group: workflow-prNum||ref` + `cancel-in-progress`.
@@ -266,7 +267,7 @@ O roadmap está dividido em **7 fases + trilhas contínuas**. Cada fase tem:
 - **Critérios de aceite** (verificáveis)
 - **Dependências** (fases/entregáveis prévios)
 - **Estimativa** (semanas: baixa / provável / alta)
-- **Épicos Linear (GAR)** quando aplicável
+- **Épicos** (tracker interno; IDs `GAR-xxx` são histórico do Linear) quando aplicável
 
 Fases 1-2 são **fundação técnica**. Fase 3 é o **salto de produto** (Group Workspace). Fase 4 é **experiência**. Fase 5 é **qualidade/compliance**. Fase 6 é **lançamento**. Fase 7 é **pós-GA**. Trilhas contínuas cortam todas as fases.
 
@@ -279,8 +280,8 @@ Fases 1-2 são **fundação técnica**. Fase 3 é o **salto de produto** (Group 
 ### 1.1 TurboQuant+ — Inferência local otimizada
 
 - [ ] Benchmark dos providers locais atuais (Ollama, llama.cpp) em latência/tokens-por-segundo em `benches/inference.rs` (Criterion).
-- [ ] **KV Cache compression** para sessões longas: investigar integração com `llama.cpp` flags `--cache-type-k q8_0 --cache-type-v q8_0`; expor via `garraia-agents` como opção `kv_quant` no provider config.
-- [ ] **PagedAttention / Continuous Batching**: avaliar `candle` vs `mistral.rs` como backend alternativo em Rust nativo; decisão registrada em ADR `docs/adr/0001-local-inference-backend.md`.
+- [x] **KV Cache compression** para sessões longas: `LlamaCppProvider` expõe `cache_type_k`/`cache_type_v` via `extra` do provider (q8_0/q4_0/f16 + turbo2/3/4 do TurboQuant+), passados como `--cache-type-k/-v` ao `llama.cpp` (`crates/garraia-agents/src/llama_cpp.rs`); stack local em `docker-compose.turboquant.yml` + `scripts/build-turboquant-llama.sh`. *(A opção não se chama `kv_quant`; o compose monta `docs/deployment/config.turboquant.yml`, que não existe no repo — follow-up em `TODO.md`.)*
+- [ ] **PagedAttention / Continuous Batching**: decisão registrada — [ADR 0001](docs/adr/0001-local-inference-backend.md) Accepted (2026-04-21) escolhe `mistral.rs` como backend default com Ollama como fallback; a implementação do backend `mistral.rs` ainda não começou (sem dependência no `Cargo.lock`).
 - [ ] **Backends paralelos**: detectar CUDA/MPS/Vulkan em runtime e passar flags apropriadas.
 - [ ] **Quantização**: suporte a modelos Q4_K_M, Q5_K_M, Q8_0 com auto-seleção por VRAM disponível.
 
@@ -312,13 +313,13 @@ Dar ao Garra um modo agente avançado de primeira-classe acionável por `garra m
 
 - Comando `garra max-power` (no `garraia-cli`) que ativa o modo, imprime banner e roteia para a próxima ação certa.
 - **Capability prompt** nativo (não importado do `.claude/`) montado em runtime a partir do que o `AgentRuntime` realmente expõe (providers, tools, canais, MCP servers ativos).
-- Workflow `brainstorm → spec → plan → execute → review → finish` como máquina de estados explícita em `garraia-agents` (ou novo crate `garraia-maxpower`), com gate obrigatório no `spec` antes de qualquer escrita de código.
+- Workflow `brainstorm → spec → plan → execute → review → finish` como máquina de estados explícita (entregue em `garraia-cli/src/team.rs` — `TeamPhase`/`AgentTeam` — sem crate novo), com gate obrigatório no `spec` antes de qualquer escrita de código.
 - **Repo workflow seguro** para GitHub: clonar/branch/PR via `gh`/`git` com checagens de "branch atual não é `main`" e "tree limpo antes de force operations".
 - **Safety gates de bash** centralizados (uma única função que valida antes de spawnar): bloqueia `rm -rf /`, `rm -rf ~`, fork bombs, `git push --force` em `main`, escrita em `.env`/credenciais.
 - 3-5 **skills MVP** nativas (não markdown solto): `brainstorm`, `write-spec`, `write-plan`, `pre-commit`, `verify` — registradas no `garraia-skills` registry.
-- **Agent team MVP**: orquestrador + 2 sub-agentes (revisor + executor) usando `AgentRuntime` real, sem depender do plugin Superpowers do Claude Code.
-- **Handoff / Auto Dream**: arquivo `.garra-estado.md` versionado com último spec, último plan, último review, próxima ação — lido no início da próxima sessão.
-- `garra verify` — validação local idempotente: `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace`, `flutter analyze` (se presente), `gitleaks` (se presente). Sai com exit code estilo `sysexits` (0/2/65).
+- **Agent team MVP**: orquestrador + 2 sub-agentes (revisor + executor) — entregue como pipeline síncrono via canais `mpsc` tipados (`team.rs`), sem depender do plugin Superpowers do Claude Code; execução provider-backed via `AgentRuntime` real é follow-up (ver `TODO.md`).
+- **Handoff / Auto Dream**: arquivo `.garra-estado.md` local (gitignored — handoff, não versionado) com último spec, último plan, último review, próxima ação — lido no início da próxima sessão.
+- `garra verify` — validação local idempotente: `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace`, `flutter analyze` (se presente), `gitleaks` (se presente). Sai com exit code 0 (ok) / 2 (step falhou).
 
 **Fora de escopo (explícito):**
 
@@ -334,12 +335,12 @@ Dar ao Garra um modo agente avançado de primeira-classe acionável por `garra m
 1. ADR `docs/adr/0011-garra-max-power.md` — decisão arquitetural, escopo, alternativas avaliadas.
 2. Subseção §1.2.1 deste ROADMAP (este documento).
 3. Subcomando `garra max-power` no `garraia-cli` (esqueleto + roteamento, sem implementação dos passos pesados).
-4. Crate ou módulo `garraia-maxpower` (ou seção em `garraia-skills`) com a máquina de estados do workflow.
+4. Máquina de estados do workflow — entregue em `garraia-cli/src/{max_power,team}.rs` (sem crate `garraia-maxpower`).
 5. Função `safety_gate(cmd: &str) -> Result<()>` em `garraia-tools` ou `garraia-common`, com testes unitários cobrindo a denylist mínima.
 6. Skills MVP em `garraia-skills` (registry-driven, não arquivos markdown soltos).
 7. `garra verify` em `garraia-cli` com pipeline Rust+Flutter+gitleaks.
 8. `.garra-estado.md` schema documentado + leitor/escritor.
-9. Issues Linear filhas (épico GarraMaxPower abaixo) referenciadas neste documento.
+9. Issues filhas (épico GarraMaxPower abaixo; IDs `GAR-xxx` históricos do Linear, tracker interno hoje) referenciadas neste documento.
 
 **Critérios de aceite:**
 
@@ -360,26 +361,26 @@ Dar ao Garra um modo agente avançado de primeira-classe acionável por `garra m
 - **Memória/Auto Dream PII-leak:** `.garra-estado.md` versionado com prompt do usuário pode vazar dados. Mitigação: schema com allow-list de campos; nada de message bodies por padrão.
 - **CI overhead:** `garra verify` em CI pode ficar lento. Mitigação: passos paralelos + cache; budget documentado por etapa.
 
-**Issues Linear filhas do épico GAR-492:**
+**Issues filhas do épico GAR-492 (histórico Linear; tracker interno hoje):**
 
 - ~~`GarraMaxPower roadmap + ADR` (GAR-493) — esta seção + ADR 0011 (umbrella já registra; issue filha amarra commits).~~ ✅ Done (PR #492 `95618d3`)
-- `/max-power MVP` (GAR-494) — subcomando `garra max-power` esqueleto + roteamento + banner.
-- `Capability prompt nativo` (GAR-495) — gerador provider-agnóstico em runtime, testado contra ≥ 3 providers.
-- `Repo workflow seguro` (GAR-496) — wrappers `gh`/`git` com pré-checagens; cobertura de "main protegida" e "tree limpo".
-- `Safety gates para bash` (GAR-497) — `safety_gate(cmd)` + denylist + testes + integração com tools.
+- ~~`/max-power MVP` (GAR-494) — subcomando `garra max-power` esqueleto + roteamento + banner.~~ ✅ Done (PR #431 `8a9a915`)
+- ~~`Capability prompt nativo` (GAR-495) — gerador provider-agnóstico em runtime, testado contra ≥ 3 providers.~~ ✅ Done (PR #453 `e5a2a08`)
+- ~~`Repo workflow seguro` (GAR-496) — wrappers `gh`/`git` com pré-checagens; cobertura de "main protegida" e "tree limpo".~~ ✅ Done (PR #455 `1b7f04c`)
+- ~~`Safety gates para bash` (GAR-497) — `safety_gate(cmd)` + denylist + testes + integração com tools.~~ ✅ Done (PR #437 `f2ab1d9`)
 - ~~`Skills MVP` (GAR-498) — 3-5 skills nativas via registry `garraia-skills`.~~ ✅ Done (PR #488 `c65e099`)
-- ~~`Agent team MVP` (GAR-499) — orquestrador + 2 sub-agentes, dogfooded em um bug real.~~ ✅ Done (PR #490 `7e45ec5`)
-- `Auto Dream / handoff` (GAR-500) — schema `.garra-estado.md` + reader/writer + redaction.
+- ~~`Agent team MVP` (GAR-499) — orquestrador + 2 sub-agentes, dogfooded em um bug real.~~ ✅ Done (PR #490 `7e45ec5`) *(pipeline entregue; o dogfood em bug real segue pendente — §7 / `TODO.md`)*
+- ~~`Auto Dream / handoff` (GAR-500) — schema `.garra-estado.md` + reader/writer + redaction.~~ ✅ Done (PR #445 `f1fb596`)
 - ~~`garra verify` (GAR-501) — pipeline local idempotente, exit-codes sysexits, relatório markdown.~~ ✅ Done (PR #441 `ca9f1fa2`)
 
 **Estimativa:** 3 / 5 / 8 semanas, em paralelo a 1.2 e 1.3.
 
 ### 1.3 Config & Runtime Wiring unificado
 
-- [ ] **Schema único** de config em `garraia-config` (novo crate) com `serde` + `validator`; fontes: `.garraia/config.toml` > `mcp.json` > env > CLI flags.
+- [x] **Schema único** de config em `garraia-config` com `serde` + `validator` ✅; fontes reais: `<config_dir>/config.yml` (fallback `config.toml`) > `mcp.json` > env > CLI flags, com `config_dir` = `$GARRAIA_CONFIG_DIR` → `~/.config/garraia` (→ `~/.garraia` legado).
 - [ ] **Reactive config**: endpoint SSE `GET /v1/admin/config/stream` emite eventos ao alterar config via Web UI/CLI; `AppState` reage sem restart.
-- [ ] **Provider hot-reload**: alterar API keys ou endpoints propaga para `AgentRuntime` em < 500ms.
-- [ ] **Dry-run validation**: `garraia-cli config check` valida config sem iniciar o servidor.
+- [ ] **Provider hot-reload**: alterar API keys ou endpoints propaga para `AgentRuntime` em < 500ms. *(Parcial: `ConfigWatcher` (notify) recarrega `config.yml` ao vivo para a maioria das settings; providers e canais ainda só no boot.)*
+- [x] **Dry-run validation**: `garraia config check [--json] [--strict]` valida config sem iniciar o servidor — plan 0035 / GAR-379 slice 1 ✅ (+ `PATCH /api/settings` em dry-run no Web Console).
 
 **Critério de aceite:**
 
@@ -396,7 +397,7 @@ Dar ao Garra um modo agente avançado de primeira-classe acionável por `garra m
 > installer já estabelecidos), adicionando os 4 loops novos (Mine, Use+Evaluate,
 > Auto-Update, Promote-to-Manual).
 >
-> **Decisão arquitetural completa:** [`docs/adr/0010-garra-learning-agent.md`](docs/adr/0010-garra-learning-agent.md) (Proposed em 2026-05-17).
+> **Decisão arquitetural completa:** [`docs/adr/0010-garra-learning-agent.md`](docs/adr/0010-garra-learning-agent.md) (Accepted em 2026-05-17, via PR #393 / plan 0144).
 
 **Objetivo:**
 
@@ -415,29 +416,29 @@ aprendido, sem nunca promover skill não-validada.
 
 **Sub-componentes (10):**
 
-1. **Skill Miner** (`garraia-learning::miner`) — lê session logs (`.garra-estado.md` + opt-in `~/.garra/sessions/`), detecta padrões repetíveis (≥3 ocorrências em contextos similares), emite candidates em `~/.garra/skills/_candidates/`.
-2. **Skill Generator** (`garraia-learning::generator`) — LLM-assisted skill drafting com prompt provider-agnóstico (default `openrouter/free`); gera Markdown + YAML frontmatter compatível com `SkillFrontmatter` do crate `garraia-skills`.
+1. **Skill Miner** (`garraia-learning::miner`) — lê session logs (opt-in `~/.garra/sessions/<id>.json`), detecta padrões repetíveis (≥3 ocorrências em contextos similares), emite candidates em `~/.garra/skills/_candidates/`.
+2. **Skill Generator** (`garraia-learning::generator`) — LLM-assisted skill drafting com prompt provider-agnóstico (provider injetado via trait `SkillDraftProvider`, sem default embutido); gera Markdown + YAML frontmatter compatível com `SkillFrontmatter` do crate `garraia-skills`.
 3. **Skill Registry** (`garraia-learning::registry`) — wrapper sobre `garraia-skills`, dual-scope: global (`~/.garra/skills/`, compartilhado entre projetos) + por-projeto (`.garra/skills/`, versionado no repo). Lock-file em `_locks/` para concorrência.
-4. **Skill Retriever** (`garraia-learning::retriever`) — embedding match via `garraia-embeddings` (Fase 2.1 prereq) + filtro por escopo + score mínimo. Skill encontrada vira contexto adicional no prompt do `AgentRuntime`. MVP roda sem Retriever (match por tag/scope) até embeddings estarem prontos.
+4. **Skill Retriever** (`garraia-learning::retriever`) — embedding match via `garraia-embeddings` (Fase 2.1 prereq) + filtro por escopo + score mínimo. Skill encontrada vira contexto adicional no prompt do `AgentRuntime`. Hoje `retriever::retrieve` é um stub que retorna erro (sem fallback por tag/scope) — GAR-646 aguarda a Fase 2.1.
 5. **Skill Evaluator** (`garraia-learning::evaluator`) — mede sucesso via sinais objetivos: exit codes, `cargo test` pass count, `gh pr checks` após skill aplicada, diffs (linhas/arquivos tocados), logs (presença de `ERROR`/`panic`), latência. Atualiza score (EMA exponencial). Skills com score < 0.3 marcadas `deprecated` (não removidas — preserva histórico).
 6. **Skill Auto-Updater** (`garraia-learning::updater`) — quando Evaluator detecta falha ou melhoria, gera diff (skill v2), cria branch `learning/skill-X-vN-vN+1`, submete PR via `gh`. Nunca auto-merge; promoção só via Safety Gate + Human Override.
 7. **Git-backed Versioning** (`garraia-learning::versioning`) — cada skill é arquivo git-tracked em `.garra/skills/`; histórico = `git log` do arquivo; diff = `git diff`; rollback = `git revert`. Score histórico em `.garra/skills/_history/<skill-name>.json` (append-only).
-8. **Safety Gate** (`garraia-learning::safety`) — reusa `garraia-tools::safety_gate` do GarraMaxPower (§1.2.1) + extensões: (a) denylist hard-coded de comandos destrutivos aprendidos (`rm -rf /`, `git push --force`, `DROP TABLE`); (b) paths críticos (`garraia-auth/`, `garraia-security/`, `.github/workflows/`, `deny.toml`) exigem `@security-auditor` + `@code-reviewer` approval; (c) score < threshold não promove; (d) anti-flap (3 falhas consecutivas → deprecated); (e) PII redaction antes do LLM (regex email/path/token via `garraia-telemetry::redact`).
-9. **Human Override** (`garraia-learning::override`) — CLI `garra skills {list,show,lock,unlock,approve,reject,delete,rollback}` + Web UI. Estados: `candidate → proposed → approved → promoted → deprecated → locked`. Editar manualmente vira skill `authored` (protege contra auto-update).
+8. **Safety Gate** (`garraia-learning::safety`) — denylist própria em `garraia-learning::safety` (não reusa `garraia_common::safety_gate` do §1.2.1) + extensões: (a) denylist hard-coded de comandos destrutivos aprendidos (`rm -rf /`, `git push --force`, `DROP TABLE`); (b) paths críticos (`garraia-auth/`, `garraia-security/`, `.github/workflows/`, `deny.toml`) exigem `@security-auditor` + `@code-reviewer` approval; (c) score < threshold não promove; (d) anti-flap (3 falhas consecutivas → deprecated); (e) PII redaction antes do LLM (regex própria de email/path/token).
+9. **Human Override** (`garraia-learning::override`) — Web UI entregue (`/learning` + `/api/learning/*`: approve/reject/lock/rollback/delete); o CLI `garra skills {show,lock,unlock,approve,reject,delete,rollback}` e o módulo `skill_override` ainda são stubs (só `list|install|remove` existem). Estados: `candidate → proposed → approved → promoted → deprecated → locked`. Editar manualmente vira skill `authored` (protege contra auto-update).
 10. **Web UI for Skills and Learning Logs** (`garraia-gateway::web_console::skills`) — aba "Skills" no Web Console Garra Glass (ADR 0009): lista global + por-projeto, score, last_used, promoted_at; detalhe com markdown render + history git + diffs entre versões + score timeline (chart) + logs de execução + botões Rollback/Lock/Delete. Aba "Learning Logs" mostra sessões observadas + candidates pendentes + scores recentes.
 
 **Critérios de aceite:**
 
-- [ ] Crate `garraia-learning` compila com `cargo check -p garraia-learning`.
-- [ ] `garra skills mine --from session-log.json` cria candidate em `~/.garra/skills/_candidates/` sem intervenção manual.
-- [ ] `garra skills list` recupera skill relevante (top-1 por embedding + scope-match) e injeta como contexto no prompt do `AgentRuntime`.
-- [ ] Evaluator propõe atualização quando vê falha ou caminho melhor — abre PR via `gh`, nunca auto-merge.
-- [ ] Tentativa de promover skill contendo `rm -rf /` (test fixture) é bloqueada com `SafetyDenial::DangerousCommand`.
-- [ ] Tentativa de promover skill que altera `crates/garraia-auth/src/lib.rs` (test fixture) exige label `security-audit-passed`, senão `SafetyDenial::CriticalPath`.
-- [ ] Toda mudança de skill tem diff (`git diff`), versão (semver no frontmatter), motivo (PR body), evidência (test/CI link) e rollback (`git revert`) acessíveis via CLI e Web UI.
-- [ ] Separação clara entre memória/skill/log/manual (tabela acima) documentada em CLAUDE.md + README do crate + ADR 0010.
-- [ ] Hermes Agent mencionado **apenas** como referência conceitual; busca por importações de código do Hermes em `Cargo.lock` retorna zero.
-- [ ] Sistema seguro contra: aprendizado errado (Safety Gate denylist + Evaluator threshold), comandos perigosos (hard denylist), acúmulo de lixo (TTL 90d para candidates não-promovidos).
+- [x] Crate `garraia-learning` compila com `cargo check -p garraia-learning` (membro do workspace consumido por `garraia-gateway`).
+- [ ] `garra skills mine --from session-log.json` cria candidate em `~/.garra/skills/_candidates/` sem intervenção manual. *(O Miner existe em `miner.rs`; o subcomando CLI ainda não.)*
+- [ ] `garra skills list` recupera skill relevante (top-1 por embedding + scope-match) e injeta como contexto no prompt do `AgentRuntime`. *(Retriever é stub — GAR-646.)*
+- [x] Evaluator propõe atualização quando vê falha ou caminho melhor — abre PR via `gh`, nunca auto-merge (GAR-647 + GAR-648: `propose_update_with_runner`, `auto_merge_guard`).
+- [x] Tentativa de promover skill contendo `rm -rf /` (test fixture) é bloqueada com `SafetyDenial::DangerousCommand` (GAR-649).
+- [x] Tentativa de promover skill que altera `crates/garraia-auth/src/lib.rs` (test fixture) exige label `security-audit-passed`, senão `SafetyDenial::CriticalPath` (GAR-649).
+- [ ] Toda mudança de skill tem diff (`git diff`), versão (semver no frontmatter), motivo (PR body), evidência (test/CI link) e rollback (`git revert`) acessíveis via CLI e Web UI. *(Parcial: Web UI ✅ via `/api/learning/skills/{name}/rollback` + `versioning::history`; CLI ⏳.)*
+- [ ] Separação clara entre memória/skill/log/manual (tabela acima) documentada em CLAUDE.md + README do crate + ADR 0010. *(Parcial: CLAUDE.md ✅ + ADR 0010 ✅; README do crate ainda não existe.)*
+- [x] Hermes Agent mencionado **apenas** como referência conceitual; busca por importações de código do Hermes em `Cargo.lock` retorna zero.
+- [ ] Sistema seguro contra: aprendizado errado (Safety Gate denylist + Evaluator threshold), comandos perigosos (hard denylist), acúmulo de lixo (TTL 90d para candidates não-promovidos). *(Parcial: denylist + threshold ✅; TTL 90d de candidates não implementado.)*
 
 **Não-fazer (escopo explícito):**
 
@@ -447,13 +448,13 @@ aprendido, sem nunca promover skill não-validada.
 - Não promover skill sem human-in-the-loop em paths sensíveis.
 - Não substituir `garraia-skills` nem `garraia-workspace memory` — Learning Agent **integra**; não duplica.
 
-**Issues Linear filhas do épico `GAR-641`** (criadas 2026-05-17, label `epic:learning-agent`) — **10/10 Done ✅ 2026-05-20**:
+**Issues filhas do épico `GAR-641`** (histórico Linear, tracker interno hoje; criadas 2026-05-17, label `epic:learning-agent`) — **9/10 Done ✅ 2026-05-20** (GAR-646 Retriever segue stub até a Fase 2.1):
 
 - `GAR-642` **Learning Agent Architecture** (High, label `adr-needed`) — ADR 0010 → Accepted + scaffold + integração com `AgentRuntime`.
 - `GAR-643` **Skill Miner** (Medium)
 - `GAR-644` **Skill Generator** (Medium)
 - `GAR-645` **Skill Registry** (High)
-- `GAR-646` **Skill Retriever** (Medium, depende de Fase 2.1)
+- `GAR-646` **Skill Retriever** (Medium, depende de Fase 2.1) — ⏳ stub (`retriever.rs` retorna erro)
 - `GAR-647` **Skill Evaluator** (High)
 - `GAR-648` **Skill Auto-Updater** (Medium)
 - `GAR-649` **Skill Safety Gates** (Urgent — hard wall)
@@ -480,11 +481,11 @@ aprendido, sem nunca promover skill não-validada.
 
 ### 2.1 Memória de longo prazo & RAG local
 
-- [ ] **Embeddings locais**: integrar `mxbai-embed-large-v1` via `ort` (onnxruntime) em novo crate `garraia-embeddings`. Fallback para `fastembed-rs`.
-- [ ] **Vector store**: escolha documentada em ADR `docs/adr/0002-vector-store.md` entre `lancedb` (embutido, colunar) e `qdrant` (embutido ou sidecar). Recomendação inicial: **lancedb** pela simplicidade de deploy.
-- [ ] **Schema**: tabelas `memory_embeddings(memory_item_id, vector, model, created_at)` e índice HNSW.
+- [ ] **Embeddings locais**: crate `garraia-embeddings` scaffoldado (traits `EmbeddingProvider`/`VectorStore` + `DeterministicProvider`, plan 0145, 2026-05-18); o provider real (`MxbaiProvider` via candle, ADR 0001/0002) e o `PgVectorStore` seguem pendentes. Hoje os embeddings reais vêm de `garraia-agents` (`OllamaEmbeddingProvider` nomic-embed-text / OpenAI `text-embedding-3-small`) para a memória SQLite.
+- [x] **Vector store**: [ADR 0002](docs/adr/0002-vector-store.md) Accepted (2026-04-21) — **pgvector** como store primário (migration 005); LanceDB documentado apenas como opção futura para edge/offline.
+- [x] **Schema**: `memory_embeddings` (`vector(768)`, PK `(memory_item_id, model)`) + índice HNSW cosine — migration 005 / GAR-389 ✅
 - [ ] **RAG pipeline**: `garraia-agents` ganha `RetrievalTool` que faz ANN search + re-rank por BM25 (via `tantivy`) + injeção em prompt.
-- [ ] **Governance**: TTL, sensitivity level (`public|group|private`), auditoria de acesso.
+- [ ] **Governance**: TTL + sensitivity (`public|group|private|secret`) na migration 005 e filtrados em `/v1/memory` ✅; audit de escrita/pin/deleção ✅; auditoria de **leitura** ainda pendente.
 
 **Critério de aceite:**
 
@@ -492,11 +493,11 @@ aprendido, sem nunca promover skill não-validada.
 
 ### 2.2 MCP + Plugins WASM
 
-- [ ] **MCP servers expandidos**: registro dinâmico via admin API; health-check periódico.
-- [ ] **WASM sandbox**: integrar `wasmtime` em novo crate `garraia-plugins`; plugins expõem interface WIT (`wit-bindgen`).
-- [ ] **Capabilities-based**: cada plugin declara permissões (`net`, `fs:/allowed/path`, `llm:call`) — nenhum por padrão.
+- [x] **MCP servers expandidos**: registro dinâmico via admin API (`POST /admin/api/mcp`, `DELETE`, `/restart`) + `spawn_health_monitor` a cada 30s ✅
+- [ ] **WASM sandbox**: `wasmtime` 48 + WASI p1 integrados em `garraia-plugins` com ABI de export própria (`plugin_execute`) ✅; interface WIT / component model (`wit-bindgen`) ainda pendente.
+- [ ] **Capabilities-based**: `Permissions { network, filesystem, filesystem_read_paths, filesystem_write_paths, env_vars }` deny-by-default em `manifest.rs` ✅; `llm:call` ainda não existe.
 - [ ] **Self-authoring tools**: sub-agentes podem gerar plugins WASM via template e testá-los no sandbox antes de registrar.
-- [ ] **Plugin registry local**: `~/.garraia/plugins/` com manifesto assinado (ed25519).
+- [ ] **Plugin registry local**: `<config_dir>/plugins/` (`~/.config/garraia/plugins/`) via `PluginRegistry::from_dir` ✅; assinatura ed25519 do manifesto pendente.
 
 **Critério de aceite:**
 
@@ -504,15 +505,15 @@ aprendido, sem nunca promover skill não-validada.
 
 ### 2.3 Zero-latency streaming & Telemetria
 
-**Status:** ✅ baseline entregue em 2026-04-13 via GAR-384 (commit `84c4753`). Crate `garraia-telemetry` em produção atrás de feature flag `telemetry` (default on). Follow-ups: GAR-411 (TLS docs, cardinality, idempotência) e GAR-412 (/metrics auth não-loopback).
+**Status:** ✅ baseline entregue em 2026-04-13 via GAR-384 (commit `84c4753`). Crate `garraia-telemetry` em produção atrás de feature flag `telemetry` (default on). Follow-ups: GAR-411 (TLS docs, cardinality, idempotência) pendente; GAR-412 (/metrics auth não-loopback) ✅ entregue via plan 0024 (`metrics_auth.rs`).
 
 - [ ] **Tokio tuning**: buffers enxutos em WebSocket handlers; `tokio-tungstenite` com `flush_interval` configurável.
-- [x] **OpenTelemetry**: crate `garraia-telemetry` com `tracing-opentelemetry` 0.27 + `opentelemetry-otlp` 0.26 (gRPC), fail-soft init, sampler `TraceIdRatioBased`, guard RAII com shutdown em Drop. ✅
-- [x] **Prometheus**: `/metrics` baseline com 4 métricas (`requests_total`, `http_latency_seconds`, `errors_total`, `active_sessions`) via `metrics-exporter-prometheus 0.15`, bind default `127.0.0.1:9464`. ✅ (métricas adicionais por subsistema ficam como issue futuro)
+- [x] **OpenTelemetry**: crate `garraia-telemetry` com `tracing-opentelemetry` 0.33 + `opentelemetry-otlp` 0.32 (gRPC; 0.26 → 0.32 no plan 0252), fail-soft init, sampler `TraceIdRatioBased`, guard RAII com shutdown em Drop. ✅
+- [x] **Prometheus**: `/metrics` baseline com 4 métricas (`requests_total`, `http_latency_seconds`, `errors_total`, `active_sessions`) via `metrics-exporter-prometheus 0.18` (métricas com prefixo `garraia_`), bind default `127.0.0.1:9464`. ✅ (métricas adicionais por subsistema ficam como issue futuro)
 - [x] **Trace correlation**: `request_id` via `tower-http::SetRequestIdLayer` + propagate layer; `#[tracing::instrument]` em `AgentRuntime::process_message*` (skip_all, has_user_id boolean para LGPD) e `SessionStore::append_message*`/`load_recent_messages`. ✅
-- [x] **PII safety**: `http_trace_layer()` exclui headers dos spans por default; `redact.rs` com header allowlist; `redaction_smoke.rs` como regression guard. ✅
+- [x] **PII safety**: `http_trace_layer()` exclui headers dos spans por default; `redact.rs` com header allowlist; unit tests em `redact.rs` como regression guard. ✅
 - [x] **Infra local**: `ops/compose.otel.yml` (Jaeger 1.60 + Prometheus v2.54 + Grafana 11.2) com provisioning de datasources. ✅
-- [ ] **Dashboards**: templates Grafana em `ops/grafana/dashboards/` para latência, errors, inference p95, fila de jobs. (folder stub existe, dashboards como issue futuro)
+- [ ] **Dashboards**: templates Grafana em `ops/grafana/provisioning/dashboards/` para latência, errors, inference p95, fila de jobs. (só o provider `garraia.yml` existe; nenhum dashboard JSON ainda)
 
 **Critério de aceite:**
 
@@ -527,20 +528,20 @@ aprendido, sem nunca promover skill não-validada.
 
 **Objetivo:** transformar Garra de mono-usuário em **workspace compartilhado** com arquivos, chats e memória IA escopados por grupo, conforme `deep-research-report.md`.
 
-**Status (2026-04-15):** 🟢 **Epic GAR-391 FECHADO — Fase 3.3 completa.** Plan 0014 (GAR-391d, app-layer cross-group authz matrix via HTTP) entregue em `a688497` / PR #17: 15-case table-driven matrix sobre `GET /v1/me`, `POST /v1/groups`, `GET /v1/groups/{id}` × {alice, bob, eve} com fixture `seed_user_without_group`. Revisões `security-auditor` + `code-reviewer` APPROVE. Rule 10 do `CLAUDE.md` satisfeita para os 3 endpoints tenant-scoped existentes. Histórico da Fase 3.3: ADR 0003 + ADR 0005 (com Amendment 2026-04-13) accepted; `garraia-workspace` com **10 migrations**; `garraia-auth` com `Principal` extractor (Axum) + `RequirePermission` struct method + `Role`/`Action` enums tipados + `fn can()` central (110-case test) + `SignupPool` newtype + `signup_user` free function + `RedactedStorageError` wrapper + `AuthConfig` em `garraia-config` + 4 endpoints `/v1/auth/{login,refresh,logout,signup}` wired no `AppState` real + métricas Prometheus baseline + **migration 010** fechando os 3 structural gaps (Gap A `GRANT SELECT ON sessions`, Gap B `garraia_signup NOLOGIN BYPASSRLS`, Gap C `GRANT SELECT ON group_members`) + **GAR-392 RLS matrix** (plan 0013, 81 cenários). ADRs 0004 (storage), 0006 (search) e 0008 (docs collab) ainda pendentes.
+**Status (2026-04-15):** 🟢 **Epic GAR-391 FECHADO — Fase 3.3 completa.** Plan 0014 (GAR-391d, app-layer cross-group authz matrix via HTTP) entregue em `a688497` / PR #17: 15-case table-driven matrix sobre `GET /v1/me`, `POST /v1/groups`, `GET /v1/groups/{id}` × {alice, bob, eve} com fixture `seed_user_without_group`. Revisões `security-auditor` + `code-reviewer` APPROVE. Rule 10 do `CLAUDE.md` satisfeita para os 3 endpoints tenant-scoped existentes. Histórico da Fase 3.3: ADR 0003 + ADR 0005 (com Amendment 2026-04-13) accepted; `garraia-workspace` com **10 migrations**; `garraia-auth` com `Principal` extractor (Axum) + `RequirePermission` struct method + `Role`/`Action` enums tipados + `fn can()` central (110-case test) + `SignupPool` newtype + `signup_user` free function + `RedactedStorageError` wrapper + `AuthConfig` em `garraia-config` + 4 endpoints `/v1/auth/{login,refresh,logout,signup}` wired no `AppState` real + métricas Prometheus baseline + **migration 010** fechando os 3 structural gaps (Gap A `GRANT SELECT ON sessions`, Gap B `garraia_signup NOLOGIN BYPASSRLS`, Gap C `GRANT SELECT ON group_members`) + **GAR-392 RLS matrix** (plan 0013, 81 cenários). ADRs 0004 (storage), 0006 (search) e 0008 (docs collab) foram aceitas em 2026-04-21.
 
 > Esta é a fase de maior valor de produto e a de maior risco de segurança. Tudo aqui nasce com "privacidade por padrão" e testes de autorização.
 
 ### 3.1 Decisões arquiteturais (ADRs obrigatórios antes de codar)
 
 - [x] [`docs/adr/0003-database-for-workspace.md`](docs/adr/0003-database-for-workspace.md) — **Postgres 16 + pgvector + pg_trgm** escolhido com benchmark empírico no PoC `benches/database-poc/` (removido em 2026-08-16 após estabilização; números preservados no ADR 0003). SQLite mantido para dev/CLI single-user. Entregue em 2026-04-13 via GAR-373. ✅
-- [ ] `docs/adr/0004-object-storage.md` — S3 compatível (MinIO default self-host; suporte R2/S3/GCS/Azure). Versionamento obrigatório. (GAR-374)
+- [x] [`docs/adr/0004-object-storage.md`](docs/adr/0004-object-storage.md) — S3 compatível (MinIO default self-host; suporte R2/S3/GCS/Azure). Versionamento obrigatório. Accepted 2026-04-21 (GAR-374). ✅
 - [x] [`docs/adr/0005-identity-provider.md`](docs/adr/0005-identity-provider.md) — **`garraia_login` BYPASSRLS dedicated role + Argon2id RFC 9106 + HS256 JWT v1 + lazy upgrade dual-verify PBKDF2→Argon2id** escolhidos. Resolve o hard blocker do login flow sob RLS documentado em GAR-408. Trait `IdentityProvider` shape congelada para futuros adapters OIDC. Entregue em 2026-04-13 via GAR-375. ✅
-- [ ] `docs/adr/0006-search-strategy.md` — Postgres FTS (tsvector) como start, Tantivy como evolução, Meilisearch como opção externa. (GAR-376)
+- [x] [`docs/adr/0006-search-strategy.md`](docs/adr/0006-search-strategy.md) — Postgres FTS (tsvector) como start, Tantivy como evolução, Meilisearch como opção externa. Accepted 2026-04-21 (GAR-376). ✅
 
 ### 3.2 Domínio & Schema
 
-Crate `garraia-workspace` ✅ **schema completo da Fase 3** entregue em 2026-04-13/14 via 8 migrations sequenciais: 001 (GAR-407, users/groups/sessions/api_keys), 002 (GAR-386, RBAC + audit_events + single-owner index), 004 (GAR-388, chats + messages com `tsvector` GIN + compound FK), 005 (GAR-389, memory_items + memory_embeddings com pgvector HNSW cosine), 006 (GAR-390, tasks Tier 1 Notion-like com RLS embedded), 007 (GAR-408, FORCE RLS em 10 tabelas com NULLIF fail-closed + prova empírica via ownership transfer panic-safe), 008 (GAR-391a, `garraia_login NOLOGIN BYPASSRLS` dedicated role + 4 GRANTs exatos do ADR 0005) e 009 (GAR-391b prereq, `user_identities.hash_upgraded_at`). Smoke test testcontainers `pgvector/pgvector:pg16` cobre todas as migrations em ~10-13s wall. PII-safe `Workspace` handle via `#[instrument(skip(config))]` + custom `Debug` redacting `database_url`. Slot 003 reservado para GAR-387 (files, bloqueado por ADR 0004). Plans: [`plans/0003`](plans/0003-gar-407-workspace-schema-bootstrap.md) → [`plans/0010`](plans/0010-gar-391a-garraia-auth-crate-skeleton.md) → [`plans/0011.5`](plans/0011.5-gar-391b-migration-009-hash-upgraded-at.md).
+Crate `garraia-workspace` ✅ **schema da Fase 3** entregue em 2026-04-13/14 via 8 migrations sequenciais (hoje são 33 migrations / 37 tabelas / 32 sob FORCE RLS): 001 (GAR-407, users/groups/sessions/api_keys), 002 (GAR-386, RBAC + audit_events + single-owner index), 004 (GAR-388, chats + messages com `tsvector` GIN + compound FK), 005 (GAR-389, memory_items + memory_embeddings com pgvector HNSW cosine), 006 (GAR-390, tasks Tier 1 Notion-like com RLS embedded), 007 (GAR-408, FORCE RLS em 10 tabelas com NULLIF fail-closed + prova empírica via ownership transfer panic-safe), 008 (GAR-391a, `garraia_login NOLOGIN BYPASSRLS` dedicated role + 4 GRANTs exatos do ADR 0005) e 009 (GAR-391b prereq, `user_identities.hash_upgraded_at`). Smoke test testcontainers `pgvector/pgvector:pg16` cobre todas as migrations em ~10-13s wall. PII-safe `Workspace` handle via `#[instrument(skip(config))]` + custom `Debug` redacting `database_url`. Migration 003 (GAR-387: folders/files/file_versions, plan 0033) entregue após o ADR 0004. Plans: [`plans/0003`](plans/0003-gar-407-workspace-schema-bootstrap.md) → [`plans/0010`](plans/0010-gar-391a-garraia-auth-crate-skeleton.md) → [`plans/0011.5`](plans/0011.5-gar-391b-migration-009-hash-upgraded-at.md).
 
 **Tabelas (Postgres + SQLx migrations):**
 
@@ -550,7 +551,7 @@ Crate `garraia-workspace` ✅ **schema completo da Fase 3** entregue em 2026-04-
 - [x] `api_keys` (`id`, `user_id`, `label`, `key_hash UNIQUE`, `scopes jsonb`, `created_at`, `revoked_at`, `last_used_at`) — Argon2id pinned, migration 001 ✅
 - [x] `groups` (`id`, `name`, `type`, `created_by`, `settings jsonb`, `created_at`, `updated_at`) — migration 001 ✅
 - [x] `group_members` (`group_id`, `user_id`, `role`, `status`, `joined_at`, `invited_by`) — migration 001 ✅
-- [x] `group_invites` (`id`, `group_id`, `invited_email citext`, `proposed_role`, `token_hash UNIQUE`, `expires_at`, `created_by`, `created_at`, `accepted_at`, `accepted_by`, `revoked_at`, `revoked_by`) — migration 001 + 021 (plan 0257) ✅
+- [x] `group_invites` (`id`, `group_id`, `invited_email citext`, `proposed_role`, `token_hash UNIQUE`, `expires_at`, `created_by`, `created_at`, `accepted_at`, `accepted_by`, `revoked_at`, `revoked_by`) — migration 001 + 024 (`revoked_*`, plan 0257) + 025 (`declined_*`, plan 0258) ✅
 - [x] `roles`, `permissions`, `role_permissions` — migration 002 ✅ (5 roles + 22 permissions + 63 role_permissions, seed estático)
 - [x] `audit_events` (`id`, `group_id`, `actor_user_id`, `actor_label`, `action`, `resource_type`, `resource_id`, `ip`, `user_agent`, `metadata`, `created_at`) — NO FK intencional, sobrevive CASCADE para LGPD art. 8 §5 / GDPR art. 17(1), migration 002 ✅
 - [x] `group_members_single_owner_idx` — partial unique index `WHERE role = 'owner'` (fecha GAR-414 M1), migration 002 ✅
@@ -559,8 +560,8 @@ Crate `garraia-workspace` ✅ **schema completo da Fase 3** entregue em 2026-04-
 - [x] `messages` (`id`, `chat_id`, **`group_id` denormalizado**, `sender_user_id`, `sender_label`, `body` CHECK len 1..100k, **`body_tsv tsvector GENERATED STORED + GIN`**, `reply_to_id ON DELETE SET NULL`, `thread_id` plain uuid, `deleted_at` soft-delete, **compound FK `(chat_id, group_id) → chats(id, group_id)`**) — migration 004 ✅
 - [x] `message_threads` (`id`, `chat_id`, `root_message_id UNIQUE`, `title`, `resolved_at`) — migration 004 ✅
 - [x] `message_attachments` (M:N join, `message_id + file_id`, FORCE RLS via `message_attachments_through_messages` policy) — migration 020, GAR-697 (plan 0179) + GAR-700 (plan 0182). ✅
-- [ ] `folders` (`id`, `group_id`, `parent_id`, `name`)
-- [ ] `files`, `file_versions`, `file_shares`
+- [x] `folders` (`id`, `group_id`, `parent_id`, `name`, `deleted_at`) — migration 003 (GAR-387, plan 0033), FORCE RLS ✅
+- [x] `files`, `file_versions` — migration 003, FORCE RLS ✅ (`file_shares` não existe em nenhuma migration — pendente)
 - [x] `memory_items` (`id`, `scope_type` CHECK user/group/chat, `scope_id` sem FK, **`group_id` NULL-able** para user-scope, `created_by ON DELETE SET NULL` + `created_by_label` cache, `kind` CHECK 6 valores, `content` CHECK 10k, `sensitivity` CHECK 4 níveis + partial index em secret, `source_chat_id/source_message_id ON DELETE SET NULL`, `ttl_expires_at` CHECK future) — migration 005 ✅
 - [x] `memory_embeddings` (`memory_item_id` FK CASCADE, `model` CHECK 256, `embedding vector(768)`, PK `(memory_item_id, model)`, **HNSW `vector_cosine_ops`** index) — migration 005 ✅
 - [x] **Row-Level Security (FORCE) em 10 tabelas tenant-scoped** (`messages`, `chats`, `chat_members`, `message_threads`, `memory_items`, `memory_embeddings`, `audit_events`, `sessions`, `api_keys`, `user_identities`) com 3 classes de policies (direct / JOIN / dual) + `NULLIF(current_setting(...), '')::uuid` fail-closed + role `garraia_app` NOLOGIN + `ALTER DEFAULT PRIVILEGES` forward-compat + 8 cenários de smoke test incluindo **prova empírica de FORCE** via ownership transfer para role não-superuser (com `scopeguard::defer!` panic-safe) — migration 007 ✅. **Impacto em GAR-391:** login flow precisa de role BYPASSRLS ou SECURITY DEFINER para ler `user_identities.password_hash` (hard blocker documentado no README).
@@ -574,31 +575,31 @@ Crate `garraia-workspace` ✅ **schema completo da Fase 3** entregue em 2026-04-
 
 Novo crate: `garraia-auth` (separado de `garraia-security`).
 
-**Status (2026-04-13):** 🟢 **Skeleton entregue** via GAR-391a — crate `garraia-auth` existe com `IdentityProvider` trait + `InternalProvider` stub + `LoginPool` newtype validado por `current_user` + migration `008_login_role.sql` criando `garraia_login NOLOGIN BYPASSRLS` com 4 GRANTs exatos do ADR 0005. Próximas fatias: **391b** (`verify_credential` real + dual-verify + JWT), **391c** (extractor Axum + `RequirePermission` + wiring), **391d**/GAR-392 (suite cross-group authz). [ADR 0005](docs/adr/0005-identity-provider.md) accepted; trait shape congelada.
+**Status (2026-04-15):** 🟢 **Fase 3.3 completa** — 391a (skeleton), 391b (`verify_credential` real + dual-verify + JWT), 391c (extractor Axum + `RequirePermission` + wiring) e 391d/GAR-392 (suites cross-group authz) entregues; ver o status da Fase 3 acima. [ADR 0005](docs/adr/0005-identity-provider.md) accepted; trait shape congelada.
 
 - [x] **Skeleton (GAR-391a):** crate `garraia-auth` + `IdentityProvider` trait + `InternalProvider` stub + `LoginPool` newtype com `static_assertions::assert_not_impl_all!(LoginPool: Clone)` + migration 008 + smoke tests (3 unit + 3 integration). ✅
 - [x] `struct Principal { user_id, group_id, role: Option<Role> }` — typed `Role` enum shipped in 391c; `Principal` implements `FromRequestParts` with JWT verify + optional group membership lookup. ✅
-- [x] **`verify_credential` real (GAR-391b):** Argon2id (RFC 9106 first recommendation `m=64MiB, t=3, p=4`) + PBKDF2 dual-verify + lazy upgrade transacional + `SELECT ... FOR NO KEY UPDATE OF ui` + constant-time anti-enumeration via `DUMMY_HASH` gerado em build.rs + `audit_events` em todos os terminais + JWT HS256 access token (15min, algorithm-confusion guards) + endpoint `POST /v1/auth/login` sob feature `auth-v1` retornando 401 byte-identical em todos os modos de falha. 32 testes verdes (16 unit + 13 integration garraia-auth + 3 endpoint integration garraia-gateway). ✅
+- [x] **`verify_credential` real (GAR-391b):** Argon2id (RFC 9106 first recommendation `m=64MiB, t=3, p=4`) + PBKDF2 dual-verify + lazy upgrade transacional + `SELECT ... FOR NO KEY UPDATE OF ui` + constant-time anti-enumeration via `DUMMY_HASH` gerado em build.rs + `audit_events` em todos os terminais + JWT HS256 access token (15min, algorithm-confusion guards) + endpoint `POST /v1/auth/login` (default-on; a feature `auth-v1` foi removida em 391c) retornando 401 byte-identical em todos os modos de falha. 32 testes verdes (16 unit + 13 integration garraia-auth + 3 endpoint integration garraia-gateway). ✅
 - [x] **Refresh tokens + `SessionStore::issue` no endpoint (GAR-391c):** migration 010 adiciona `GRANT SELECT ON sessions TO garraia_login` (Gap A); `POST /v1/auth/refresh` (rotação default ON) + `POST /v1/auth/logout` (idempotente, 204 sempre) shipped default-on. ✅
 - [x] **`create_identity` real + signup endpoint (GAR-391c):** `garraia_signup NOLOGIN BYPASSRLS` role + `SignupPool` newtype análogo ao `LoginPool` + `signup_user` free function + `POST /v1/auth/signup` endpoint (201 + tokens em sucesso, 409 em duplicate email). Gap B fechado. ✅
 - [x] **`Principal` extractor + `RequirePermission` (GAR-391c):** `Principal` implementa `FromRequestParts` (Bearer JWT verify + optional `X-Group-Id` membership lookup via Gap C `GRANT SELECT ON group_members`); `RequirePermission` é struct method `check()` + free function `require_permission()` (NOT `FromRequestParts` por const-generic limitation do Axum). ✅
 - [x] `fn can(principal: &Principal, action: Action) -> bool` central — 22-action enum, 5-role enum, 110-case table-driven test (`can_matrix_matches_seed`) cobrindo as 63 rows seedadas em migration 002. ✅
 - [x] Papéis: `Owner`, `Admin`, `Member`, `Guest`, `Child` — `Role` enum tipado com tier numérico (100/80/50/20/10) batendo com `roles` seed. ✅
 - [x] **Capabilities (22 variants):** `files.*`, `chats.*`, `memory.*`, `tasks.*`, `docs.*`, `members.manage`, `group.{settings,delete}`, `export.{self,group}` — `Action` enum mapeado via `fn can()`. ✅
-- [ ] `enum Scope { User(Uuid), Group(Uuid), Chat(Uuid) }` com regra de resolução `Chat > Group > User`.
-- [x] **Defense-in-depth**: Postgres RLS (`CREATE POLICY`) em `messages`, `chats`, `chat_members`, `message_threads`, `memory_items`, `memory_embeddings`, `audit_events`, `sessions`, `api_keys`, `user_identities`, `task_lists`, `tasks`, `task_assignees`, `task_labels`, `task_label_assignments`, `task_comments`, `task_subscriptions`, `task_activity` — 18 tabelas com FORCE RLS + NULLIF fail-closed. Migrations 006 e 007. ✅
+- [ ] `enum Scope { User(Uuid), Group(Uuid), Chat(Uuid) }` com regra de resolução `Chat > Group > User`. *(Parcial: `Scope { User, Group, Chat }` tipado existe em `garraia-embeddings::Scope` e no `ValidatedScopeType` da busca; a regra de resolução ainda não.)*
+- [x] **Defense-in-depth**: Postgres RLS (`CREATE POLICY`) em `messages`, `chats`, `chat_members`, `message_threads`, `memory_items`, `memory_embeddings`, `audit_events`, `sessions`, `api_keys`, `user_identities`, `task_lists`, `tasks`, `task_assignees`, `task_labels`, `task_label_assignments`, `task_comments`, `task_subscriptions`, `task_activity` — hoje 32 tabelas com FORCE RLS + NULLIF fail-closed (migrations 003, 006, 007, 014, 017, 018, 020-022, 026-029); só `users`, `roles`, `permissions`, `role_permissions` e `group_invites` ficam fora. ✅
 - [x] **FORCE RLS em `groups` + `group_members`** — migration 018, plan 0106 / GAR-589, merged 2026-05-12 via PR #294 (`36b2b72`). `groups_member_access` + `group_members_visible` policies; fixes `get_group` FIXME (missing SET LOCAL) e `list_members` (missing `app.current_group_id`). ✅
 - [x] **Identity provider decision:** [ADR 0005](docs/adr/0005-identity-provider.md) — BYPASSRLS dedicated role (`garraia_login` NOLOGIN BYPASSRLS) + Argon2id (m=64MiB, t=3, p=4) + HS256 JWT + PBKDF2→Argon2id lazy upgrade dual-verify + `IdentityProvider` trait shape congelada. ✅
 - [ ] **Guardrails Child/Dependent**: sem export, sem share externo, content filter aplicado pré-LLM.
 
 **Critério de aceite:**
 
-- Suite de testes `tests/authz/` com > 100 cenários (cross-group leak attempts, role escalation, token replay) — 100% verde.
+- Suites de authz com > 100 cenários ✅: `crates/garraia-auth/tests/rls_matrix.rs` (81 casos RLS), `crates/garraia-gateway/tests/authz_http_matrix.rs` (50 casos HTTP) e a tabela de 110 pares em `can.rs`.
 - Teste específico: usuário do grupo A **não** consegue listar, ler, buscar, nem aparecer em auditoria do grupo B mesmo tentando IDs diretos.
 
 ### 3.4 API REST `/v1` (OpenAPI documented)
 
-Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
+Contrato versionado. OpenAPI gerada com `utoipa` 5 e servida em `GET /v1/openapi.json` + Swagger UI em `/docs` ✅.
 
 **Grupos**
 
@@ -607,7 +608,7 @@ Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
 - [x] `GET /v1/groups/{group_id}` — plan 0016 M4, entregue 2026-04-14
 - [x] `PATCH /v1/groups/{group_id}` — plan 0017, entregue 2026-04-16
 - [x] `POST /v1/groups/{group_id}/invites` — plan 0018, entregue 2026-04-16
-- [x] `POST /v1/groups/{group_id}/members/{user_id}:setRole` — plan 0020, entregue 2026-04-20
+- [x] `POST /v1/groups/{group_id}/members/{user_id}/setRole` — plan 0020, entregue 2026-04-20 (path com barra, não dois-pontos — limitação Axum 0.8 / matchit)
 - [x] `DELETE /v1/groups/{group_id}/members/{user_id}` — plan 0020, entregue 2026-04-20
 - [x] `GET /v1/groups/{group_id}/members` — plan 0097 / GAR-574, implementado 2026-05-11 (Florida)
 - [x] `GET /v1/groups/{group_id}/members/{user_id}` (fetch single group member) — plan 0286 / GAR-823 ✅
@@ -615,6 +616,7 @@ Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
 - [x] `GET /v1/groups/{group_id}/invites/{invite_id}` — plan 0257 / GAR-780 ✅
 - [x] `DELETE /v1/groups/{group_id}/invites/{invite_id}` (revoke) — plan 0257 / GAR-780 ✅
 - [x] `DELETE /v1/groups/{group_id}` (owner-only soft-delete; sets `archived_at`; idempotent 204; `GroupArchived` audit; migration 031) — plan 0346 / GAR-890 ✅
+- [x] `POST /v1/invites/{token}/accept` — aceite por token (plan 0019) ✅
 - [x] `GET /v1/me` — plan 0015 (skeleton Fase 3.4), entregue 2026-04-14
 - [x] `PATCH /v1/me` (display_name self-update) — plan 0110 / GAR-599 ✅
 - [x] `GET /v1/me/chats` — caller-scoped chat membership inbox (cursor-paginated, type filter) — plan 0245 / GAR-765 ✅
@@ -645,6 +647,8 @@ Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
 
 - [x] `POST /v1/groups/{group_id}/chats` — plan 0054 / GAR-506, implementado 2026-05-04 (Florida)
 - [x] `GET /v1/groups/{group_id}/chats` — plan 0054 / GAR-506, implementado 2026-05-04 (Florida)
+- [x] `GET` / `PATCH` / `DELETE /v1/chats/{chat_id}` — plan 0076 ✅
+- [x] `GET` / `POST /v1/chats/{chat_id}/members` + `DELETE /v1/chats/{chat_id}/members/{user_id}` ✅
 - [x] `POST /v1/chats/{chat_id}/messages` — plan 0055 / GAR-507, implementado 2026-05-05 (Florida)
 - [x] `GET /v1/chats/{chat_id}/messages?cursor=...` — plan 0055 / GAR-507, implementado 2026-05-05 (Florida)
 - [x] `POST /v1/messages/{message_id}/threads` — plan 0058 / GAR-509, implementado 2026-05-05 (Florida)
@@ -669,6 +673,7 @@ Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
 - [ ] `POST /v1/groups/{group_id}/files:initUpload` (presigned URL + multipart)
 - [ ] `POST /v1/groups/{group_id}/files:completeUpload`
 - [x] `GET /v1/groups/{group_id}/files?folder_id=...` + `GET /v1/groups/{group_id}/folders` ✅ PR #235 GAR-555
+- [x] `POST /v1/groups/{group_id}/folders` + `PATCH` / `DELETE /v1/groups/{group_id}/folders/{folder_id}` — plans 0091/0092 ✅
 - [x] `GET /v1/groups/{group_id}/files/{file_id}` + `GET /v1/groups/{group_id}/folders/{folder_id}` (single resource read) — plan 0090 / GAR-559, implementado 2026-05-09 (Florida) ✅ PR #242 (`4adcb02`)
 - [x] `PATCH /v1/groups/{group_id}/files/{file_id}` (rename) — plan 0089 / GAR-557, implementado 2026-05-09 (Florida) ✅ PR #238 (`9255515`)
 - [x] `GET /v1/files/{file_id}/download` (streaming bytes via ObjectStore) — plan 0093 / GAR-564, implementado 2026-05-10 (Florida) ✅ PR #250 (`b2de161`)
@@ -705,6 +710,7 @@ Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
 - [x] `GET /v1/search?...&types=users` — plan 0214 / GAR-730, implementado 2026-05-28 (Florida). Slice 13: `users.display_name` FTS via `to_tsvector('simple', display_name)` (no new migration); JOIN through `group_members` for group isolation; `status = 'active'` guard; email excluded from FTS (PII safety); group scope only; result `type: "user"`, `excerpt` = display_name, `sender_user_id` = user's own id, `chat_id` = null, `kind` = null.
 - [x] `GET /v1/search?...&types=groups` — plan 0215 / GAR-733, implementado 2026-05-28 (Florida). Slice 14: `groups.name` FTS via `to_tsvector('simple', name)` (no new migration); user scope only (FORCE RLS migration 018 enforces membership via `app.current_user_id` — no explicit SQL filter needed); result `type: "group"`, `excerpt` = name, `group_id` = group's own id, `sender_user_id` = `created_by`, `kind` = type ('family'/'team'/'personal').
 - [x] `GET /v1/search?...&types=labels` — plan 0219 / GAR-737, implementado 2026-05-29 (Florida). Slice 15: `task_labels.name` FTS via `to_tsvector('simple', name)` (no new migration); group scope only (FORCE RLS `task_labels_group_isolation` migration 006 + explicit `AND group_id = $2`); result `type: "label"`, `excerpt` = name, `kind` = color (`#RRGGBB`), `sender_user_id` = `created_by` (nullable), `chat_id` = null.
+- [x] `GET /v1/search?...&types=doc_pages` + `types=doc_blocks` — plan 0317 / GAR-856. Slices 16-17: `doc_pages.title` e `doc_blocks.content_jsonb::text` via `to_tsvector('simple', ...)` em runtime (sem índice GIN); group scope only.
 
 **Auditoria**
 
@@ -714,19 +720,19 @@ Contrato versionado. Usar `utoipa` para gerar OpenAPI + Swagger UI em `/docs`.
 
 **Critério de aceite:**
 
-- Spec OpenAPI 3.1 gerada e servida em `/docs`.
-- Contract tests via `schemathesis` ou `dredd` rodam em CI.
+- [x] Spec OpenAPI gerada (`utoipa` 5) e servida em `GET /v1/openapi.json` + Swagger UI em `/docs`.
+- [ ] Contract tests via `schemathesis` ou `dredd` rodam em CI.
 
 ### 3.5 Object storage & uploads
 
 Novo crate: `garraia-storage`.
 
-- [ ] Abstração `trait ObjectStore` com impls: `LocalFs`, `S3Compatible` (via `aws-sdk-s3`), `Minio`.
-- [ ] **Presigned URLs** (PUT/GET) com expiração ≤ 15 min e escopo mínimo.
+- [x] Abstração `trait ObjectStore` com impls `LocalFs` e `S3Compatible` (via `aws-sdk-s3`, feature `storage-s3`; MinIO via `endpoint_url` + path-style, não impl separada) — plans 0037/0038 / GAR-394 ✅
+- [x] **Presigned URLs** (PUT/GET) com TTL em [30s, 900s] — só no `S3Compatible` (`LocalFs` responde unsupported) ✅
 - [ ] **Multipart upload** nativo do S3 para arquivos > 16 MiB.
-- [ ] **tus 1.0** server implementation para clientes mobile.
-- [ ] **Versionamento**: cada update cria `file_versions` nova; soft delete move para lixeira com retenção configurável (default 30 dias).
-- [ ] **Criptografia em repouso**: SSE-S3/SSE-KMS quando em cloud; chave local via `CredentialVault` quando `LocalFs`.
+- [x] **tus 1.0** server implementation para clientes mobile — `POST`/`OPTIONS /v1/uploads`, `HEAD`/`PATCH`/`DELETE /v1/uploads/{id}`, migrations 014 + 032 (plans 0041/0044/0047 / GAR-395, PR #62) ✅
+- [ ] **Versionamento**: `file_versions` por update + soft delete (`deleted_at`) ✅ (migration 003, plans 0094/0095); lixeira com retenção configurável / purge worker ainda pendente.
+- [ ] **Criptografia em repouso**: SSE-S3 obrigatório em todo `put` do `S3Compatible` ✅ (ADR 0004 §Security); SSE-KMS e chave local via `CredentialVault` para `LocalFs` pendentes.
 - [ ] **Antivírus opcional**: hook para ClamAV (feature flag `av-clamav`).
 
 **Critério de aceite:**
@@ -745,26 +751,26 @@ Novo crate: `garraia-storage`.
 - [x] Anexos via `message_attachments` → `files` — plan 0182 / GAR-700. ✅
 - [x] **Bot Garra no chat**: agente pode ser invocado por `/garra <prompt>` e responde respeitando o scope do chat. *(plan 0240, GAR-759)*
 - [x] `GET /v1/me/chats` — caller-scoped chat membership inbox (cursor-paginated, type filter) — plan 0245 / GAR-765.
-- [x] **Busca**: Postgres FTS (`tsvector`) com índice GIN; migração para Tantivy quando > 10M mensagens — slices 1-12 (planos 0084-0085, 0185, 0192-0193, 0200, 0225, 0231-0237 etc.), GAR-549..GAR-726, todos ✅.
+- [x] **Busca**: Postgres FTS (`tsvector`) com índice GIN; migração para Tantivy quando > 10M mensagens — slices 1-17 (planos 0084-0086, 0179, 0185, 0192-0195, 0199-0200, 0208, 0211, 0214-0215, 0219, 0317), GAR-549..GAR-856, todos ✅.
 
 **Critério de aceite:**
 
-- Dois usuários conversam em WebSocket com latência < 100ms intra-LAN.
+- Dois usuários conversam via SSE stream (decisão em 3.4: canal server→client) com latência < 100ms intra-LAN.
 - Busca full-text retorna top-20 em < 150ms p95 com 1M de mensagens.
 
 ### 3.7 Memória IA compartilhada
 
-- [ ] **Três níveis** rigorosamente separados: `personal`, `group`, `chat`.
-- [ ] **UI de memória** (web + mobile): ver, editar, fixar, expirar, excluir.
-- [ ] **Políticas**: retenção por grupo, sensitivity por item, TTL.
-- [ ] **Auditoria**: toda leitura/escrita/deleção de memória gera `audit_events`.
+- [x] **Três níveis** rigorosamente separados: `user` (personal), `group`, `chat` — `memory_items.scope_type` (migration 005) + filtro em `/v1/memory` + `Scope` tipado ✅ (isolamento no retrieval ainda sem teste dedicado — ver critério abaixo).
+- [ ] **UI de memória** (web + mobile): ver, editar, fixar, expirar, excluir. *(Parcial: Web Console gerencia memória; editar/fixar/excluir via `PATCH`/`DELETE /v1/memory/{id}` + `pin`/`unpin`; mobile pendente.)*
+- [ ] **Políticas**: retenção por grupo, sensitivity por item, TTL. *(Parcial: `sensitivity` (4 níveis) + `ttl_expires_at` por item na migration 005 ✅; retenção por grupo pendente.)*
+- [ ] **Auditoria**: toda leitura/escrita/deleção de memória gera `audit_events`. *(Parcial: criação/edição/pin/deleção emitem `memory.*` ✅; leitura ainda não.)*
 - [ ] **Consentimento**: ao salvar memória derivada de chat, mostrar prompt "Salvar para: só eu / grupo / este chat".
-- [ ] **LGPD direitos do titular**: export JSON + delete por user_id dentro de um grupo.
+- [ ] **LGPD direitos do titular**: export JSON + delete por user_id dentro de um grupo. *(Parcial: `GET /v1/me/export` (JSON), `DELETE /v1/me` e `POST /v1/me/anonymize` ✅ — o export ainda não inclui `memory_items`/tasks/mensagens; delete de memória por user_id dentro de um grupo pendente.)*
 
 **Critério de aceite:**
 
 - Memória pessoal do usuário A **nunca** aparece em retrieval do grupo mesmo com query idêntica.
-- Export LGPD de um usuário gera zip com todos os dados em < 30s.
+- Export LGPD de um usuário gera um arquivo (hoje JSON só com perfil/sessões/keys/audit/memberships) com todos os dados em < 30s.
 
 ### 3.8 Tasks & Docs (Notion-like) — módulo de acompanhamento
 
@@ -784,7 +790,7 @@ Módulo dentro de `garraia-workspace`. Schema entregue via migration 006 com **R
 - [x] `task_comments` (`id`, `task_id` CASCADE, `author_user_id ON DELETE SET NULL` + `author_label` cache, `body_md` CHECK 50k, `edited_at`, `deleted_at`) — migration 006 ✅
 - [x] `task_attachments` (PK composta `(task_id, file_id)`, `group_id` denorm, `attached_by ON DELETE SET NULL`, `attached_by_label` cache, `attached_at`) — migration 017, FORCE RLS via JOIN tasks, plan 0096 / GAR-572 ✅
 - [x] `task_subscriptions` (PK composta `(task_id, user_id)` CASCADE, `subscribed_at`, `muted`) — migration 006 ✅
-- [x] `task_activity` (`id`, `task_id` CASCADE, **`group_id` denormalizado**, `actor_user_id` plain uuid sem FK, `actor_label` cache, `kind` CHECK 12 valores, `payload jsonb`) — migration 006 ✅
+- [x] `task_activity` (`id`, `task_id` CASCADE, **`group_id` denormalizado**, `actor_user_id` plain uuid sem FK, `actor_label` cache, `kind` CHECK 13 valores (12 em 006 + `moved` em 016), `payload jsonb`) — migration 006 ✅
 - [x] Status enum: `backlog|todo|in_progress|review|done|canceled` — migration 006 ✅
 - [x] Priority enum: `none|low|medium|high|urgent` — migration 006 ✅
 - [x] Índices críticos: `(list_id, status)`, `(group_id, status)`, `(due_at) WHERE deleted_at IS NULL AND due_at IS NOT NULL`, `(parent_task_id)` partial, `(group_id, completed_at DESC) WHERE status = 'done'` — migration 006 ✅
@@ -833,9 +839,9 @@ Módulo dentro de `garraia-workspace`. Schema entregue via migration 006 com **R
 
 **RBAC:**
 
-- [ ] Novas capabilities: `tasks.read`, `tasks.write`, `tasks.assign`, `tasks.delete`, `tasks.admin`.
-- [ ] Mapeamento padrão: Owner/Admin/Member → read+write+assign; Guest → read + comment; Child → read + comment + complete próprias.
-- [x] Auditoria: toda mudança de status/assignee/due_at gera `task_activity` (plan 0080 / GAR-541 ✅); `audit_events` fan-out deferido para GAR-397.
+- [x] Capabilities `tasks.read`, `tasks.write`, `tasks.assign`, `tasks.delete` — migration 002 + `Action` enum ✅ (`tasks.admin` não existe; remover ou tratar como futuro).
+- [x] Mapeamento padrão (seed da migration 002): Owner/Admin → read+write+assign+delete; Member → read+write (**sem** assign); Guest → read; Child → read+write. *(Diverge do desenho original — Member sem assign, Guest sem comment — revisar se a intenção mudou.)*
+- [x] Auditoria: toda mudança de status/assignee/due_at gera `task_activity` (plan 0080 / GAR-541 ✅); `audit_events` já emitidos para lists/tasks/comments/assignees/labels (`audit_workspace.rs`); fan-out de notificações segue em GAR-397.
 
 **Integração com memória IA & agentes:**
 
@@ -884,7 +890,7 @@ Módulo dentro de `garraia-workspace`. Schema entregue via migration 006 com **R
 - [x] `GET /v1/doc-blocks/{block_id}` — plan 0314 / GAR-853
 - [x] `PATCH /v1/doc-blocks/{block_id}` — plan 0304 / GAR-840
 - [x] `DELETE /v1/doc-blocks/{block_id}` — plan 0304 / GAR-840
-- [x] `POST /v1/doc-pages/{page_id}:duplicate` — plan 0309 / GAR-847
+- [x] `POST /v1/doc-pages/{page_id}/duplicate` — plan 0309 / GAR-847
 - [x] `GET /v1/doc-pages/{page_id}/versions` — plan 0307 / GAR-845
 - [x] `POST /v1/doc-pages/{page_id}/versions` (snapshot) — plan 0307 / GAR-845
 - [x] `GET /v1/doc-pages/{page_id}/versions/{version_id}` — plan 0307 / GAR-845
@@ -897,7 +903,7 @@ Módulo dentro de `garraia-workspace`. Schema entregue via migration 006 com **R
 
 **Colaboração em tempo real:**
 
-- [ ] CRDT via `y-crdt` (Rust) ou OT simplificado; decisão em `docs/adr/0008-doc-collab-strategy.md`.
+- [ ] CRDT via `y-crdt` — decisão tomada em [`docs/adr/0008-doc-collaboration.md`](docs/adr/0008-doc-collaboration.md) (Accepted 2026-04-21: single-editor agora, `y-crdt` acionado por gatilho); implementação pendente.
 - [ ] WebSocket `/v1/doc-pages/{id}/stream` com awareness (cursor/selection).
 - [ ] Modo offline com merge no reconnect.
 
@@ -910,7 +916,7 @@ Módulo dentro de `garraia-workspace`. Schema entregue via migration 006 com **R
 
 **Busca:**
 
-- [x] FTS indexa `doc_blocks.content_jsonb` via tsvector.
+- [x] Busca em `doc_blocks.content_jsonb` via `to_tsvector` em runtime (slice 17, plan 0317) — sem coluna tsvector/índice GIN ainda.
 - [x] Busca unificada passa a cobrir `messages + files + memory + tasks + docs`.
 
 **Critério de aceite Tier 2:**
@@ -940,8 +946,8 @@ Módulo dentro de `garraia-workspace`. Schema entregue via migration 006 com **R
 
 ### 3.9 Busca unificada
 
-- [x] Endpoint `/v1/search` retorna resultados heterogêneos (messages, memory) ordenados por relevância — slices 1-4 completos (files deferred para quando file-FTS for implementado).
-- [x] Filtros: `scope` ✅ (slices 1+2), `types` ✅ (slices 1+2), `from_date` ✅ (slice 3 / GAR-552), `author` ✅ (slice 3 / GAR-552), `has_attachment` ✅ (slice 4 / GAR-697 / plan 0179).
+- [x] Endpoint `/v1/search` retorna resultados heterogêneos ordenados por relevância — slices 1-17 completos, 14 tipos (messages, memory, files, tasks, task_comments, folders, chats, task_lists, threads, users, groups, labels, doc_pages, doc_blocks).
+- [x] Filtros: `scope` ✅ (slices 1+2), `types` ✅ (slices 1+2), `from_date` ✅ (slice 3 / GAR-552), `author` ✅ (slice 3 / GAR-552), `has_attachment` ✅ (slice 4 / GAR-697 / plan 0179), `to_date` ✅ (slice 3), `sort_by` ✅ (slice 8 / GAR-713).
 - [ ] **Híbrido**: BM25 + ANN vetorial + re-rank.
 
 **Critério de aceite:**
@@ -959,17 +965,19 @@ Módulo dentro de `garraia-workspace`. Schema entregue via migration 006 com **R
 
 ### 4.1 Garra Desktop (Tauri v2 — Win/Mac/Linux)
 
-- [ ] **Stack web**: migrar WebView de HTML puro para **SvelteKit** ou **Solid** (decisão em ADR `0007-desktop-frontend.md`).
-- [ ] **Design system**: tokens em `ops/design-tokens/`; dark mode imersivo; glassmorphism com `backdrop-filter`.
+- [x] **Stack web**: decidido em [ADR 0007](docs/adr/0007-desktop-frontend.md) (Accepted 2026-04-21) — fica **HTML + JS vanilla**; migração para **SolidJS** só se o gatilho S1 do ADR disparar (SvelteKit descartado).
+- [ ] **Design system**: tokens `--garra-*` + glassmorphism entregues no Web Console (`webchat.html`, ADR 0009) ✅; ainda não aplicados à UI do desktop (`crates/garraia-desktop/ui/`) e sem `ops/design-tokens/`.
 - [ ] **Micro-interações**: transições 120Hz via `motion.dev` ou `svelte-motion`.
 - [ ] **Bridge Rust ↔ TS**: comandos Tauri typed via `specta` ou `tauri-bindgen`.
 - [ ] **Offline-first**: cache local de chats/arquivos recentes via IndexedDB.
 - [ ] **Workspaces**: seletor de grupo no topo; switch rápido com `Ctrl+K`.
-- [x] **Instaladores -- Windows**: `install.ps1` (`irm | iex`) + MSI/NSIS via Tauri, entregues em 2026-08-30. Ambos **sem assinatura de codigo** -- o certificado OV/EV para remover o aviso do SmartScreen segue em aberto.
+- [x] **Instaladores -- Windows**: `install.ps1` (`irm | iex`) + MSI/NSIS via Tauri, entregues em 2026-08-30 (primeira release com os assets: v0.3.4, 2026-08-31). Ambos **sem assinatura de codigo** -- o certificado OV/EV para remover o aviso do SmartScreen segue em aberto.
 - [x] **Instaladores -- Linux**: `.deb` + `.rpm` (nfpm) e AppImage x86_64 (appimagetool), entregues em 2026-08-31 no job best-effort `package-linux` (ADR 0015, plan 0361). Sem assinatura GPG/repositorio apt-dnf hospedado.
 - [x] **Windows ARM64 nativo**: `garraia-windows-aarch64.exe` + `.zip` best-effort (job `build-windows-aarch64`), com `garra update` e `install.ps1` resolvendo o asset — entregue em 2026-08-31 (plan 0361).
+- [x] **Garra Desktop -- Linux**: `.deb` + AppImage x86_64 do app desktop via bundler Tauri (`scripts/build-desktop-linux.sh`, job best-effort `build-linux-desktop`), entregues em 2026-09-01 na v0.3.5 (plan 0362, Amendment do ADR 0015). O `.deb` declara `Provides/Conflicts/Replaces: garraia` porque instala o sidecar em `/usr/bin/garraia`.
 - [ ] **Instaladores -- restantes**: DMG (Mac, notarizado — exige segredos Apple do mantenedor); AppImage aarch64 (`--runtime-file` + segundo pin de runtime).
 - [x] **Archives**: entregues para todas as plataformas em 2026-08-30 (`.tar.gz` / `.zip`), aditivos aos binarios crus que o `garra update` consome; `garraia-windows-aarch64.zip` juntou-se em 2026-08-31.
+- [ ] **Auto-updater do desktop**: `tauri-plugin-updater` ligado (`check_for_updates`/`install_update` na bandeja) mas inerte — sem chave de assinatura e nenhum workflow publica `latest.json` (`docs/releasing.md` §Débito conhecido).
 
 **Critério de aceite:**
 
@@ -978,9 +986,9 @@ Módulo dentro de `garraia-workspace`. Schema entregue via migration 006 com **R
 
 ### 4.2 Garra Mobile (Flutter — Android & iOS)
 
-- [ ] **Fix build Android**: atualizar `gradle` → 8.x, AGP → 8.x, Java 17, `compileSdk 35`.
+- [x] **Fix build Android**: gradle 8.14, AGP 8.11.1, Java 17; `compileSdk` delegado ao Flutter SDK (`flutter.compileSdkVersion`) ✅
 - [ ] **iOS target**: `flutter create --platforms ios`, ajustes CocoaPods, assinatura dev.
-- [ ] **WebSocket seguro** (wss) para chat em tempo real; fallback REST.
+- [ ] **WebSocket seguro** (wss) para chat em tempo real; fallback REST. *(Parcial: cliente wss em `sync_service.dart`; fallback REST pendente.)*
 - [ ] **Upload retomável**: integrar `tus_client` para arquivos grandes.
 - [ ] **Grupo switcher** com cache de membership.
 - [ ] **Tiny-LLMs locais** (fase posterior): avaliar `llama.cpp` via FFI ou ONNX Mobile para modelos ≤ 1B em dispositivos NPU.
@@ -994,11 +1002,23 @@ Módulo dentro de `garraia-workspace`. Schema entregue via migration 006 com **R
 
 ### 4.3 Garra CLI
 
-- [ ] `garraia-cli chat` interativo com streaming (markdown renderer).
+- [ ] `garraia-cli chat` interativo com streaming ✅ (`garra chat`, spinner de atividade, `Ctrl+C` cancela o turno — PR #884); markdown renderer ainda pendente.
 - [ ] `garraia-cli workspace` (list/create/join/invite).
 - [ ] `garraia-cli files upload/download/ls`.
 - [ ] `garraia-cli bench` (baseline inference).
 - [ ] Autocomplete para bash/zsh/fish/pwsh.
+- [ ] `garra memory` (list/search/forget) — hoje a memória só é gerenciada pelo Web Console e pela API do gateway (README §Memory).
+
+### 4.4 Canais restantes (wiring no gateway)
+
+Os adapters existem em `garraia-channels` (features desligadas por default) mas não são instanciados pelo bootstrap do gateway (`crates/garraia-gateway/src/bootstrap/`):
+
+- [ ] Google Chat
+- [ ] Microsoft Teams
+- [ ] Matrix
+- [ ] LINE
+- [ ] IRC
+- [ ] Signal
 
 **Estimativa fase 4:** 8 / 10 / 14 semanas.
 **Épicos sugeridos:** `GAR-DESK-AAA`, `GAR-MOB-BUILD`, `GAR-MOB-WS`, `GAR-CLI-CHAT`.
@@ -1009,15 +1029,17 @@ Módulo dentro de `garraia-workspace`. Schema entregue via migration 006 com **R
 
 ### 5.1 Security & Vaults
 
-- [ ] **CredentialVault final (GAR-410)**: única fonte de secrets do gateway; rotação de chaves; master key via `argon2id`. Fecha GAR-291 (criptografia de tokens MCP, ✅ Done 2026-03-04) ampliando para todos os secrets do gateway.
-- [ ] **TLS 1.3 obrigatório** em todas as superfícies públicas via `rustls`.
-- [ ] **Argon2id** para senhas de usuários (mobile_users → users).
-- [ ] **Rate limiting** por IP + por user_id via `tower-governor`.
-- [ ] **CSRF + CORS** hardening no Gateway (`tower-http`).
-- [ ] **Headers de segurança**: CSP, HSTS, X-Content-Type-Options, Referrer-Policy.
-- [ ] **Secrets scanning** no CI via `gitleaks`.
-- [ ] **Threat model** documentado em `docs/security/threat-model.md` (STRIDE por componente).
+- [ ] **CredentialVault final (GAR-410)**: única fonte de secrets do gateway; rotação de chaves; master key via `argon2id`. *(Parcial: leitura de secrets centralizada em `garraia-config::auth` — plan 0046; o gateway ainda não consome o cofre e não há rotação. Adiado — ver `TODO.md`.)* Fecha GAR-291 (criptografia de tokens MCP, ✅ Done 2026-03-04) ampliando para todos os secrets do gateway.
+- [ ] **TLS 1.3 obrigatório** em todas as superfícies públicas via `rustls`. *(Parcial: TLS via `rustls` disponível atrás da feature `tls` do gateway (`axum-server`); obrigatoriedade e passthrough da feature no binário `garraia` pendentes.)*
+- [x] **Argon2id** para senhas de usuários — `garraia-auth` (RFC 9106, argon2 0.6) + lazy upgrade PBKDF2→Argon2id dos `mobile_users` legados (plan 0036) ✅
+- [x] **Rate limiting** por IP + por user_id + por API key via `governor`/`tower-governor` (`rate_limiter.rs`, GAR-426) + limite de SSE por usuário (GAR-679) ✅
+- [ ] **CSRF + CORS** hardening no Gateway. *(Parcial: CSRF no admin via `require_csrf` ✅; `CorsLayer` ainda não.)*
+- [ ] **Headers de segurança**: CSP, X-Content-Type-Options e Referrer-Policy aplicados globalmente (`admin/middleware.rs`) ✅; HSTS pendente.
+- [x] **Secrets scanning** no CI via `gitleaks` — job `Secret Scan (gitleaks)` no `ci.yml` + hook pre-commit + `garra verify` ✅
+- [x] **Threat model** documentado em [`docs/security/threat-model.md`](docs/security/threat-model.md) (STRIDE por componente; Draft v1 2026-04-21, revisão trimestral) ✅
 - [ ] **Pentest interno** com checklist OWASP ASVS L2.
+- [ ] **Auth por padrão na API local** — `gateway.api_key` / `session_tokens_required` são opt-in hoje (README §Security).
+- [ ] **Cofre como default do wizard** — `garra init` grava chaves em `config.yml` (0600) por padrão; o cofre é opção.
 
 ### 5.2 Testes & Continuous Fuzzing
 
@@ -1025,24 +1047,24 @@ Módulo dentro de `garraia-workspace`. Schema entregue via migration 006 com **R
 - [ ] **Integration tests** com testcontainers (Postgres, MinIO) em CI. *(Parcial 2026-08-18: job `auth-integration` roda os 16 binários de integração do garraia-auth — matriz RLS incluída — contra pgvector/pg16 em todo PR; MinIO segue gated por feature.)*
 - [ ] **Property tests** (`proptest`) em parsers, scopes, RBAC.
 - [ ] **Fuzzing contínuo** via `cargo-fuzz` nos parsers de MCP, config e protocolos de canais.
-- [ ] **Mutation testing** (`cargo-mutants`) mensal. *(Piloto semanal em garraia-auth existe desde 2026-04; baseline destravado em 2026-08-18 — o seed quebrado que o mantinha vermelho foi corrigido no plan 0354.)*
+- [ ] **Mutation testing** (`cargo-mutants`) — `mutants.yml` roda **semanal** (segundas 05:00 UTC) em `garraia-auth`; verde desde 2026-08-24 após o fix do seed no plan 0354. Expandir a outros crates pendente.
 - [ ] **Load testing**: `k6` ou `vegeta` com cenários de 1k concurrent users.
 - [ ] **Chaos testing**: matar DB/storage e validar degradação graciosa.
 
 ### 5.3 Compliance LGPD / GDPR
 
-- [ ] **DPIA** (Data Protection Impact Assessment) em `docs/compliance/dpia.md`.
+- [x] **DPIA** (Data Protection Impact Assessment) em [`docs/compliance/dpia.md`](docs/compliance/dpia.md) — Draft v1 (2026-04-21), revisão legal externa pendente antes do GA.
 - [ ] **Privacy policy** + **Terms of Service** em PT-BR e EN.
-- [ ] **Records of Processing Activities (RoPA)** documentados.
-- [ ] **Data subject rights**: endpoints de export e delete (art. 18 LGPD / art. 15/17 GDPR). *(Export entregue — GAR-885/plan 0344; anonymize entregue e CORRIGIDO em 2026-08-18 — plan 0354, retornava 500 desde junho; delete de conta pendente.)*
+- [x] **Records of Processing Activities (RoPA)** documentados — `docs/compliance/dpia.md` §6 (Draft v1).
+- [ ] **Data subject rights**: endpoints de export e delete (art. 18 LGPD / art. 15/17 GDPR). *(Export entregue — GAR-885/plan 0344; anonymize entregue e CORRIGIDO em 2026-08-18 — plan 0354, retornava 500 desde junho; soft-delete de conta entregue — `DELETE /v1/me`, GAR-884; hard delete / retention worker pendente.)*
 - [ ] **Retention policies** configuráveis por grupo.
-- [ ] **Incident response runbook**: fluxo de notificação ANPD (comunicado de incidente) e autoridades UE em ≤ 72h quando aplicável.
-- [ ] **Data minimization**: revisão de todos os logs para garantir que não vaze PII.
+- [x] **Incident response runbook**: [`docs/compliance/incident-response.md`](docs/compliance/incident-response.md) — fluxo ANPD / autoridades UE em ≤ 72h (Draft v1, tabletop pendente).
+- [ ] **Data minimization**: revisão de todos os logs para garantir que não vaze PII. *(Parcial: `RedactingWriter` + `garraia-telemetry::redact` no lugar; revisão site a site pendente.)*
 - [ ] **Child protection**: modo Child/Dependent com content filter.
 
 ### 5.4 UX inicial impecável
 
-- [ ] **First-run wizard** (Desktop + Gateway web admin):
+- [ ] **First-run wizard** (Desktop + Gateway web admin). *(Parcial: o wizard CLI `garra init` + `install.sh`/`install.ps1` já detectam GPU/Ollama, escolhem cloud vs local e oferecem o cofre; faltam wizard no Desktop/web admin, detecção de Docker/llama.cpp e convite de grupo.)*:
   - Detecção automática de Docker, Ollama, llama.cpp local.
   - Escolha entre "tudo local" / "hybrid" / "cloud".
   - Setup do CredentialVault (master password).
@@ -1070,9 +1092,9 @@ Módulo dentro de `garraia-workspace`. Schema entregue via migration 006 com **R
 
 ### 6.1 Deploy & Infra
 
-- [ ] **Dockerfiles multi-stage** para gateway, workers, frontend.
+- [x] **Dockerfile multi-stage** (cargo-chef planner/builder + runtime `debian:trixie-slim`, binário único `garra`) ✅ — imagens separadas para workers/frontend não se aplicam.
 - [ ] **Helm chart** `charts/garraia/` com: StatefulSet (Postgres), Deployment (gateway/workers), Ingress, HPA, Secrets, RBAC, Probes.
-- [ ] **docker-compose** para dev local com Postgres, MinIO, Ollama, OTel collector.
+- [ ] **docker-compose** para dev local: Postgres (`docker-compose.postgres.yml`), Ollama (`docker-compose.ollama.yml`), OTel/Jaeger/Prometheus/Grafana (`ops/compose.otel.yml`) ✅; MinIO ainda ausente.
 - [ ] **Terraform modules** (`infra/terraform/`) para AWS/GCP/Hetzner (opcional).
 
 #### 6.1.1 Runpod Load Balancer Serverless compatibility (GAR-603)
@@ -1106,9 +1128,9 @@ Módulo dentro de `garraia-workspace`. Schema entregue via migration 006 com **R
 - [ ] Runpod worker becomes healthy under Load Balancer Serverless.
 - [ ] `GET https://<ENDPOINT_ID>.api.runpod.ai/ping` returns HTTP 200.
 - [x] No REPL blocks the container start command (`Dockerfile` runs `garra start --host 0.0.0.0`).
-- [ ] CI remains green before merge.
+- [x] CI remains green before merge (PR #327 merged 2026-05-13).
 
-Related: GAR-333 (provisionar `api.garraia.org` com gateway cloud — Urgent, Backlog) is the closest sibling and shares the cloud-deploy goal; GAR-603 narrows it to the Runpod LB Serverless surface.
+Related: GAR-333 (provisionar `api.garraia.org` com gateway cloud — em aberto no tracker interno) is the closest sibling and shares the cloud-deploy goal; GAR-603 narrows it to the Runpod LB Serverless surface.
 
 ### 6.2 Observabilidade em prod
 
@@ -1119,11 +1141,11 @@ Related: GAR-333 (provisionar `api.garraia.org` com gateway cloud — Urgent, Ba
 
 ### 6.3 Release
 
-- [ ] **Semver** estrito; `CHANGELOG.md` por release.
+- [x] **Semver** estrito; `CHANGELOG.md` por release — tags `vX.Y.Z` (v0.1.1 … v0.3.5) + seções por release ✅
 - [ ] **Beta program** com feature flags por grupo.
 - [ ] **Cutover gradual**: 1% → 10% → 50% → 100%.
-- [ ] **Docs**: `https://docs.garraia.org` (mdBook ou Docusaurus).
-- [ ] **Marketing site**: landing + demo + pricing (open-source + cloud hospedado opcional).
+- [ ] **Docs**: `https://docs.garraia.org`. *(Parcial: scaffold mdBook em `docs/book.toml` + `docs/src/`, e `wiki/` sincronizado com o GitHub Wiki via `wiki-sync.yml`; site hospedado pendente.)*
+- [ ] **Marketing site**: landing + demo + pricing. *(Parcial: a landing `garraia.org` vive no repo `michelbr84/garraia-74c335d5` (Lovable) e serve os instaladores; demo/pricing pendentes.)*
 
 **Estimativa fase 6:** 4 / 5 / 7 semanas.
 
@@ -1146,8 +1168,8 @@ Related: GAR-333 (provisionar `api.garraia.org` com gateway cloud — Urgent, Ba
 ### T1 — Documentação
 
 - `docs/adr/` — todas as decisões arquiteturais.
-- `docs/api/` — OpenAPI gerado + exemplos curl.
-- `docs/guides/` — getting started, self-host, development.
+- OpenAPI gerada em runtime (`GET /v1/openapi.json`, Swagger em `/docs`) + `docs/mobile-api-v1.yaml`; exemplos curl em `docs/`.
+- Guias em `docs/installation.md`, `docs/deployment.md`, `docs/contributing.md` e no mdBook `docs/src/` — getting started, self-host, development.
 - `CHANGELOG.md` sempre atualizado.
 - **Escritor técnico**: `@doc-writer` roda em cada PR grande.
 
@@ -1158,13 +1180,13 @@ Related: GAR-333 (provisionar `api.garraia.org` com gateway cloud — Urgent, Ba
 
 ### T3 — CI/CD
 
-- GitHub Actions: `fmt`, `clippy -D warnings`, `test`, `coverage`, `audit`, `deny`, `fuzz smoke`.
-- Release pipeline: tag → build → sign → publish (crates.io, Docker Hub, GitHub Releases, MSI).
+- GitHub Actions (`ci.yml` + irmãos): `fmt`, `clippy -D warnings`, `test`, `coverage` (cargo-llvm-cov), `audit`, `deny`, `gitleaks`, `auth-integration` (matriz RLS), `msrv`, `e2e`, `playwright`, CodeQL, `quality-ratchet` (report-only), `mutants` (semanal). Sem fuzz smoke ainda.
+- Release pipeline: tag → build → checksum (`SHA256SUMS` + `.sha256` por asset) → publish (GitHub Releases: binários, archives, `.deb`/`.rpm`/AppImage, MSI/NSIS, desktop Linux; imagem no GHCR via `deploy.yml`). Assinatura, crates.io e Docker Hub pendentes.
 
 ### T4 — Community
 
-- `CONTRIBUTING.md` com guia de PR, código de conduta, DCO.
-- Issue templates (bug, feature, security).
+- `CONTRIBUTING.md` com guia de PR ✅ + `CODE_OF_CONDUCT.md` ✅; DCO ainda não.
+- Issue templates ✅ (bug, feature, general, mcp, provider, telegram); vulnerabilidades via `SECURITY.md`, sem template de issue por design.
 - Discord/Matrix público para contribuidores.
 
 ---
@@ -1180,7 +1202,7 @@ Related: GAR-333 (provisionar `api.garraia.org` com gateway cloud — Urgent, Ba
 | WASM plugin foge do sandbox | Baixa | **Crítico** | Capabilities default-deny + proptest + audit de wasmtime releases |
 | Compliance LGPD inadequado | Média | **Crítico** | DPIA + legal review externo antes do GA |
 | Complexidade de deploy afasta usuários self-host | Alta | Médio | docker-compose 1-comando + wizard de FTUE |
-| Dependência de provider cloud degrada UX local | Média | Médio | Backends locais first-class (Ollama, llama.cpp, candle) |
+| Dependência de provider cloud degrada UX local | Média | Médio | Backends locais first-class (Ollama e llama.cpp hoje; `mistral.rs` como default planejado — ADR 0001) |
 
 ---
 
@@ -1245,11 +1267,11 @@ Foram materializadas ~40 issues críticas (`GAR-371` a `GAR-410`) cobrindo: 8 AD
 | `GAR-INFRA-GA` | 6.1 | Helm + Terraform + Docker |
 | `GAR-OBS-GA` | 6.2 | SLOs + runbooks + DR |
 | `GAR-RELEASE-GA` | 6.3 | Beta → GA + docs |
-| `GAR-641` | 1.4 | Garra Learning Agent / Self-Improving Operations Manual (sub: GAR-642 Architecture, GAR-643 Skill Miner, GAR-644 Skill Generator, GAR-645 Skill Registry, GAR-646 Skill Retriever, GAR-647 Skill Evaluator, GAR-648 Skill Auto-Updater, GAR-649 Skill Safety Gates, GAR-650 Skill Versioning/Rollback, GAR-651 Web UI) — **✅ 10/10 Done 2026-05-20** |
+| `GAR-641` | 1.4 | Garra Learning Agent / Self-Improving Operations Manual (sub: GAR-642 Architecture, GAR-643 Skill Miner, GAR-644 Skill Generator, GAR-645 Skill Registry, GAR-646 Skill Retriever, GAR-647 Skill Evaluator, GAR-648 Skill Auto-Updater, GAR-649 Skill Safety Gates, GAR-650 Skill Versioning/Rollback, GAR-651 Web UI) — **✅ 9/10 Done 2026-05-20** (GAR-646 Retriever segue stub) |
 
 ---
 
-## 5. Timeline indicativo (Gantt)
+## 5. Timeline indicativo (Gantt — estimativa original de 2026-04, mantida como referência histórica)
 
 ```mermaid
 gantt
@@ -1314,7 +1336,7 @@ gantt
 
 ## 7. Próximos passos imediatos (próxima sessão)
 
-**Atualizado 2026-05-24** — `TODO.md` criado e esta seção sincronizada. GAR-493/ADR 0011 ✅ Done via PR #492 (`95618d3`). GAR-498 Skills MVP ✅ Done (PR #488, `c65e099`). GAR-499 Agent Team MVP ✅ Done (PR #490, `7e45ec5`). GAR-695 health run 23 docs ✅ Done (PRs #493/#494). GAR-603 Runpod checklist parcialmente reconciliada: implementação/docs estáticas marcadas, smoke Docker/Runpod real segue pendente. Anterior (2026-05-21): GAR-496 Repo workflow seguro ✅ Done (PR #455, `1b7f04c`); GAR-495 ✅ Done (PR #453, `e5a2a08`).
+**Atualizado 2026-09-02** — sincronizado com `main` na v0.3.5 (auditoria docs↔código). Estado anterior desta seção (2026-05-24): `TODO.md` criado e esta seção sincronizada. GAR-493/ADR 0011 ✅ Done via PR #492 (`95618d3`). GAR-498 Skills MVP ✅ Done (PR #488, `c65e099`). GAR-499 Agent Team MVP ✅ Done (PR #490, `7e45ec5`). GAR-695 health run 23 docs ✅ Done (PRs #493/#494). GAR-603 Runpod checklist parcialmente reconciliada: implementação/docs estáticas marcadas, smoke Docker/Runpod real segue pendente. Anterior (2026-05-21): GAR-496 Repo workflow seguro ✅ Done (PR #455, `1b7f04c`); GAR-495 ✅ Done (PR #453, `e5a2a08`).
 
 Quando retomar execução, priorizar **nesta ordem**:
 
@@ -1338,7 +1360,7 @@ Quando retomar execução, priorizar **nesta ordem**:
 
 4. ~~**Fase 1.2.1 GarraMaxPower — GAR-501 `garra verify`**~~ ✅ **Done** (2026-05-19). Pipeline local idempotente com 5 steps: `cargo fmt --check`, `cargo clippy`, `cargo test`, `flutter analyze` (skip se ausente), `gitleaks detect` (skip se ausente). Saída `--json` com schema estável em `docs/maxpower/verify-schema.json`. Exit codes: 0 ok / 2 step-failed. 9 unit tests. Plan: `plans/0155-gar-501-garra-verify.md`. Merged via PR #441 (`ca9f1fa2`).
 
-5. ~~**Garra Learning Agent — Web UI (GAR-651, 10/10)**~~ ✅ **Done** (2026-05-20). `GET /learning` Garra Glass page + REST namespace `/api/learning/*` (10 endpoints: list/detail/approve/reject/lock/rollback/delete skills + list logs/candidates/scores). 11 unit tests. Plan: `plans/0156-gar-651-learning-web-ui.md`. Merged via PR #443 (`21a13f1`). Epic **GAR-641 completo** (10/10).
+5. ~~**Garra Learning Agent — Web UI (GAR-651, 10/10)**~~ ✅ **Done** (2026-05-20). `GET /learning` Garra Glass page + REST namespace `/api/learning/*` (10 endpoints: list/detail/approve/reject/lock/rollback/delete skills + list logs/candidates/scores). 11 unit tests. Plan: `plans/0156-gar-651-learning-web-ui.md`. Merged via PR #443 (`21a13f1`). Epic **GAR-641 em 9/10** (GAR-646 Retriever é stub até a Fase 2.1).
 
 5. ~~**Fase 1.2.1 GarraMaxPower — GAR-500 Auto Dream / handoff**~~ ✅ **Done** (2026-05-20, plan 0157, PR #445 `f1fb596`). `HandoffState` + `RedactedString` + `redact()` em `garraia-common`; `.garra-estado.md` TOML; 17 unit tests; 97.93% cobertura.
 
@@ -1348,21 +1370,25 @@ Quando retomar execução, priorizar **nesta ordem**:
 
 5. ~~**Fase 1.2.1 GarraMaxPower — GAR-498 Skills MVP**~~ ✅ **Done** (2026-05-23, plan 0171, PR #488 `c65e099`). `NativeSkillRegistry` em `garraia-skills` com built-ins `brainstorm`, `write-spec`, `write-plan`, `pre-commit`, `verify`; comandos produzidos passam por `garraia_common::safety_gate`.
 
-5. ~~**Fase 1.2.1 GarraMaxPower — GAR-499 Agent team MVP**~~ ✅ **Done** (2026-05-23/24, plan 0173, PR #490 `7e45ec5`). `AgentTeam` com `OrchestratorAgent`, `ExecutorAgent` e `ReviewerAgent` via canais tipados, pipeline Brainstorm → Spec → Plan → Execute → Review → Finish, 13 unit tests.
+5. ~~**Fase 1.2.1 GarraMaxPower — GAR-499 Agent team MVP**~~ ✅ **Done** (2026-05-23/24, plan 0175, PR #490 `7e45ec5`). `AgentTeam` com `OrchestratorAgent`, `ExecutorAgent` e `ReviewerAgent` via canais tipados, pipeline Brainstorm → Spec → Plan → Execute → Review → Finish, 13 unit tests.
 
-5. **Fase 1.2.1 GarraMaxPower — follow-ups após ADR 0011 (GAR-492)** — manter próximos slices pequenos: execução async/provider-backed das native skills, dogfood em bug real com relatório de review, e expansão incremental do registry sem reescrever `garraia-agents`. Registrar follow-ups concretos em `TODO.md` até virarem issues Linear.
+5. **Fase 1.2.1 GarraMaxPower — follow-ups após ADR 0011 (GAR-492)** — manter próximos slices pequenos: execução async/provider-backed das native skills, dogfood em bug real com relatório de review, e expansão incremental do registry sem reescrever `garraia-agents`. Registrar follow-ups concretos em `TODO.md` até virarem itens do tracker interno.
 
 5. ~~**Trilha T1 — criar `TODO.md` operacional**~~ ✅ **Done** (2026-05-24). O arquivo agora resume concluídos, parciais, adiados, decisões e próximos passos recomendados para a próxima sessão autônoma.
 
-6. **Fase 2.1 RAG / embeddings (`GAR-372`)** — pré-requisito direto do Skill Retriever do Learning Agent (componente 4/10). Sem `garraia-embeddings`, o Retriever roda em fallback degradado (match por tag/scope). MVP do Learning Agent pode coexistir, mas Retriever full só com Fase 2.1 pronta.
+6. **Fase 2.1 RAG / embeddings (`GAR-372`)** — pré-requisito direto do Skill Retriever do Learning Agent (componente 4/10). O crate `garraia-embeddings` existe como scaffold (traits + `DeterministicProvider`, plan 0145); o Retriever ainda é um stub que retorna erro — `PgVectorStore` + `MxbaiProvider` + wiring em learning/agents são os próximos slices.
 
 7. **Fase 3.5 — Object storage S3-compatible validation** — ADR 0004 + plans 0037/0038/0041/0044/0047 implementados; resta exercitar `feature = "storage-s3"` contra MinIO real em CI e contra S3/R2/GCS produção. Issue: GAR-374.
 
-8. **Fase 5.1 — CredentialVault final** (GAR-410, Urgent Backlog) — requisito de segurança pré-existente; bloqueia release público mas não o desenvolvimento da Fase 3/1.4. Fecha o escopo aberto pela GAR-291 (MCP tokens, ✅ Done).
+8. **Fase 5.1 — CredentialVault final** (GAR-410, adiado — ver `TODO.md`) — requisito de segurança pré-existente; bloqueia release público mas não o desenvolvimento da Fase 3/1.4. Fecha o escopo aberto pela GAR-291 (MCP tokens, ✅ Done).
+
+9. **Fase 4.1 — Desktop follow-ups**: DMG notarizado, AppImage aarch64, chave de assinatura + `latest.json` do auto-updater (`docs/releasing.md`).
+
+10. **Fase 5.1 — hardening pendente**: CORS, HSTS, auth por padrão na API local, passthrough da feature `tls` no binário `garraia`.
 
 Trilhas paralelas disponíveis para um segundo dev/agente:
-- **Fase 1.3 — Config reativo** (ainda não materializado).
-- **Fase 4.2 — Mobile build Android update** (gradle 8.x / AGP 8.x / Java 17).
+- **Fase 1.3 — Config reativo** (parcial: schema único + file-watch + `config check` entregues; SSE `/v1/admin/config/stream`, provider hot-reload e persistência do `PATCH /api/settings` pendentes).
+- **Fase 4.2 — Mobile** (build Android já em gradle 8.14 / AGP 8.11.1 / Java 17; próximos: iOS target, fallback REST, `tus_client`, push).
 - **Fase 3.4 — Endpoints restantes da API REST `/v1`**: embeds de tasks/files/chats (WebSocket stream ✅ entregue como SSE em PR #459; tus upload ✅ entregue GAR-395).
 
 ---
@@ -1371,6 +1397,6 @@ Trilhas paralelas disponíveis para um segundo dev/agente:
 
 - `deep-research-report.md` — Arquitetura Group Workspace (base da Fase 3).
 - `CLAUDE.md` — Convenções de código e protocolo de sessão.
-- `.garra-estado.md` — Estado da sessão anterior.
-- `docs/adr/` — Decisões arquiteturais (a popular).
+- `.garra-estado.md` — handoff da sessão anterior gerado por `garra max-power` (gitignored; ausente em clone novo — use `TODO.md`).
+- `docs/adr/` — 15 ADRs (0001-0015), todas Accepted; índice em `docs/adr/README.md`.
 - OWASP ASVS L2, LGPD arts. 46-49, GDPR arts. 25/32/33, OpenTelemetry spec, RFC 9457 Problem Details, RFC 8446 TLS 1.3, RFC 9106 Argon2.

--- a/TODO.md
+++ b/TODO.md
@@ -5,17 +5,79 @@ Status operacional do backlog do GarraIA/GarraRUST. Este arquivo complementa
 foi concluído, o que ficou parcial ou adiado, decisões tomadas e próximos passos
 curtos para a próxima sessão autônoma.
 
-**Atualizado:** 2026-08-31 (America/New_York)
+**Atualizado:** 2026-09-02 (America/New_York)
 
-## Concluído nesta sessão (2026-08-31 — release v0.3.4 + pacotes Linux + Windows ARM64)
+> O Linear foi descontinuado em 2026-08-18; o planejamento vive no tracker
+> interno. Menções a "Done in Linear", "In Review" ou "issues Linear" nas seções
+> históricas abaixo são registro da época, não estado atual. IDs `GAR-xxx`
+> permanecem como identificadores históricos.
 
-- **Release v0.3.4 preparada** (plan 0361, ADR 0015): `[Unreleased]` fundido na
+## Concluído em 2026-09-02 (auditoria docs ↔ código)
+
+- **Reconciliação de `README.md`, `ROADMAP.md` e `TODO.md` com `main@v0.3.5`**:
+  662 afirmações verificadas contra código, CI e API do GitHub; 300 corrigidas.
+  Destaques: MSRV 1.94 → 1.95 no badge/Quick Start; `--features tls` não existe
+  no binário (documentado `cargo build -p garraia --features garraia-gateway/tls`);
+  bloco `embeddings:`/`memory.auto_extract` reescrito na forma real do
+  `AppConfig`; transports MCP aceitos no `config.yml` (`stdio`/`http`);
+  matriz de assets ganha os bundles do Garra Desktop; `POST /v1/messages` +
+  `garra agents setup` (plan 0360 / ADR 0014) documentados pela primeira vez;
+  contagens unificadas (22 crates, 33 migrations, 37 tabelas, 32 sob FORCE RLS,
+  6 binários CLI, wasmtime 48). ROADMAP: ~50 checkboxes `[ ]` já entregues
+  marcados com evidência; contradições GAR-410 / GAR-603 / GAR-641 (9/10)
+  resolvidas; §7 e cabeçalho atualizados; nova §4.4 (canais sem wiring).
+- **Docs irmãos sincronizados** no mesmo PR: `README.pt-BR.md`, `CLAUDE.md`,
+  `CHANGELOG.md` ([0.3.4] e [0.3.5] completados), `docs/installation.md`
+  (MSRV + receita Docker que fazia `ENTRYPOINT ["garraia"]` de um binário
+  `garra`), `docs/configuration.md`/`docs/memory.md`/`docs/hardening-gateway.md`
+  (chaves inventadas `auto_extract`/`extraction_interval`/`max_facts`,
+  `--features tls`), `CONTRIBUTING.md` (MSRV, links `linear.app`),
+  `plans/README.md` (linha 0362; 0358 mergeado; 0022-0024 reapontados),
+  `docs/adr/README.md` (data do 0009), `.github/dependabot.yml` (comentário
+  MSRV).
+
+## Concluído em 2026-09-01 (release v0.3.5 — Garra Desktop Linux + Chat Bar)
+
+- **Release v0.3.5 publicada** (plan 0362, Amendment 2026-09-01 do ADR 0015):
+  Release run #13 via `workflow_dispatch` com os 10 jobs verdes (incl. os
+  best-effort `package-linux`, `build-linux-desktop`, `build-windows-aarch64`,
+  `build-windows-installer`), Deploy #12 manual e `install-endpoints.yml` #7
+  verde no mesmo dia. 47 assets, incluindo
+  `garraia-desktop-linux-x86_64.{deb,AppImage}`.
+- **Garra Desktop para Linux** (`.deb` + AppImage x86_64 via bundler Tauri):
+  job best-effort `build-linux-desktop` no `release.yml` + gate
+  `build-linux-bundles` no `desktop.yml`, `scripts/build-desktop-linux.sh`
+  (irmão do `build-installer.ps1`). O `.deb` declara
+  `Provides/Conflicts/Replaces: garraia` porque instala o sidecar em
+  `/usr/bin/garraia`. Docs em `docs/installation.md` §"Garra Desktop on Linux".
+  Antes disso, quem baixava o AppImage esperando o papagaio recebia a CLI.
+- **Garra Chat Bar**: barra flutuante (`chat_bar.rs`, `ui/chat-bar.html`)
+  substitui o quick-chat (`quick_chat.rs`/`quick-chat.html` removidos);
+  `Ctrl+Space`, item da bandeja, posição/visibilidade persistidas em
+  `chat-bar.json`; cliente WebSocket compartilhado em `ui/ws.js`. Uma única
+  sessão `parrot-desktop` com o papagaio.
+- **Streaming no `/ws/parrot`**: frames `{"type":"chunk"}` por delta + o
+  `{"type":"response"}` final autoritativo (`parrot_ws.rs`).
+- **Papagaio visível de novo**: `ui/assets/parrot-sprite.png` estava no
+  `.gitignore` (todo MSI da v0.3.4 embarcava um overlay transparente que ainda
+  comia cliques); commitado + job `assert-ui-assets` no CI.
+- **Deps de segurança**: argon2 0.6 + pbkdf2 0.13 + password-hash 0.6.1 em
+  `garraia-auth` (GAR-669 slice 3, fecha o Dependabot #430; registrado em
+  `docs/security/dependabot-status.md`).
+- **Fixes menores**: `.deb` da CLI volta a carregar LICENSE/README (#897);
+  `install-endpoints.yml` sobrevive a errexit e imprime o código HTTP (#892);
+  `tests/install_ps1/platform.ps1` em ASCII puro para o PSScriptAnalyzer;
+  `set -euo pipefail` no `Get version` do `package-linux`; bumps do dependabot
+  (#894/#895).
+
+## Concluído em 2026-08-31 (release v0.3.4 + pacotes Linux + Windows ARM64)
+
+- **Release v0.3.4 publicada** (plan 0361, ADR 0015): `[Unreleased]` fundido na
   seção `[0.3.4]` do CHANGELOG (data 2026-08-31). Primeira release a exercitar
-  a matriz do plan 0359 (archives, MSI/NSIS, `install.ps1` — a sonda
-  `release-cdn/install.ps1` do `install-endpoints.yml` fica verde com ela).
-  Publicação: `workflow_dispatch` do Release com `version=v0.3.4` + dispatch
-  manual do Deploy (tag via `GITHUB_TOKEN` não dispara workflows de tag-push —
-  documentado no runbook §2/§4).
+  a matriz do plan 0359 (archives, MSI/NSIS, `install.ps1`); 43 assets.
+  Publicação: Release #12 via `workflow_dispatch` (`version=v0.3.4`) + Deploy
+  #11 manual (tag via `GITHUB_TOKEN` não dispara workflows de tag-push —
+  documentado no runbook §2/§4); `install-endpoints.yml` #6 verde em seguida.
 - **Pacotes Linux `.deb`/`.rpm`/AppImage** no novo job best-effort
   `package-linux` do `release.yml`: nfpm 2.47.0 + appimagetool 1.9.1, ambos
   pinados por versão + SHA-256; empacotam os binários já buildados
@@ -40,30 +102,62 @@ curtos para a próxima sessão autônoma.
   (lista aditiva ganha `.deb`/`.rpm`/`.AppImage`); typo do ADR 0014 (plan
   0360, não 0361) corrigido.
 
+## Concluído em 2026-08-27..30 (v0.3.3 + plans 0355-0360)
+
+- **Release v0.3.3** (2026-08-27): primeira com `install.sh` como asset de
+  release (13 assets: 5 binários crus + `install.sh` + `SHA256SUMS`).
+- **wasmtime 47 → 48 + MSRV 1.94 → 1.95** (PR #865, 2026-08-28): migra a API
+  WASI; `ci.yml` ganha o job `MSRV check (1.95)`. *(Badges e docs seguiram em
+  1.94 até 2026-09-02.)*
+- **sqlx 0.9** (PR #868): `SqlSafeStr` enforçado pelo compilador;
+  `AssertSqlSafe` só em alvos de teste (regra 5 do CLAUDE.md).
+- **Guard SSRF centralizado** em `garraia_common::ssrf` (`vet_url` +
+  `pinned_client`; PRs #869/#883/#889; regra 14 do CLAUDE.md).
+- **`garra chat`**: spinner de atividade + `Ctrl+C` cancela o turno em vez de
+  matar o processo (PR #884); default Ollama `qwen3.8:latest` (plan 0357).
+- **ADR 0013** (plan 0355): motor de recorrência RFC 5545 em
+  `garraia-workspace::recurrence` + `tasks_recurrence_worker` (migration 033)
+  e lifecycle dos servidores MCP.
+- **Interop Hermes ↔ Garra via MCP** (PR #859); workflow
+  `codeql-apply-dismissals` (PR #871); `wiki/` sincronizado com o GitHub Wiki
+  (`wiki-sync.yml`); lopdf 0.44 (plan 0356) e rmcp 1.7 → 2.2 (plan 0358, PR
+  #876) destravados em 2026-08-29.
+- **`garra agents setup|status|link|rollback|web`** (plan 0360, front-end do
+  AgentDeck para provisionar GarraIA/OpenClaw/Hermes/Claude Code com um mesmo
+  provedor+modelo) + **shim Anthropic-compatible `POST /v1/messages`**
+  (ADR 0014, 2026-08-30) para o Claude Code apontar para o gateway. *(Ficou fora
+  do README/ROADMAP/CHANGELOG até 2026-09-02.)*
+- **`install.ps1`** (`irm | iex`) + archives `.tar.gz`/`.zip` + MSI/NSIS via
+  `build-installer.ps1` (plan 0359, PR #878, 2026-08-30).
+
 ## Concluído em 2026-08-18 (cleanup total + v0.3.1/v0.3.2)
 
 - **Repo zerado e verificado**: 0 issues abertas, 0 PRs abertos, só a branch
-  `main`. Trigger `garra-routine-trigger.yml` **desativado** (`gh workflow
-  disable`, reversível) — era ele que mantinha 1 issue de tracking rolante.
+  `main` (ainda verdadeiro em 2026-09-02). Trigger `garra-routine-trigger.yml`
+  **desativado** no GitHub (`gh workflow disable`, reversível; o arquivo ainda
+  tem o `schedule` — o estado vive só no GitHub) — era ele que mantinha 1 issue
+  de tracking rolante.
 - **Linear descontinuado**: planejamento interno migrou para o tracker interno.
-  README/ROADMAP/CLAUDE.md/docs atualizados (links mortos removidos; IDs
-  `GAR-xxx` preservados como histórico).
+  README/ROADMAP/CLAUDE.md atualizados (links mortos removidos dos docs de topo;
+  `plans/README.md` e `docs/adr/README.md` mantêm as URLs antigas como índice
+  histórico; IDs `GAR-xxx` preservados).
 - **Fix crítico LGPD** (plan 0354, PR #843): `POST /v1/me/anonymize` retornava
   **500 em toda chamada** desde junho (coluna fantasma `user_identities.login`
   portada do repo interno sem o schema — regra 14). Agora anonimiza
   `provider_sub` + `users.email` + `group_invites.invited_email` com token
   determinístico de UUID completo. Revisado por security-auditor +
   code-reviewer. Era a causa do cargo-mutants vermelho desde 2026-04-28.
-- **Gap estrutural de CI fechado** (PR #843): job `auth-integration` roda os 16
+- **Gap estrutural de CI fechado** (PR #843): job `auth-integration` roda os 15
   binários de integração do garraia-auth (matriz RLS 81 cenários) em todo PR —
   antes o `cargo test --workspace` os pulava silenciosamente
   (`required-features`). Promover a required check: tracker interno #164.
 - **Deps consolidadas** (PR #844): jsonwebtoken 11, validator 0.21, base64
   0.23, serial_test 4, itertools 0.15, uuid/tauri, e **wasmtime 47 em par**
-  (grupo dependabot novo evita o par quebrado). lopdf destravado em 2026-08-29
-  (0.42→0.44 com a feature `time` off, plan 0356) e **rmcp destravado no
-  mesmo dia** (1.7→2.2, `ContentBlock`, plan 0358) — do #163 resta só o salto
-  3.x. h2 0.4.16 (RUSTSEC-2026-0258).
+  (grupo dependabot novo evita o par quebrado; 47 → 48 + MSRV 1.95 vieram no
+  PR #865 em 2026-08-28). lopdf destravado em 2026-08-29 (0.42→0.44 com a
+  feature `time` off, plan 0356) e **rmcp destravado no mesmo dia** (1.7→2.2,
+  `ContentBlock`, plan 0358) — do #163 resta só o salto 3.x. h2 0.4.16
+  (RUSTSEC-2026-0258).
 - **CI higiene** (PR #842): `timeout-minutes` em e2e/playwright (2 runs de 6h
   presos no download do Chromium em 2026-08-17), `Cross.toml` para o build
   ARM64.
@@ -74,7 +168,12 @@ curtos para a próxima sessão autônoma.
   por release asset + jsDelivr (#826); RUSTSEC do `lru` migrado para o tracker
   interno #162 (re-triage ≤ 2026-11-14).
 
-## Concluído em 2026-06-10
+## Histórico (maio–junho 2026, sessões `garra-routine`)
+
+Registro das entregas das sessões autônomas anteriores. Todos os PRs abaixo
+foram mergeados (ver `plans/README.md` para hash e data de cada um).
+
+### 2026-06-10
 
 - GAR-835 / plan 0297 — Docs Tier 2 scaffold: migration 026 + POST/GET /v1/groups/{group_id}/doc-pages:
   - Migration `026_doc_pages.sql`: `doc_pages` table with FORCE RLS, NULLIF fail-closed group
@@ -87,9 +186,8 @@ curtos para a próxima sessão autônoma.
   - `openapi.rs`: paths + schemas registered.
   - ROADMAP §3.8 Tier 2: `doc_pages` schema + 2 API endpoints marked ✅.
   - PR #706 squash-merged 2026-06-10 (`54f88bc`) — 20/20 CI green.
-  - GAR-835 → Done in Linear.
 
-## Concluído em sessões anteriores
+### 2026-06-05..06
 
 - GAR-806 / plan 0269 — GET /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}:
   - `get_task_comment` handler in `comments.rs`: validates group_id, TasksRead check,
@@ -101,8 +199,7 @@ curtos para a próxima sessão autônoma.
   - 6 unit tests: serializes all fields, nil author_user_id → null, nil edited_at → null,
     edited_at UTC ISO-8601 Z, nil UUID round-trip, task_id preserved.
   - `cargo clippy --workspace` clean (0 warnings). 12 total comments tests pass.
-  - Branch: `routine/202506061830-get-task-comment`.
-
+  - Branch `routine/202506061830-get-task-comment`; squash-merged PR #655 (`760dfd8`) 2026-06-06.
 
 - GAR-800 / plan 0266 — PATCH /v1/groups/{group_id}/task-labels/{label_id}:
   - `PatchTaskLabelRequest { name, color }` + `patch_task_label` handler in `labels.rs`.
@@ -112,7 +209,7 @@ curtos para a próxima sessão autônoma.
   - OpenAPI: `super::tasks::labels::patch_task_label` path + `PatchTaskLabelRequest` schema.
   - 6 unit tests: name-only / color-only / both-absent roundtrip, hex valid/invalid, response nil-UUID.
   - `cargo clippy --workspace` clean; 634 unit tests pass. Branch: `routine/202506060020-task-label-patch`.
-  - PR pending CI.
+  - Merged PR #649 (`28d052a`).
 
 - GAR-798 / plan 0265 — GET /v1/threads/{thread_id}:
   - `get_thread` handler in `chats.rs` (before `patch_thread`): validates group_id, ChatsRead check,
@@ -124,9 +221,9 @@ curtos para a próxima sessão autônoma.
   - 6 unit tests: serializes all fields, nil title → null, nil created_by → null,
     unresolved → null resolved_at, resolved → UTC ISO-8601 Z timestamp, nil UUID round-trip.
   - `cargo clippy --workspace` clean (0 warnings). Branch: `routine/202506051820-get-thread`.
-  - PR pending CI.
+  - Merged PR #646 (`7913904`).
 
-- PR #643 (docs/mark-plan-0263-merged) — merged (20/20 CI green); GAR-794 → Done in Linear.
+- PR #643 (docs/mark-plan-0263-merged) — merged (20/20 CI green); GAR-794 fechado.
 
 - GAR-795 / plan 0264 — PATCH /v1/groups/{group_id}/tasks/{task_id}/comments/{comment_id}:
   - `TaskCommentEdited` variant added to `WorkspaceAuditAction` in `garraia-auth`.
@@ -137,7 +234,6 @@ curtos para a próxima sessão autônoma.
   - 6 unit tests pass. `cargo clippy --workspace` green (622+6 tests, 0 warnings).
   - Closes CRUD gap: POST/GET/DELETE were GAR-520; PATCH was missing.
   - Squash-merged PR #644 (`6974812`) 2026-06-05 — 20/20 CI green.
-  - GAR-795 → Done in Linear.
 
 - GAR-794 / plan 0263 — POST /v1/me/invites/{invite_id}/accept:
   - `accept_my_invite` handler in `me.rs`: UUID-based authenticated accept.
@@ -148,12 +244,10 @@ curtos para a próxima sessão autônoma.
   - 6 unit tests covering: serialization, no-PII fields, role variants, nil UUID round-trip, PendingInviteSummary excludes accepted_at, exactly-3-fields shape.
   - Completes the invite lifecycle: list (GAR-777) → accept (GAR-794) / decline (GAR-783); token-based accept (plan 0019) unchanged.
 
-## Concluído em sessões anteriores
+### 2026-06-02..03
 
 - GAR-777 / plan 0255 — GET /v1/me/invites (caller-scoped pending group invites inbox):
-  - Merged PR #621 (`762d63c`) after CI went 20/20 green.
-  - GAR-777 → Done in Linear.
-  - Bookkeeping PR #624 (docs/mark-plan-0255-merged) open, CI running.
+  - Merged PR #621 (`762d63c`) after CI went 20/20 green; bookkeeping PR #624 (docs/mark-plan-0255-merged) merged.
 
 - GAR-780 / plan 0257 — GET + DELETE /v1/groups/{id}/invites/{invite_id} (invite revocation):
   - Migration 024: `revoked_at` + `revoked_by` columns on `group_invites`; recreated partial unique index to exclude revoked rows (enables re-invite after revocation).
@@ -163,12 +257,9 @@ curtos para a próxima sessão autônoma.
   - `revoke_invite` handler: `UPDATE SET revoked_at = now()`, emits `InviteRevoked` audit event, 204 No Content (404 if already accepted/revoked).
   - Routes in all 3 `mod.rs` branches. OpenAPI paths + schemas (`InviteSummary`, `ListInvitesResponse`).
   - 5 unit tests (serialization, cursor, role round-trip, no `revoked_at` in response).
-  - Squash-merged PR #625 (`46a8658`) 2026-06-03 — 20/20 CI green.
-  - GAR-780 → Done in Linear.
-  - Bookkeeping PR (docs/mark-plan-0257-merged) open.
+  - Squash-merged PR #625 (`46a8658`) 2026-06-03 — 20/20 CI green; bookkeeping PR (docs/mark-plan-0257-merged) merged.
 
-## Concluído em sessões anteriores
-
+### 2026-05-31..06-01
 
 - GAR-767 / plan 0246 — GET /v1/me/files (caller-scoped uploaded-files inbox):
   - `ListMyFilesQuery` struct with `group_id` (required), `after`, `limit`, `folder_id` (optional).
@@ -178,7 +269,7 @@ curtos para a próxima sessão autônoma.
   - Route `.route("/v1/me/files", get(me::list_my_files))` registered in all 3 `mod.rs` branches.
   - OpenAPI annotation + component registration in `openapi.rs`.
   - 8 new unit tests (serialization, limit clamp, folder filter, cursor, large size).
-  - Branch: `routine/202506010015-me-files-inbox`. GAR-767 In Progress → Done pending CI.
+  - Branch `routine/202506010015-me-files-inbox`; merged 2026-06-01 via PR #603.
 
 - GAR-765 / plan 0245 — GET /v1/me/chats (caller-scoped chat membership inbox):
   - `ListMyChatsQuery` struct with `group_id` (required), `after`, `limit`, `type` (optional).
@@ -188,10 +279,9 @@ curtos para a próxima sessão autônoma.
   - Route `.route("/v1/me/chats", get(me::list_my_chats))` registered in `mod.rs`.
   - OpenAPI annotation + component registration in `openapi.rs`.
   - 8 new unit tests (serialization, type filter validation, cursor, muted/last_read_at).
-  - All CI checks expected green (no migration, additive handler only).
-  - Branch: `routine/202605311818-me-chats-inbox`. GAR-765 In Progress → Done.
+  - Branch `routine/202605311818-me-chats-inbox`; merged 2026-05-31 via PR #601 (`2bf1f5b`).
 
-## Concluído em sessões anteriores
+### 2026-05-25..29
 
 - GAR-733 / plan 0215 — Search slice 14 (`types=groups` group name FTS):
   - `SearchResultType::Group` variant; `include_groups: bool` in `ValidatedSearch`.
@@ -199,7 +289,7 @@ curtos para a próxima sessão autônoma.
   - `GroupSearchRow` struct + `fetch_groups()` async (runtime `to_tsvector('simple', g.name)`).
   - Handler block: `if validated.include_groups { ... }` mapping to `SearchResult`.
   - 6 unit tests (scope guards + multi-type combos). No migration needed — FORCE RLS migration 018.
-  - PR #561 squash-merged 2026-05-29 (`1bb2f10`). GAR-733 Done in Linear.
+  - PR #561 squash-merged 2026-05-29 (`1bb2f10`).
 
 - GAR-705 / plan 0187 — Health run 30: all surfaces clean, priority (i). PR #508 squash-merged (`ef040ad`).
 
@@ -210,8 +300,6 @@ curtos para a próxima sessão autônoma.
     asserts `Err(UnknownHashFormat)` + 1 audit row committed + ip populated.
   - Total: 11 integration tests (was 10). Tests-only PR, no production code changes.
   - PR #509 squash-merged (`a1b0fdd`).
-
-## Concluído em sessões anteriores
 
 - GAR-702 / plan 0184 — Health run 28: all surfaces clean, priority (i). PR #504 squash-merged.
 
@@ -233,7 +321,7 @@ curtos para a próxima sessão autônoma.
     quando `types` não inclui `messages`), predicado SQL EXISTS-equality trick.
   - Tests: 5 unit tests novos (slice 4 block), S18/S19/S20 integration scenarios.
   - ROADMAP.md + plans/README.md + TODO.md atualizados.
-  - Branch: `routine/202605250015-search-has-attachment`, PR em revisão.
+  - Branch: `routine/202605250015-search-has-attachment`; merged 2026-05-25 via PR #498 (`be8c880`).
 
 ## Parcialmente concluído
 
@@ -242,80 +330,124 @@ curtos para a próxima sessão autônoma.
     container bindando `0.0.0.0`, rotas `/ping` e `/health`, `PORT`/`HOST`,
     Dockerfile sem REPL, receita local Docker, settings Runpod e distinção
     queue-based vs Load Balancer.
-  - Pendente: smoke Docker local nesta sessão e smoke público
+  - Pendente: smoke Docker local e smoke público
     `https://<ENDPOINT_ID>.api.runpod.ai/ping`.
   - Pendente técnico: suporte a `PORT_HEALTH` separado quando a health port
     precisar diferir de `PORT`; hoje a documentação exige `PORT_HEALTH=PORT`.
+- GAR-641 Garra Learning Agent (9/10): tudo entregue exceto GAR-646 Skill
+  Retriever — `retriever.rs` é stub que retorna erro até a Fase 2.1; o CLI
+  de override (`garra skills approve|lock|rollback|...`) e o módulo
+  `skill_override` também são stubs (só a Web UI faz isso hoje).
+- Desktop auto-updater: `tauri-plugin-updater` ligado (`check_for_updates`/
+  `install_update` na bandeja) mas inerte — sem chave de assinatura e nenhum
+  workflow publica `latest.json` (`docs/releasing.md` §Débito conhecido).
 
 ## Adiado com justificativa
 
-- GAR-372 / Fase 2.1 RAG embeddings: adiado porque a próxima entrega real
-  exige toolchain Rust e testes; o ambiente local desta sessão não tinha
-  `cargo`, `rustc` ou `rustfmt`.
+- GAR-372 / Fase 2.1 RAG embeddings: scaffold do crate `garraia-embeddings`
+  entregue (PR #396, 2026-05-18 — traits + `DeterministicProvider`); faltam o
+  `PgVectorStore` real (sqlx/pgvector sobre `memory_embeddings`), o
+  `MxbaiProvider` (candle, ADR 0001/0002) e o wiring em learning/agents.
+  Adiado por ser o maior slice aberto da Fase 2 e pré-requisito do GAR-646.
 - GAR-374 / Object storage S3-compatible validation: adiado por depender de
-  MinIO/S3/R2/GCS ou CI com serviço externo configurado.
-- GAR-410 / CredentialVault final: adiado por ser item crítico de segurança,
-  amplo e inadequado para alteração sem toolchain local e validação profunda.
-- GAR-504 / benchmark evidence run: adiado por depender de infra externa
-  (droplet/host dedicado).
+  MinIO/S3/R2/GCS ou CI com serviço externo configurado (o `S3Compatible`
+  existe atrás da feature `storage-s3`; nenhum job de CI exercita MinIO).
+- GAR-410 / CredentialVault final: adiado por ser item crítico de segurança e
+  amplo. O que já existe: leitura de secrets centralizada em
+  `garraia-config::auth` (plan 0046) e refactor do `admin/secrets.rs` (plan
+  0133). O que falta: gateway consumindo o cofre como fonte única, rotação de
+  chaves, master key via argon2id. (ROADMAP §1.1 dizia "mergeado em
+  2026-05-17" — corrigido para "parcial" em 2026-09-02.)
+- GAR-504 / benchmark evidence run: o run em VM x86_64 está versionado em
+  `benches/agent-framework-comparison/results/2026-08-28-vm/` e alimenta a
+  tabela do README; só o run de referência no droplet 1 vCPU / 1 GB segue
+  adiado por depender de infra externa.
 - Execução async/provider-backed das native skills GarraMaxPower: adiada para
   slice próprio após decidir o fechamento do épico GAR-492.
 
-## Novas pendências encontradas
+## Pendências abertas
 
-- O repositório não tinha `TODO.md`; manter este arquivo atualizado em toda
-  sessão autônoma daqui para frente.
-- O ambiente local tinha `git`, `node` e `rg`, mas não tinha `cargo`,
-  `rustc`, `rustfmt`, `gitleaks` ou `markdownlint`. Mudanças de runtime devem
-  esperar toolchain local ou depender explicitamente de CI no PR.
-- `ROADMAP.md` ainda contém vários itens antigos marcados como `[ ]` que podem
-  estar parcialmente entregues por PRs anteriores. Próxima limpeza deve
-  reconciliar apenas itens com evidência clara para evitar falsear status.
-- `GAR-492` está em In Review: decidir se fecha como MVP completo ou se mantém
-  aberto somente até abrir follow-ups separados.
+- `ROADMAP.md` continha dezenas de itens `[ ]` já entregues — reconciliado em
+  2026-09-02 apenas onde havia evidência clara (path:line). Itens sem evidência
+  ficaram `[ ]`.
+- Débitos de código encontrados na auditoria de 2026-09-02 (viram itens, não
+  patches na PR de docs):
+  - `sessions.db` cai em `~/.garraia/data/` (`crates/garraia-gateway/src/server.rs:232-241`)
+    enquanto `memory.db` e `memoria/fatos.json` usam o config dir XDG —
+    unificar via `ConfigLoader::default_config_dir()`.
+  - Feature `tls` sem passthrough no binário `garraia`
+    (`crates/garraia-cli/Cargo.toml`) — adicionar `tls = ["garraia-gateway/tls"]`
+    como já existe para `mcp-http`; até lá o README documenta
+    `--features garraia-gateway/tls`.
+  - `docker-compose.turboquant.yml` monta `docs/deployment/config.turboquant.yml`,
+    que não existe no repo.
+  - `benches/agent-framework-comparison/results/2026-08-28-vm/README.md:12`
+    cita checkout `ea06286` enquanto `environment.txt:44` registra `f34cbfa`.
+  - Comentário "16 binários" em `ci.yml:437` (são 15 arquivos em
+    `crates/garraia-auth/tests/`).
+  - `MemoryConfig` não tem `auto_extract`/`extraction_interval`/`max_facts`
+    (a extração roda em todo turno, sem knob) — as docs que prometiam essas
+    chaves foram corrigidas; decidir se viram configuração real.
+  - `.claude/commands/garra-routine.md` (linhas 2/16/44/79) ainda instrui
+    consultar o Linear.
+- `install-endpoints.yml:133-150`: remover o bloco de tolerância
+  `KNOWN_PRE_PS1_TAG="v0.3.3"` e o argumento extra do probe
+  `release-cdn/install.ps1` — o próprio workflow pede isso após a primeira
+  release ≥ v0.3.4 (v0.3.4 e v0.3.5 já publicam `install.ps1`).
+- `GAR-492`: decidir no tracker interno se o épico fecha como MVP completo ou
+  se abre follow-ups (execução provider-backed das native skills, dogfood em
+  bug real com relatório de review).
 
 ## Decisões tomadas
 
-- Não alterar runtime Rust nesta sessão: sem toolchain local, o caminho seguro
-  foi documentação, rastreabilidade e reconciliação de backlog.
-- Marcar GAR-603 como parcialmente concluído, não totalmente fechado: a
-  implementação/documentação está presente, mas falta prova operacional recente
-  em Docker e Runpod público.
-- Criar `TODO.md` como backlog operacional curto, evitando sobrecarregar
+- 2026-09-02: reconciliar docs com código **só** com evidência apontável;
+  manter as seções históricas de maio–junho como registro datado (com a nota
+  sobre o Linear no topo) em vez de apagá-las; bugs de código achados durante
+  a auditoria viram pendências aqui, não patches na PR de docs.
+- 2026-05-24: marcar GAR-603 como parcialmente concluído, não totalmente
+  fechado — a implementação/documentação está presente, mas falta prova
+  operacional recente em Docker e Runpod público.
+- 2026-05-24: criar `TODO.md` como backlog operacional, evitando sobrecarregar
   `ROADMAP.md` com detalhes de sessão.
 
 ## Próximos passos recomendados
 
-1. Conferir o cargo-mutants no próximo agendamento semanal (esperado **verde
-   pela primeira vez** após o fix do baseline no plan 0354).
-2. Promover `Auth Integration (test-support)` a required check do ruleset após
-   ~1 semana sem flakes (tracker interno #164).
-3. Retomar o salto **rmcp 2.2→3.x** quando houver janela (tracker interno
-   #163). O degrau 1.7→2.2 foi entregue em 2026-08-29 (plan 0358); o 3.x mantém
+1. Promover `Auth Integration (test-support)` a required check do ruleset
+   (tracker interno #164): sem flakes conhecidos e o `cargo-mutants` semanal
+   está verde desde 2026-08-24 (runs #21/#22) — manter o monitoramento.
+2. Retomar o salto **rmcp 2.2→3.x** quando houver janela (tracker interno
+   #163). `Cargo.lock` está em 2.2.0; o 3.x mantém
    `ContentBlock`/`Role`/`PromptMessage` e as features que usamos, mas adiciona
    módulos novos (`mrtr`, `request_state`, `service/client/`, `mcp_headers`)
    ainda não auditados. O `@dependabot ignore` de rmcp foi aplicado por
-   comentário em PR, não pelo `.github/dependabot.yml` — mergear o 2.2 **não** o
-   limpa sozinho. lopdf 0.44 entregue em 2026-08-29 (plan 0356) — a feature
-   `time` fica desligada até um release > 0.44.0 trazer o fix do upstream #518.
-4. Re-triage do RUSTSEC-2026-0253 (`lru` via aws-sdk-s3) até 2026-11-14
-   (tracker interno #162).
-5. Ajustar a skill `garra-routine` (`.claude/commands/garra-routine.md`), que
-   ainda instrui consultar o Linear.
-6. Rodar smoke Docker GAR-603:
+   comentário em PR, não pelo `.github/dependabot.yml`. lopdf fica em 0.44 com a
+   feature `time` desligada até um release > 0.44.0 trazer o fix do upstream
+   #518.
+3. Re-triage do RUSTSEC-2026-0253 (`lru` via aws-sdk-s3) até 2026-11-14 —
+   o ignore em `deny.toml`/`.cargo/audit.toml` expira em 2026-11-15 e ainda
+   cita o owner antigo (`#812 / GAR-896`; hoje tracker interno #162).
+4. Limpar o bloco `KNOWN_PRE_PS1_TAG` do `install-endpoints.yml` (ver
+   Pendências) e ajustar `.claude/commands/garra-routine.md` para o tracker
+   interno.
+5. Desktop (ROADMAP §4.1): chave de assinatura + `latest.json` para o
+   `tauri-plugin-updater`; DMG notarizado; AppImage aarch64
+   (`--runtime-file` + segundo pin de runtime).
+6. Fase 2.1 (GAR-372 → GAR-646): `PgVectorStore` + `MxbaiProvider` + wiring do
+   Skill Retriever — único item aberto do épico GAR-641.
+7. Débitos de código da auditoria (ver Pendências): começar por
+   `sessions.db` no config dir e pelo passthrough `tls` no binário — ambos
+   pequenos e com docs já apontando para o comportamento esperado.
+8. Rodar smoke Docker GAR-603:
    `docker build -t garraia:local .`,
    `docker run --rm -p 3888:3888 garraia:local`,
    `curl -fsS http://localhost:3888/ping`,
-   `curl -fsS http://localhost:3888/health`.
-7. Rodar smoke público Runpod quando houver endpoint disponível:
-   `curl -fsS https://<ENDPOINT_ID>.api.runpod.ai/ping`.
-8. Abrir follow-up para `PORT_HEALTH` separado somente se Runpod exigir health
-   listener distinto de `PORT`.
-9. Decidir destino de GAR-492: fechar épico como MVP completo ou abrir issues
-   separadas para dogfood em bug real e execução async/provider-backed.
-10. Preparar ambiente local com Rust toolchain para permitir mudanças de código
-    mais ambiciosas nas próximas sessões.
-11. Pós-merge da v0.3.4: disparar o Release (`version=v0.3.4`), verificar os
-    assets (incl. aditividade dos 5 nomes crus da v0.3.3), disparar o Deploy
-    (`tag=v0.3.4`) e conferir o `install-endpoints.yml` do dia seguinte.
-    Follow-ups registrados: AppImage aarch64 e DMG notarizado (ROADMAP §4.1).
+   `curl -fsS http://localhost:3888/health`;
+   depois o smoke público Runpod `curl -fsS https://<ENDPOINT_ID>.api.runpod.ai/ping`
+   quando houver endpoint. Abrir follow-up para `PORT_HEALTH` separado só se o
+   Runpod exigir listener distinto de `PORT`.
+9. Decidir destino de GAR-492 (ver Pendências).
+10. A cada release, repetir o checklist de sincronia dos docs: versão, badge
+    MSRV, contagens (crates / migrations / tabelas / FORCE RLS / binários /
+    wasmtime), matriz de assets do `release.yml`, bloco novo aqui e no
+    cabeçalho do ROADMAP, `[Unreleased]` do CHANGELOG. Candidato a virar seção
+    do `docs/releasing.md`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -48,7 +48,7 @@ Rationale curta ("porque sim") é sinal de que a decisão não deveria ser ADR �
 | [0006](0006-search-strategy.md) | Search strategy (Postgres FTS → Tantivy → Meilisearch) | ✅ accepted | 2026-04-21 | [GAR-376](https://linear.app/chatgpt25/issue/GAR-376) |
 | [0007](0007-desktop-frontend.md) | Desktop frontend (HTML+Vanilla baseline → SolidJS trigger) | ✅ accepted | 2026-04-21 | [GAR-377](https://linear.app/chatgpt25/issue/GAR-377) |
 | [0008](0008-doc-collaboration.md) | Doc collaboration (Tier 1 single-editor → y-crdt Tier 2) | ✅ accepted | 2026-04-21 | [GAR-378](https://linear.app/chatgpt25/issue/GAR-378) |
-| [0009](0009-web-console-design-system.md) | Web Console design system "Garra Glass" (HTML+CSS custom tokens, zero CDN) | ✅ accepted | 2026-05-13 | [GAR-607](https://linear.app/chatgpt25/issue/GAR-607) |
+| [0009](0009-web-console-design-system.md) | Web Console design system "Garra Glass" (HTML+CSS custom tokens, zero CDN) | ✅ accepted | 2026-05-14 | [GAR-607](https://linear.app/chatgpt25/issue/GAR-607) |
 | [0010](0010-garra-learning-agent.md) | Garra Learning Agent / Self-Improving Operations Manual | ✅ accepted | 2026-05-17 | [GAR-641](https://linear.app/chatgpt25/issue/GAR-641) |
 | [0011](0011-garra-max-power.md) | GarraMaxPower — Native Agent-Advanced Mode (`garra max-power`) | ✅ accepted | 2026-05-24 | [GAR-492](https://linear.app/chatgpt25/issue/GAR-492) |
 | [0012](0012-garra-persona.md) | Persona Amistosa do Garra — tom de voz padrão (inspirado em OpenHuman) | ✅ accepted | 2026-06-01 | GAR-771 |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,9 +4,12 @@ Complete reference for GarraIA configuration options.
 
 ## Configuration File Location
 
-GarraIA looks for configuration in:
-1. `./config.yml` (current directory)
-2. `~/.garraia/config.yml` (home directory)
+GarraIA looks for `config.yml` (fallback `config.toml`) in its config directory, resolved as:
+1. `$GARRAIA_CONFIG_DIR` (when set)
+2. `~/.config/garraia` (XDG; the default on new installs)
+3. `~/.garraia` (legacy — only when the XDG directory does not exist)
+
+Run `garraia config check` to see which directory and file are active.
 
 ## Full Configuration Example
 
@@ -123,16 +126,16 @@ agents:
 # Memory Configuration
 memory:
   enabled: true
-  auto_extract: true      # Extract facts automatically
-  extraction_interval: 5   # Minutes between extractions
-  max_facts: 100
+  embedding_provider: ollama-embed   # key of the `embeddings` entry below
+  # shared_continuity: false         # optional; fact extraction runs on every turn (no auto_extract knob)
 
-# Embeddings Configuration
+# Embeddings Configuration (named map — pick one entry via memory.embedding_provider)
 embeddings:
-  provider: ollama
-  model: nomic-embed-text
-  base_url: "http://localhost:11434"
-  dimension: 768
+  ollama-embed:
+    provider: ollama
+    model: nomic-embed-text
+    base_url: "http://localhost:11434"
+    dimensions: 768
 
 # Voice Configuration
 voice:
@@ -270,7 +273,7 @@ requires an explicit `--model` flag.
 ## Hot Reload
 
 Configuration changes in `config.yml` are applied automatically:
-1. Edit `~/.garraia/config.yml`
+1. Edit `<config-dir>/config.yml` (`~/.config/garraia/config.yml` by default)
 2. Changes detected within seconds
 3. No restart required
 

--- a/docs/hardening-gateway.md
+++ b/docs/hardening-gateway.md
@@ -55,7 +55,7 @@ gateway:
 ```
 
 - **TLS**: os binários release atuais **não** incluem a feature `tls`
-  (compilável com `--features tls` a partir do código). O caminho
+  (compilável a partir do código com `cargo build -p garraia --features garraia-gateway/tls`). O caminho
   suportado hoje é um **reverse proxy com TLS** (Caddy/nginx/Traefik) na
   frente do gateway em loopback — ou seja, muitas vezes o Perfil A + um
   proxy exposto resolve melhor que `0.0.0.0` direto.
@@ -157,5 +157,5 @@ Arquivo completo comentado, validado com `garra config check`:
    default está no roadmap.
 3. "Controle de aplicativos" (GUI/automação de apps) não existe como
    tool — ver a nota em mcp-capacidades.md.
-4. TLS embutido exige build com `--features tls`; binários release
+4. TLS embutido exige build com `--features garraia-gateway/tls`; binários release
    atuais servem HTTP puro (use reverse proxy).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@ This guide covers installing GarraIA on various platforms.
 
 ## Prerequisites
 
-- **Rust 1.94+** (if building from source)
+- **Rust 1.95+** (if building from source)
 - **FFmpeg** (for voice mode)
 - **Linux (prebuilt binaries):** glibc ≥ 2.35 — Ubuntu 22.04+, Debian 12+.
   Older distros and musl-based systems (Alpine) must build from source.
@@ -159,7 +159,7 @@ The app itself works on both.
 ### Prerequisites
 
 ```bash
-# Install Rust 1.94+
+# Install Rust 1.95+
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 rustup update stable
 
@@ -330,15 +330,18 @@ docker-compose up -d
 ### Manual Docker
 
 ```dockerfile
-FROM rust:1.94-trixie
+# Runtime-only image: build the binary first with `cargo build --release -p garraia`
+# (Rust 1.95+). The repo's own Dockerfile does the multi-stage build for you.
+FROM debian:trixie-slim
 
-RUN apt-get update && apt-get install -y ffmpeg
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates ffmpeg \
+    && apt-get clean
 
-# Build and copy binary
-COPY target/release/garra /usr/local/bin/
+# cargo names the binary `garra`
+COPY target/release/garra /usr/local/bin/garra
 
-ENTRYPOINT ["garraia"]
-CMD ["start"]
+ENTRYPOINT ["garra"]
+CMD ["start", "--host", "0.0.0.0"]
 ```
 
 ## Pre-compiled Binaries

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -63,15 +63,15 @@ Semantic search using:
 ```yaml
 memory:
   enabled: true
-  auto_extract: true        # Extract facts automatically
-  extraction_interval: 5     # Minutes between extractions
-  max_facts: 100           # Maximum facts to store
+  embedding_provider: ollama-embed   # key of the `embeddings` entry below
+  # fact extraction runs on every turn — there is no auto_extract/interval/max_facts knob
 
 embeddings:
-  provider: ollama
-  model: nomic-embed-text
-  base_url: "http://localhost:11434"
-  dimension: 768
+  ollama-embed:
+    provider: ollama
+    model: nomic-embed-text
+    base_url: "http://localhost:11434"
+    dimensions: 768
 ```
 
 ## CLI Commands
@@ -125,7 +125,7 @@ garraia memory export
 ## Data Location
 
 ```
-~/.garraia/
+~/.config/garraia/            # <config-dir>; ~/.garraia only on legacy installs
 ├── memoria/
 │   ├── fatos.json          # Extracted facts
 │   └── embeddings/         # Embedding cache

--- a/plans/README.md
+++ b/plans/README.md
@@ -30,9 +30,9 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0019 | [GAR-393 slice 3 — Invite Accept (`POST /v1/invites/{token}/accept`)](0019-gar-393-invite-accept.md) | [GAR-393](https://linear.app/chatgpt25/issue/GAR-393) | ✅ Merged |
 | 0020 | [GAR-394 — ObjectStore trait + LocalFs (storage slice 1)](0020-gar-394-object-store-local-fs.md) | [GAR-394](https://linear.app/chatgpt25/issue/GAR-394) | ✅ Merged |
 | 0021 | [GAR-408 — tus 1.0 uploads (Fase 3.5 slice 1)](0021-gar-408-tus-uploads.md) | [GAR-408](https://linear.app/chatgpt25/issue/GAR-408) | ✅ Merged |
-| 0022 | [GAR-412 — `/metrics` dedicated listener + Prometheus auth](0022-gar-412-metrics-listener.md) | [GAR-412](https://linear.app/chatgpt25/issue/GAR-412) | ✅ Merged |
-| 0023 | [GAR-411 — Rate limiter (Governor/tower-governor)](0023-gar-411-rate-limiter.md) | [GAR-411](https://linear.app/chatgpt25/issue/GAR-411) | ✅ Merged |
-| 0024 | *(renumbered → see 0022)* | — | — |
+| 0022 | [GAR-426 — Workspace security hardening part 2 (rate-limit refinements + audit robustness)](0022-gar-426-workspace-security-part-2.md) | GAR-426 | ✅ Merged |
+| 0023 | [GAR-427 — Migrate api.rs session-IP stamp to real_client_ip](0023-gar-427-xff-api-session-ip.md) | GAR-427 | ✅ Merged |
+| 0024 | [GAR-412 — /metrics endpoint auth (Bearer + IP ACL + startup fail-closed)](0024-gar-412-metrics-endpoint-auth.md) | GAR-412 | ✅ Merged |
 | 0025 | [GAR-415 — Trusted proxy + real_client_ip](0025-gar-415-trusted-proxy.md) | [GAR-415](https://linear.app/chatgpt25/issue/GAR-415) | ✅ Merged |
 | 0026 | [GAR-416 — Request-ID propagation](0026-gar-416-request-id.md) | [GAR-416](https://linear.app/chatgpt25/issue/GAR-416) | ✅ Merged |
 | 0027 | [GAR-417 — Health check `/health`](0027-gar-417-health-check.md) | [GAR-417](https://linear.app/chatgpt25/issue/GAR-417) | ✅ Merged |
@@ -368,7 +368,8 @@ Este diretório contém os planos de implementação para o projeto GarraRUST.
 | 0355 | [Robustez sempre-online: ciclo de vida MCP + recorrência](0355-recurrence-and-mcp-lifecycle.md) | plan 0355 (origem) | ✅ Entregue 2026-08-29 (ADR 0013) |
 | 0356 | [lopdf 0.42 → 0.44 com a feature `time` desligada (E0599 do BorrowedFormatItem)](0356-lopdf-044-time-feature-off.md) | Dependabot PR #851 / upstream lopdf#518 | 🚧 Em revisão (2026-08-29) |
 | 0357 | [Padrão `qwen3.8`, `garraia --model <tag>` e preparo para `ollama launch`](0357-ollama-defaults-and-launch.md) | pedido direto | ✅ Entregue 2026-08-29 |
-| 0358 | [rmcp 1.7 → 2.2 (`ContentBlock` e o fim do `Annotated<RawContent>`)](0358-rmcp-220-content-block-migration.md) | Dependabot PR #853 / upstream rust-sdk#927 | 🚧 Em revisão (2026-08-29) |
+| 0358 | [rmcp 1.7 → 2.2 (`ContentBlock` e o fim do `Annotated<RawContent>`)](0358-rmcp-220-content-block-migration.md) | Dependabot PR #853 / upstream rust-sdk#927 | ✅ Merged 2026-08-29 via PR #876 (`5e635ab`) |
 | 0359 | [Instalador Windows `install.ps1` + matriz de artefatos multiplataforma](0359-windows-installer-and-release-matrix.md) | pedido direto | ✅ Entregue 2026-08-30 |
 | 0360 | [`garra agents setup`: provisionamento e roteamento multi-agente](0360-garra-agents-setup.md) | pedido direto | ✅ Entregue 2026-08-30 (ADR 0014) |
 | 0361 | [Pacotes Linux `.deb`/`.rpm`/AppImage + Windows ARM64 nativo + release v0.3.4](0361-linux-packages-and-windows-arm64.md) | pedido direto | ✅ Entregue 2026-08-31 (ADR 0015) |
+| 0362 | [Papagaio de volta, Garra Chat Bar e desktop Linux](0362-garra-chat-bar-e-desktop-linux.md) | pedido direto | ✅ Entregue 2026-09-01 (v0.3.5, Amendment do ADR 0015) |


### PR DESCRIPTION
## Descrição

Auditoria docs ↔ código (662 afirmações verificadas contra código, CI e API do GitHub; 300 corrigidas) para responder "TODO.md, README.md e ROADMAP.md estão atualizados?". Resposta: não — e este PR os reconcilia com `main@v0.3.5`, em 4 commits (um por arquivo/grupo) para facilitar a revisão.

- **`174895b` README.md** — erros que faziam o leitor falhar: badge/Quick Start diziam Rust 1.94 (MSRV é 1.95 desde #865); `--features tls` não existe no binário `garraia` (documenta `--features garraia-gateway/tls`, validado com `cargo tree`); bloco `embeddings:`/`memory.auto_extract` não desserializava (reescrito na forma real do `AppConfig`); `sse`/`streamable-http` não são aceitos no `config.yml`; bloco de build do desktop falhava sem `mkdir -p binaries/`. Também: assets do Garra Desktop na matriz de release, `POST /v1/messages` + `garra agents setup` (ADR 0014), contagens unificadas (37 tabelas / 33 migrations / 32 FORCE RLS; 6 binários), TTS real, slug do label `good first issue`.
- **`3425b42` ROADMAP.md** — cabeçalho na v0.3.5 + plan 0360/ADR 0014; contradições de status resolvidas pelo código (GAR-410 CredentialVault parcial, GAR-603 Runpod parcial, GAR-641 Learning Agent 9/10, GAR-494/495/496/497/500 riscados como Done); ~50 checkboxes `[ ]` já entregues marcados com evidência; rotas `/v1` ausentes adicionadas; nova §4.4 (canais sem wiring); §7 atualizado; menções ao Linear como vivo viram histórico.
- **`fb683c1` arquivos irmãos** — README.pt-BR, CLAUDE.md, CHANGELOG ([0.3.4]/[0.3.5] retroativos), `docs/installation.md` (MSRV + receita Docker que copiava `garra` e chamava `garraia`), `docs/configuration.md`, `docs/memory.md`, `docs/hardening-gateway.md`, CONTRIBUTING (links do Linear), `plans/README.md`, `docs/adr/README.md`, comentário do `dependabot.yml`. Pode ser descartado sem afetar os outros commits.
- **`11469f6` TODO.md** — blocos v0.3.5 e 27-30/08, histórico unificado (5 headers duplicados), "Adiado" com estado real, próximos passos reais e os débitos de código achados na auditoria (`sessions.db` fora do config dir, passthrough `tls`, mount inexistente do compose turboquant, ref do benchmark, comentário "16 binários", knobs de memória inexistentes) — registrados como pendências, não corrigidos aqui.

## Tipo de mudança

- [x] `docs`: Documentação apenas

## Classe de Risco

- [x] **Classe A (Baixo Risco)**: Documentação, comentários, formatação, bumps de dependências de desenvolvimento sem impacto em tempo de execução.

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [ ] `cargo fmt --check` — não executado localmente: nenhum `.rs` tocado (o job Format Check do CI já está verde neste head)
- [ ] `cargo clippy` / `cargo test` — não executados localmente pelo mesmo motivo; aguardando o CI
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo, API key, token ou credencial commitada (diff varrido)
- [x] Nenhuma migração Postgres com operações destrutivas sem estratégia de transição forward-only

## Mudanças na API pública e Schema

- Nenhuma mudança na API pública. Único arquivo fora de docs: `.github/dependabot.yml` (só um comentário, 1.94 → 1.95).

## Como testar

1. Contagens citadas nos docs batem com o repo:
   ```bash
   grep -c '^    "crates/' Cargo.toml                    # 22
   ls crates/garraia-workspace/migrations/*.sql | wc -l  # 33
   grep -hioE 'CREATE TABLE (IF NOT EXISTS )?[a-z_]+' crates/garraia-workspace/migrations/*.sql | awk '{print $NF}' | sort -u | wc -l  # 37
   grep -hoE 'ALTER TABLE [a-z_]+ FORCE ROW LEVEL SECURITY' crates/garraia-workspace/migrations/*.sql | sort -u | wc -l             # 32
   grep rust-version Cargo.toml                          # 1.95
   ```
2. O bloco `memory`/`embeddings` do README tem a mesma forma do teste `parses_memory_and_embedding_config` em `crates/garraia-config/src/model.rs` (`cargo test -p garraia-config parses_memory` continua verde).
3. `cargo tree -p garraia --features garraia-gateway/tls -i axum-server` resolve o `axum-server` com `tls-rustls` (comando documentado no README).
4. Nenhum token obsoleto restante: `grep -n -E '1\.94|29 tab|32 migr|5 targets|10/10|good-first-issue' README.md ROADMAP.md` retorna só histórico rotulado.

## Plano de Rollback

`git revert` dos 4 commits (ou só do `fb683c1`, se a sincronização dos arquivos irmãos não for desejada). Nenhum efeito em runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHaWrvriQKCJVAugH2UfVs