### PR TITLE
docs: ADR 0016 Garra Mobile (Termux local-first) + sync dos irmãos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- **Garra no Android (Termux) — Fase 0 do Garra Mobile Local
+  ([ADR 0016](docs/adr/0016-mobile-termux-local-first.md)).** Novo asset
+  best-effort `garraia-android-aarch64` (job `build-android-arm64` no
+  `release.yml`, alvo bionic `aarch64-linux-android` via cargo-ndk — musl
+  proibido no Android por quebrar DNS), branch Termux no `install.sh`
+  (detecção por `$TERMUX_VERSION` ou `$PREFIX` *com.termux*; default
+  `$PREFIX/bin`, sem sudo, skip do preflight glibc, notice sobre o phantom
+  process killer e bateria; nada muda fora do Termux), braço
+  `("android", "aarch64")` no `garra update` e suíte nova
+  `tests/install_sh/detect_platform.sh` no job de shellcheck. Onboarding:
+  `curl install.sh | bash` → `garraia doctor` → `garraia chat`.
+- **`garra doctor` — diagnóstico da instalação numa passada.** Quatro
+  seções (diretórios, config via `config check`, providers com fonte de
+  credencial presence-only, daemon via pidfile+porta) com flags `--json` e
+  `--strict` e exit codes sysexits 0/2/65, no padrão do `config check`.
+  Probes TCP dos daemons locais keyless (ollama/llamacpp) passam pelo
+  guard SSRF (`IpScope::AllowPrivate` — loopback/LAN liberados,
+  link-local/CGNAT/multicast continuam bloqueados); probes são
+  diagnóstico e nunca afetam o exit code.
+- **Provider `llamacpp` keyless no CLI e no gateway.** `garra chat
+  --provider llamacpp` / `garra ask` falam com um llama-server local
+  (default `http://localhost:8080`, `--url` vence a config), `garraia
+  config set-model --provider llamacpp` aceito sem credential, e o boot
+  loop do gateway ganhou o braço espelhando ollama — `config check`
+  continua truthful (lockstep `provider_key_env`).
+
 ## [0.3.5] - 2026-09-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -523,5 +523,5 @@ python3 -m pytest scripts/quality/tests/
 - @imports `TODO.md` (backlog operacional) e `.garra-estado.md` (handoff local, gitignored) para estado da sessão anterior
 - @imports `ROADMAP.md` — plano AAA em 7 fases, fonte de verdade do planejamento
 - @imports `deep-research-report.md` — base arquitetural da Fase 3 (Group Workspace multi-tenant)
-- @imports `docs/adr/` — decisões arquiteturais: 15 ADRs (0001-0015), todas **Accepted**. Ver `docs/adr/README.md` para o índice.
+- @imports `docs/adr/` — decisões arquiteturais: 16 ADRs (0001-0016), todas **Accepted**. Ver `docs/adr/README.md` para o índice.
 - Tracking: tracker interno (o Linear foi descontinuado em 2026-08-18 — não criar/consultar issues lá; IDs `GAR-xxx` permanecem como registro histórico de entregas)

--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ and exits 0 instead of blocking.
 
 Releases ship 6 prebuilt CLI binaries: Linux x86_64/aarch64,
 macOS x86_64/aarch64, Windows x86_64/aarch64 (the three aarch64 builds
-are best-effort) — each also as a `.tar.gz`
+are best-effort) — plus, from `v0.3.6`, an Android aarch64 build for
+Termux (best-effort; see the Android section below) — each also as a `.tar.gz`
 (`.zip` on Windows) containing the binary named plainly `garraia`,
 plus `LICENSE` and `README.md`. From `v0.3.4` they also carry Linux
 packages — `garraia-linux-{x86_64,aarch64}.deb`/`.rpm` and a portable
@@ -203,6 +204,36 @@ The binaries and installers are **not code-signed**, so SmartScreen shows
 "Windows protected your PC" on first run of the desktop MSI — expected, not
 tampering. See [docs/installation.md](docs/installation.md) for the full
 Windows section.
+
+</details>
+
+<details>
+<summary>Install on Android (Termux) — <code>curl | bash</code> inside Termux</summary>
+
+From `v0.3.6` the installer has a Termux branch: run it **inside the
+[Termux](https://github.com/termux/termux-app#installation) app** (the
+F-Droid or GitHub build — the Play Store fork is unsupported) and it
+detects Termux via `$TERMUX_VERSION` / `$PREFIX`, skips the glibc preflight,
+and installs `garraia` into `$PREFIX/bin` (on your PATH, no sudo):
+
+```bash
+pkg install curl
+curl -fsSL https://garraia.org/install.sh | bash
+garraia doctor    # platform, dirs, config, providers, daemon — sysexits
+garraia chat      # cloud provider, or --url http://PC-LAN:8080 for a LAN LLM
+```
+
+The Android binary targets bionic (`aarch64-linux-android`, API 21+,
+built with cargo-ndk in the `build-android-arm64` release job, best-effort)
+— static musl builds are deliberately not shipped because they break DNS
+on Android. `garra update` resolves the `garraia-android-aarch64` asset
+inside Termux. Your LLM can live in the cloud or on your LAN: any
+OpenAI-compatible server (llama.cpp / LM Studio / vLLM / Ollama) works via
+`--url`, and `--provider llamacpp` talks to a llama-server on
+`localhost:8080`. Keep the Termux session in the foreground (or acquire a
+wakelock) — Android's phantom process killer and battery optimization can
+stop long-running background daemons. Strategy and the Termux → native
+roadmap live in [ADR 0016](docs/adr/0016-mobile-termux-local-first.md).
 
 </details>
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -228,6 +228,37 @@ ser reiniciados.
 </details>
 
 <details>
+<summary>Instalar no Android (Termux) — <code>curl | bash</code> dentro do Termux</summary>
+
+> **A partir da `v0.3.6`** o instalador tem branch Termux: rode **dentro do
+> app [Termux](https://github.com/termux/termux-app#installation)** (build
+> F-Droid ou GitHub — o fork da Play Store não é suportado). Ele detecta o
+> Termux por `$TERMUX_VERSION` / `$PREFIX`, pula o preflight de glibc e
+> instala o `garraia` em `$PREFIX/bin` (no PATH, sem sudo):
+
+```bash
+pkg install curl
+curl -fsSL https://garraia.org/install.sh | bash
+garraia doctor    # plataforma, dirs, config, providers, daemon — sysexits
+garraia chat      # provider cloud, ou --url http://PC-LAN:8080 para LLM na rede
+```
+
+> O binário Android é bionic (`aarch64-linux-android`, API 21+,
+> cargo-ndk no job `build-android-arm64` do release, best-effort) — builds
+> musl estáticos não são publicados de propósito: quebram DNS no Android.
+> O `garra update` resolve o asset `garraia-android-aarch64` dentro do
+> Termux. A LLM pode estar na nuvem ou na sua rede: qualquer servidor
+> OpenAI-compatible (llama.cpp / LM Studio / vLLM / Ollama) funciona via
+> `--url`, e `--provider llamacpp` fala com um llama-server em
+> `localhost:8080`. Mantenha a sessão do Termux em primeiro plano (ou use
+> wakelock) — o phantom process killer do Android e a otimização de
+> bateria podem parar daemons longos em background. A estratégia e o
+> trilho Termux → nativo vivem no
+> [ADR 0016](docs/adr/0016-mobile-termux-local-first.md).
+
+</details>
+
+<details>
 <summary>Atualizar uma instalação existente — <code>garraia update</code></summary>
 
 ```bash
@@ -244,7 +275,7 @@ garraia rollback
 
 </details>
 
-As releases atuais (v0.3.4+) publicam 6 binários CLI (Linux x86_64/aarch64, macOS x86_64/aarch64, Windows x86_64/aarch64) com seus archives, pacotes Linux (`.deb`/`.rpm`/AppImage) e os instaladores desktop do Windows (`.msi` + `-setup.exe`, de volta ao pipeline desde 2026-08-30) — os formatos além dos binários x86_64 são best-effort. O `.apk` mobile (Android) foi publicado até a v0.2.1. Tudo nas [Versões do GitHub](https://github.com/michelbr84/GarraRUST/releases). Desde a v0.3.5, também o Garra Desktop para Linux (`garraia-desktop-linux-x86_64.deb` / `.AppImage`).
+As releases atuais (v0.3.4+) publicam 6 binários CLI (Linux x86_64/aarch64, macOS x86_64/aarch64, Windows x86_64/aarch64) com seus archives, pacotes Linux (`.deb`/`.rpm`/AppImage), os instaladores desktop do Windows (`.msi` + `-setup.exe`, de volta ao pipeline desde 2026-08-30) e, a partir da `v0.3.6`, o binário Android aarch64 para Termux (`garraia-android-aarch64`, best-effort — §Android acima) — os formatos além dos binários x86_64 são best-effort. O `.apk` mobile (Android) foi publicado até a v0.2.1. Tudo nas [Versões do GitHub](https://github.com/michelbr84/GarraRUST/releases). Desde a v0.3.5, também o Garra Desktop para Linux (`garraia-desktop-linux-x86_64.deb` / `.AppImage`).
 
 ## Por que GarraIA?
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1020,6 +1020,40 @@ Os adapters existem em `garraia-channels` (features desligadas por default) mas 
 - [ ] IRC
 - [ ] Signal
 
+### 4.5 Garra Mobile Local (Termux → nativo)
+
+Trilho distinto do 4.2 (que é o app Flutter **cliente** do gateway). Aqui o
+core Rust **executa no próprio aparelho**, local-first, com LLM opcional na
+nuvem ou na LAN. Estratégia e gerações v0-v3 definidas em
+[ADR 0016](docs/adr/0016-mobile-termux-local-first.md). Alvo Android é
+**bionic dinâmico** (`aarch64-linux-android` via NDK/cargo-ndk) — musl
+estático proibido (quebra DNS).
+
+- [x] **v0 — Fase 0 (release v0.3.6)**: asset `garraia-android-aarch64` (job
+  best-effort `build-android-arm64` no `release.yml`, openssl vendido);
+  branch Termux no `install.sh` (`$TERMUX_VERSION` / `$PREFIX` *com.termux*
+  → default `$PREFIX/bin`, skip do preflight glibc, notice de phantom
+  process killer); `garra update` resolve o asset no Android
+  (`("android", "aarch64")`); suíte `tests/install_sh/detect_platform.sh`;
+  `garra doctor` (sysexits 0/2/65, `--json`/`--strict`, probe SSRF-vetado
+  dos daemons locais); provider `llamacpp` keyless wired no CLI e no
+  bootstrap do gateway. ✅ 2026-09-02
+- [ ] **v0 follow-up**: usuário validando fim-a-fim em aparelho real
+  (Termux → installer → `garraia doctor` → `garraia chat` na cloud/LAN) —
+  pré-requisito para a v1.
+- [ ] **v1 — Companion Kotlin/Compose**: app novo (decisão do dono) com
+  `com.termux.permission.RUN_COMMAND` + `<queries>` com.termux, setup
+  guiado de `allow-external-apps=true`, stdout/exit via
+  `RUN_COMMAND_PENDING_INTENT` (cap 100KB), detecção do fork Play do Termux
+  com degradação avisada, foreground service "Always On".
+- [ ] **v2 — Híbrido JNI**: core como `cdylib` no APK (NDK); capabilities
+  migram do Termux para APIs Android; F-Droid (runtime com opt-in) ou Play
+  (jniLibs embutidos — nunca download de executável).
+- [ ] **v3 — Nativo**: sem Termux; capabilities 100% Android (CameraX,
+  LocationManager, NotificationManager); descoberta LAN sob as permissões
+  de cada API level (`NEARBY_WIFI_DEVICES` hoje; `ACCESS_LOCAL_NETWORK`
+  blocked-by-default p/ targetSdk 37+ ~2027) — URL manual como UX primária.
+
 **Estimativa fase 4:** 8 / 10 / 14 semanas.
 **Épicos sugeridos:** `GAR-DESK-AAA`, `GAR-MOB-BUILD`, `GAR-MOB-WS`, `GAR-CLI-CHAT`.
 
@@ -1384,6 +1418,8 @@ Quando retomar execução, priorizar **nesta ordem**:
 
 9. **Fase 4.1 — Desktop follow-ups**: DMG notarizado, AppImage aarch64, chave de assinatura + `latest.json` do auto-updater (`docs/releasing.md`).
 
+9. **Fase 4.5 — Garra Mobile Local (ADR 0016)**: v0 entregue na v0.3.6 (asset android + branch Termux no installer + `garra doctor` + `llamacpp`); validar fim-a-fim em aparelho real; então a v1 (companion Kotlin/Compose via RUN_COMMAND).
+
 10. **Fase 5.1 — hardening pendente**: CORS, HSTS, auth por padrão na API local, passthrough da feature `tls` no binário `garraia`.
 
 Trilhas paralelas disponíveis para um segundo dev/agente:
@@ -1398,5 +1434,5 @@ Trilhas paralelas disponíveis para um segundo dev/agente:
 - `deep-research-report.md` — Arquitetura Group Workspace (base da Fase 3).
 - `CLAUDE.md` — Convenções de código e protocolo de sessão.
 - `.garra-estado.md` — handoff da sessão anterior gerado por `garra max-power` (gitignored; ausente em clone novo — use `TODO.md`).
-- `docs/adr/` — 15 ADRs (0001-0015), todas Accepted; índice em `docs/adr/README.md`.
+- `docs/adr/` — 16 ADRs (0001-0016), todas Accepted; índice em `docs/adr/README.md`.
 - OWASP ASVS L2, LGPD arts. 46-49, GDPR arts. 25/32/33, OpenTelemetry spec, RFC 9457 Problem Details, RFC 8446 TLS 1.3, RFC 9106 Argon2.

--- a/TODO.md
+++ b/TODO.md
@@ -12,6 +12,42 @@ curtos para a próxima sessão autônoma.
 > históricas abaixo são registro da época, não estado atual. IDs `GAR-xxx`
 > permanecem como identificadores históricos.
 
+## Concluído em 2026-09-02 (Fase 0 Garra Mobile + fix Dependabot Updates)
+
+- **Fix dos runs falhando do Dependabot Updates (#281-283)**: entradas
+  `docker`/`docker-compose` apontando para `/deploy/docker` (que nunca
+  existiu no repo público — layout do privado) removidas do
+  `.github/dependabot.yml`; bumps `futures 0.3.34` + `toml 1.1.5`
+  pré-aplicados à mão para contornar o bug upstream dependabot-core
+  [#12487](https://github.com/dependabot/dependabot-core/pull/12487)
+  (VersionResolver vs LockfileUpdater em workspaces).
+- **Fase 0 Garra Mobile Local ([ADR 0016](docs/adr/0016-mobile-termux-local-first.md))**
+  na v0.3.6: job `build-android-arm64` no `release.yml` (bionic
+  `aarch64-linux-android` via cargo-ndk; openssl vendido; asset
+  `garraia-android-aarch64` aditivo, regra 15); branch Termux no
+  `install.sh` + suíte `tests/install_sh/detect_platform.sh`; braço
+  `("android", "aarch64")` no `garra update`; `garra doctor` novo
+  subcomando (sysexits 0/2/65, `--json`/`--strict`, probe SSRF-vetado);
+  `llamacpp` keyless wired no CLI (chat/ask/set-model) e no bootstrap do
+  gateway (lockstep `provider_key_env`).
+- **Fix shellcheck herdado de #904**: a prosa "# shellcheck list of the
+  installer job" em `tests/install_sh/detect_platform.sh` era parseada
+  como diretiva (SC1073/SC1072) e derrubava o job Install.sh shellcheck
+  no `main` desde 2026-09-02T17:01Z.
+
+### Próximos passos (Fase 0 → v1)
+
+1. **Release v0.3.6** — validar o job `build-android-arm64` via
+   `workflow_dispatch` antes da tag; tag + GH release com o asset android +
+   `.sha256`; **publish manual do site na Lovable é passo do dono** (regra
+   17 — o merge não muda o que garraia.org serve).
+2. **Aparelho real** (dono): Termux → `curl install.sh | bash` →
+   `garraia doctor` → `garraia chat` na cloud/LAN; depois da tag,
+   `garraia update` dentro do Termux.
+3. **v1 — companion Kotlin/Compose** (ADR 0016): RUN_COMMAND +
+   `allow-external-apps`, cap 100KB no PENDING_INTENT, detecção do fork
+   Play, foreground service.
+
 ## Concluído em 2026-09-02 (auditoria docs ↔ código)
 
 - **Reconciliação de `README.md`, `ROADMAP.md` e `TODO.md` com `main@v0.3.5`**:

--- a/docs/adr/0016-mobile-termux-local-first.md
+++ b/docs/adr/0016-mobile-termux-local-first.md
@@ -1,0 +1,137 @@
+# 16. Garra Mobile — Termux como camada de execução (local-first no Android)
+
+- **Status:** Accepted
+- **Deciders:** @michelbr84 + Claude (sessão 2026-09-02)
+- **Date:** 2026-09-02
+- **Tags:** mobile, android, termux, local-first, installers, llm-providers
+- **Supersedes:** none
+- **Superseded by:** none
+- **Links:**
+  - ROADMAP: §4.5 Garra Mobile Local (Termux → nativo)
+  - Antecedentes: ADR 0001 (inference backend), ADR 0015 (toolchain de pacotes/regra 15 de assets), ADR 0004 (storage), `docs/security/threat-model.md` §5.6 (SSRF guard)
+  - Implementação Fase 0: job `build-android-arm64` no `release.yml`; branch Termux no `install.sh` + suíte `tests/install_sh/detect_platform.sh`; `garra doctor` + provider `llamacpp` no `garraia-cli`; asset `garraia-android-aarch64`
+
+---
+
+## Context and Problem Statement
+
+O Garra existe em desktop (CLI + Tauri) e num app Flutter (`apps/garraia-mobile`)
+que é **cliente** do gateway — exige um servidor rodando em algum lugar e rede.
+O dono do projeto quer o Garra como assistente **no próprio Android**: executar
+localmente no aparelho, conversar com uma LLM que pode estar (a) na nuvem, (b)
+na LAN do PC/LAN-serve, ou (c) — futuramente — no próprio dispositivo. Sem
+dependência de "deixar o PC ligado", sem pagar runtime de terceiros, e sem
+abandonar a base Rust existente.
+
+A pergunta arquitetural: **como executar o core Rust no Android em gerações,
+sem reescrever Termux nem adotar um fork fragmentado do ecossistema Android?**
+
+## Decision Drivers
+
+1. **★★★★★ Nunca recriar um Termux** — bootstrap/compiladores/`pkg`/W^X
+   liberado é ecossistema mantido por outras pessoas; usar, não duplicar.
+2. **★★★★★ Core agnóstico de capabilities** — o core Rust nunca fala com API
+   Android diretamente; capabilities (notificação, storage, camera) entram por
+   camadas acima (Termux hoje, RUN_COMMAND no v1, JNI no v2, APIs nativas no v3).
+3. **★★★★★ Bionic dinâmico, musl proibido** — musl estático quebra DNS no
+   Android (`/etc/resolv.conf` inexistente; resolver interno do musl não passa
+   pelo `dnsproxyd`; `LD_PRELOAD` não intercepta binário estático). Todo target
+   Android usa `aarch64-linux-android` via NDK.
+4. **★★★★ LLM externa opcional desde o dia 1** — o CLI já aceita
+   OpenAI-compatible em `--base-url` (llama.cpp/LM Studio/vLLM/Ollama na LAN) e
+   providers cloud; nada na Fase 0 depende de inferência no aparelho.
+5. **★★★ Canais separados do core** — Telegram/Discord/etc. são wiring do
+   gateway; no mobile eles podem nem subir (o doctor reporta, não impede).
+6. **★★★ Assets aditivos (regra 15)** — `garraia-android-aarch64` entra ao lado
+   dos crus existentes; `garra update` resolve por nome exato.
+
+## Considered Options
+
+| Opção | Avaliação |
+|---|---|
+| **v0: Termux + binário bionic dedicado (escolhida)** | Compila hoje sem mudança de código no core (recon 2); distribuição por `curl install.sh \| bash` funciona de fábrica no Termux oficial (bootstrap traz curl/bash/tar/xz/sha256sum; ELF em `$PREFIX/bin` executa — W^X não se aplica no SDK 28); custo = um job de CI e um branch no installer. |
+| Flutter app como runtime (executar LLM no app) | `apps/garraia-mobile` é cliente HTTP; hospedar o core dentro do Flutter exigiria FFI imediato + distribuição de binário no APK (Play proíbe download de código executável). Pula a distância toda de uma vez. |
+| Termux + compilar no aparelho (`pkg install rust`) | rustc 1.97 + rust-std-android existem no Termux, mas o phantom process killer mata builds paralelos longos; não é canal de distribuição, é fallback de emergência. |
+| musl estático "universal" | Violação direta do driver 3 (DNS quebra). Proibido neste contexto. |
+| PWA / WebView local | Sem execução de binário nativo; não atende "executar o core no aparelho". |
+
+## Decision Outcome
+
+**Quatro gerações, cada uma entregável isoladamente:**
+
+- **v0 (Fase 0, esta ADR — release v0.3.6):** binário full
+  `aarch64-linux-android` (bionic, `cargo-ndk -t arm64-v8a -p 21`) com openssl
+  vendido; asset `garraia-android-aarch64`; branch Termux no `install.sh`
+  (`$TERMUX_VERSION` ou `$PREFIX` *com.termux* → default `$PREFIX/bin`, skip do
+  preflight glibc, notice de phantom process killer/bateria); `garra update`
+  resolve o asset no Android; `garra doctor` como passo de onboarding;
+  `llamacpp` wired no CLI como segundo provider keyless local.
+- **v1 — Companion Kotlin/Compose (app novo, decisão do dono):** o app declara
+  `com.termux.permission.RUN_COMMAND` + `<queries>` com.termux; exige
+  `allow-external-apps=true` (setup guiado); stdout/exit via
+  `RUN_COMMAND_PENDING_INTENT` (cap 100KB); detecta o fork do Play do Termux
+  (sem RUN_COMMAND) e degrada com aviso; foreground service para "Always On".
+  O código sobrevive até o v2.
+- **v2 — Híbrido JNI:** core como `cdylib` no APK via NDK; app assume
+  capabilities do Termux (notificação, storage, location); distribuição:
+  F-Droid (download de runtime com opt-in explícito) ou Play com jniLibs
+  embutidos — **nunca** download de executável no Play.
+- **v3 — Nativo:** sem Termux; capabilities 100% Android (CameraX,
+  LocationManager, NotificationManager); descoberta LAN com permissões
+  (`NEARBY_WIFI_DEVICES` hoje; `ACCESS_LOCAL_NETWORK` blocked-by-default
+  targetSdk 37+ ~2027) — entrada manual de URL é UX primária desde o dia 1.
+
+### Decisões de Fase 0 e rationale
+
+- **Binário FULL com openssl vendido** em vez de feature-gating channels/
+  telemetry: zero mudança de código no core (recon 2 confirmou que
+  `wasmtime` e `aws-sdk-s3` NÃO estão no grafo do binário; os C-deps
+  rusqlite/sqlite-vec compilam com CC/AR do NDK). Feature-gate/pin `ring`
+  fica para a Fase 1 como otimização — tocar no provider TLS é mudança
+  crypto no binário desktop inteiro.
+- **`garra doctor`** (sysexits 0/2/65, `--json`/`--strict`) como passo 2 do
+  onboarding (`install.sh` → `doctor` → `chat`): sobrevive a config
+  ausente/não-parseável, reporta plataforma (com detecção Termux), dirs,
+  config (reuso de `run_check`), fonte de credencial presence-only e probe
+  TCP vetado por `garra_common::ssrf` (`IpScope::AllowPrivate` — o alvo
+  local é legítimo, mas link-local/CGNAT/multicast continuam bloqueados,
+  regra 14). Probes são diagnóstico e nunca afetam o exit code.
+- **`llamacpp` keyless no CLI e no gateway** (`http://localhost:8080`):
+  llama-server é o daemon local natural de quem já tem a LLM na LAN via
+  OpenAI-compatible; mirroring do ollama arm mantém `config check` truthful
+  (lockstep `provider_key_env`).
+
+### Consequences
+
+- **Positivas:** execução local no Android já na v0.3.6 sem tocar no core;
+  trilho de migração explícito que reaproveita cada camada (v0 binário → v1
+  app → v2 lib → v3 nativo); regra 15 intacta; o guard SSRF é o mesmo do
+  desktop.
+- **Negativas / assumidas:**
+  - OpenSSL vendido alonga o job android (minutos extras; aceitável).
+  - Fork do Play do Termux **removeu** RUN_COMMAND e tem W^X diferente — a
+    v1 detecta e degrada; a Fase 0 não funciona nele de forma oficial (o
+    usuário pode instalar o Termux F-Droid/GitHub ao lado).
+  - Phantom process killer + gestão de bateria matam processos longos em
+    background — o installer imprime o notice; o "Always On" real chega no
+    v1 (foreground service). `garra start -d` (fork/setsid, `cfg(unix)`)
+    funciona dentro do Termux.
+  - Android 16/17 (LNP) restringem scan de LAN — port-probe nunca foi o
+    caminho (nenhum servidor LLM anuncia mDNS); URL manual + `--base-url`
+    é a UX primária.
+  - Sem assinatura de código (mesmo status do resto da matriz; integridade
+    via `SHA256SUMS`).
+  - `garraia-android-aarch64` é best-effort (job fora do `if:` de gate do
+    `release.yml`, padrão needs-mas-fora-do-`if:`, `continue-on-error`
+    proibido).
+
+---
+
+## Amendment 2026-09-02 — distribuição e o site
+
+O `install.sh` servido por `garraia.org` é cópia estática sincronizada do
+`main` deste repo (regra 17): o cron de sync roda no repo do site, mas o
+**publish na Lovable é manual**. O merge deste ADR + branch Termux não muda
+o que `irm https://garraia.org/install.sh` serve até o publish do dono. Até
+lá, o Termux resolve o script pelos mirrors diretos (GitHub release CDN,
+raw, jsDelivr) documentados no README.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -55,6 +55,7 @@ Rationale curta ("porque sim") é sinal de que a decisão não deveria ser ADR �
 | [0013](0013-scheduling-two-tier-recurrence.md) | Recorrência de agendamento em duas camadas (cron no SQLite pessoal + RRULE no workspace) | ✅ accepted | 2026-08-29 | plan 0355 |
 | [0014](0014-anthropic-messages-shim.md) | Superfície Anthropic-compatible no gateway (`POST /v1/messages`) | ✅ accepted | 2026-08-30 | plan 0360 |
 | [0015](0015-linux-packaging-toolchain.md) | Toolchain de empacotamento Linux (nfpm `.deb`/`.rpm` + appimagetool AppImage) | ✅ accepted | 2026-08-31 | plan 0361 |
+| [0016](0016-mobile-termux-local-first.md) | Garra Mobile — Termux como camada de execução (local-first no Android, gerações v0-v3) | ✅ accepted | 2026-09-02 | ADR + release v0.3.6 |
 
 Legenda: ✅ accepted · 📋 proposed (aguardando execução) · 🔒 blocked (issue Linear aguardando este ADR ser escrito).
 


### PR DESCRIPTION
## O que

PR B4 do plano Garra Mobile — a documentação da decisão (regra 8) e a
sincronização dos docs irmãos.

### ADR 0016 — `docs/adr/0016-mobile-termux-local-first.md`

- Contexto: executar o core Rust no Android, local-first, LLM opcional
  (cloud / LAN / futura no-aparelho).
- Drivers: nunca recriar um Termux; core agnóstico de capabilities;
  **bionic dinâmico obrigatório, musl proibido** (quebra DNS); LLM
  externa desde o dia 1; canais separados do core; assets aditivos.
- Gerações: **v0** Termux + installer (esta release, v0.3.6) → **v1**
  companion Kotlin/Compose via RUN_COMMAND → **v2** híbrido JNI (cdylib
  no APK) → **v3** nativo (capabilities 100% Android).
- Riscos documentados: fork Play do Termux (sem RUN_COMMAND), phantom
  process killer/bateria, LNP Android 16/17, sem code-signing.
- Amendment: distribuição do install.sh pelo site (regra 17) — publish
  manual na Lovable é passo do dono.

### Sync dos irmãos

- `docs/adr/README.md`: índice com 16 ADRs.
- `ROADMAP.md`: nova **§4.5 Garra Mobile Local (Termux → nativo)**
  (4.3/4.4 já ocupados), item 9 do §7 apontando a validação em aparelho
  real, §8 com a contagem de ADRs.
- `TODO.md`: seção "Concluído em 2026-09-02 (Fase 0 Garra Mobile + fix
  Dependabot Updates)" + próximos passos (release v0.3.6, aparelho
  real, v1).
- `CHANGELOG.md`: `[Unreleased]` com os 3 entregáveis da Fase 0.
- `README.md` + `README.pt-BR.md`: seção **"Install on Android
  (Termux)"** com o fluxo `pkg install curl` → `curl | bash` → `doctor`
  → `chat`, aviso de fork Play, wakelock/phantom process killer, e a
  contagem de assets atualizada (`garraia-android-aarch64` best-effort).
- `CLAUDE.md`: contagem de ADRs 15 → 16.

Sem mudança de código neste PR (o fix do shellcheck que derruba o
estaleiro do `main` desde o merge de #904 está no PR #905).

Co-Authored-By: Claude Code <noreply@anthropic.com>