### PR TITLE
feat(cli): garra doctor + provider llamacpp wired no CLI

### DIFF
--- a/crates/garraia-agents/src/llama_cpp.rs
+++ b/crates/garraia-agents/src/llama_cpp.rs
@@ -173,6 +173,15 @@ impl LlamaCppProvider {
         &self.config
     }
 
+    /// The effective base URL this provider talks to.
+    ///
+    /// Observability getter: lets CLI tests assert base-url precedence
+    /// (`--url` > `config.llm[*].base_url` > default) without reaching into
+    /// the private field.
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
     fn build_request_body(&self, request: &LlmRequest, stream: bool) -> Value {
         let model = if request.model.is_empty() {
             self.model.clone()

--- a/crates/garraia-cli/src/ask.rs
+++ b/crates/garraia-cli/src/ask.rs
@@ -283,7 +283,12 @@ pub(crate) async fn ask_oneshot(config: &AppConfig, opts: AskOptions) -> AskOutc
 
     // 1. Resolve provider.
     let (provider_name, model_name, provider) = if let Some(ref p) = opts.provider_override {
-        match chat::select_explicit_provider(config, p.as_str(), opts.model_override.as_deref()) {
+        match chat::select_explicit_provider(
+            config,
+            p.as_str(),
+            opts.model_override.as_deref(),
+            opts.url_override.as_deref(),
+        ) {
             Ok(triple) => triple,
             Err(e) => {
                 return AskOutcome::Failure(AskError::NoProvider(sanitize_provider_error(

--- a/crates/garraia-cli/src/chat.rs
+++ b/crates/garraia-cli/src/chat.rs
@@ -1614,8 +1614,8 @@ mod tests {
     #[test]
     fn select_explicit_provider_uses_the_default_table_for_ollama() {
         let cfg = AppConfig::default();
-        let (name, model, _) =
-            select_explicit_provider(&cfg, "ollama", None, None).expect("ollama needs no credential");
+        let (name, model, _) = select_explicit_provider(&cfg, "ollama", None, None)
+            .expect("ollama needs no credential");
         assert_eq!(name, "ollama");
         assert_eq!(model, "qwen3.8:latest");
     }

--- a/crates/garraia-cli/src/chat.rs
+++ b/crates/garraia-cli/src/chat.rs
@@ -10,8 +10,8 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use garraia_agents::{
     AgentRuntime, AnthropicProvider, BashTool, ChatMessage, ChatRole, FileReadTool, FileWriteTool,
-    LlmProvider, MessagePart, OllamaProvider, OpenAiProvider, normalize_ollama_tag,
-    tools::git_diff_tool::GitDiffTool,
+    LlamaCppProvider, LlmProvider, MessagePart, OllamaProvider, OpenAiProvider,
+    normalize_ollama_tag, tools::git_diff_tool::GitDiffTool,
 };
 use garraia_config::AppConfig;
 use tokio::sync::mpsc;
@@ -239,8 +239,9 @@ fn decide_default_provider(
 
     let cfg_has_key = cfg.api_key.as_deref().is_some_and(|k| !k.is_empty());
     let credential_ok = match provider_kind {
-        // Local — health-checked by the caller.
-        "ollama" => true,
+        // Local — health-checked by the caller. `llamacpp` talks to a local
+        // llama-server (default http://localhost:8080), keyless like ollama.
+        "ollama" | "llamacpp" => true,
         "anthropic" => env_has_anthropic_key || cfg_has_key,
         // OpenAI-compatible local backends (e.g. LM Studio) commonly omit
         // the api_key and rely on `base_url` reachability. Treat them as
@@ -282,6 +283,10 @@ pub(crate) fn hardcoded_default_model(provider_kind: &str) -> String {
         // context, vision + tools). Kept byte-identical to
         // `garraia_agents::ollama::DEFAULT_MODEL`.
         "ollama" => "qwen3.8:latest",
+        // llama-server serves whatever model it was started with; the
+        // OpenAI-compatible API accepts any string here — `default` matches
+        // `garraia_agents::llama_cpp::DEFAULT_MODEL` byte-for-byte.
+        "llamacpp" => "default",
         "anthropic" => "claude-sonnet-4-5-20250929",
         "openai" => "gpt-4o",
         "openrouter" => "openrouter/auto",
@@ -289,6 +294,19 @@ pub(crate) fn hardcoded_default_model(provider_kind: &str) -> String {
         _ => "auto",
     }
     .to_string()
+}
+
+/// Base URL do `llamacpp` — precedência `--url` > `config.llm["llamacpp"]`.
+///
+/// Retorna `None` quando nenhuma fonte fornece URL e o provider usa o
+/// default interno (`http://localhost:8080`). Extraído como função pura
+/// para que a precedência seja afirmável em teste (o provider devolvido
+/// pelo arm é um `Arc<dyn LlmProvider>` sem downcast).
+fn resolve_llamacpp_base_url(config: &AppConfig, url_override: Option<&str>) -> Option<String> {
+    url_override
+        .filter(|u| !u.is_empty())
+        .map(|u| u.to_string())
+        .or_else(|| config.llm.get("llamacpp").and_then(|c| c.base_url.clone()))
 }
 
 /// GAR-576 — Construct an [`LlmProvider`] from a config-resolved default.
@@ -314,6 +332,13 @@ async fn try_build_default_provider(
                 return None;
             }
             Some(Arc::new(ollama) as Arc<dyn LlmProvider>)
+        }
+        "llamacpp" => {
+            let llama = LlamaCppProvider::new(Some(model.to_string()), cfg.base_url.clone(), None);
+            if !llama.health_check().await.unwrap_or(false) {
+                return None;
+            }
+            Some(Arc::new(llama) as Arc<dyn LlmProvider>)
         }
         "anthropic" => {
             let key = get_api_key(config, "anthropic", "ANTHROPIC_API_KEY")?;
@@ -358,12 +383,17 @@ async fn try_build_default_provider(
 /// per-kind fallback. Unknown `kind` is an error; missing api_key for a
 /// cloud provider is an error.
 ///
+/// `url_override` is the CLI `--url` flag. Today only the `llamacpp` arm
+/// consumes it (the keyless local providers are exactly where an ad-hoc
+/// URL matters most); the cloud arms keep their fixed endpoints.
+///
 /// Shared by `chat::run_chat` and `ask::run_ask` so the explicit-provider
 /// path lives in exactly one place.
 pub(crate) fn select_explicit_provider(
     config: &AppConfig,
     kind: &str,
     model_override: Option<&str>,
+    url_override: Option<&str>,
 ) -> Result<(String, String, Arc<dyn LlmProvider>)> {
     match kind {
         "ollama" => {
@@ -374,6 +404,17 @@ pub(crate) fn select_explicit_provider(
                 "ollama".to_string(),
                 model,
                 Arc::new(ollama) as Arc<dyn LlmProvider>,
+            ))
+        }
+        "llamacpp" => {
+            let model = resolve_provider_model(config, "llamacpp", model_override)
+                .unwrap_or_else(|| hardcoded_default_model("llamacpp"));
+            let base_url = resolve_llamacpp_base_url(config, url_override);
+            let llama = LlamaCppProvider::new(Some(model.clone()), base_url, None);
+            Ok((
+                "llamacpp".to_string(),
+                model,
+                Arc::new(llama) as Arc<dyn LlmProvider>,
             ))
         }
         "anthropic" => {
@@ -434,7 +475,7 @@ pub(crate) fn select_explicit_provider(
             ))
         }
         other => anyhow::bail!(
-            "Provider desconhecido: {other}. Use: ollama, anthropic, openai, openrouter"
+            "Provider desconhecido: {other}. Use: ollama, llamacpp, anthropic, openai, openrouter"
         ),
     }
 }
@@ -910,7 +951,12 @@ pub async fn run_chat(
         // GAR-579: shared with `garra ask` — the explicit-provider path
         // lives in `select_explicit_provider` so chat and ask agree
         // byte-for-byte on construction + model resolution + error msgs.
-        select_explicit_provider(&config, p.as_str(), model_override.as_deref())?
+        select_explicit_provider(
+            &config,
+            p.as_str(),
+            model_override.as_deref(),
+            url_override.as_deref(),
+        )?
     } else {
         detect_provider(
             &config,
@@ -921,7 +967,8 @@ pub async fn run_chat(
         .await
     };
 
-    let mode = if provider_name.contains("ollama") {
+    // Keyless local daemons are the "local" mode; everything else is cloud.
+    let mode = if provider_name.contains("ollama") || provider_name.contains("llamacpp") {
         "local"
     } else {
         "cloud"
@@ -1277,7 +1324,7 @@ mod tests {
     #[test]
     fn select_explicit_provider_echo_needs_no_key() {
         let cfg = AppConfig::default();
-        let (name, model, _provider) = select_explicit_provider(&cfg, "echo", None)
+        let (name, model, _provider) = select_explicit_provider(&cfg, "echo", None, None)
             .expect("echo deve ser selecionável com a feature dev-echo-provider");
         assert_eq!(name, "echo");
         assert_eq!(model, "echo-stub");
@@ -1289,7 +1336,7 @@ mod tests {
     #[test]
     fn select_explicit_provider_echo_rejected_without_feature() {
         let cfg = AppConfig::default();
-        assert!(select_explicit_provider(&cfg, "echo", None).is_err());
+        assert!(select_explicit_provider(&cfg, "echo", None, None).is_err());
     }
 
     // ─── resolve_provider_model ────────────────────────────────────────
@@ -1510,6 +1557,7 @@ mod tests {
     #[test]
     fn hardcoded_default_model_table_is_locked() {
         assert_eq!(hardcoded_default_model("ollama"), "qwen3.8:latest");
+        assert_eq!(hardcoded_default_model("llamacpp"), "default");
         assert_eq!(
             hardcoded_default_model("anthropic"),
             "claude-sonnet-4-5-20250929"
@@ -1567,9 +1615,68 @@ mod tests {
     fn select_explicit_provider_uses_the_default_table_for_ollama() {
         let cfg = AppConfig::default();
         let (name, model, _) =
-            select_explicit_provider(&cfg, "ollama", None).expect("ollama needs no credential");
+            select_explicit_provider(&cfg, "ollama", None, None).expect("ollama needs no credential");
         assert_eq!(name, "ollama");
         assert_eq!(model, "qwen3.8:latest");
+    }
+
+    /// `llamacpp` é o segundo arm keyless: resolução de modelo pela mesma
+    /// tabela e precedência de base_url `--url` > `config.llm["llamacpp"]` >
+    /// default do provider (http://localhost:8080).
+    #[test]
+    fn select_explicit_provider_llamacpp_resolves_model_and_base_url_precedence() {
+        // Sem nada configurado: default da tabela, default do provider.
+        let (name, model, provider) =
+            select_explicit_provider(&AppConfig::default(), "llamacpp", None, None)
+                .expect("llamacpp é keyless");
+        assert_eq!(name, "llamacpp");
+        assert_eq!(model, "default");
+        assert_eq!(provider.provider_id(), "llama-cpp");
+
+        // `--model` vence a config.
+        let cfg = config_with_default(
+            "llamacpp",
+            &[(
+                "llamacpp",
+                make_llm_cfg("llamacpp", Some("qwen3-8b"), None, Some("http://pc:8080")),
+            )],
+        );
+        let (name, model, _) =
+            select_explicit_provider(&cfg, "llamacpp", Some("custom"), None).unwrap();
+        assert_eq!(name, "llamacpp");
+        assert_eq!(model, "custom");
+
+        // Precedência do base_url, afirmável pela função pura do arm:
+        // config alimenta quando não há `--url`; `--url` vence quando há;
+        // string vazia conta como ausente (não apaga a config).
+        assert_eq!(
+            resolve_llamacpp_base_url(&cfg, None).as_deref(),
+            Some("http://pc:8080")
+        );
+        assert_eq!(
+            resolve_llamacpp_base_url(&cfg, Some("http://box:9090")).as_deref(),
+            Some("http://box:9090")
+        );
+        assert_eq!(
+            resolve_llamacpp_base_url(&cfg, Some("")).as_deref(),
+            Some("http://pc:8080")
+        );
+        assert_eq!(resolve_llamacpp_base_url(&AppConfig::default(), None), None);
+    }
+
+    /// Provider desconhecido lista `llamacpp` junto dos demais no bail —
+    /// o contrato de mensagem é o que os testes E2E de onboarding citam.
+    #[test]
+    fn select_explicit_provider_unknown_lists_all_keyless_and_cloud_kinds() {
+        // `expect_err` exige `T: Debug` e o trio de retorno carrega um
+        // `Arc<dyn LlmProvider>` sem Debug — casar com `let Err` direto.
+        let Err(err) = select_explicit_provider(&AppConfig::default(), "fogos", None, None) else {
+            panic!("provider desconhecido deve falhar");
+        };
+        let msg = format!("{err}");
+        for kind in ["ollama", "llamacpp", "anthropic", "openai", "openrouter"] {
+            assert!(msg.contains(kind), "mensagem `{msg}` não cita `{kind}`");
+        }
     }
 
     // ─── stream_turn (regression: bounded-channel deadlock, GAR chat hang) ─

--- a/crates/garraia-cli/src/config_cmd.rs
+++ b/crates/garraia-cli/src/config_cmd.rs
@@ -18,7 +18,7 @@ use garraia_config::{AppConfig, ConfigCheck, ConfigLoader, LlmProviderConfig, Se
 /// Keeps error output bounded without losing the leading line/column context.
 const PARSE_ERROR_MAX_LEN: usize = 256;
 
-fn truncate_error(raw: String) -> String {
+pub(crate) fn truncate_error(raw: String) -> String {
     if raw.len() <= PARSE_ERROR_MAX_LEN {
         return raw;
     }
@@ -305,8 +305,8 @@ pub(crate) struct SetModelRequest<'a> {
 /// dropped, so switching to a local model does not disable a configured cloud
 /// provider outright.
 pub(crate) fn apply_set_model(config: &mut AppConfig, req: &SetModelRequest<'_>) {
-    let api_key = if req.provider == "ollama" {
-        // Native Ollama needs no credential.
+    let api_key = if req.provider == "ollama" || req.provider == "llamacpp" {
+        // Keyless local daemons: ollama e llama-server não exigem credencial.
         None
     } else {
         // Ollama's OpenAI-compatible endpoint ignores the key but the client
@@ -429,6 +429,16 @@ mod set_model_tests {
     }
 
     #[test]
+    fn native_llamacpp_provider_stays_keyless() {
+        let mut cfg = AppConfig::default();
+        let mut r = req("local-llama", "qwen3-8b");
+        r.provider = "llamacpp";
+        apply_set_model(&mut cfg, &r);
+        assert!(cfg.llm["local-llama"].api_key.is_none());
+        assert_eq!(cfg.llm["local-llama"].provider, "llamacpp");
+    }
+
+    #[test]
     fn rerunning_updates_in_place_without_duplicating() {
         let mut cfg = AppConfig::default();
         apply_set_model(&mut cfg, &req("ollama-launch", "qwen3.8:latest"));
@@ -515,6 +525,8 @@ fn default_base_url(provider: &str) -> Option<&'static str> {
     match provider {
         "openrouter" => Some("https://openrouter.ai/api/v1"),
         "ollama" => Some("http://localhost:11434"),
+        // llama-server's documented default HTTP port.
+        "llamacpp" => Some("http://localhost:8080"),
         "openai" | "anthropic" => None, // provider clients carry their own default
         _ => None,
     }

--- a/crates/garraia-cli/src/doctor.rs
+++ b/crates/garraia-cli/src/doctor.rs
@@ -1,0 +1,625 @@
+//! `garraia doctor` — saúde da instalação numa passada.
+//!
+//! Fase 0 do Garra Mobile (ADR 0016): o onboarding no Termux é
+//! `curl … install.sh | bash` → `garraia doctor` → `garraia chat`. O doctor
+//! precisa então sobreviver a config inexistente **e** a config
+//! não-parseável, reportando sysexits como `config check` — por isso é
+//! interceptado em `main()` antes do `load()` global.
+//!
+//! Seções:
+//!   1. Plataforma — versão, SO/arquitetura, detecção Termux, dir de config.
+//!   2. Diretórios — `ensure_dirs` (cria o que falta, valida escrita).
+//!   3. Config — reuso direto de [`garraia_config::run_check`].
+//!   4. Providers — para cada entrada `llm:`: fonte da credencial
+//!      (presence-only) e, para os daemons locais keyless (`ollama`,
+//!      `llamacpp`), probe TCP com alvo vetado por `garraia_common::ssrf`
+//!      ([`IpScope::AllowPrivate`] — link-local, CGNAT, multicast e
+//!      unspecified continuam bloqueados; regra 14).
+//!   5. Daemon — reconciliação pidfile + porta (mesma fonte do `status`),
+//!      não-fatal quando parado.
+//!
+//! Exit codes (sysexits, padrão do `config check`):
+//!   - `0` — OK (avisos permitidos fora de `--strict`).
+//!   - `2` — erros de validação da config (ou avisos sob `--strict`).
+//!   - `65` — `EX_DATAERR`, arquivo existe mas não parseia.
+//!
+//! Probes de provider/daemon **não** afetam o exit code — são diagnóstico,
+//! não validação. Invariante de redaction mantida: credenciais aparecem só
+//! como fonte (`config.yml`, `credential vault`, `environment variable`),
+//! nunca como valor.
+
+use std::net::{TcpStream, ToSocketAddrs};
+use std::time::Duration;
+
+use anyhow::Result;
+use garraia_common::ssrf::{IpScope, SsrfCategory, UrlPolicy, vet_url};
+use garraia_config::{
+    AppConfig, ConfigCheck, ConfigLoader, provider_key_env, resolve_provider_key_source,
+};
+use serde::Serialize;
+
+/// Budget de cada probe TCP. Mesmo valor que o boot loop usa para os
+/// daemons locais — 2s é generoso para loopback/LAN.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Política do probe de daemon local: plaintext é a escolha legítima do
+/// operador (llama-server/ollama servem HTTP cru na LAN), escopo
+/// AllowPrivate porque o alvo **é** suposto ser local — o que o guard ainda
+/// bloqueia (link-local = metadata de cloud, CGNAT, multicast, unspecified)
+/// continua bloqueado.
+fn daemon_probe_policy() -> UrlPolicy {
+    UrlPolicy {
+        allowed_schemes: &["http", "https"],
+        host_allowlist: None,
+        ip_scope: IpScope::AllowPrivate,
+        timeout: PROBE_TIMEOUT,
+        user_agent: concat!("garraia-doctor/", env!("CARGO_PKG_VERSION")),
+    }
+}
+
+/// Resultado do probe de um daemon local.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub(crate) enum ProbeResult {
+    /// Pelo menos um endereço vetado aceitou conexão.
+    Reachable,
+    /// Resolveu e vetou OK, mas nada aceitou conexão.
+    Unreachable { reason: String },
+    /// O guard SSRF recusou o alvo — a URL nunca foi tocada.
+    Blocked { category: &'static str },
+}
+
+fn category_label(category: SsrfCategory) -> &'static str {
+    match category {
+        SsrfCategory::BadRequest => "bad_request",
+        SsrfCategory::Forbidden => "forbidden",
+        SsrfCategory::Upstream => "upstream",
+    }
+}
+
+/// Vetar a URL e conectar TCP aos endereços aprovados, em ordem.
+///
+/// `vet_url` resolve o host uma vez e devolve os endereços pinados —
+/// conectar neles fecha a janela TOCTOU do DNS. Probe é diagnóstico: nenhum
+/// erro aqui é fatal, tudo vira [`ProbeResult`].
+fn probe_local_daemon(base_url: &str, timeout: Duration) -> ProbeResult {
+    let vetted = match vet_url(base_url, &daemon_probe_policy()) {
+        Ok(v) => v,
+        Err(rejection) => {
+            return ProbeResult::Blocked {
+                category: category_label(rejection.category()),
+            };
+        }
+    };
+
+    let mut last_err = "nenhum endereço após o veto".to_string();
+    for addr in &vetted.addrs {
+        match TcpStream::connect_timeout(addr, timeout) {
+            Ok(_) => return ProbeResult::Reachable,
+            Err(e) => last_err = e.to_string(),
+        }
+    }
+    ProbeResult::Unreachable { reason: last_err }
+}
+
+/// Termux detectado? Mesma heurística do `install.sh` (branch Android):
+/// `$TERMUX_VERSION` exportado por todo shell do Termux, ou `$PREFIX`
+/// apontando para o sandbox `com.termux`.
+fn detect_termux(termux_version: Option<&str>, prefix: Option<&str>) -> bool {
+    termux_version.is_some_and(|v| !v.is_empty()) || prefix.is_some_and(|p| p.contains("com.termux"))
+}
+
+fn termux_detected() -> bool {
+    detect_termux(
+        std::env::var("TERMUX_VERSION").ok().as_deref(),
+        std::env::var("PREFIX").ok().as_deref(),
+    )
+}
+
+/// Base URL com que um daemon local deve ser sondado, ou `None` para
+/// providers que não são daemon local. Defaults espelham os arms de boot do
+/// gateway (`garraia-gateway/src/bootstrap/mod.rs`).
+fn resolve_daemon_base_url(kind: &str, base_url: Option<&str>) -> Option<String> {
+    match kind {
+        "ollama" => Some(base_url.unwrap_or("http://localhost:11434").to_string()),
+        "llamacpp" => Some(base_url.unwrap_or("http://localhost:8080").to_string()),
+        _ => None,
+    }
+}
+
+/// Diagnóstico de um provider configurado.
+#[derive(Debug, Serialize)]
+pub(crate) struct ProviderCheck {
+    /// Chave da entrada em `llm:`.
+    pub name: String,
+    /// Tipo declarado (`provider:`).
+    pub kind: String,
+    pub model: Option<String>,
+    /// `true` para os daemons locais keyless (`ollama`, `llamacpp`).
+    pub keyless: bool,
+    /// Fonte da credencial, presence-only — nunca o valor. `None` quando
+    /// keyless.
+    pub credential_source: Option<String>,
+    /// Probe de reachability — só para daemons locais keyless.
+    pub probe: Option<ProbeResult>,
+    /// URL efetivamente sondada (com o default aplicado).
+    pub probe_url: Option<String>,
+}
+
+/// Diagnóstico do daemon do gateway (mesma fonte de verdade do `status`).
+#[derive(Debug, Serialize)]
+pub(crate) struct DaemonCheck {
+    pub pid_file_present: bool,
+    pub pid: Option<u32>,
+    pub process_alive: bool,
+    /// pidfile existe mas o PID não está vivo.
+    pub stale_pid_file: bool,
+    pub gateway_host: String,
+    pub gateway_port: u16,
+    pub port_listening: bool,
+}
+
+/// Relatório completo do doctor — é o payload `report` do `--json`.
+#[derive(Debug, Serialize)]
+pub(crate) struct DoctorReport {
+    pub version: &'static str,
+    pub os: &'static str,
+    pub arch: &'static str,
+    pub termux: bool,
+    pub config_dir: String,
+    pub dirs_ok: bool,
+    /// Presente quando a config existe mas não parseia (exit 65).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config_error: Option<String>,
+    /// Presente quando a config carregou — é o `ConfigCheck` do `config check`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config_check: Option<ConfigCheck>,
+    pub providers: Vec<ProviderCheck>,
+    pub daemon: DaemonCheck,
+}
+
+/// Um provider é keyless-local (e portanto sondável) quando o tipo é um dos
+/// daemons locais; o resto é classificado pela tabela de credenciais.
+fn classify_provider_kind(kind: &str) -> KeylessOrCredential {
+    match provider_key_env(kind) {
+        Some(_) => KeylessOrCredential::NeedsCredential,
+        None if kind == "ollama" || kind == "llamacpp" => KeylessOrCredential::KeylessLocal,
+        // `echo` é dev-only e tipos desconhecidos caem aqui; o `config check`
+        // já reporta o desconhecido como Error — o doctor só rotula.
+        None => KeylessOrCredential::NeedsCredential,
+    }
+}
+
+enum KeylessOrCredential {
+    KeylessLocal,
+    NeedsCredential,
+}
+
+/// Ordem determinística (chave ordenada) porque `config.llm` é map não-ordenado
+/// e a saída humana/JSON do doctor é afirmável em teste.
+fn collect_provider_checks(config: &AppConfig) -> Vec<ProviderCheck> {
+    let mut names: Vec<&str> = config.llm.keys().map(|k| k.as_str()).collect();
+    names.sort_unstable();
+
+    names
+        .into_iter()
+        .map(|name| {
+            let entry = &config.llm[name];
+            let kind = entry.provider.as_str();
+            let model = entry.model.clone().filter(|m| !m.is_empty());
+
+            let (keyless, credential_source) = match classify_provider_kind(kind) {
+                KeylessOrCredential::KeylessLocal => (true, None),
+                KeylessOrCredential::NeedsCredential => (
+                    false,
+                    Some(
+                        resolve_provider_key_source(kind, entry.api_key.as_deref())
+                            .label()
+                            .to_string(),
+                    ),
+                ),
+            };
+
+            let (probe, probe_url) = match resolve_daemon_base_url(kind, entry.base_url.as_deref())
+            {
+                Some(url) => (
+                    Some(probe_local_daemon(&url, PROBE_TIMEOUT)),
+                    Some(url),
+                ),
+                None => (None, None),
+            };
+
+            ProviderCheck {
+                name: name.to_string(),
+                kind: kind.to_string(),
+                model,
+                keyless,
+                credential_source,
+                probe,
+                probe_url,
+            }
+        })
+        .collect()
+}
+
+/// Probe TCP curto para a porta do gateway. Host vem da config do operador
+/// (mesmo nível de confiança do `garraia status`, que faz reqwest direto) —
+/// falha aqui é diagnóstico, nunca pânico.
+fn tcp_reachable(host: &str, port: u16, timeout: Duration) -> bool {
+    match (host, port).to_socket_addrs() {
+        Ok(mut addrs) => addrs.any(|addr| TcpStream::connect_timeout(&addr, timeout).is_ok()),
+        Err(_) => false,
+    }
+}
+
+fn check_daemon(gateway_host: &str, gateway_port: u16) -> DaemonCheck {
+    let pid = crate::read_pid();
+    let pid_file_present = pid.is_some();
+    let process_alive = pid.map(crate::is_process_running).unwrap_or(false);
+
+    DaemonCheck {
+        pid_file_present,
+        pid,
+        process_alive,
+        stale_pid_file: pid_file_present && !process_alive,
+        gateway_host: gateway_host.to_string(),
+        gateway_port,
+        port_listening: tcp_reachable(gateway_host, gateway_port, PROBE_TIMEOUT),
+    }
+}
+
+/// Exit code do doctor. Falha de parse domina (65); depois os findings da
+/// config (2, ou sob `--strict`); probes e daemon são diagnóstico e não
+/// afetam o código.
+fn compute_doctor_exit_code(report: &DoctorReport, strict: bool) -> i32 {
+    if report.config_error.is_some() {
+        return 65;
+    }
+    if let Some(check) = &report.config_check
+        && (check.has_errors() || (strict && check.has_warnings()))
+    {
+        return 2;
+    }
+    0
+}
+
+/// Ponto de entrada do `garraia doctor`. Retorna o exit code (sysexits).
+pub fn run_doctor(json: bool, strict: bool) -> Result<i32> {
+    let loader = ConfigLoader::new()?;
+    let dirs_ok = loader.ensure_dirs().is_ok();
+
+    let (config_check, config_error, providers, gateway) = match loader.load() {
+        Ok(config) => {
+            let check = garraia_config::run_check(&loader, &config);
+            let providers = collect_provider_checks(&config);
+            let gateway = (config.gateway.host.clone(), config.gateway.port);
+            (Some(check), None, providers, gateway)
+        }
+        Err(e) => {
+            // Mesma truncagem do `config check` (SEC-L-01): o erro nunca
+            // imprime o arquivo inteiro.
+            (
+                None,
+                Some(crate::config_cmd::truncate_error(format!("{e}"))),
+                Vec::new(),
+                (
+                    AppConfig::default().gateway.host,
+                    AppConfig::default().gateway.port,
+                ),
+            )
+        }
+    };
+
+    let report = DoctorReport {
+        version: env!("CARGO_PKG_VERSION"),
+        os: std::env::consts::OS,
+        arch: std::env::consts::ARCH,
+        termux: termux_detected(),
+        config_dir: loader.config_dir().display().to_string(),
+        dirs_ok,
+        config_error,
+        config_check,
+        providers,
+        daemon: check_daemon(&gateway.0, gateway.1),
+    };
+
+    let exit_code = compute_doctor_exit_code(&report, strict);
+
+    if json {
+        let payload = serde_json::json!({
+            "ok": exit_code == 0,
+            "exit_code": exit_code,
+            "report": report,
+        });
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+    } else {
+        print_human(&report, strict);
+    }
+
+    Ok(exit_code)
+}
+
+fn print_human(report: &DoctorReport, strict: bool) {
+    println!("🩺 GarraIA doctor v{}", report.version);
+    println!(
+        "  Plataforma     : {}/{}{}",
+        report.os,
+        report.arch,
+        if report.termux { " (Termux)" } else { "" }
+    );
+    println!("  Config         : {}", report.config_dir);
+    println!();
+
+    println!("  [1/4] Diretórios ......... {}", ok_or(report.dirs_ok, "FALHA — sem escrita"));
+
+    match (&report.config_error, &report.config_check) {
+        (Some(err), _) => {
+            println!("  [2/4] Configuração ....... ERRO (exit 65)");
+            println!("        {err}");
+            println!("        dica: o arquivo existe mas não parseia; corrija o YAML/TOML.");
+        }
+        (None, Some(check)) => {
+            let errors = check
+                .findings
+                .iter()
+                .filter(|f| f.severity == garraia_config::Severity::Error)
+                .count();
+            let warnings = check.findings.len() - errors;
+            println!(
+                "  [2/4] Configuração ....... {}",
+                ok_or(errors == 0 && (warnings == 0 || !strict), "PROBLEMAS")
+            );
+            for finding in &check.findings {
+                let label = match finding.severity {
+                    garraia_config::Severity::Error => "erro",
+                    garraia_config::Severity::Warning => "aviso",
+                };
+                println!("        [{label}] {}: {}", finding.field, finding.message);
+            }
+        }
+        (None, None) => unreachable!("load falhou sem erro nem check"),
+    }
+
+    println!("  [3/4] Providers ({}) :", report.providers.len());
+    if report.providers.is_empty() {
+        println!("        (nenhum — rode `garraia init` ou `garraia config set-model`)");
+    }
+    for p in &report.providers {
+        let mut line = format!("        • {} ({})", p.name, p.kind);
+        if let Some(model) = &p.model {
+            line.push_str(&format!(", modelo {model}"));
+        }
+        if p.keyless {
+            line.push_str(" — keyless");
+        }
+        println!("{line}");
+        if let Some(source) = &p.credential_source {
+            println!("          credencial: {source}");
+        }
+        match (&p.probe, &p.probe_url) {
+            (Some(ProbeResult::Reachable), Some(url)) => {
+                println!("          probe {url} → acessível");
+            }
+            (Some(ProbeResult::Unreachable { reason }), Some(url)) => {
+                println!("          probe {url} → inacessível ({reason})");
+            }
+            (Some(ProbeResult::Blocked { category }), Some(url)) => {
+                println!("          probe {url} → bloqueado pelo guard SSRF ({category})");
+            }
+            _ => {}
+        }
+    }
+
+    let daemon = &report.daemon;
+    let daemon_status = if daemon.process_alive && daemon.port_listening {
+        format!(
+            "OK — PID {} vivo, porta {} respondendo",
+            daemon.pid.unwrap_or_default(),
+            daemon.gateway_port
+        )
+    } else if daemon.process_alive {
+        format!(
+            "parcial — PID {} vivo mas a porta {} não responde (iniciando? host/porta da config diferentes?)",
+            daemon.pid.unwrap_or_default(),
+            daemon.gateway_port
+        )
+    } else if daemon.stale_pid_file {
+        format!(
+            "parado — pidfile obsoleto (PID {} não está vivo)",
+            daemon.pid.unwrap_or_default()
+        )
+    } else {
+        "parado — sem pidfile (`garraia start` sobe o daemon)".to_string()
+    };
+    println!("  [4/4] Daemon ............. {daemon_status}");
+
+    let code = compute_doctor_exit_code(report, strict);
+    println!();
+    println!(
+        "  Resultado: {}",
+        match code {
+            0 => "OK".to_string(),
+            65 => "config não-parseável (exit 65)".to_string(),
+            _ => "PROBLEMAS (exit 2)".to_string(),
+        }
+    );
+}
+
+fn ok_or(ok: bool, fail_label: &str) -> String {
+    if ok {
+        "OK".to_string()
+    } else {
+        fail_label.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use garraia_config::LlmProviderConfig;
+    use std::collections::HashMap;
+
+    fn llm_entry(provider: &str, model: Option<&str>, base_url: Option<&str>) -> LlmProviderConfig {
+        LlmProviderConfig {
+            provider: provider.to_string(),
+            model: model.map(String::from),
+            api_key: None,
+            base_url: base_url.map(String::from),
+            extra: HashMap::new(),
+        }
+    }
+
+    fn config_with(entries: &[(&str, LlmProviderConfig)]) -> AppConfig {
+        let mut cfg = AppConfig::default();
+        for (k, v) in entries {
+            cfg.llm.insert((*k).to_string(), v.clone());
+        }
+        cfg
+    }
+
+    // ─── detect_termux ─────────────────────────────────────────────────────
+
+    #[test]
+    fn termux_detection_matches_the_installer_heuristic() {
+        assert!(detect_termux(Some("0.119.0"), None));
+        assert!(detect_termux(None, Some("/data/data/com.termux/files/usr")));
+        assert!(detect_termux(Some("0.119.0"), Some("/usr")));
+        // String vazia não conta como presente (paridade com install.sh).
+        assert!(!detect_termux(Some(""), Some("/usr")));
+        assert!(!detect_termux(None, None));
+        assert!(!detect_termux(None, Some("/home/me/.local")));
+    }
+
+    // ─── resolve_daemon_base_url ───────────────────────────────────────────
+
+    #[test]
+    fn daemon_base_url_defaults_mirror_the_gateway_boot_arms() {
+        assert_eq!(
+            resolve_daemon_base_url("ollama", None).as_deref(),
+            Some("http://localhost:11434")
+        );
+        assert_eq!(
+            resolve_daemon_base_url("llamacpp", None).as_deref(),
+            Some("http://localhost:8080")
+        );
+        assert_eq!(
+            resolve_daemon_base_url("llamacpp", Some("http://pc:9090")).as_deref(),
+            Some("http://pc:9090")
+        );
+        assert_eq!(resolve_daemon_base_url("openrouter", Some("http://x")), None);
+    }
+
+    // ─── probe_local_daemon ────────────────────────────────────────────────
+
+    #[test]
+    fn probe_blocks_non_http_schemes_without_touching_the_url() {
+        let probe = probe_local_daemon("ftp://127.0.0.1:21", PROBE_TIMEOUT);
+        assert_eq!(
+            probe,
+            ProbeResult::Blocked {
+                category: "bad_request"
+            }
+        );
+    }
+
+    #[test]
+    fn probe_blocks_link_local_even_under_allow_private() {
+        // O AllowPrivate libera loopback/LAN, mas link-local (metadata de
+        // cloud) continua bloqueado — regra 14.
+        let probe = probe_local_daemon("http://169.254.169.254:80", PROBE_TIMEOUT);
+        assert_eq!(
+            probe,
+            ProbeResult::Blocked {
+                category: "forbidden"
+            }
+        );
+    }
+
+    #[test]
+    fn probe_reports_unreachable_on_closed_loopback_port() {
+        // Porta 1 do loopback é fechada em qualquer runner de CI.
+        let probe = probe_local_daemon("http://127.0.0.1:1", PROBE_TIMEOUT);
+        assert!(matches!(probe, ProbeResult::Unreachable { .. }));
+    }
+
+    // ─── collect_provider_checks ───────────────────────────────────────────
+
+    #[test]
+    fn provider_checks_are_key_sorted_and_classify_keyless_locals() {
+        let cfg = config_with(&[
+            ("main", llm_entry("openrouter", Some("openrouter/auto"), None)),
+            ("zeta", llm_entry("unknown-kind", None, None)),
+            ("local", llm_entry("ollama", Some("qwen3.8:latest"), None)),
+            (
+                "llama",
+                llm_entry("llamacpp", None, Some("http://127.0.0.1:1")),
+            ),
+        ]);
+
+        let checks = collect_provider_checks(&cfg);
+        let names: Vec<&str> = checks.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, vec!["llama", "local", "main", "zeta"]);
+
+        let llama = &checks[0];
+        assert!(llama.keyless);
+        assert!(llama.credential_source.is_none());
+        assert_eq!(llama.probe_url.as_deref(), Some("http://127.0.0.1:1"));
+        // Porta 1 fechada → inacessível, e o doctor não morre nisso.
+        assert!(matches!(llama.probe, Some(ProbeResult::Unreachable { .. })));
+
+        let ollama = &checks[1];
+        assert!(ollama.keyless);
+        assert_eq!(ollama.probe_url.as_deref(), Some("http://localhost:11434"));
+
+        let openrouter = &checks[2];
+        assert!(!openrouter.keyless);
+        assert!(openrouter.credential_source.is_some());
+        assert!(openrouter.probe.is_none());
+        assert!(openrouter.probe_url.is_none());
+
+        let unknown = &checks[3];
+        assert!(!unknown.keyless);
+        assert!(unknown.probe.is_none());
+    }
+
+    // ─── exit codes ────────────────────────────────────────────────────────
+
+    #[test]
+    fn doctor_exit_code_parse_failure_dominates_as_ex_dataerr() {
+        let report = DoctorReport {
+            version: "test",
+            os: "linux",
+            arch: "x86_64",
+            termux: false,
+            config_dir: "/tmp".into(),
+            dirs_ok: true,
+            config_error: Some("yaml inválido".into()),
+            config_check: None,
+            providers: vec![],
+            daemon: DaemonCheck {
+                pid_file_present: false,
+                pid: None,
+                process_alive: false,
+                stale_pid_file: false,
+                gateway_host: "127.0.0.1".into(),
+                gateway_port: 3888,
+                port_listening: false,
+            },
+        };
+        assert_eq!(compute_doctor_exit_code(&report, false), 65);
+        assert_eq!(compute_doctor_exit_code(&report, true), 65);
+    }
+
+    #[test]
+    fn tcp_reachable_false_on_closed_port_and_bad_host() {
+        assert!(!tcp_reachable("127.0.0.1", 1, PROBE_TIMEOUT));
+        assert!(!tcp_reachable("host.que.nao.existe.invalid", 80, PROBE_TIMEOUT));
+    }
+
+    #[test]
+    fn category_label_covers_every_ssrf_category() {
+        assert_eq!(category_label(SsrfCategory::BadRequest), "bad_request");
+        assert_eq!(category_label(SsrfCategory::Forbidden), "forbidden");
+        assert_eq!(category_label(SsrfCategory::Upstream), "upstream");
+    }
+}

--- a/crates/garraia-cli/src/doctor.rs
+++ b/crates/garraia-cli/src/doctor.rs
@@ -106,7 +106,8 @@ fn probe_local_daemon(base_url: &str, timeout: Duration) -> ProbeResult {
 /// `$TERMUX_VERSION` exportado por todo shell do Termux, ou `$PREFIX`
 /// apontando para o sandbox `com.termux`.
 fn detect_termux(termux_version: Option<&str>, prefix: Option<&str>) -> bool {
-    termux_version.is_some_and(|v| !v.is_empty()) || prefix.is_some_and(|p| p.contains("com.termux"))
+    termux_version.is_some_and(|v| !v.is_empty())
+        || prefix.is_some_and(|p| p.contains("com.termux"))
 }
 
 fn termux_detected() -> bool {
@@ -222,10 +223,7 @@ fn collect_provider_checks(config: &AppConfig) -> Vec<ProviderCheck> {
 
             let (probe, probe_url) = match resolve_daemon_base_url(kind, entry.base_url.as_deref())
             {
-                Some(url) => (
-                    Some(probe_local_daemon(&url, PROBE_TIMEOUT)),
-                    Some(url),
-                ),
+                Some(url) => (Some(probe_local_daemon(&url, PROBE_TIMEOUT)), Some(url)),
                 None => (None, None),
             };
 
@@ -350,7 +348,10 @@ fn print_human(report: &DoctorReport, strict: bool) {
     println!("  Config         : {}", report.config_dir);
     println!();
 
-    println!("  [1/4] Diretórios ......... {}", ok_or(report.dirs_ok, "FALHA — sem escrita"));
+    println!(
+        "  [1/4] Diretórios ......... {}",
+        ok_or(report.dirs_ok, "FALHA — sem escrita")
+    );
 
     match (&report.config_error, &report.config_check) {
         (Some(err), _) => {
@@ -506,7 +507,10 @@ mod tests {
             resolve_daemon_base_url("llamacpp", Some("http://pc:9090")).as_deref(),
             Some("http://pc:9090")
         );
-        assert_eq!(resolve_daemon_base_url("openrouter", Some("http://x")), None);
+        assert_eq!(
+            resolve_daemon_base_url("openrouter", Some("http://x")),
+            None
+        );
     }
 
     // ─── probe_local_daemon ────────────────────────────────────────────────
@@ -547,7 +551,10 @@ mod tests {
     #[test]
     fn provider_checks_are_key_sorted_and_classify_keyless_locals() {
         let cfg = config_with(&[
-            ("main", llm_entry("openrouter", Some("openrouter/auto"), None)),
+            (
+                "main",
+                llm_entry("openrouter", Some("openrouter/auto"), None),
+            ),
             ("zeta", llm_entry("unknown-kind", None, None)),
             ("local", llm_entry("ollama", Some("qwen3.8:latest"), None)),
             (
@@ -613,7 +620,11 @@ mod tests {
     #[test]
     fn tcp_reachable_false_on_closed_port_and_bad_host() {
         assert!(!tcp_reachable("127.0.0.1", 1, PROBE_TIMEOUT));
-        assert!(!tcp_reachable("host.que.nao.existe.invalid", 80, PROBE_TIMEOUT));
+        assert!(!tcp_reachable(
+            "host.que.nao.existe.invalid",
+            80,
+            PROBE_TIMEOUT
+        ));
     }
 
     #[test]

--- a/crates/garraia-cli/src/main.rs
+++ b/crates/garraia-cli/src/main.rs
@@ -5,6 +5,7 @@ mod capability_prompt;
 mod chat;
 mod cli_args;
 mod config_cmd;
+mod doctor;
 mod glob_cmd;
 mod max_power;
 mod mcp_server;
@@ -112,6 +113,17 @@ enum Commands {
 
     /// Show current status
     Status,
+
+    /// Diagnose the installation (platform, dirs, config, providers, daemon)
+    Doctor {
+        /// Emit a machine-readable JSON report instead of human output
+        #[arg(long)]
+        json: bool,
+
+        /// Treat config warnings as errors (exit 2)
+        #[arg(long)]
+        strict: bool,
+    },
 
     /// Run the onboarding wizard
     Init,
@@ -601,11 +613,11 @@ fn validate_plugin_path(path_str: &str) -> Result<PathBuf> {
     Ok(path)
 }
 
-fn garraia_dir() -> PathBuf {
+pub(crate) fn garraia_dir() -> PathBuf {
     garraia_config::ConfigLoader::default_config_dir()
 }
 
-fn pid_file_path() -> PathBuf {
+pub(crate) fn pid_file_path() -> PathBuf {
     garraia_dir().join("garraia.pid")
 }
 
@@ -615,7 +627,7 @@ fn log_file_path() -> PathBuf {
 }
 
 /// Read the PID from the PID file.
-fn read_pid() -> Option<u32> {
+pub(crate) fn read_pid() -> Option<u32> {
     let path = pid_file_path();
     std::fs::read_to_string(&path)
         .ok()
@@ -624,13 +636,13 @@ fn read_pid() -> Option<u32> {
 
 /// Check if a process with the given PID is running.
 #[cfg(unix)]
-fn is_process_running(pid: u32) -> bool {
+pub(crate) fn is_process_running(pid: u32) -> bool {
     // Signal 0 checks existence without sending a signal
     unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
 }
 
 #[cfg(windows)]
-fn is_process_running(pid: u32) -> bool {
+pub(crate) fn is_process_running(pid: u32) -> bool {
     use windows_sys::Win32::Foundation::{CloseHandle, FALSE, STILL_ACTIVE};
     use windows_sys::Win32::System::Threading::{
         GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
@@ -655,7 +667,7 @@ fn is_process_running(pid: u32) -> bool {
 }
 
 #[cfg(not(any(unix, windows)))]
-fn is_process_running(_pid: u32) -> bool {
+pub(crate) fn is_process_running(_pid: u32) -> bool {
     false
 }
 
@@ -926,6 +938,18 @@ fn main() -> Result<()> {
     } = cli.command
     {
         let code = config_cmd::run_config_check(json, strict)?;
+        if code != 0 {
+            std::process::exit(code);
+        }
+        return Ok(());
+    }
+
+    // Fase 0 Garra Mobile (ADR 0016) — `doctor` é o passo de onboarding
+    // (install.sh → doctor → chat), então como o `config check` precisa
+    // sobreviver a config ausente/não-parseável e reportar sysexits em vez
+    // de estourar no `load()` global.
+    if let Commands::Doctor { json, strict } = cli.command {
+        let code = doctor::run_doctor(json, strict)?;
         if code != 0 {
             std::process::exit(code);
         }
@@ -1730,6 +1754,10 @@ async fn async_main(
         Commands::Verify { .. } => {
             // Handled in main() before the async runtime starts.
             unreachable!("Commands::Verify is intercepted in main() before async_main");
+        }
+        Commands::Doctor { .. } => {
+            // Handled in main() before the async runtime starts.
+            unreachable!("Commands::Doctor is intercepted in main() before async_main");
         }
     }
 

--- a/crates/garraia-config/src/check.rs
+++ b/crates/garraia-config/src/check.rs
@@ -531,9 +531,12 @@ fn validate(config: &AppConfig) -> Vec<Finding> {
 
     // An `llm:` entry whose `provider` the runtime does not recognize is
     // silently dropped with `warn!("unknown LLM provider type")` at boot.
+    // The keyless locals (`ollama`, `llamacpp`) have no env var in the shared
+    // table, so they are whitelisted here explicitly — keep in lockstep with
+    // the boot loop's arms in `garraia-gateway/src/bootstrap/mod.rs`.
     for (name, llm) in &config.llm {
         let known = crate::provider_keys::provider_key_env(&llm.provider).is_some()
-            || matches!(llm.provider.as_str(), "ollama" | "echo");
+            || matches!(llm.provider.as_str(), "ollama" | "llamacpp" | "echo");
         if !known {
             push_err(
                 &mut findings,

--- a/crates/garraia-config/src/provider_keys.rs
+++ b/crates/garraia-config/src/provider_keys.rs
@@ -70,15 +70,18 @@ impl KeySource {
 /// The environment variable (and credential-vault entry name — they are the
 /// same string by convention) that holds the API key for `provider`.
 ///
-/// Returns `None` for providers that need no key: `ollama` talks to a local
-/// daemon, and `echo` is the feature-gated dev provider. An unknown provider
-/// string also yields `None`, matching the gateway's
-/// `warn!("unknown LLM provider type")` arm.
+/// Returns `None` for providers that need no key: `ollama` and `llamacpp`
+/// talk to local daemons, and `echo` is the feature-gated dev provider. An
+/// unknown provider string also yields `None`, matching the gateway's
+/// `warn!("unknown LLM provider type")` arm — callers that must distinguish
+/// "keyless" from "unknown" whitelist the locals explicitly (see
+/// `check.rs`).
 ///
 /// Keep in lockstep with the `match llm_config.provider.as_str()` arms in
 /// `garraia-gateway/src/bootstrap/mod.rs`. The gateway test
 /// `bootstrap::config::tests::provider_key_table_covers_every_arm_of_the_boot_loop`
-/// asserts the two agree, including that `ollama` and `echo` stay keyless.
+/// asserts the two agree, including that `ollama`, `llamacpp` and `echo`
+/// stay keyless.
 pub fn provider_key_env(provider: &str) -> Option<&'static str> {
     Some(match provider {
         "anthropic" => "ANTHROPIC_API_KEY",
@@ -165,7 +168,7 @@ pub fn resolve_api_key(config_key: Option<&str>, vault_key: &str, env_var: &str)
 }
 
 /// Resolve the key for a configured `llm:` entry, keyed off its `provider`
-/// field. Providers that need no key (`ollama`, `echo`) report
+/// field. Providers that need no key (`ollama`, `llamacpp`, `echo`) report
 /// [`KeySource::Config`] with no value, since absence of a key is not a fault
 /// for them.
 pub fn resolve_provider_key_source(provider: &str, config_key: Option<&str>) -> KeySource {
@@ -220,6 +223,7 @@ mod tests {
     #[test]
     fn keyless_providers_are_never_reported_missing() {
         assert!(provider_key_env("ollama").is_none());
+        assert!(provider_key_env("llamacpp").is_none());
         assert!(provider_key_env("echo").is_none());
         assert!(provider_key_env("totally-unknown").is_none());
 
@@ -227,7 +231,12 @@ mod tests {
             resolve_provider_key_source("ollama", None),
             KeySource::Config
         );
+        assert_eq!(
+            resolve_provider_key_source("llamacpp", None),
+            KeySource::Config
+        );
         assert!(resolve_provider_key_source("ollama", None).is_resolved());
+        assert!(resolve_provider_key_source("llamacpp", None).is_resolved());
     }
 
     #[test]

--- a/crates/garraia-gateway/src/bootstrap/config.rs
+++ b/crates/garraia-gateway/src/bootstrap/config.rs
@@ -133,6 +133,7 @@ mod tests {
 
         // Keyless arms: these must never be reported as missing a key.
         assert_eq!(provider_key_env("ollama"), None);
+        assert_eq!(provider_key_env("llamacpp"), None);
         assert_eq!(provider_key_env("echo"), None);
     }
 }

--- a/crates/garraia-gateway/src/bootstrap/mod.rs
+++ b/crates/garraia-gateway/src/bootstrap/mod.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use garraia_agents::tools::Tool;
 use garraia_agents::{
     AgentRuntime, AnthropicProvider, BashTool, CohereEmbeddingProvider, FileReadTool,
-    FileWriteTool, McpManager, OllamaEmbeddingProvider, OllamaProvider, OpenAiEmbeddingProvider,
-    OpenAiProvider, WebFetchTool, WebSearchTool,
+    FileWriteTool, LlamaCppProvider, McpManager, OllamaEmbeddingProvider, OllamaProvider,
+    OpenAiEmbeddingProvider, OpenAiProvider, WebFetchTool, WebSearchTool,
 };
 use garraia_config::{AppConfig, provider_key_env};
 use garraia_db::MemoryStore;
@@ -193,6 +193,54 @@ pub fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
                         .with_client(llm_client.clone());
                 runtime.register_provider(Arc::new(provider));
                 info!("configured ollama provider: {name}");
+            }
+            // Keyless local daemon, mirroring the ollama arm: llama-server
+            // exposes the OpenAI-compatible API on its documented default
+            // port 8080 (ADR 0016 — Garra Mobile local-first).
+            "llamacpp" => {
+                let base_url = llm_config
+                    .base_url
+                    .clone()
+                    .unwrap_or_else(|| "http://localhost:8080".to_string());
+
+                let addr = base_url
+                    .trim_start_matches("http://")
+                    .trim_start_matches("https://")
+                    .trim_end_matches('/');
+                let sock_addr = if addr.contains(':') {
+                    addr.to_string()
+                } else {
+                    format!("{}:8080", addr)
+                };
+                match std::net::TcpStream::connect_timeout(
+                    &sock_addr
+                        .parse()
+                        .unwrap_or_else(|_| std::net::SocketAddr::from(([127, 0, 0, 1], 8080))),
+                    std::time::Duration::from_secs(2),
+                ) {
+                    Ok(_) => {
+                        info!(
+                            "✅ llama.cpp server reachable at {} — registering provider: {name}",
+                            base_url
+                        );
+                    }
+                    Err(e) => {
+                        warn!(
+                            "⚠️  llama.cpp server not reachable at {} — provider registered but \
+                             will fail until llama-server starts. Error: {}. \
+                             Run: llama-server -m <model>",
+                            base_url, e
+                        );
+                    }
+                }
+
+                let provider = LlamaCppProvider::new(
+                    llm_config.model.clone(),
+                    llm_config.base_url.clone(),
+                    None,
+                );
+                runtime.register_provider(Arc::new(provider));
+                info!("configured llamacpp provider: {name}");
             }
             "sansa" => {
                 let base_url = llm_config

--- a/tests/install_sh/detect_platform.sh
+++ b/tests/install_sh/detect_platform.sh
@@ -13,7 +13,7 @@
 # `detect_platform` in subshells where `uname` is shadowed by a function
 # printing the case's OS/arch and the Termux environment is simulated.
 # Written in POSIX sh (like checksum_format.sh) so it stays in the
-# shellcheck list of the installer job, not just `bash -n`.
+# static-analysis step of the installer job, not just `bash -n`.
 set -eu
 
 repo_root="$(cd "$(dirname "$0")/../.." && pwd)"

--- a/tests/install_sh/detect_platform.sh
+++ b/tests/install_sh/detect_platform.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+# SC2030/SC2031 are expected here, not bugs: every case builds a throwaway
+# environment inside a subshell (env vars + shadowed uname) and the export's
+# scope ending with that subshell is the isolation the test relies on.
+# shellcheck disable=SC2030,SC2031
 # Unit tests for `detect_platform` (Termux branch) and the Android paths of
 # `install_binary` / `print_next_steps_legacy` in `install.sh`.
 #
@@ -46,8 +50,8 @@ run_platform_case() {
     out_file="$(mktemp)"
     rc=0
     (
-        TERMUX_VERSION="${termux_version}"
-        PREFIX="${prefix}"
+        export TERMUX_VERSION="${termux_version}"
+        export PREFIX="${prefix}"
         eval "uname() { case \"\$1\" in -s) printf '%s\n' '${stub_os}' ;; -m) printf '%s\n' '${stub_arch}' ;; esac; }"
         detect_platform
         echo "OS_NAME=${OS_NAME}"
@@ -78,8 +82,8 @@ run_error_case() {
     out_file="$(mktemp)"
     rc=0
     (
-        TERMUX_VERSION="${termux_version}"
-        PREFIX="${prefix}"
+        export TERMUX_VERSION="${termux_version}"
+        export PREFIX="${prefix}"
         eval "uname() { case \"\$1\" in -s) printf '%s\n' '${stub_os}' ;; -m) printf '%s\n' '${stub_arch}' ;; esac; }"
         detect_platform
     ) >"${out_file}" 2>&1 || rc=$?
@@ -136,12 +140,12 @@ printf '#!/bin/sh\nexit 0\n' > "${fake_artifact}"
 fake_prefix="${tmp_root}/prefix"
 rc=0
 (
-    OS_NAME="android"
-    PREFIX="${fake_prefix}"
-    ARTIFACT="garraia-android-aarch64"
-    GARRAIA_TMPDIR="${tmp_root}"
-    GARRAIA_INSTALL_DIR=""
-    VERSION="vTEST"
+    export OS_NAME="android"
+    export PREFIX="${fake_prefix}"
+    export ARTIFACT="garraia-android-aarch64"
+    export GARRAIA_TMPDIR="${tmp_root}"
+    export GARRAIA_INSTALL_DIR=""
+    export VERSION="vTEST"
     install_binary
 ) >/dev/null 2>&1 || rc=$?
 if [ "${rc}" -ne 0 ]; then
@@ -156,12 +160,12 @@ fi
 custom_dir="${tmp_root}/custom"
 rc=0
 (
-    OS_NAME="android"
-    PREFIX="${fake_prefix}"
-    ARTIFACT="garraia-android-aarch64"
-    GARRAIA_TMPDIR="${tmp_root}"
-    GARRAIA_INSTALL_DIR="${custom_dir}"
-    VERSION="vTEST"
+    export OS_NAME="android"
+    export PREFIX="${fake_prefix}"
+    export ARTIFACT="garraia-android-aarch64"
+    export GARRAIA_TMPDIR="${tmp_root}"
+    export GARRAIA_INSTALL_DIR="${custom_dir}"
+    export VERSION="vTEST"
     install_binary
 ) >/dev/null 2>&1 || rc=$?
 if [ "${rc}" -ne 0 ]; then
@@ -176,11 +180,11 @@ fi
 gate_out="$(mktemp)"
 rc=0
 (
-    OS_NAME="android"
-    ARTIFACT="garraia-android-aarch64"
-    GARRAIA_TMPDIR="${tmp_root}"
-    GARRAIA_INSTALL_DIR="/usr/bin"
-    VERSION="vTEST"
+    export OS_NAME="android"
+    export ARTIFACT="garraia-android-aarch64"
+    export GARRAIA_TMPDIR="${tmp_root}"
+    export GARRAIA_INSTALL_DIR="/usr/bin"
+    export VERSION="vTEST"
     install_binary
 ) >"${gate_out}" 2>&1 || rc=$?
 if [ "${rc}" -ne 1 ]; then
@@ -210,7 +214,7 @@ esac
 # check_glibc is a linux-only probe: on android it must return 0 before
 # touching ldd — Termux has no glibc/musl loader to interrogate.
 rc=0
-( OS_NAME="android"; ARCH="aarch64"; check_glibc ) >/dev/null 2>&1 || rc=$?
+( export OS_NAME="android" ARCH="aarch64"; check_glibc ) >/dev/null 2>&1 || rc=$?
 if [ "${rc}" -eq 0 ]; then
     pass "check_glibc skipped on android"
 else


### PR DESCRIPTION
## O que

Fase 0 Garra Mobile (ADR 0016, PR B3 do plano). Onboarding Termux é
`install.sh → garraia doctor → garraia chat`, então:

### B5 — `garra doctor` (novo subcomando)

- Interceptado em `main()` **antes** do `load()` global — sobrevive a
  config ausente (fresh install → defaults, exit 0) e não-parseável
  (exit 65), no padrão do `config check`.
- Seções: [1/4] Diretórios (ensure_dirs), [2/4] Configuração (reuso
  direto de `garraia_config::run_check`), [3/4] Providers (fonte de
  credencial presence-only via `resolve_provider_key_source().label()`;
  daemons locais keyless recebem probe TCP), [4/4] Daemon (pidfile +
  porta, mesma fonte do `status`, não-fatal quando parado).
- Probes vetados por `garra_common::ssrf` (`vet_url` +
  `IpScope::AllowPrivate` — loopback/LAN permitidos; link-local,
  CGNAT, multicast e unspecified continuam bloqueados, regra 14).
  Conecta aos IPs pinados do veto, fechando a janela DNS-rebind.
- Flags `--json` (payload `{"ok","exit_code","report"}`) e `--strict`
  (aviso vira erro). Sysexits: 0 / 2 / 65. **Probes nunca afetam o
  exit code** — são diagnóstico.
- Invariante de redaction mantida: credencial aparece só como fonte
  ("credential vault" / "config.yml" / "environment variable"),
  nunca valor.

### B6 — `llamacpp` wired no CLI

- `chat --provider llamacpp` e `ask`: `LlamaCppProvider::new(model,
  base_url, None)` com health-check (cai no fallback como ollama).
- `config set-model --provider llamacpp` keyless, default base_url
  `http://localhost:8080`.
- Precedência do base_url extraída para função pura
  `resolve_llamacpp_base_url` (`--url` > `config.llm["llamacpp"]` >
  default), testável sem tocar no trait object.
- Bail de provider desconhecido cita os 5 kinds.
- **Braço `llamacpp` no boot loop do gateway** (espelha ollama):
  sem ele, `config check` reportaria provider "conhecido" que o
  gateway nunca subiria. Lockstep `provider_key_env` estendido nos
  testes dos dois lados.

## Testes

- 10 testes novos (doctor: detect_termux, defaults de base_url,
  probe blocked/unreachable, classificação/ordenação, exit codes,
  tcp_reachable; chat: precedência llamacpp + bail; config: keyless
  llamacpp; gateway: lockstep).
- `cargo test -p garraia --bin garra` → 258 passed
- `cargo test -p garraia-config` → 78 passed
- `cargo test -p garraia-gateway --lib` → 857 passed
- `cargo clippy -p garraia --all-targets` → limpo
- Smoke tests manuais: saída humana, `--json`, fresh install
  (sem config → exit 0).

Co-Authored-By: Claude Code <noreply@anthropic.com>