### PR TITLE
chore(release): v0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,87 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.7] - 2026-09-03
+
+Retorno de campo da Fase 0 do Garra Mobile: cinco issues (#909-#913) abertas
+por um usuario rodando a v0.3.6 num Samsung A16 / Android 13 / Termux, com o
+Garra em producao orquestrado por outro agente via MCP. Detalhes e rationale
+no Amendment 2026-09-03 da
+[ADR 0016](docs/adr/0016-mobile-termux-local-first.md).
+
+### Fixed
+- **Filhos MCP no Termux nao ficam mais orfaos (#913).**
+  `apply_parent_death_signal` estava sob `#[cfg(target_os = "linux")]`, e em
+  Rust `target_os = "android"` **nao** e coberto por isso — embora o bionic
+  exponha o mesmo `prctl(PR_SET_PDEATHSIG)`. Na pratica, todo servidor MCP
+  filho spawnado dentro do Termux sobrevivia a morte abrupta do gateway
+  (`crates/garraia-agents/src/mcp/manager.rs`).
+- **Servidores MCP npm/pip voltam a executar no Termux (#913).** No Android o
+  exec de ELF resolve atraves do shim termux-exec; um host que spawna o
+  gateway com ambiente filtrado (`env -i PATH=... HOME=...`) remove
+  `LD_PRELOAD`, e a partir dai todo filho que e script npm/pip morre no
+  shebang `/usr/bin/env node` — caminho que o Termux nao tem. O novo
+  `termux_ld_preload` injeta o shim nos filhos sob `cfg(target_os =
+  "android")`, sem nunca sobrescrever um `LD_PRELOAD` do config do servidor
+  nem herdado do processo, e exigindo o shim de fato instalado
+  (`pkg install termux-exec`).
+
+### Added
+- **Wrapper `garra-mcp-server` para hosts MCP externos (#909).** Quando um
+  host spawna `garraia mcp-server` com ambiente filtrado, o exec falha
+  **antes** de o processo existir — nenhuma correcao dentro do binario
+  alcanca o caso. O `install.sh` passa a escrever
+  `$PREFIX/bin/garra-mcp-server` no ramo Android: um wrapper que exporta o
+  shim (quando instalado) e faz exec do CLI. Aponte o host para ele em vez de
+  `garraia mcp-server`. Shebang com caminho absoluto do Termux de proposito —
+  `/usr/bin/env` nao existe la. Arquivo novo e aditivo: nenhum asset de
+  release e tocado.
+- **Bloco Termux acionavel no `garra doctor` (#909/#911/#913).** Sete
+  verificacoes com o passo seguinte de cada item que falta: trust store TLS em
+  uso, `SSL_CERT_FILE` (cobrado apenas quando ha Postgres configurado,
+  detectado por presenca de env var e nunca pelo valor), termux-exec,
+  `LD_PRELOAD` herdado, wrapper MCP instalado e `$PREFIX/bin` no PATH. So
+  aparece dentro do Termux e nao altera exit code — diagnostico nao e
+  veredito.
+
+### Changed
+- **Job `android` no CI, e o alvo deixa de quebrar so na tag.** Ate aqui
+  `aarch64-linux-android` era compilado apenas no `release.yml`, entao uma
+  quebra do target so aparecia **depois** de a tag ser empurrada — foi assim
+  que o bug do cargo-ndk 4.x (`-p` deixou de ser `--platform` e virou
+  `--package`) derrubou o job android da v0.3.6. O job novo roda
+  `cargo ndk check` em cada PR.
+- **Guarda contra `rustls-platform-verifier` no grafo Android (#911).** Esse
+  crate entra em panic fora da JVM (`Expect rustls-platform-verifier to be
+  initialized`, `android.rs:90`), e num binario standalone do Termux nao
+  existe Context Java nenhum. Hoje ele fica fora do grafo do `garra` por
+  acidente feliz de features — o `reqwest 0.13` que o traz so ativa a feature
+  `rustls` via `tauri-plugin-updater`, e `garraia-desktop` nunca e buildado
+  para Android. Um bump que ative essa feature em qualquer ponto do grafo do
+  CLI quebraria **todo** o HTTPS no Termux em runtime, silenciosamente; a
+  guarda e o alarme. (Registrando o corolario: todo o HTTPS do `garra` usa
+  webpki-roots compilados no binario, entao `SSL_CERT_FILE` nao afeta esse
+  trafego — a excecao e TLS de Postgres, via `sqlx`/native-roots.)
+- **Sonda de endpoints valida o frescor do `install.sh` servido (#910).** Dois
+  modos de falha ja derrubaram a rota publica do instalador (HTML da home em
+  HTTP 200; depois 404 puro). Este e o terceiro e o unico que passava em todas
+  as guardas existentes: o endpoint existe, responde 200, tem shebang, parseia
+  em `sh -n` — e esta velho. O `install-endpoints.yml` passou a checar um
+  marcador de frescor no corpo servido.
+- **Asset Android ausente virou `::error` no `release.yml`.** O job segue
+  best-effort e a release nao aborta, mas a consequencia nao e "um download a
+  menos": o `install.sh` resolve `garraia-android-aarch64` por nome exato,
+  entao uma tag sem o asset quebra a instalacao no Termux por completo.
+- **Documentacao Termux ponta a ponta (#912).** `docs/installation.md` — o doc
+  canonico, para onde o README aponta — nao tinha uma unica mencao a Android
+  ou Termux. Ganhou `### Android (Termux)` no Quick Install, a linha que
+  faltava na tabela de assets, `### Build on Termux (fallback)` com o override
+  de LTO (o `[profile.release]` usa `lto = true`, e num aparelho intermediario
+  o linker e morto por OOM com um `Signal 9` pelado, sem nada apontando para
+  memoria) e tres secoes de troubleshooting. `docs/mcp.md` e
+  `docs/cli-mcp-server.md` cobrem as duas direcoes de MCP, que sao problemas
+  distintos com correcoes distintas.
+
 ## [0.3.6] - 2026-09-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3187,7 +3187,7 @@ dependencies = [
 
 [[package]]
 name = "garraia"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -3233,7 +3233,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-agents"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "async-trait",
  "axum",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-auth"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-channels"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "async-trait",
  "axum",
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-common"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-config"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "dirs 6.0.0",
  "garraia-common",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-db"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-desktop"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -3391,7 +3391,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-embeddings"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "async-trait",
  "serde",
@@ -3405,7 +3405,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-gateway"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3491,7 +3491,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-learning"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "garraia-common",
  "garraia-skills",
@@ -3505,7 +3505,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-media"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "base64 0.23.1",
  "bytes",
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-plugins"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3555,7 +3555,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-security"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "base64 0.23.1",
  "garraia-common",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-skills"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "garraia-common",
  "reqwest 0.12.28",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-storage"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3611,7 +3611,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-telemetry"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "axum",
@@ -3647,7 +3647,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-voice"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3661,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-workspace"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.6"
+version = "0.3.7"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/michelbr84/GarraRUST"

--- a/TODO.md
+++ b/TODO.md
@@ -54,14 +54,27 @@ tema. Detalhes e rationale no Amendment 2026-09-03 da `docs/adr/0016-mobile-term
   troubleshooting; `docs/mcp.md` e `docs/cli-mcp-server.md` cobrem as duas
   direções de MCP; wiki pt-BR e `docs/index.md` atualizados.
 
+- **Sonda de endpoints rodada, e o diagnóstico de #910 corrigido.** Eu havia
+  atribuído o relato a um `install.sh` estale servido pelo `garraia.org`. Está
+  errado: o `public/install.sh` do repo do site já tem o ramo Termux, e o run
+  manual do `install-endpoints.yml` em `46fe0ff` (o primeiro com a guarda de
+  frescor) passou nos 8 endpoints — *"Todos os endpoints de instalação servem o
+  script correto"*. A timeline fecha contra a hipótese: o site foi atualizado
+  2026-09-03 00:23Z e a issue foi aberta 14:47Z. Explicação provável: o
+  repórter testou antes de a v0.3.6 ser publicada (22:13Z do dia anterior), o
+  que bate com ele descrever o binário em uso como build própria com NDK r27d.
+  Correção postada em #910.
+
 ### Próximos passos
 
 1. Validar em aparelho real (só o dono tem o Samsung A16): `install.sh` →
    `garraia doctor` → `garra-mcp-server` sob host MCP com env filtrado.
-2. Republicar o site no Lovable e disparar o `install-endpoints.yml` manualmente
-   para confirmar que o `garraia.org/install.sh` deixou de estar estale.
-3. Cortar a v0.3.7 com o wrapper e a injeção de `LD_PRELOAD` (a doc já os
-   referencia por essa versão).
+2. Fechar #910 quando o repórter confirmar a instalação, e #911 (não se aplica
+   ao binário `garra`; o job `android` do `ci.yml` mantém o invariante).
+3. Nota de manutenção: o `install.ps1` servido pelo `garraia.org` está ~700
+   chars atrás do `main` (a nota de paridade da regra 16 que entrou no #914).
+   É comentário, não comportamento — o sync diário resolve. Se quiser antes,
+   é um publish manual no Lovable.
 
 ## Concluído em 2026-09-02 (Fase 0 Garra Mobile + fix Dependabot Updates)
 


### PR DESCRIPTION
## Descrição

PR de release da **v0.3.7**, seguindo `docs/releasing.md` §1. Escopo: os 7 commits em `main` além da tag `v0.3.6`, todos do PR #914 (Termux hardening, issues #909–#913).

O motivo de cortar agora não é cosmético. A injeção de `LD_PRELOAD` vive no binário (`crates/garraia-agents/src/mcp/manager.rs`), então **só chega ao usuário por release** — o wrapper `garra-mcp-server` se propaga pelo `install.sh` nos mirrors raw/jsDelivr, mas a parte que corrige o spawn de servidores MCP npm/pip no Termux, não. E três documentos já dizem "from `v0.3.7`" (`docs/cli-mcp-server.md:242`, `docs/installation.md:610`, `docs/mcp.md:176`): hoje são promessas.

**Commit `chore(release)` toca exatamente os 3 arquivos canônicos**, no mesmo padrão de `662ff36` (v0.3.6) e `9b13c6a` (v0.3.5) — conferi que as duas anteriores têm as mesmas contagens:

| Arquivo | Mudança |
|---|---|
| `Cargo.toml:29` | `0.3.6` → `0.3.7` (única edição manual de versão) |
| `Cargo.lock` | 38 linhas, 19 entradas `garraia*` — gerado por `cargo check`, nunca à mão |
| `CHANGELOG.md` | seção `## [0.3.7] - 2026-09-03` |

O segundo commit (`docs(todo)`) fica fora do commit de release de propósito, para ele não sair dos 3 arquivos.

### `[Unreleased]` estava vazio

Ao contrário do que o runbook §1.3 supõe ("mover o conteúdo de `[Unreleased]`"), nenhum dos 7 commits pós-tag tocou o `CHANGELOG.md`. A seção da v0.3.7 foi **escrita do zero**, no estilo da casa (bullet abre com título em negrito, depois prosa citando arquivos/jobs/ADRs). Três subseções, sem `### Security`.

### Correção de diagnóstico em #910

Eu havia atribuído o relato a um `install.sh` estale servido pelo `garraia.org`. **Está errado**, e o segundo commit registra isso. Disparei o `install-endpoints.yml` em `46fe0ff` — o primeiro run com a guarda de frescor que entrou no #914 — e os 8 endpoints passaram:

```
##[group]garraia.org/install.sh
OK — HTTP 200, assinatura #!/bin/sh
...
Todos os endpoints de instalação servem o script correto.
```

O `public/install.sh` do repo do site também já tem o ramo Termux. A timeline fecha contra a hipótese: site atualizado 2026-09-03 00:23Z, issue aberta 14:47Z. Correção já postada em #910.

Refs #909, #910, #911, #912, #913

## Tipo de mudança

- [x] `chore`: Manutenção (deps, CI, build)
- [x] `docs`: Documentação apenas

## Classe de Risco

- [x] **Classe A (Baixo Risco)**: Documentação, comentários, formatação, bumps de dependências de desenvolvimento sem impacto em tempo de execução.

Bump de versão + changelog + TODO. Nenhuma mudança de código, schema, API ou CI.

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo fmt --check` executado e limpo
- [x] `cargo clippy` — sem código novo; o CI cobre
- [x] `cargo check --workspace --exclude garraia-desktop` (é o que regenera o lock)
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo, API key, token ou credencial commitada
- [x] Nenhuma migração Postgres

## Mudanças na API pública e Schema

- Nenhuma. O `--version` do binário passa a reportar `0.3.7`.
- **Não** foram tocados (verificado): `tauri.conf.json` (não tem campo `version`; Tauri 2 herda do workspace), `apps/garraia-mobile/pubspec.yaml` (versionamento independente, `0.2.1+2`), `tests/package.json`, `SHA256SUMS` da raiz. As ~25 ocorrências de `0.3.6` em README/ROADMAP/docs são prosa histórica ("a partir da v0.3.6…"), permanentemente verdadeiras.

## Como testar

```bash
grep -n '^version' Cargo.toml                        # 0.3.7
grep -B1 'version = "0.3.6"' Cargo.lock | grep -c 'garraia'   # 0
head -12 CHANGELOG.md                                # [Unreleased] vazio, [0.3.7] logo abaixo
cargo +1.95 fmt --all -- --check                     # limpo

# a guarda de #911 continua silenciosa
cargo tree -p garraia --target aarch64-linux-android --edges normal --locked \
  | grep -c rustls-platform-verifier                 # 0
```

## Plano de Rollback

Antes da tag: reverter os dois commits, ou fechar o PR. Nada foi publicado ainda.

Depois da tag, o runbook é explícito e vale repetir: **nunca reutilizar a tag**. Apagar Release + tag (`git push origin :refs/tags/v0.3.7`), corrigir por PR, cortar `v0.3.8`.

## Depois do merge (fora deste PR)

1. `git tag v0.3.7 <sha> && git push origin v0.3.7` — **por push, não por `workflow_dispatch`**: tag criada pelo dispatch nasce do `GITHUB_TOKEN` e não dispara workflows de tag-push, o que deixaria o `deploy.yml` (imagem ghcr) órfão.
2. Vigiar o `build-android-arm64`. Ele é best-effort (está em `needs:` mas fora do `if:` de gate) e uma release sem `garraia-android-aarch64` quebra a instalação no Termux por completo — o `install.sh` resolve esse nome exato. Graças ao #914 a ausência agora emite `::error` visível.
3. `docs/releasing.md` §4 — os 7 passos de verificação.

⚠️ Nota apurada: **nada valida que a versão do `Cargo.toml` bate com a tag.** Empurrar `v0.3.7` sem este PR mergeado produziria binários que reportam `0.3.6` em `--version`, sem nenhum job falhar. Por isso este PR vem primeiro.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhgYfAhUrE3zUA6if87eKh

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhgYfAhUrE3zUA6if87eKh)_