### PR TITLE
fix(ci): pina cargo-ndk 3.5.0 no job android

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,7 +265,12 @@ jobs:
           echo "ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/${ANDROID_NDK_VERSION}" >> "$GITHUB_ENV"
 
       - name: Install cargo-ndk
-        run: cargo install cargo-ndk --locked
+        # Pinado na 3.5.0: a partir da 4.x o `-p` passou a significar
+        # `--package` (seleção de pacote Cargo) e não mais `--platform`
+        # (API level Android) — na 4.1.2 o build do job morre em panic
+        # "unknown package: 21". Na 3.5.0, `-p/--platform <N>` é o API
+        # level que o comando abaixo espera.
+        run: cargo install cargo-ndk --locked --version 3.5.0
 
       - name: Build release
         # -p 21: platform/minSdkLevel 21 — baseline android do rustc e abaixo


### PR DESCRIPTION
## Resumo

O job `build-android-arm64` falhou no primeiro dispatch real (release v0.3.6, run 33685326475):

```
error: cargo-ndk panicked! Generating report...
message: unknown package: 21
args: ["cargo-ndk", "ndk", "-t", "arm64-v8a", "-p", "21", "--", "build", "--release", "--package", "garraia"]
```

## Causa raiz

Na série 4.x do cargo-ndk (4.1.2 instalado pelo `cargo install cargo-ndk --locked`), o flag `-p` mudou de `--platform` (API level Android) para `--package` (seleção de pacote Cargo). O valor `21` foi parar no resolvedor de pacotes → panic `unknown package: 21`.

## Fix

Pin: `cargo install cargo-ndk --locked --version 3.5.0` — na 3.5.0, `-p/--platform <N>` mantém a semântica de API level (minSdk 21, baseline do rustc android e abaixo do mínimo do Termux atual).

## Impacto

Zero no publish da v0.3.6: o `if` do job `release` exige apenas os builds x86_64 (best-effort documentado). Com o pin mergeado, um re-dispatch de `release.yml -f version=v0.3.6` reprocessa os builds e o softprops atualiza a release com o asset `garraia-android-aarch64` + `.sha256`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)