### PR TITLE
feat(installer): branch Android/Termux + asset arm no garra update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
         run: shellcheck tests/install_sh/fixtures/garraia-stub.sh
 
       - name: Run shellcheck on installer unit tests
-        run: shellcheck tests/install_sh/checksum_format.sh tests/install_sh/resolve_version.sh tests/install_sh/documented_urls.sh
+        run: shellcheck tests/install_sh/checksum_format.sh tests/install_sh/resolve_version.sh tests/install_sh/documented_urls.sh tests/install_sh/detect_platform.sh
 
       - name: Syntax-check the bash test runners
         run: |
@@ -123,6 +123,7 @@ jobs:
           bash -n tests/install_sh/check_glibc.sh
           bash -n tests/install_sh/parse_args.sh
           bash -n tests/install_sh/documented_urls.sh
+          bash -n tests/install_sh/detect_platform.sh
 
       - name: Execute installer bootstrap_phase tests
         run: bash tests/install_sh/bootstrap_phase.sh
@@ -151,6 +152,12 @@ jobs:
       # duas nao podem divergir.
       - name: Execute installer documented-URL tests
         run: bash tests/install_sh/documented_urls.sh
+
+      # Contrato da detecção Android/Termux (Garra Mobile Fase 0, ADR 0016):
+      # uname reporta Linux dentro do Termux, então sem o ramo dedicado o
+      # installer baixaria o asset glibc e morreria no loader.
+      - name: Execute installer detect-platform tests
+        run: bash tests/install_sh/detect_platform.sh
 
   # `install.ps1` is the Windows sibling of `install.sh` and the `irm | iex`
   # entry point, so it gets the same treatment: a blocking lint plus unit tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,6 +222,69 @@ jobs:
           name: garraia-windows-aarch64
           path: release/garraia-windows-aarch64.exe
 
+  # Build for Android ARM64 (Termux, bionic dinâmico).
+  #
+  # Best-effort by design: in the `release` job's `needs:` but deliberately
+  # NOT in its `if:` — the same treatment as build-linux-arm64 and
+  # build-windows-aarch64 (sem `continue-on-error`, que o projeto proíbe).
+  # Uma falha aqui deixa a release sem o asset `garraia-android-aarch64`;
+  # nunca a bloqueia. Garra Mobile Fase 0 — ADR 0016.
+  #
+  # Por quê bionic e NÃO musl: musl estático quebra DNS no Android — não
+  # existe /etc/resolv.conf (o resolver embutido do musl leria esse arquivo)
+  # e LD_PRELOAD não intercepta binário estático. O alvo
+  # aarch64-linux-android (bionic dinâmico) fala com o dnsproxyd do Android.
+  #
+  # Toolchain: cargo-ndk seta linker + CC/AR do NDK para as C-deps do grafo
+  # (openssl vendored, rusqlite bundled, sqlite-vec). openssl vendored exige
+  # perl+make — pré-instalados no runner. Termux executa ELF bionic
+  # dinâmico nativamente em $PREFIX/bin (SDK 28, W^X não se aplica).
+  build-android-arm64:
+    name: Build Android ARM64 (Termux)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      # Pinado por reprodutibilidade: o ubuntu-latest já traz um NDK, mas a
+      # versão do runner muda sem aviso — um bump de NDK não pode quebrar a
+      # release sozinho.
+      ANDROID_NDK_VERSION: 27.3.13750724
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android
+
+      - name: Pin Android NDK
+        run: |
+          set -euo pipefail
+          "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" "ndk;${ANDROID_NDK_VERSION}" >/dev/null
+          echo "ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/${ANDROID_NDK_VERSION}" >> "$GITHUB_ENV"
+
+      - name: Install cargo-ndk
+        run: cargo install cargo-ndk --locked
+
+      - name: Build release
+        # -p 21: platform/minSdkLevel 21 — baseline android do rustc e abaixo
+        # do mínimo do Termux atual (Android 7+/API 24), então roda em todos.
+        # O `--` é a sintaxe documentada do cargo-ndk para repassar args.
+        run: cargo ndk -t arm64-v8a -p 21 -- build --release --package garraia
+
+      - name: Package binary
+        run: |
+          mkdir -p release
+          cp target/aarch64-linux-android/release/garra release/garraia-android-aarch64
+          chmod +x release/garraia-android-aarch64
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: garraia-android-aarch64
+          path: release/garraia-android-aarch64
+
   # Build the Windows desktop installers (MSI + NSIS).
   #
   # Best-effort by design: this job is in the `release` job's `needs:` so the
@@ -506,6 +569,7 @@ jobs:
       - build-linux-arm64
       - build-windows-x86_64
       - build-windows-aarch64
+      - build-android-arm64
       - build-macos-x86_64
       - build-macos-arm64
       - build-windows-installer
@@ -561,6 +625,11 @@ jobs:
             cp artifacts/garraia-windows-aarch64/garraia-windows-aarch64.exe release/
           else
             echo "::warning ::Windows aarch64 binary not built; release will ship without it."
+          fi
+          if [ -f artifacts/garraia-android-aarch64/garraia-android-aarch64 ]; then
+            cp artifacts/garraia-android-aarch64/garraia-android-aarch64 release/
+          else
+            echo "::warning ::Android aarch64 binary not built; release will ship without it."
           fi
 
           # The Windows desktop installers, when the best-effort job produced
@@ -675,6 +744,7 @@ jobs:
           pack garraia-macos-aarch64      garraia-macos-aarch64  garraia     tar
           pack garraia-windows-x86_64.exe garraia-windows-x86_64 garraia.exe zip
           pack garraia-windows-aarch64.exe garraia-windows-aarch64 garraia.exe zip
+          pack garraia-android-aarch64    garraia-android-aarch64 garraia    tar
 
           rm -rf "$stage"
           echo "--- release/ ---"
@@ -745,10 +815,12 @@ jobs:
             release/garraia-windows-aarch64.exe
             release/garraia-macos-x86_64
             release/garraia-macos-aarch64
+            release/garraia-android-aarch64
             release/garraia-linux-x86_64.tar.gz
             release/garraia-linux-aarch64.tar.gz
             release/garraia-macos-x86_64.tar.gz
             release/garraia-macos-aarch64.tar.gz
+            release/garraia-android-aarch64.tar.gz
             release/garraia-windows-x86_64.zip
             release/garraia-windows-aarch64.zip
             release/garraia-linux-x86_64.deb

--- a/crates/garraia-cli/src/update.rs
+++ b/crates/garraia-cli/src/update.rs
@@ -49,7 +49,8 @@ fn platform_asset_name() -> Result<&'static str> {
 /// `garraia-windows-aarch64.exe` exists from v0.3.4 onward; a native ARM64
 /// binary asking for it against an older release fails with "no asset for
 /// this platform", which is accurate — those releases only served ARM64 via
-/// the x86_64 binary under emulation.
+/// the x86_64 binary under emulation. `garraia-android-aarch64` (bionic,
+/// Termux) exists from v0.3.6 onward (ADR 0016).
 fn asset_name_for(os: &str, arch: &str) -> Result<&'static str> {
     match (os, arch) {
         ("macos", "aarch64") => Ok("garraia-macos-aarch64"),
@@ -58,6 +59,7 @@ fn asset_name_for(os: &str, arch: &str) -> Result<&'static str> {
         ("linux", "aarch64") => Ok("garraia-linux-aarch64"),
         ("windows", "x86_64") => Ok("garraia-windows-x86_64.exe"),
         ("windows", "aarch64") => Ok("garraia-windows-aarch64.exe"),
+        ("android", "aarch64") => Ok("garraia-android-aarch64"),
         (os, arch) => bail!("unsupported platform: {os}/{arch}"),
     }
 }
@@ -369,6 +371,8 @@ mod tests {
             (("macos", "aarch64"), "garraia-macos-aarch64"),
             (("windows", "x86_64"), "garraia-windows-x86_64.exe"),
             (("windows", "aarch64"), "garraia-windows-aarch64.exe"),
+            // bionic/Termux desde a v0.3.6 (ADR 0016).
+            (("android", "aarch64"), "garraia-android-aarch64"),
         ];
         for ((os, arch), name) in expected {
             assert_eq!(asset_name_for(os, arch).unwrap(), name, "{os}/{arch}");

--- a/install.sh
+++ b/install.sh
@@ -27,6 +27,12 @@
 #   GARRAIA_INSTALL_DIR     Override install directory. Must NOT be a
 #                           system path (/bin, /sbin, /usr/bin, /usr/sbin, /etc).
 #
+# Android (Termux): when run inside Termux ($TERMUX_VERSION set, or a
+# *com.termux* $PREFIX), the installer picks the garraia-android-aarch64
+# asset (bionic, built by release.yml's build-android-arm64 job) and
+# installs to $PREFIX/bin — no sudo on Android. Requires official Termux
+# builds (F-Droid/GitHub). See docs/adr/0016.
+#
 #   GARRAIA_SKIP_INIT=1     Skip the auto-run of `garraia init`.
 #   GARRAIA_SKIP_START=1    Skip the auto-run of `garraia start`.
 #                           Both set together → installer prints next-steps
@@ -181,11 +187,28 @@ detect_platform() {
     OS="$(uname -s)"
     ARCH="$(uname -m)"
 
-    case "${OS}" in
-        Linux)  OS_NAME="linux" ;;
-        Darwin) OS_NAME="macos" ;;
-        *)      error "Unsupported OS: ${OS}. Only Linux and macOS are supported." ;;
+    # Termux tem precedência sobre o uname: o Android reporta `uname -s` =
+    # Linux, e sem este ramo o installer baixaria o asset glibc linux e
+    # morreria no loader. $TERMUX_VERSION é exportado por todo shell do
+    # Termux; o case em $PREFIX cobre ambientes em que só o prefixo sobrevive
+    # (su, alguns forks). Fora do Termux o fluxo linux/macos é o de sempre.
+    OS_IS_TERMUX=0
+    if [ -n "${TERMUX_VERSION:-}" ]; then
+        OS_IS_TERMUX=1
+    fi
+    case "${PREFIX:-}" in
+        *com.termux*) OS_IS_TERMUX=1 ;;
     esac
+
+    if [ "${OS_IS_TERMUX}" -eq 1 ]; then
+        OS_NAME="android"
+    else
+        case "${OS}" in
+            Linux)  OS_NAME="linux" ;;
+            Darwin) OS_NAME="macos" ;;
+            *)      error "Unsupported OS: ${OS}. Only Linux, macOS and Android (Termux) are supported." ;;
+        esac
+    fi
 
     case "${ARCH}" in
         x86_64|amd64)  ARCH_NAME="x86_64" ;;
@@ -193,9 +216,9 @@ detect_platform() {
         *)             error "Unsupported architecture: ${ARCH}" ;;
     esac
 
-    # release.yml emits `garraia-{linux,macos}-aarch64` from v0.2.1 onwards
-    # (aligned with `std::env::consts::ARCH` consumed by garraia-cli's
-    # update command). No remapping needed.
+    # release.yml emits `garraia-{linux,macos,android}-aarch64` from v0.2.1
+    # onwards (aligned with `std::env::consts::OS`/`ARCH` consumed by
+    # garraia-cli's update command). No remapping needed.
     ARTIFACT="${BINARY}-${OS_NAME}-${ARCH_NAME}"
     echo "Detected platform: ${OS_NAME}-${ARCH_NAME}"
 }
@@ -350,7 +373,9 @@ select_checksum_line() {
 }
 
 install_binary() {
-    # Priority: $GARRAIA_INSTALL_DIR > ~/.local/bin (if in PATH) > /usr/local/bin
+    # Priority:
+    #   Android/Termux: $GARRAIA_INSTALL_DIR > $PREFIX/bin
+    #   Other OS:       $GARRAIA_INSTALL_DIR > ~/.local/bin (if in PATH) > /usr/local/bin
     if [ -n "${GARRAIA_INSTALL_DIR:-}" ]; then
         case "${GARRAIA_INSTALL_DIR}" in
             /bin*|/sbin*|/usr/bin*|/usr/sbin*|/etc*)
@@ -358,6 +383,11 @@ install_binary() {
                 ;;
         esac
         INSTALL_DIR="${GARRAIA_INSTALL_DIR}"
+    elif [ "${OS_NAME:-}" = "android" ]; then
+        # Termux: $PREFIX/bin está no PATH, é gravável sem root e é onde os
+        # pacotes do Termux instalam. /usr/local/bin seria criado FORA do
+        # PATH (o rootfs do Termux é gravável) — uma armadilha silenciosa.
+        INSTALL_DIR="${PREFIX}/bin"
     elif echo "${PATH}" | tr ':' '\n' | grep -qx "${HOME}/.local/bin"; then
         INSTALL_DIR="${HOME}/.local/bin"
     else
@@ -425,6 +455,7 @@ bootstrap_phase() {
         echo "Starting GarraIA in the foreground. Press Ctrl+C to stop."
         echo "  To run later in background: garraia start -d"
         echo "  Either way, 'garraia status' and 'garraia stop' manage the process."
+        print_termux_notice
         exec "${INSTALL_PATH}" start </dev/tty
     fi
 
@@ -436,6 +467,20 @@ print_next_steps_legacy() {
     echo "Next steps:"
     echo "  garraia init    # interactive setup wizard"
     echo "  garraia start   # start the gateway"
+    print_termux_notice
+}
+
+# Android-only advisory (Garra Mobile Fase 0, ADR 0016): o Android mata
+# processos de longa duração em background (phantom process killer) e
+# congela apps agressivamente por bateria. O gateway funciona melhor no
+# foreground da sessão Termux em que foi iniciado.
+print_termux_notice() {
+    [ "${OS_NAME:-}" = "android" ] || return 0
+    echo ""
+    echo "Termux: Android may kill background processes (phantom process"
+    echo "  killer, battery optimization). If the gateway dies in background,"
+    echo "  keep the Termux session open, run 'termux-wake-lock' and disable"
+    echo "  battery optimization for Termux."
 }
 
 error() {

--- a/tests/install_sh/detect_platform.sh
+++ b/tests/install_sh/detect_platform.sh
@@ -1,0 +1,224 @@
+#!/bin/sh
+# Unit tests for `detect_platform` (Termux branch) and the Android paths of
+# `install_binary` / `print_next_steps_legacy` in `install.sh`.
+#
+# Garra Mobile Fase 0 (ADR 0016): inside Termux the installer must pick the
+# `garraia-android-aarch64` asset. Android reports `uname -s` = Linux, so
+# without the Termux branch the installer would download the glibc linux
+# binary and die in the loader. Detection is $TERMUX_VERSION (exported by
+# every Termux shell) or a *com.termux* $PREFIX.
+#
+# Strategy mirrors check_glibc.sh: source install.sh with
+# GARRAIA_INSTALL_SH_LIBRARY=1 so main() does not run, then invoke
+# `detect_platform` in subshells where `uname` is shadowed by a function
+# printing the case's OS/arch and the Termux environment is simulated.
+# Written in POSIX sh (like checksum_format.sh) so it stays in the
+# shellcheck list of the installer job, not just `bash -n`.
+set -eu
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+install_sh="${repo_root}/install.sh"
+
+export GARRAIA_INSTALL_SH_LIBRARY=1
+# shellcheck source=/dev/null
+. "${install_sh}"
+
+results_pass=0
+results_fail=0
+
+pass() { echo "  PASS: $1"; results_pass=$((results_pass + 1)); }
+fail() { echo "  FAIL: $1" >&2; results_fail=$((results_fail + 1)); }
+
+# run_platform_case <label> <stub_os> <stub_arch> <termux_version> <prefix>
+#                   <want_os_name> <want_artifact>
+# Runs detect_platform in a subshell with `uname` shadowed to print the
+# given OS/arch and the Termux environment variables set to the given
+# values (empty string = unset/empty). Expects success; asserts OS_NAME and
+# ARTIFACT.
+run_platform_case() {
+    label="$1"
+    stub_os="$2"
+    stub_arch="$3"
+    termux_version="$4"
+    prefix="$5"
+    want_os_name="$6"
+    want_artifact="$7"
+    out_file="$(mktemp)"
+    rc=0
+    (
+        TERMUX_VERSION="${termux_version}"
+        PREFIX="${prefix}"
+        eval "uname() { case \"\$1\" in -s) printf '%s\n' '${stub_os}' ;; -m) printf '%s\n' '${stub_arch}' ;; esac; }"
+        detect_platform
+        echo "OS_NAME=${OS_NAME}"
+        echo "ARTIFACT=${ARTIFACT}"
+    ) >"${out_file}" 2>&1 || rc=$?
+    if [ "${rc}" -ne 0 ]; then
+        fail "${label} — expected exit 0 got ${rc}: $(cat "${out_file}")"
+    elif ! grep -qx "OS_NAME=${want_os_name}" "${out_file}"; then
+        fail "${label} — expected OS_NAME=${want_os_name}: $(cat "${out_file}")"
+    elif ! grep -qx "ARTIFACT=${want_artifact}" "${out_file}"; then
+        fail "${label} — expected ARTIFACT=${want_artifact}: $(cat "${out_file}")"
+    else
+        pass "${label}"
+    fi
+    rm -f "${out_file}"
+}
+
+# run_error_case <label> <stub_os> <stub_arch> <termux_version> <prefix>
+#                <expect_stderr_substring>
+# Same subshell setup, but expects detect_platform to fail (exit 1).
+run_error_case() {
+    label="$1"
+    stub_os="$2"
+    stub_arch="$3"
+    termux_version="$4"
+    prefix="$5"
+    want_substr="$6"
+    out_file="$(mktemp)"
+    rc=0
+    (
+        TERMUX_VERSION="${termux_version}"
+        PREFIX="${prefix}"
+        eval "uname() { case \"\$1\" in -s) printf '%s\n' '${stub_os}' ;; -m) printf '%s\n' '${stub_arch}' ;; esac; }"
+        detect_platform
+    ) >"${out_file}" 2>&1 || rc=$?
+    if [ "${rc}" -ne 1 ]; then
+        fail "${label} — expected exit 1 got ${rc}"
+    elif ! grep -q "${want_substr}" "${out_file}"; then
+        fail "${label} — output missing [${want_substr}]: $(cat "${out_file}")"
+    else
+        pass "${label}"
+    fi
+    rm -f "${out_file}"
+}
+
+echo "== detect_platform: Termux branch =="
+
+# --- Termux detection wins over uname ----------------------------------------
+run_platform_case "termux via TERMUX_VERSION" \
+    Linux aarch64 "0.119.0" "" \
+    android "garraia-android-aarch64"
+run_platform_case "termux via *com.termux* PREFIX" \
+    Linux aarch64 "" "/data/data/com.termux/files/usr" \
+    android "garraia-android-aarch64"
+run_platform_case "termux precedence over foreign uname" \
+    SunOS aarch64 "0.119.0" "/data/data/com.termux/files/usr" \
+    android "garraia-android-aarch64"
+
+# --- non-Termux flow unchanged ------------------------------------------------
+run_platform_case "plain linux x86_64" \
+    Linux x86_64 "" "/usr" \
+    linux "garraia-linux-x86_64"
+run_platform_case "plain linux aarch64" \
+    Linux aarch64 "" "/usr" \
+    linux "garraia-linux-aarch64"
+run_platform_case "plain macos aarch64" \
+    Darwin arm64 "" "/usr" \
+    macos "garraia-macos-aarch64"
+
+# --- errors keep failing outside Termux ----------------------------------------
+run_error_case "unsupported OS rejected" \
+    SunOS x86_64 "" "" \
+    "Unsupported OS: SunOS"
+run_error_case "unsupported arch rejected" \
+    Linux riscv64 "" "" \
+    "Unsupported architecture: riscv64"
+
+echo ""
+echo "== detect_platform: install_binary on Termux =="
+
+tmp_root="$(mktemp -d)"
+fake_artifact="${tmp_root}/garraia-android-aarch64"
+printf '#!/bin/sh\nexit 0\n' > "${fake_artifact}"
+
+# Default install dir on Termux is $PREFIX/bin (in PATH, writable, no sudo).
+fake_prefix="${tmp_root}/prefix"
+rc=0
+(
+    OS_NAME="android"
+    PREFIX="${fake_prefix}"
+    ARTIFACT="garraia-android-aarch64"
+    GARRAIA_TMPDIR="${tmp_root}"
+    GARRAIA_INSTALL_DIR=""
+    VERSION="vTEST"
+    install_binary
+) >/dev/null 2>&1 || rc=$?
+if [ "${rc}" -ne 0 ]; then
+    fail "install_binary default \$PREFIX/bin — exit ${rc}"
+elif [ -x "${fake_prefix}/bin/garraia" ]; then
+    pass "install_binary default \$PREFIX/bin"
+else
+    fail "install_binary default \$PREFIX/bin — binary not at ${fake_prefix}/bin/garraia"
+fi
+
+# $GARRAIA_INSTALL_DIR still wins over the Termux default.
+custom_dir="${tmp_root}/custom"
+rc=0
+(
+    OS_NAME="android"
+    PREFIX="${fake_prefix}"
+    ARTIFACT="garraia-android-aarch64"
+    GARRAIA_TMPDIR="${tmp_root}"
+    GARRAIA_INSTALL_DIR="${custom_dir}"
+    VERSION="vTEST"
+    install_binary
+) >/dev/null 2>&1 || rc=$?
+if [ "${rc}" -ne 0 ]; then
+    fail "install_binary honors GARRAIA_INSTALL_DIR on android — exit ${rc}"
+elif [ -x "${custom_dir}/garraia" ]; then
+    pass "install_binary honors GARRAIA_INSTALL_DIR on android"
+else
+    fail "install_binary honors GARRAIA_INSTALL_DIR on android — binary not at ${custom_dir}/garraia"
+fi
+
+# The system-path refusal gate is intact on Android too.
+gate_out="$(mktemp)"
+rc=0
+(
+    OS_NAME="android"
+    ARTIFACT="garraia-android-aarch64"
+    GARRAIA_TMPDIR="${tmp_root}"
+    GARRAIA_INSTALL_DIR="/usr/bin"
+    VERSION="vTEST"
+    install_binary
+) >"${gate_out}" 2>&1 || rc=$?
+if [ "${rc}" -ne 1 ]; then
+    fail "install_binary refuses /usr/bin on android — exit ${rc}"
+elif grep -q "refuses to write to system path" "${gate_out}"; then
+    pass "install_binary refuses /usr/bin on android"
+else
+    fail "install_binary refuses /usr/bin on android — output: $(cat "${gate_out}")"
+fi
+rm -f "${gate_out}"
+
+echo ""
+echo "== detect_platform: android notices and glibc skip =="
+
+# The Termux advisory only prints on android.
+notice_out="$(OS_NAME="android"; print_next_steps_legacy)"
+case "${notice_out}" in
+    *"phantom process"*) pass "next-steps prints Termux advisory on android" ;;
+    *) fail "next-steps prints Termux advisory on android" ;;
+esac
+notice_out="$(OS_NAME="linux"; print_next_steps_legacy)"
+case "${notice_out}" in
+    *"phantom process"*) fail "next-steps stays silent on linux" ;;
+    *) pass "next-steps stays silent on linux" ;;
+esac
+
+# check_glibc is a linux-only probe: on android it must return 0 before
+# touching ldd — Termux has no glibc/musl loader to interrogate.
+rc=0
+( OS_NAME="android"; ARCH="aarch64"; check_glibc ) >/dev/null 2>&1 || rc=$?
+if [ "${rc}" -eq 0 ]; then
+    pass "check_glibc skipped on android"
+else
+    fail "check_glibc skipped on android — exit ${rc}"
+fi
+
+rm -r "${tmp_root}"
+
+echo ""
+echo "detect_platform.sh: ${results_pass} passed, ${results_fail} failed"
+[ "${results_fail}" -eq 0 ]


### PR DESCRIPTION
## Contexto

Garra Mobile Fase 0 (ADR 0016 no PR de docs). Dentro do Termux, `uname -s` reporta `Linux` — sem um ramo dedicado, o installer baixaria o asset glibc linux e morreria no loader do bionic.

## Mudanças

**`install.sh`**
- `detect_platform`: `$TERMUX_VERSION` setado **ou** `$PREFIX` contendo `*com.termux*` → `OS_NAME="android"` → asset `garraia-android-aarch64`. Fluxo linux/macos **inalterado** fora do Termux.
- `install_binary`: default `$PREFIX/bin` no Termux (em PATH, gravável sem root); `$GARRAIA_INSTALL_DIR` continua vencendo; gate de system-path (`/bin*`, `/usr/bin*`…) intacto.
- `check_glibc`: skip por `OS_NAME != linux` já existente — agora coberto por teste.
- Notice de phantom process killer / battery optimization nas saídas finais quando `OS_NAME=android`.

**`update.rs`** — braço `("android", "aarch64") => "garraia-android-aarch64"` em `asset_name_for` + contrato da regra 15 na tabela de teste. Sem isso, `garra update` morre no Termux ("unsupported platform").

**`ci.yml`** — suíte nova `tests/install_sh/detect_platform.sh` (14 casos, POSIX sh, `uname` sombreado por função) registrada nas 3 listas do job installer (shellcheck, bash -n, execute).

## Paridade (regra 16)

`install.ps1` **não muda comportamento** — Android é shell-only; o espelho do instalador Windows continua válido.

## Verificação

- `bash tests/install_sh/detect_platform.sh`: 14/14 PASS
- 6 suítes existentes: OK
- `cargo test -p garraia`: 258 testes verdes (incluindo contrato de asset names)

🤖 Generated with [Claude Code](https://claude.com/claude-code)