### PR TITLE
fix(gateway): tira o download do npm do caminho crítico do boot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -894,6 +894,13 @@ jobs:
       - name: Start gateway in background
         env:
           GARRAIA_CONFIG_DIR: /tmp/garraia-e2e
+          # O boot provisiona um MCP `npx -y @modelcontextprotocol/server-filesystem`
+          # quando mcp.json nao existe — e aqui nunca existe, porque o config dir
+          # e novo a cada run. O `-y` baixa do npm na primeira execucao, DENTRO do
+          # orcamento de 30s abaixo. Foi assim que este passo caiu na main em
+          # 6f4ec06 (~36s ate o timeout). O e2e nao exercita MCP, entao o start
+          # nao deve depender da rede.
+          GARRAIA_DISABLE_MCP_AUTOPROVISION: "1"
         run: |
           # Loopback, not 0.0.0.0: both jobs reach the gateway via
           # http://localhost:3888 on this same runner, so binding every
@@ -1038,6 +1045,11 @@ jobs:
         working-directory: .
         env:
           GARRAIA_CONFIG_DIR: /tmp/garraia-test-config
+          # Mesma razao do job e2e: sem isto o boot spawna `npx -y
+          # @modelcontextprotocol/server-filesystem` e o download do npm entra
+          # no caminho critico do start. Este passo caiu por isso na main em
+          # 6f4ec06. As specs Playwright do admin nao exercitam MCP server real.
+          GARRAIA_DISABLE_MCP_AUTOPROVISION: "1"
         run: |
           # Loopback, not 0.0.0.0: both jobs reach the gateway via
           # http://localhost:3888 on this same runner, so binding every

--- a/TODO.md
+++ b/TODO.md
@@ -5,12 +5,74 @@ Status operacional do backlog do GarraIA/GarraRUST. Este arquivo complementa
 foi concluído, o que ficou parcial ou adiado, decisões tomadas e próximos passos
 curtos para a próxima sessão autônoma.
 
-**Atualizado:** 2026-09-03 (America/New_York)
+**Atualizado:** 2026-09-04 (America/New_York)
 
 > O Linear foi descontinuado em 2026-08-18; o planejamento vive no tracker
 > interno. Menções a "Done in Linear", "In Review" ou "issues Linear" nas seções
 > históricas abaixo são registro da época, não estado atual. IDs `GAR-xxx`
 > permanecem como identificadores históricos.
+
+## Em andamento 2026-09-04 — de-flake do boot do gateway (PR #916)
+
+Depois do merge do #915 (`chore(release): v0.3.7`) quatro jobs ficaram
+vermelhos na `main` em `6f4ec06`: `Test (ubuntu-latest)`, `Coverage`,
+`E2E Tests` e `Playwright E2E`, mais o `Security Gate (BOLA)`.
+
+**Não é regressão do #915** — aquele commit tocou 4 arquivos e nenhum `.rs`, e
+a árvore idêntica (`f8109bb`) passou 20/20 no PR minutos antes.
+
+**Não é flake.** O re-run (attempt 2) falhou nos mesmos quatro jobs e nos
+mesmos passos — `Start gateway` estourando 35 s duas vezes, `Run tests` e
+`Generate lcov coverage`. Isso corrige a leitura inicial: um flake seria
+intermitente; um download de npm dentro do orçamento de boot falha de forma
+consistente assim que o registry fica lento.
+
+### Causa raiz
+
+`crates/garraia-gateway/src/server.rs:97` chama
+`McpPersistenceService::provision_filesystem_if_missing()` no boot, que grava
+uma entrada MCP com `command: "npx"` e `args: ["-y",
+"@modelcontextprotocol/server-filesystem", …]`. O boot seguinte spawna esse
+servidor, e o `-y` **baixa o pacote do npm na primeira execução** — dentro do
+caminho crítico do start.
+
+O `projects_test.rs` faz `config.mcp.clear()` justamente para não depender de
+MCP; o provisionamento desfazia isso pelas costas, gravando no config dir
+temporário do próprio teste.
+
+### Correções (PR #916)
+
+1. Opt-out `GARRAIA_DISABLE_MCP_AUTOPROVISION` em
+   `provision_filesystem_if_missing()`, cobrindo os dois call sites
+   (`server.rs:97` e `state.rs:219`), + 3 unit tests.
+2. `GARRAIA_DISABLE_MCP_AUTOPROVISION=1` nos passos "Start gateway" do
+   `E2E Tests` e do `Playwright E2E` no `ci.yml`.
+3. Opt-out nos 5 fixtures que sobem o gateway.
+4. **Config dir isolado** em `rest_v1_me.rs` e `router_smoke_test.rs`, os dois
+   únicos que subiam o gateway sem desviar `GARRAIA_CONFIG_DIR` — liam o config
+   dir REAL do desenvolvedor (XDG: `~/.config/garraia`). O opt-out sozinho não
+   os salvava: ele impede *gravar* a entrada, não *spawnar* servidores de um
+   `mcp.json` que já exista. O `skins_test.rs` já fazia esse desvio, com o
+   comentário "Point config dir to a temp location to avoid loading real MCP
+   configs" — o problema era conhecido ali e nunca foi propagado.
+5. O fixture do `projects_test.rs` deixou de engolir o erro de `server.run()`
+   (`let _ =`) e o laço de espera passou a `panic!` com o erro de boot em vez
+   de retornar em silêncio e produzir um `ConnectionRefused` sem contexto.
+
+Medição local com o `mcp.json` poluído presente e o cache do npx frio:
+`rest_v1_me` FAILED em 40,56 s → ok em 0,27 s. Os quatro fixtures no mesmo
+pior caso: 22 testes, 0 falhas, nenhuma linha `Secure MCP Filesystem Server
+running on stdio`.
+
+### Fora de escopo, para um PR seguinte
+
+- Migrar `projects_test.rs` para `build_router_for_test` + `oneshot`
+  (`server.rs:766`, já existe sob `#[cfg(feature = "test-helpers")]`) — sem
+  socket nenhum. É a solução estrutural.
+- Reavaliar os `#[ignore]` de `auth_test.rs:71` e `gateway_integration.rs:70,82`,
+  marcados com "server.run() exits silently on startup in CI … Deferred to the
+  gateway-test-fixture follow-up PR". O #916 **é** aquele follow-up; os ignores
+  podem cair depois que a causa comum estiver corrigida na `main`.
 
 ## Concluído em 2026-09-03 (Termux hardening — issues #909-#913)
 

--- a/crates/garraia-gateway/src/mcp/persistence.rs
+++ b/crates/garraia-gateway/src/mcp/persistence.rs
@@ -12,7 +12,7 @@
 
 use std::path::{Path, PathBuf};
 
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use super::{McpConfig, McpRuntimeRegistry, is_sensitive_key};
 
@@ -69,6 +69,13 @@ impl McpPersistenceService {
         &self.path
     }
 
+    /// Env var that opts a boot out of first-run MCP provisioning.
+    ///
+    /// Set it to `1` (or any non-empty value) when the gateway must come up
+    /// without touching the network. See
+    /// [`provision_filesystem_if_missing`](Self::provision_filesystem_if_missing).
+    pub const DISABLE_AUTOPROVISION_ENV: &'static str = "GARRAIA_DISABLE_MCP_AUTOPROVISION";
+
     /// Seed `mcp.json` with a Filesystem MCP entry when the file does not exist yet.
     ///
     /// This is a first-run convenience: new installations get local filesystem
@@ -77,7 +84,39 @@ impl McpPersistenceService {
     ///
     /// The allowed root is the user's home directory (`$HOME` / `%USERPROFILE%`),
     /// falling back to the parent of `~/.garraia/` if the env var is absent.
+    ///
+    /// # Por que existe um opt-out
+    ///
+    /// A entrada provisionada roda `npx -y @modelcontextprotocol/server-filesystem`,
+    /// e o `-y` **baixa o pacote do npm na primeira execução**. Como o boot do
+    /// gateway spawna os servidores MCP logo em seguida (`build_mcp_tools`), num
+    /// ambiente de cache frio esse download entra no caminho crítico do start.
+    ///
+    /// Em CI isso já custou uma `main` vermelha: o primeiro
+    /// `start_test_gateway()` de `projects_test.rs` estourou os 30 s do laço de
+    /// espera enquanto o npm baixava, e o teste seguinte bateu numa porta
+    /// fechada com um `ConnectionRefused` que não dizia nada sobre a causa. Os
+    /// jobs `E2E Tests` e `Playwright` caíram no mesmo passo "Start gateway".
+    ///
+    /// Pior: um teste que faz `config.mcp.clear()` para se isolar de MCP tinha
+    /// esse isolamento desfeito aqui, porque a provisão grava no config dir
+    /// temporário do próprio teste.
+    ///
+    /// Por isso [`DISABLE_AUTOPROVISION_ENV`](Self::DISABLE_AUTOPROVISION_ENV):
+    /// quem sobe o gateway sabendo que não vai exercitar MCP declara isso e o
+    /// boot deixa de depender da rede. Não muda nada para o usuário final — o
+    /// default segue provisionando.
     pub fn provision_filesystem_if_missing(&self) {
+        if std::env::var_os(Self::DISABLE_AUTOPROVISION_ENV)
+            .is_some_and(|v| !v.is_empty() && v != "0")
+        {
+            debug!(
+                "mcp: auto-provisionamento desligado por {}",
+                Self::DISABLE_AUTOPROVISION_ENV
+            );
+            return;
+        }
+
         if self.path.exists() {
             return;
         }
@@ -401,5 +440,70 @@ mod tests {
         let loaded = svc.load().expect("reload");
         assert_eq!(loaded.mcp_servers.len(), 1);
         assert!(loaded.mcp_servers.contains_key("my-server"));
+    }
+
+    /// O default segue provisionando — o opt-out não pode mudar o que o
+    /// usuário final vê num primeiro boot.
+    #[test]
+    #[serial_test::serial]
+    fn provision_writes_the_filesystem_entry_by_default() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("mcp.json");
+        // SAFETY: teste serializado; ninguém mais lê esta var em paralelo.
+        unsafe { std::env::remove_var(McpPersistenceService::DISABLE_AUTOPROVISION_ENV) };
+
+        McpPersistenceService::new(&path).provision_filesystem_if_missing();
+
+        let loaded = McpPersistenceService::new(&path).load().expect("load");
+        let fs = loaded
+            .mcp_servers
+            .get("filesystem")
+            .expect("entrada filesystem provisionada");
+        assert_eq!(fs.command.as_deref(), Some("npx"));
+    }
+
+    /// Com o opt-out ligado o boot não grava nada — e portanto não spawna
+    /// `npx -y`, que baixa do npm na primeira execução. É o que mantém o start
+    /// do gateway fora da rede em CI (ver o doc de
+    /// `provision_filesystem_if_missing`).
+    #[test]
+    #[serial_test::serial]
+    fn provision_is_skipped_when_the_opt_out_is_set() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("mcp.json");
+        // SAFETY: teste serializado; ninguém mais lê esta var em paralelo.
+        unsafe { std::env::set_var(McpPersistenceService::DISABLE_AUTOPROVISION_ENV, "1") };
+
+        McpPersistenceService::new(&path).provision_filesystem_if_missing();
+
+        assert!(
+            !path.exists(),
+            "opt-out ligado deve deixar o mcp.json inexistente"
+        );
+
+        // SAFETY: idem.
+        unsafe { std::env::remove_var(McpPersistenceService::DISABLE_AUTOPROVISION_ENV) };
+    }
+
+    /// `0` e vazio são "desligado" — senão um `export VAR=` de shell viraria
+    /// opt-out acidental.
+    #[test]
+    #[serial_test::serial]
+    fn opt_out_treats_zero_and_empty_as_disabled() {
+        for value in ["0", ""] {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let path = dir.path().join("mcp.json");
+            // SAFETY: teste serializado.
+            unsafe { std::env::set_var(McpPersistenceService::DISABLE_AUTOPROVISION_ENV, value) };
+
+            McpPersistenceService::new(&path).provision_filesystem_if_missing();
+
+            assert!(
+                path.exists(),
+                "valor {value:?} nao deve contar como opt-out"
+            );
+        }
+        // SAFETY: idem.
+        unsafe { std::env::remove_var(McpPersistenceService::DISABLE_AUTOPROVISION_ENV) };
     }
 }

--- a/crates/garraia-gateway/tests/projects_test.rs
+++ b/crates/garraia-gateway/tests/projects_test.rs
@@ -53,15 +53,34 @@ async fn start_test_gateway() -> TestEnv {
     // SAFETY: we are in a test and no other threads are reading this env var yet.
     unsafe {
         std::env::set_var("GARRAIA_CONFIG_DIR", tmp.path().to_str().unwrap());
+        // O boot provisiona um MCP `npx -y @modelcontextprotocol/server-filesystem`
+        // quando mcp.json nao existe — e aqui ele nunca existe, porque o config dir
+        // e um tempdir novo. O `-y` baixa do npm na primeira execucao, o que ja
+        // estourou o orcamento de espera deste fixture em CI. Estes testes nao
+        // exercitam MCP (o config ja faz `mcp.clear()`), entao o boot nao deve
+        // depender da rede.
+        std::env::set_var(
+            garraia_gateway::mcp::McpPersistenceService::DISABLE_AUTOPROVISION_ENV,
+            "1",
+        );
         std::env::set_var(
             garraia_gateway::project_root::ROOTS_ENV,
             root.to_str().unwrap(),
         );
     }
 
+    // O erro de boot precisa sobreviver ao spawn. Antes isto era
+    // `let _ = server.run().await;`, e uma falha de start virava silêncio: o
+    // laço abaixo esgotava o orçamento, `start_test_gateway` retornava assim
+    // mesmo, e o teste morria muito depois num `ConnectionRefused` que não
+    // dizia nada sobre a causa. Foi como a `main` ficou vermelha em 6f4ec06.
+    let boot_error = std::sync::Arc::new(std::sync::Mutex::new(None::<String>));
+    let boot_error_tx = std::sync::Arc::clone(&boot_error);
     tokio::spawn(async move {
         let server = GatewayServer::new(config);
-        let _ = server.run().await;
+        if let Err(e) = server.run().await {
+            *boot_error_tx.lock().expect("boot error mutex") = Some(e.to_string());
+        }
     });
 
     // Wait for the server to actually accept TCP connections
@@ -70,6 +89,7 @@ async fn start_test_gateway() -> TestEnv {
         .build()
         .expect("build reqwest client");
 
+    let mut ready = false;
     for _ in 0..60 {
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
         if client
@@ -78,9 +98,21 @@ async fn start_test_gateway() -> TestEnv {
             .await
             .is_ok()
         {
+            ready = true;
             break;
         }
     }
+
+    // Esgotar o orçamento é falha, e falha aqui — não 40 linhas adiante.
+    assert!(
+        ready,
+        "gateway nao subiu em 30s na porta {port}. Erro de boot: {}",
+        boot_error
+            .lock()
+            .expect("boot error mutex")
+            .clone()
+            .unwrap_or_else(|| "nenhum (o start ainda estava em andamento)".to_string())
+    );
 
     TestEnv {
         base: format!("http://127.0.0.1:{port}"),

--- a/crates/garraia-gateway/tests/rest_v1_me.rs
+++ b/crates/garraia-gateway/tests/rest_v1_me.rs
@@ -30,6 +30,15 @@ fn random_port() -> u16 {
 /// is spawned, so no other thread touches the env block.
 fn clear_auth_env() {
     unsafe {
+        // O boot provisiona um MCP `npx -y @modelcontextprotocol/server-filesystem`
+        // quando mcp.json nao existe, e o `-y` baixa do npm na primeira
+        // execucao — dentro do caminho critico do start. Foi o que estourou
+        // os tres aumentos sucessivos de orcamento documentados abaixo
+        // (10s -> 20s -> 40s): o problema nunca foi o orcamento.
+        std::env::set_var(
+            garraia_gateway::mcp::McpPersistenceService::DISABLE_AUTOPROVISION_ENV,
+            "1",
+        );
         std::env::remove_var("GARRAIA_JWT_SECRET");
         std::env::remove_var("GARRAIA_REFRESH_HMAC_SECRET");
         std::env::remove_var("GARRAIA_LOGIN_DATABASE_URL");
@@ -51,9 +60,15 @@ async fn get_v1_me_fails_soft_with_503_problem_details_when_auth_unconfigured() 
     config.gateway.port = port;
     config.memory.enabled = false;
 
+    // O erro de boot precisa chegar na mensagem de panico la embaixo; sem
+    // isto o teste so diz "gateway never came up", sem o porque.
+    let boot_error = std::sync::Arc::new(std::sync::Mutex::new(None::<String>));
+    let boot_error_tx = std::sync::Arc::clone(&boot_error);
     tokio::spawn(async move {
         let server = GatewayServer::new(config);
-        let _ = server.run().await;
+        if let Err(e) = server.run().await {
+            *boot_error_tx.lock().expect("boot error mutex") = Some(e.to_string());
+        }
     });
 
     // Wait for the listener to actually bind. Gateway bootstrap pulls
@@ -94,7 +109,14 @@ async fn get_v1_me_fails_soft_with_503_problem_details_when_auth_unconfigured() 
                 let _ = err;
                 continue;
             }
-            Err(err) => panic!("gateway never came up: {err}"),
+            Err(err) => panic!(
+                "gateway never came up: {err}. Erro de boot: {}",
+                boot_error
+                    .lock()
+                    .expect("boot error mutex")
+                    .clone()
+                    .unwrap_or_else(|| "nenhum (start ainda em andamento)".to_string())
+            ),
         }
     };
 

--- a/crates/garraia-gateway/tests/rest_v1_me.rs
+++ b/crates/garraia-gateway/tests/rest_v1_me.rs
@@ -28,8 +28,20 @@ fn random_port() -> u16 {
 /// because `std::env::remove_var` is marked unsafe for multi-threaded
 /// programs — acceptable here because this runs before the server task
 /// is spawned, so no other thread touches the env block.
-fn clear_auth_env() {
+///
+/// Tambem desvia `GARRAIA_CONFIG_DIR` para um tempdir. Sem isso o boot le o
+/// config dir REAL do desenvolvedor (XDG: `~/.config/garraia`) e spawna os
+/// servidores MCP que estiverem la — inclusive um `npx -y ...` que baixa do
+/// npm. O `TempDir` devolvido precisa ser mantido vivo pelo chamador ate o
+/// fim do teste; se cair antes, o diretorio some debaixo do gateway.
+#[must_use]
+fn clear_auth_env() -> tempfile::TempDir {
+    let config_dir = tempfile::tempdir().expect("create temp config dir");
     unsafe {
+        std::env::set_var(
+            "GARRAIA_CONFIG_DIR",
+            config_dir.path().to_str().expect("temp path is utf-8"),
+        );
         // O boot provisiona um MCP `npx -y @modelcontextprotocol/server-filesystem`
         // quando mcp.json nao existe, e o `-y` baixa do npm na primeira
         // execucao — dentro do caminho critico do start. Foi o que estourou
@@ -44,6 +56,7 @@ fn clear_auth_env() {
         std::env::remove_var("GARRAIA_LOGIN_DATABASE_URL");
         std::env::remove_var("GARRAIA_SIGNUP_DATABASE_URL");
     }
+    config_dir
 }
 
 // `#[serial]` isolates this test from any other that reads or mutates
@@ -53,12 +66,16 @@ fn clear_auth_env() {
 #[tokio::test]
 #[serial]
 async fn get_v1_me_fails_soft_with_503_problem_details_when_auth_unconfigured() {
-    clear_auth_env();
+    // Mantido vivo ate o fim do teste: e o `GARRAIA_CONFIG_DIR` do gateway.
+    let _config_dir = clear_auth_env();
 
     let port = random_port();
     let mut config = AppConfig::default();
     config.gateway.port = port;
     config.memory.enabled = false;
+    // Este teste so exercita `/v1/me`; MCP nao tem papel nenhum aqui e
+    // spawnar servidor no boot so adiciona latencia e rede.
+    config.mcp.clear();
 
     // O erro de boot precisa chegar na mensagem de panico la embaixo; sem
     // isto o teste so diz "gateway never came up", sem o porque.

--- a/crates/garraia-gateway/tests/router_smoke_test.rs
+++ b/crates/garraia-gateway/tests/router_smoke_test.rs
@@ -22,6 +22,20 @@ async fn router_build_does_not_panic() {
     config.gateway.port = port;
     config.memory.enabled = false;
 
+    // Preventivo, nao corretivo: este teste nao espera o gateway subir, entao
+    // nao falha por boot lento como os outros. Mas sem o opt-out o boot
+    // spawna `npx -y @modelcontextprotocol/server-filesystem` — download do
+    // npm e escrita no ~/.garraia real — para um teste que so quer saber se o
+    // router monta.
+    // SAFETY: cada arquivo de teste e seu proprio binario; os dois testes
+    // deste escrevem o mesmo valor.
+    unsafe {
+        std::env::set_var(
+            garraia_gateway::mcp::McpPersistenceService::DISABLE_AUTOPROVISION_ENV,
+            "1",
+        );
+    }
+
     // This will panic if any route uses legacy `/:` or `/*` patterns
     // without the `without_v07_checks()` escape hatch.
     tokio::spawn(async move {
@@ -38,6 +52,14 @@ async fn router_build_does_not_panic() {
 /// Test with voice enabled configuration
 #[tokio::test]
 async fn router_build_with_voice_does_not_panic() {
+    // SAFETY: ver a nota no teste acima.
+    unsafe {
+        std::env::set_var(
+            garraia_gateway::mcp::McpPersistenceService::DISABLE_AUTOPROVISION_ENV,
+            "1",
+        );
+    }
+
     let port = random_port();
     let mut config = AppConfig::default();
     config.gateway.port = port;

--- a/crates/garraia-gateway/tests/router_smoke_test.rs
+++ b/crates/garraia-gateway/tests/router_smoke_test.rs
@@ -21,6 +21,12 @@ async fn router_build_does_not_panic() {
     let mut config = AppConfig::default();
     config.gateway.port = port;
     config.memory.enabled = false;
+    config.mcp.clear();
+
+    // Sem um config dir proprio o boot le o do desenvolvedor (XDG:
+    // `~/.config/garraia`) e spawna os servidores MCP que estiverem la.
+    // Mantido vivo ate o fim do teste.
+    let _config_dir = tempfile::tempdir().expect("create temp config dir");
 
     // Preventivo, nao corretivo: este teste nao espera o gateway subir, entao
     // nao falha por boot lento como os outros. Mas sem o opt-out o boot
@@ -33,6 +39,10 @@ async fn router_build_does_not_panic() {
         std::env::set_var(
             garraia_gateway::mcp::McpPersistenceService::DISABLE_AUTOPROVISION_ENV,
             "1",
+        );
+        std::env::set_var(
+            "GARRAIA_CONFIG_DIR",
+            _config_dir.path().to_str().expect("temp path is utf-8"),
         );
     }
 
@@ -52,11 +62,18 @@ async fn router_build_does_not_panic() {
 /// Test with voice enabled configuration
 #[tokio::test]
 async fn router_build_with_voice_does_not_panic() {
+    // Mantido vivo ate o fim do teste: ver a nota no teste acima.
+    let _config_dir = tempfile::tempdir().expect("create temp config dir");
+
     // SAFETY: ver a nota no teste acima.
     unsafe {
         std::env::set_var(
             garraia_gateway::mcp::McpPersistenceService::DISABLE_AUTOPROVISION_ENV,
             "1",
+        );
+        std::env::set_var(
+            "GARRAIA_CONFIG_DIR",
+            _config_dir.path().to_str().expect("temp path is utf-8"),
         );
     }
 
@@ -65,6 +82,7 @@ async fn router_build_with_voice_does_not_panic() {
     config.gateway.port = port;
     config.memory.enabled = false;
     config.voice.enabled = true;
+    config.mcp.clear();
 
     // This will panic if any route uses legacy patterns
     tokio::spawn(async move {

--- a/crates/garraia-gateway/tests/skills_test.rs
+++ b/crates/garraia-gateway/tests/skills_test.rs
@@ -36,6 +36,16 @@ async fn start_test_gateway_with_config_dir(config_dir: &str) -> String {
     // thread is reading these env vars concurrently.
     unsafe {
         std::env::set_var("GARRAIA_CONFIG_DIR", config_dir);
+        // O boot provisiona um MCP `npx -y @modelcontextprotocol/server-filesystem`
+        // quando mcp.json nao existe — e aqui ele nunca existe, porque o config dir
+        // e um tempdir novo. O `-y` baixa do npm na primeira execucao, o que ja
+        // estourou o orcamento de espera deste fixture em CI. Estes testes nao
+        // exercitam MCP (o config ja faz `mcp.clear()`), entao o boot nao deve
+        // depender da rede.
+        std::env::set_var(
+            garraia_gateway::mcp::McpPersistenceService::DISABLE_AUTOPROVISION_ENV,
+            "1",
+        );
     }
 
     tokio::spawn(async move {

--- a/crates/garraia-gateway/tests/skins_test.rs
+++ b/crates/garraia-gateway/tests/skins_test.rs
@@ -31,6 +31,10 @@ async fn start_test_gateway_with_skins_dir(skins_dir: &str) -> String {
     let tmp_config = tempfile::tempdir().expect("create temp config dir");
     // SAFETY: we are in a test and no other threads are reading these env vars yet.
     unsafe {
+        std::env::set_var(
+            garraia_gateway::mcp::McpPersistenceService::DISABLE_AUTOPROVISION_ENV,
+            "1",
+        );
         std::env::set_var("GARRAIA_CONFIG_DIR", tmp_config.path().to_str().unwrap());
         std::env::set_var("GARRAIA_SKINS_DIR", skins_dir);
     }
@@ -74,6 +78,10 @@ async fn start_test_gateway_bound_to_wildcard(skins_dir: &str) -> String {
     let tmp_config = tempfile::tempdir().expect("create temp config dir");
     // SAFETY: we are in a test and no other threads are reading these env vars yet.
     unsafe {
+        std::env::set_var(
+            garraia_gateway::mcp::McpPersistenceService::DISABLE_AUTOPROVISION_ENV,
+            "1",
+        );
         std::env::set_var("GARRAIA_CONFIG_DIR", tmp_config.path().to_str().unwrap());
         std::env::set_var("GARRAIA_SKINS_DIR", skins_dir);
     }


### PR DESCRIPTION
## Descrição

Quatro jobs caíram na `main` em `6f4ec06` — `Test (ubuntu-latest)`, `Coverage`, `E2E Tests` e `Playwright` — mais o `Security Gate (BOLA)`.

**Não era regressão do #915.** Aquele commit mudou 4 arquivos e **nenhum `.rs`**, e a árvore idêntica (`f8109bb`) passou no PR minutos antes: CI 20/20 verdes e Security Gate #285 verde. Dos 10 últimos Security Gate na `main`, 9 passaram.

### Causa raiz

O pânico exato, do log do job:

```
panicked at crates/garraia-gateway/tests/projects_test.rs:343:10:
request should succeed: ... ConnectError("tcp connect error", 127.0.0.1:41419,
Os { code: 111, kind: ConnectionRefused })
```

É o `.expect("request should succeed")`, **não** o `assert_eq!` do status 400 — a validação de path traversal nem chegou a ser exercitada. O gateway não subiu.

`server.rs:97` provisiona no boot um MCP `npx -y @modelcontextprotocol/server-filesystem` quando `mcp.json` não existe (`mcp/persistence.rs:80-105`). O `-y` **baixa o pacote do npm na primeira execução**, e como `build_mcp_tools()` spawna os servidores logo em seguida, esse download entra no caminho crítico do start.

A aritmética do run fecha:

- O binário de teste começou às 22:08:22 e o primeiro teste falhou às 22:08:52 — exatos **30s**, o orçamento do laço de espera (`projects_test.rs:73-83`, 60 × 500ms).
- Esse primeiro teste é o **único sem** a linha `Secure MCP Filesystem Server running on stdio` no log. Os 9 seguintes têm a linha e levam ~1,5s cada (43,85s = 30 + 9×1,54).

O mesmo mecanismo explica os outros jobs: `E2E` e `Playwright` caíram no passo **"Start gateway"** (~36s, timeout), não em nenhum teste — e esses usam porta fixa, então não é colisão de porta.

**O detalhe que fecha o caso:** o teste faz `config.mcp.clear()` justamente para se isolar de MCP, e a provisão desfazia isso pelas costas, gravando um servidor `npx` no config dir temporário do próprio teste.

### Dois agravantes que transformavam atraso em falha silenciosa

1. `let _ = server.run().await` engolia qualquer erro de boot.
2. Ao esgotar os 30s o laço **retornava assim mesmo**, empurrando a falha 40 linhas adiante como um `ConnectionRefused` sem contexto.

## O que muda

- **`provision_filesystem_if_missing` ganha o opt-out `GARRAIA_DISABLE_MCP_AUTOPROVISION`.** Checado dentro da função, então cobre os dois call sites (`server.rs:97` e `state.rs:219`) de uma vez. **Default inalterado** — o primeiro boot de um usuário segue provisionando. `0` e vazio contam como desligado, para um `export VAR=` de shell não virar opt-out acidental.
- **O fixture para de falhar em silêncio**: captura o erro de `server.run()` e o laço passa a `assert!` com o erro de boot na mensagem, no ponto certo.
- **`skills_test.rs`** recebe o mesmo opt-out; herdou o fixture idêntico.
- **CI**: os passos "Start gateway" do E2E e do Playwright setam a env var. Esses jobs não exercitam MCP e não devem depender da rede para subir.

Este é o follow-up que `auth_test.rs:71` e `gateway_integration.rs:70,82` citam nos seus `#[ignore]`: *"server.run() exits silently on startup in CI … Deferred to the gateway-test-fixture follow-up PR"*.

## Tipo de mudança

- [x] `fix`: Correção de bug
- [x] `test`: Adição ou correção de testes
- [x] `chore`: Manutenção (deps, CI, build)

## Classe de Risco

- [x] **Classe B (Médio Risco)**: refatorações internas sem alteração de schema ou de API pública.

Sem mudança de auth, cripto, RLS, migration ou endpoint. O comportamento default do provisionamento é idêntico — só passa a existir uma forma explícita de desligá-lo.

## Checklist de Segurança e Qualidade

- [x] `cargo fmt --check` executado e limpo
- [x] `cargo clippy -p garraia-gateway --all-targets -- -D warnings` sem erros
- [x] Testes passando localmente (ver abaixo)
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo commitado
- [x] Nenhuma migração Postgres

## Mudanças na API pública e Schema

- Nova constante pública `McpPersistenceService::DISABLE_AUTOPROVISION_ENV`. Aditiva.
- Nova env var `GARRAIA_DISABLE_MCP_AUTOPROVISION`, opt-in. Ausente = comportamento atual.

## Como testar

A verificação que separa correção de palpite é rodar **com o cache do npx frio** — a condição exata que quebrou o CI:

```bash
mv ~/.npm/_npx ~/.npm/_npx.bak          # simula runner frio
cargo +1.95 test -p garraia-gateway --test projects_test --test skills_test
```

Resultado nesta branch:

```
test result: ok. 10 passed; 0 failed; ... finished in 5.26s     # projects_test
test result: ok. 13 passed; 0 failed; ... finished in 6.61s     # skills_test
```

**5,26s contra os 43,85s do run que falhou** — é exatamente os 30s de espera desperdiçada desaparecendo. E nenhuma linha `Secure MCP Filesystem Server running on stdio` na saída: o `npx` não é mais spawnado.

Testes unitários do opt-out:

```bash
cargo +1.95 test -p garraia-gateway --lib mcp::persistence     # 9 passed (3 novos)
```

Cobrem os três casos que importam: o default segue provisionando, o opt-out pula a gravação, e `0`/vazio não contam como opt-out.

## Plano de Rollback

Reverter o commit. O opt-out é opt-in e o default não mudou, então nenhuma instalação existente se comporta diferente com ou sem este PR. Os passos de CI voltariam a pagar o download do npm no start — ou seja, de volta ao flake, não a algo pior.

## Fora de escopo (registrado para follow-up)

Migrar `projects_test.rs` para `build_router_for_test` + `oneshot` (`server.rs:766`, já existe sob `test-helpers`), que elimina o socket de vez, e reavaliar os `#[ignore]` de `auth_test.rs` / `gateway_integration.rs` agora que a causa comum está corrigida. É a solução estrutural e merece PR próprio.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhgYfAhUrE3zUA6if87eKh

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhgYfAhUrE3zUA6if87eKh)_