### PR TITLE
chore(release): v0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.8] - 2026-09-04
+
+Corrige uma falha de boot do gateway que deixou a `main` vermelha logo apos a
+v0.3.7, e fecha a lacuna de verificacao que a issue #910 expos no pipeline de
+release.
+
+### Fixed
+- **O boot do gateway nao baixa mais do npm no caminho critico (#916).**
+  `McpPersistenceService::provision_filesystem_if_missing()` gravava, no
+  primeiro start, uma entrada MCP com `command: "npx"` e
+  `args: ["-y", "@modelcontextprotocol/server-filesystem", ...]`. O boot
+  seguinte spawnava esse servidor, e o `-y` **baixa o pacote do npm na
+  primeira execucao** — dentro do orcamento de start. Em runner de CI, com
+  cache do npm frio, isso estourava os 35 s do passo "Start gateway" e
+  derrubava quatro jobs de forma deterministica (o re-run falhou nos mesmos
+  jobs e nos mesmos passos). Novo opt-out explicito
+  `GARRAIA_DISABLE_MCP_AUTOPROVISION`, cobrindo os dois call sites
+  (`server.rs` e `state.rs`).
+- **Fixtures de teste deixam de ler o config dir real da maquina (#916).**
+  `rest_v1_me.rs` e `router_smoke_test.rs` eram os dois unicos que subiam o
+  gateway sem desviar `GARRAIA_CONFIG_DIR`, entao liam o `~/.config/garraia`
+  do desenvolvedor e spawnavam os servidores MCP que estivessem la. O opt-out
+  sozinho nao os salvava: ele impede *gravar* a entrada, nao *spawnar*
+  servidores de um `mcp.json` que ja exista. Medido com o `mcp.json` poluido
+  presente e o cache do npx frio, o `rest_v1_me` foi de 40,56 s em falha para
+  0,27 s passando.
+- **O fixture do `projects_test.rs` nao engole mais o erro de boot.** O
+  `let _ = server.run()` descartava qualquer falha de start, e o laco de
+  espera retornava em silencio ao esgotar o orcamento, empurrando a falha
+  para um `ConnectionRefused` sem contexto la na frente.
+
+### Added
+- **Guarda de plataforma do asset Android no `release.yml`.** O pipeline
+  checava se `garraia-android-aarch64` **existe**, nunca se ele **e** Android.
+  Um binario glibc com o nome do asset Android passa no checksum — o arquivo e
+  exatamente o que foi publicado — e morre no `exec` dentro do Termux, que e
+  literalmente o relato da issue #910. Novo passo entre o empacotamento e o
+  upload assere via `readelf` que o interpreter e `/system/bin/linker64` e que
+  a machine e `AArch64`. Se disparar, o asset nao sobe e o `::error` de asset
+  ausente ja existente avisa: publicar nenhum binario Android e melhor que
+  publicar um glibc renomeado.
+- **`SOUL.md` e `SOUL.EN.md` (#917).**
+
 ## [0.3.7] - 2026-09-03
 
 Retorno de campo da Fase 0 do Garra Mobile: cinco issues (#909-#913) abertas

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3187,7 +3187,7 @@ dependencies = [
 
 [[package]]
 name = "garraia"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -3233,7 +3233,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-agents"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "axum",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-auth"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-channels"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "axum",
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-common"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-config"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "dirs 6.0.0",
  "garraia-common",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-db"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-desktop"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -3391,7 +3391,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-embeddings"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "serde",
@@ -3405,7 +3405,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-gateway"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3491,7 +3491,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-learning"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "garraia-common",
  "garraia-skills",
@@ -3505,7 +3505,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-media"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "base64 0.23.1",
  "bytes",
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-plugins"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3555,7 +3555,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-security"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "base64 0.23.1",
  "garraia-common",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-skills"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "garraia-common",
  "reqwest 0.12.28",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-storage"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3611,7 +3611,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-telemetry"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "axum",
@@ -3647,7 +3647,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-voice"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3661,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-workspace"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.7"
+version = "0.3.8"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/michelbr84/GarraRUST"


### PR DESCRIPTION
## Descrição

PR de release da **v0.3.8**, seguindo `docs/releasing.md` §1. Escopo: os commits em `main` além da tag `v0.3.7` (`6f4ec06`).

**O motivo de cortar agora é o #916.** O opt-out do auto-provisionamento MCP vive no binário (`crates/garraia-gateway/src/mcp/persistence.rs`) — então só chega ao usuário por release. Enquanto a v0.3.7 for a última, todo `garra start` continua gravando uma entrada MCP `npx -y @modelcontextprotocol/server-filesystem` no primeiro boot e pagando o download do npm dentro do start.

| Origem | Conteúdo |
|---|---|
| #916 | de-flake do boot do gateway — **código de produção** |
| #917 | `SOUL.md` / `SOUL.EN.md` — docs |
| #918 | guarda de plataforma do asset Android no `release.yml` — CI |

⚠️ **Ordem de merge:** este PR e o #918 são independentes, mas **os dois precisam estar na `main` antes da tag** — o CHANGELOG da v0.3.8 já descreve a guarda, e a guarda só tem efeito se estiver no `release.yml` no momento do run.

**Commit `chore(release)` toca exatamente os 3 arquivos canônicos**, no mesmo padrão de `442233e` (v0.3.7) e `662ff36` (v0.3.6):

| Arquivo | Mudança |
|---|---|
| `Cargo.toml:29` | `0.3.7` → `0.3.8` (única edição manual de versão) |
| `Cargo.lock` | 38 linhas, 19 entradas `garraia*` — gerado por `cargo check`, nunca à mão |
| `CHANGELOG.md` | seção `## [0.3.8] - 2026-09-04` |

### `[Unreleased]` estava vazio (de novo)

Como na v0.3.7, nenhum dos commits pós-tag tocou o `CHANGELOG.md`. A seção foi **escrita do zero**, no estilo da casa (bullet abre com título em negrito, depois prosa citando arquivos e jobs; sem acentos, como as seções anteriores).

## Tipo de mudança

- [x] `chore`: Manutenção (deps, CI, build)
- [x] `docs`: Documentação apenas

## Classe de Risco

- [x] **Classe A (Baixo Risco)**: Documentação, comentários, formatação, bumps de dependências de desenvolvimento sem impacto em tempo de execução.

Bump de versão + changelog. Nenhuma mudança de código, schema, API ou CI **neste PR** — o código que a release entrega já está na `main`, revisado nos seus próprios PRs.

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo +1.95 fmt --all -- --check` — limpo
- [x] `cargo clippy` — sem código novo neste PR; o CI cobre
- [x] `cargo +1.95 check --workspace --exclude garraia-desktop` — é o que regenera o lock; passou
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo, API key, token ou credencial commitada
- [x] Nenhuma migração Postgres

## Mudanças na API pública e Schema

- Nenhuma. O `--version` do binário passa a reportar `0.3.8`.
- Nenhum nome de asset de release muda (regra 15 intacta).

## Como testar

```bash
grep -n '^version' Cargo.toml                                  # 0.3.8
grep -B1 'version = "0.3.7"' Cargo.lock | grep -c 'garraia'    # 0
grep -B1 'version = "0.3.8"' Cargo.lock | grep -c 'garraia'    # 19
head -12 CHANGELOG.md                                          # [Unreleased] vazio, [0.3.8] abaixo
cargo +1.95 fmt --all -- --check                               # limpo
```

## Plano de Rollback

Antes da tag: reverter o commit ou fechar o PR. Nada foi publicado.

Depois da tag, o runbook é explícito e vale repetir: **nunca reutilizar a tag**. Apagar Release + tag (`git push origin :refs/tags/v0.3.8`), corrigir por PR, cortar `v0.3.9`.

## Depois do merge (fora deste PR)

1. Confirmar que o **#918 também está na `main`** — senão a guarda não roda neste release.
2. `git tag v0.3.8 <sha> && git push origin v0.3.8`. Se o push de tag for recusado (foi o caso nesta sessão, HTTP 403 no `git-receive-pack`), cair para `workflow_dispatch` do Release com `version=v0.3.8` — mas então a tag nasce do `GITHUB_TOKEN` e **não dispara** workflows de tag-push, deixando o `deploy.yml` órfão: ele precisa de dispatch manual com `tag=v0.3.8`.
3. Vigiar o `build-android-arm64`. Ele é best-effort, e agora tem duas guardas: `::error` se o asset faltar, e a nova asserção de ELF bionic se ele for da plataforma errada.
4. `docs/releasing.md` §4 — os 7 passos de verificação.

⚠️ Nota que continua valendo (registrada no #915): **nada valida que a versão do `Cargo.toml` bate com a tag.** Empurrar `v0.3.8` sem este PR mergeado produziria binários que reportam `0.3.7` em `--version`, sem nenhum job falhar. Por isso este PR vem primeiro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RhgYfAhUrE3zUA6if87eKh

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhgYfAhUrE3zUA6if87eKh)_