### PR TITLE
chore(release): v0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.6] - 2026-09-02
+
 ### Added
 - **Garra no Android (Termux) — Fase 0 do Garra Mobile Local
   ([ADR 0016](docs/adr/0016-mobile-termux-local-first.md)).** Novo asset

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3187,7 +3187,7 @@ dependencies = [
 
 [[package]]
 name = "garraia"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -3233,7 +3233,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-agents"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "axum",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-auth"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-channels"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "axum",
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-common"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-config"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "dirs 6.0.0",
  "garraia-common",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-db"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-desktop"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "serde",
  "serde_json",
@@ -3391,7 +3391,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-embeddings"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "serde",
@@ -3405,7 +3405,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-gateway"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3491,7 +3491,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-learning"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "garraia-common",
  "garraia-skills",
@@ -3505,7 +3505,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-media"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "base64 0.23.1",
  "bytes",
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-plugins"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3555,7 +3555,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-security"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "base64 0.23.1",
  "garraia-common",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-skills"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "garraia-common",
  "reqwest 0.12.28",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-storage"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3611,7 +3611,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-telemetry"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "axum",
@@ -3647,7 +3647,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-voice"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3661,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-workspace"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.5"
+version = "0.3.6"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/michelbr84/GarraRUST"


### PR DESCRIPTION
## Resumo

Bump da versão do workspace **0.3.5 → 0.3.6** e cristalização do CHANGELOG, conforme `docs/releasing.md` §1.

- `Cargo.toml`: `version = "0.3.6"`
- `Cargo.lock`: regenerado via `cargo check` (19 crates do workspace), nunca à mão
- `CHANGELOG.md`: conteúdo de `[Unreleased]` vira `[0.3.6] - 2026-09-02` (data narrativa Florida) + `[Unreleased]` vazio reaberto

## Conteúdo da v0.3.6

| Entrega | Fonte |
|---|---|
| Garra no Android via Termux — Fase 0 do Garra Mobile Local ([ADR 0016](docs/adr/0016-mobile-termux-local-first.md)): asset best-effort `garraia-android-aarch64`, branch Termux no `install.sh`, braço `("android", "aarch64")` no `garra update`, suíte `detect_platform.sh` | #903, #904 |
| `garra doctor` — diagnóstico em 4 seções com `--json`/`--strict` e sysexits 0/2/65 | #905 |
| Provider `llamacpp` keyless wired no CLI e no gateway | #905 |
| Fix do Dependabot Updates #281–283 (remoção `/deploy/docker` + pré-aplicação de futures 0.3.34 e toml 1.1.5) | #902 |

## Pós-merge (runbook §2)

1. `gh workflow run release.yml -f version=v0.3.6` — dispatch valida o job novo `build-android-arm64` **e** publica a release com o asset `garraia-android-aarch64` + `.sha256`
2. Dispatch manual do `deploy.yml` (imagem ghcr)
3. Publish manual do site na Lovable (regra 17 — passo do dono)

🤖 Generated with [Claude Code](https://claude.com/claude-code)