### PR TITLE
ci(release): assegura que o asset Android é ELF bionic, não glibc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,6 +284,48 @@ jobs:
           cp target/aarch64-linux-android/release/garra release/garraia-android-aarch64
           chmod +x release/garraia-android-aarch64
 
+      - name: Assert the binary is a bionic ELF, not glibc
+        # Issue #910: "o instalador baixa, checksum passa, e a execucao falha".
+        # O checksum NAO protege contra isto — ele confere porque o arquivo e
+        # exatamente o que foi publicado; ele so nao roda. O que falha e o
+        # loader: um binario glibc com nome de Android pede
+        # /lib/ld-linux-aarch64.so.1, que nao existe no bionic.
+        #
+        # O passo de verificacao la embaixo (job `release`) so checa se o asset
+        # EXISTE. Nada checava a plataforma dele, e o job `Android (Termux)
+        # check` do ci.yml roda `cargo ndk check`, que compila sem produzir
+        # binario para inspecionar. Entao um erro de target atravessava o
+        # pipeline inteiro e so aparecia no aparelho do usuario.
+        #
+        # Consequencia deliberada: este job e best-effort (esta em `needs:` do
+        # job `release`, mas nao no `if:`). Se esta guarda disparar, o job cai,
+        # o asset nao sobe, e o `::error` de asset ausente ja existente avisa.
+        # Isso e o desejado — publicar NENHUM asset Android e melhor que
+        # publicar um glibc renomeado: o install.sh da 404 explicito em vez de
+        # instalar algo que morre no exec.
+        run: |
+          set -euo pipefail
+          bin=release/garraia-android-aarch64
+
+          # `readelf -p .interp` imprime "  [     0]  /system/bin/linker64";
+          # o ultimo campo e o caminho do loader.
+          interp="$(readelf -p .interp "${bin}" | awk '/\[/ { print $NF }')"
+          machine="$(readelf -h "${bin}" | awk -F: '/Machine:/ { gsub(/^ +/, "", $2); print $2 }')"
+
+          echo "interpreter: ${interp}"
+          echo "machine:     ${machine}"
+
+          rc=0
+          if [ "${interp}" != "/system/bin/linker64" ]; then
+            echo "::error ::Asset Android com loader errado: esperado /system/bin/linker64 (bionic), encontrado '${interp}'. Um binario glibc com nome de Android passa no checksum e morre no exec dentro do Termux — exatamente a issue #910. Verifique o target do cargo-ndk (aarch64-linux-android) no passo 'Build release'."
+            rc=1
+          fi
+          if [ "${machine}" != "AArch64" ]; then
+            echo "::error ::Asset Android com arquitetura errada: esperado AArch64, encontrado '${machine}'."
+            rc=1
+          fi
+          exit "${rc}"
+
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:

--- a/TODO.md
+++ b/TODO.md
@@ -12,6 +12,58 @@ curtos para a próxima sessão autônoma.
 > históricas abaixo são registro da época, não estado atual. IDs `GAR-xxx`
 > permanecem como identificadores históricos.
 
+## Concluído em 2026-09-04 — #910 fechada + guarda de plataforma do asset Android
+
+Fechava-se o lote Termux (#909-#913). A #910 pedia três coisas, **todas já
+entregues** quando foi reexaminada: asset `garraia-android-aarch64` publicado
+(desde a v0.3.6), `install.sh` detectando Termux (`install.sh:196-234`, por
+`$TERMUX_VERSION` **ou** `$PREFIX` *com.termux*, com precedência sobre o
+`uname`) e build-from-source documentado (`docs/installation.md:230-263`).
+
+Ficou aberta aguardando confirmação do relator, que não respondeu a nenhum dos
+dois comentários. Fechada como `completed` com a evidência do artefato
+publicado — não do código:
+
+```
+garraia-android-aarch64: ... interpreter /system/bin/linker64   (bionic)
+garraia-linux-aarch64:   ... interpreter /lib/ld-linux-aarch64.so.1  (glibc)
+```
+
+### A lacuna que o report expôs e ninguém tinha fechado
+
+A frase do relator — *"o instalador baixa, checksum passa, e a execução
+falha"* — descreve uma falha que passava por **todas** as verificações: o
+checksum confere justamente porque o arquivo é o publicado; ele só não roda na
+plataforma certa.
+
+O `release.yml` checava se o asset Android **existe** (`::error` de ausente),
+nunca se ele **é** Android. E o job `Android (Termux) check` do `ci.yml` roda
+`cargo ndk check`, que compila sem produzir binário para inspecionar. Um erro
+de target atravessaria o pipeline inteiro e apareceria só no aparelho do
+usuário.
+
+Novo passo em `release.yml`, job `build-android-arm64`, entre o empacotamento
+e o upload: assere via `readelf` que o interpreter é `/system/bin/linker64` e a
+machine é `AArch64`. Testado nos dois sentidos contra os binários reais da
+v0.3.7 — o par ideal, mesma arquitetura e loaders diferentes:
+
+```
+garraia-android-aarch64 -> exit 0
+garraia-linux-aarch64   -> exit 1   (o bug da #910 reconstruído)
+```
+
+Consequência deliberada: o job é best-effort (está em `needs:` do job
+`release`, não no `if:`). Se a guarda disparar, o asset não sobe e o `::error`
+de ausente avisa — publicar nenhum asset Android é melhor que publicar um
+glibc renomeado, porque aí o `install.sh` dá 404 explícito em vez de instalar
+algo que morre no `exec`.
+
+É o mesmo padrão da guarda de frescor do `install.sh`, escrita por causa desta
+mesma issue: o endpoint respondia 200, tinha shebang, parseava em `sh -n` — e
+estava errado mesmo assim.
+
+**Backlog aberto pelo lote:** zero issues abertas no repo após esta.
+
 ## Em andamento 2026-09-04 — de-flake do boot do gateway (PR #916)
 
 Depois do merge do #915 (`chore(release): v0.3.7`) quatro jobs ficaram


### PR DESCRIPTION
## Descrição

A issue #910 relata: *"o instalador baixa, checksum passa, e a execução falha"*. O checksum não protege contra isso — ele confere justamente porque o arquivo **é** o que foi publicado; ele só não roda. O que falha é o loader: um binário glibc com nome de Android pede `/lib/ld-linux-aarch64.so.1`, que não existe no bionic.

Nada no pipeline pegava essa classe de falha:

- o passo de verificação do job `release` só checa se o asset Android **existe** (emite `::error` quando falta);
- o job `Android (Termux) check` do `ci.yml` roda `cargo ndk check`, que compila sem produzir binário para inspecionar.

Ou seja: um erro de configuração de target atravessaria o pipeline inteiro e só apareceria no aparelho de quem instalasse.

Este PR adiciona um passo no job `build-android-arm64`, entre o empacotamento e o upload, que assere via `readelf` que o interpreter é `/system/bin/linker64` e que a machine é `AArch64`.

É o mesmo padrão da guarda de frescor do `install.sh`, escrita por causa desta mesma issue: o endpoint respondia 200, tinha shebang, parseava em `sh -n` — e estava errado mesmo assim.

A #910 já foi fechada (os três pedidos dela estavam entregues desde a v0.3.6; o comentário de fechamento traz a evidência do ELF do asset publicado). Este PR fecha a lacuna de verificação que o relato expôs, e que ninguém tinha coberto.

Refs #910

## Tipo de mudança

- [x] `chore`: Manutenção (deps, CI, build)

## Classe de Risco

- [x] **Classe A (Baixo Risco)**: Documentação, comentários, formatação, bumps de dependências de desenvolvimento sem impacto em tempo de execução.

Nenhum arquivo Rust alterado. O diff é um passo de workflow (YAML) mais o registro no `TODO.md`.

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo fmt --check` — n/a, nenhum arquivo Rust no diff
- [x] `cargo clippy` — n/a, nenhum arquivo Rust no diff
- [x] `cargo test` — n/a; em vez disso, `tests/install_sh/detect_platform.sh` roda 21/21 sem regressão
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo, API key, token ou credencial commitada
- [x] Nenhuma migração Postgres

## Mudanças na API pública e Schema

- Nenhuma mudança na API pública, nenhum schema, nenhum endpoint.
- Nenhum nome de asset de release é criado, renomeado ou removido (regra 15 intacta).

## Como testar

A guarda foi validada **nos dois sentidos** contra os binários reais da release v0.3.7 — que são o par de teste ideal, porque têm a mesma arquitetura e loaders diferentes:

```bash
cd /tmp
curl -fsSL -O https://github.com/michelbr84/GarraRUST/releases/download/v0.3.7/garraia-android-aarch64
curl -fsSL -O https://github.com/michelbr84/GarraRUST/releases/download/v0.3.7/garraia-linux-aarch64

file garraia-android-aarch64   # interpreter /system/bin/linker64
file garraia-linux-aarch64     # interpreter /lib/ld-linux-aarch64.so.1
```

Extraindo o script do **próprio `release.yml`** (não uma cópia) e rodando contra os dois:

```
==================== VERDE: asset Android real ====================
interpreter: /system/bin/linker64
machine:     AArch64
>>> exit=0

==================== VERMELHO: glibc renomeado ====================
interpreter: /lib/ld-linux-aarch64.so.1
machine:     AArch64
::error ::Asset Android com loader errado: esperado /system/bin/linker64 (bionic),
  encontrado '/lib/ld-linux-aarch64.so.1'. ...
>>> exit=1
```

O caso vermelho é o bug da #910 reconstruído: o glibc aarch64 renomeado para o nome do asset Android. Se a guarda não reprovasse esse, ela não pegaria a regressão que existe para pegar.

Não-regressão:

```
bash tests/install_sh/detect_platform.sh   # 21 passed, 0 failed
shellcheck -s bash <script da guarda>      # limpo
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"   # válido
```

⚠️ O `release.yml` só executa de verdade num `workflow_dispatch` do Release ou num push de tag. Nenhum job de PR o exercita — por isso o teste local contra os dois binários reais acima é a validação que conta.

## Comportamento em caso de falha da guarda

Deliberado, e documentado no comentário do passo: o job `build-android-arm64` é best-effort (está em `needs:` do job `release`, mas **não** no `if:`). Se a guarda disparar, o job cai, o asset não sobe, e o `::error` de asset ausente já existente avisa.

Publicar **nenhum** asset Android é melhor que publicar um glibc renomeado: o `install.sh` dá 404 explícito, em vez de instalar um binário que passa no checksum e morre no `exec`.

## Plano de Rollback

Reverter o commit `6c4d1d8`. É um passo isolado de workflow, sem estado e sem dependências — remover restaura exatamente o comportamento anterior, e nenhum artefato já publicado é afetado retroativamente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhgYfAhUrE3zUA6if87eKh