### PR TITLE
fix(gateway): session_tokens_required deixa de mentir (#930 + achado de segurança)

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,10 +475,14 @@ the comparison section above for the evidence trail).
   loud warning, never a broken boot.
 - **Channels are deny-by-default** — per-channel allowlists; unknown
   users must present a pairing code; unauthorized messages are dropped.
-- **Local API binds 127.0.0.1 by default** — enable `gateway.api_key`
-  and/or `session_tokens_required: true` to require auth on it
-  (opt-in today; hardening this default is tracked on the roadmap).
-  The `HOST` env var can override the bind — mind your container config.
+- **Local API binds 127.0.0.1 by default** — `gateway.api_key` gates the
+  `/ws` WebSocket handshake (and only it); the REST surface has no
+  api-key auth today, so protect it with topology (loopback, firewall,
+  reverse proxy). `session_tokens_required` is NOT implemented and the
+  gateway refuses to start with it set, rather than claim a protection
+  that does not exist. Hardening these defaults is tracked on the
+  roadmap. The `HOST` env var can override the bind — mind your
+  container config.
 - **256-bit session tokens** — HttpOnly, SameSite=Strict cookie (or
   Bearer/`X-Session-Key`), rotated on resume, TTL + idle timeout.
 - **Two auth stacks, stated plainly** — Auth v1 (`/v1/auth/*`): 15-minute

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -785,7 +785,7 @@ O GarraIA foi desenvolvido para os requisitos de segurança de agentes de IA que
 - **Cofre de credenciais criptografadas (opt-in)** - AES-256-GCM em `~/.config/garraia/credentials/vault.json`, chave derivada via PBKDF2-HMAC-SHA256 (600k iterações) de `GARRAIA_VAULT_PASSPHRASE`. Dito com clareza: o default recomendado do wizard `garra init` grava as chaves de provider em `config.yml` (modo 0600, texto puro); escolha a opção do cofre e exporte a passphrase a cada start para ter criptografia em repouso. Tornar o cofre o default está no roadmap.
 - **Tokens MCP protegidos por vault** - Variáveis de ambiente sensíveis dos servidores MCP (`API_KEY`, `TOKEN`, `SECRET`, etc.) são automaticamente movidas para o vault no primeiro `save`. O `mcp.json` armazena apenas referências `vault:mcp.<server>.<key>`. Sem `GARRAIA_VAULT_PASSPHRASE`, salva em plaintext com aviso — nunca quebra o boot.
 - **Tokens de sessão criptograficamente seguros** - Cada sessão WebSocket recebe um token de 256 bits (URL-safe base64). Suportados via cookie `garraia_session` (HttpOnly, SameSite=Strict), header `Authorization: Bearer` ou `X-Session-Key`. TTL e idle-timeout configuráveis. Rotação automática no resume.
-- **Canais deny-by-default** - Usuários desconhecidos nos canais de mensageria precisam apresentar código de pareamento. A API local (WS/HTTP) faz bind em `127.0.0.1` e é aberta por default — habilite `gateway.api_key` e/ou `session_tokens_required: true` para exigir auth nela (endurecer esse default está no roadmap).
+- **Canais deny-by-default** - Usuários desconhecidos nos canais de mensageria precisam apresentar código de pareamento. A API local (WS/HTTP) faz bind em `127.0.0.1` e é aberta por default — `gateway.api_key` protege o handshake do WebSocket `/ws` (e só ele); a superfície REST não tem auth por api_key hoje, proteja-a por topologia (loopback, firewall, reverse proxy). `session_tokens_required` NÃO está implementado e o gateway recusa subir com ele ligado, em vez de afirmar uma proteção que não existe (endurecer esses defaults está no roadmap).
 - **Listas de permissões por usuário** - Listas de permissões por canal controlam quem pode interagir com o agente. Mensagens não autorizadas são descartadas silenciosamente.
 - **Filtragem heurística de entrada** - Saneamento de caracteres de controle + triagem por palavras-chave de frases comuns de prompt injection nos canais de chat e no WebSocket. É heurística, não garantia — trate prompt injection como problema em aberto, como todo framework deveria.
 - **Confirmação de comandos arriscados** - `tool_confirmation_enabled: true` pausa o agente antes de executar comandos bash destrutivos (`rm -r`, `git reset --hard`, `drop database`, etc.) e aguarda aprovação do usuário ("sim"/"yes"). Default: `false` (opt-in).
@@ -824,7 +824,8 @@ gateway:
   # GAR-202: tokens de sessão — TTL, idle timeout e exigência de autenticação
   session_ttl_secs: 86400       # validade do token (1 dia). Padrão: 86400
   session_idle_secs: 3600       # timeout por inatividade (1h). Padrão: 3600
-  session_tokens_required: false # exige token nas rotas /api/* . Padrão: false
+  # session_tokens_required: NÃO implementado — o gateway recusa subir com
+  # `true` (ver docs/hardening-gateway.md, Limitações conhecidas §2).
 
 llm:
   # ATENÇÃO sobre `api_key`: a resolução é vault > config > variável de ambiente.

--- a/config.hardened.example.yml
+++ b/config.hardened.example.yml
@@ -8,14 +8,16 @@
 gateway:
   # Perfil A (recomendado): só a própria máquina alcança o gateway.
   # Para expor na rede (Perfil B), veja docs/hardening-gateway.md §1 —
-  # api_key + session_tokens_required + allowed_origins são OBRIGATÓRIOS.
+  # api_key + allowed_origins são OBRIGATÓRIOS (api_key protege o /ws;
+  # a superfície REST depende de topologia: firewall/reverse proxy).
   host: "127.0.0.1"
   port: 3888
 
   # Auth do gateway (opt-in hoje; ligue mesmo em loopback se a máquina é
   # compartilhada). Valor LITERAL — gere com: openssl rand -hex 32
   # api_key: "TROQUE-POR-TOKEN-FORTE"
-  session_tokens_required: true
+  # session_tokens_required: NÃO adicione — o flag não está implementado e o
+  # gateway RECUSA subir com ele em `true` (investigação da issue #930).
   session_ttl_secs: 86400      # validade do token de sessão (1 dia)
   session_idle_secs: 3600      # corte por inatividade (1h)
 

--- a/crates/garraia-config/src/check.rs
+++ b/crates/garraia-config/src/check.rs
@@ -372,6 +372,27 @@ fn validate(config: &AppConfig) -> Vec<Finding> {
         );
     }
 
+    // Security finding from the GarraRUST #930 investigation: the middleware
+    // that was supposed to implement this flag (`require_session_auth` in the
+    // gateway's session_auth.rs) is not wired into any router layer, so the
+    // flag protects nothing while the hardening docs claimed it guards
+    // /api/*. The gateway refuses to boot with it set (fail loud beats a
+    // silent lie); this finding says the same thing where operators actually
+    // look first. Error, not Warning: `garra start` will refuse this exact
+    // config, and `config check` passing on a config that cannot boot would
+    // be its own lie.
+    if config.gateway.session_tokens_required {
+        push_err(
+            &mut findings,
+            "gateway.session_tokens_required",
+            "gateway.session_tokens_required: true is set, but this flag is NOT implemented — \
+             no HTTP route validates session tokens today, and the gateway refuses to start \
+             with it enabled rather than pretend to be protected. Fix: remove the flag (or \
+             set it to false); this changes nothing about actual behavior."
+                .into(),
+        );
+    }
+
     // Timeouts: 0 means "no timeout" for reqwest/tokio — warn (user probably meant something else).
     if config.timeouts.llm.default_secs == 0 {
         push_warn(
@@ -1154,6 +1175,33 @@ mod tests {
         assert!(
             !findings.iter().any(|f| f.severity == Severity::Error),
             "default config produced errors: {findings:?}"
+        );
+    }
+
+    /// Achado da investigação da #930: o flag não é implementado no gateway
+    /// (`require_session_auth` nunca vai a um layer), então tê-lo ligado é
+    /// acreditar numa proteção inexistente. Error — o `garra start` recusa
+    /// essa mesma config, e um `config check` verde numa config que não sobe
+    /// seria uma segunda mentira.
+    #[test]
+    fn inert_session_tokens_flag_is_error() {
+        let mut cfg = AppConfig::default();
+        cfg.gateway.session_tokens_required = true;
+        let findings = validate(&cfg);
+        let hit = findings
+            .iter()
+            .find(|f| f.field == "gateway.session_tokens_required")
+            .expect("flag ligado deve produzir finding");
+        assert!(matches!(hit.severity, Severity::Error));
+        assert!(
+            hit.message.contains("NOT implemented"),
+            "msg = {}",
+            hit.message
+        );
+        assert!(
+            hit.message.contains("remove the flag"),
+            "msg = {}",
+            hit.message
         );
     }
 

--- a/crates/garraia-gateway/src/server.rs
+++ b/crates/garraia-gateway/src/server.rs
@@ -37,6 +37,40 @@ pub struct GatewayServer {
     telemetry_config: Option<garraia_telemetry::TelemetryConfig>,
 }
 
+/// Refuse to boot while `gateway.session_tokens_required` is set.
+///
+/// Security finding from the #930 investigation: the middleware that was
+/// supposed to implement this flag (`require_session_auth`,
+/// `session_auth.rs`) has never been wired into any router layer — the flag
+/// is a no-op for HTTP, while `docs/hardening-gateway.md` and both READMEs
+/// told operators it protects the `/api/*` surface. An operator who followed
+/// the hardening guide believed they were protected and were not.
+///
+/// Refusing beats the two alternatives. Booting with a warning keeps the lie
+/// alive for anyone not reading logs; silently *enabling* the auth would
+/// break every local integration that relies on today's open access — the
+/// opposite surprise, delivered to different people. The refusal names the
+/// one-line way out, so nobody is stranded: removing the flag changes
+/// nothing about the gateway's actual behavior.
+///
+/// Free function rather than a method so the decision is testable without
+/// constructing a `GatewayServer` (which wants a full `AppConfig` anyway,
+/// but `run()` cannot be called twice and binds sockets).
+fn refuse_inert_auth_flag(config: &AppConfig) -> Result<()> {
+    if config.gateway.session_tokens_required {
+        return Err(garraia_common::Error::Config(
+            "gateway.session_tokens_required: true is set, but this flag is NOT implemented: \
+             no HTTP route validates session tokens today, so it would protect nothing while \
+             claiming to. Refusing to start rather than pretend. Fix: remove the flag (or set \
+             it to false) in your config file — this changes nothing about actual behavior, \
+             it only stops asserting a protection that does not exist. Track the real \
+             implementation in the GarraRUST issue tracker."
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
 impl GatewayServer {
     pub fn new(config: AppConfig) -> Self {
         Self {
@@ -83,6 +117,10 @@ impl GatewayServer {
         if let Err(e) = dotenvy::dotenv() {
             tracing::debug!("no .env file loaded: {e}");
         }
+
+        // Security finding from the #930 investigation: refuse to boot with a
+        // hardening flag that does not do what its documentation promised.
+        refuse_inert_auth_flag(&self.config)?;
 
         let addr = format!("{}:{}", self.config.gateway.host, self.config.gateway.port);
         let tls_cert = self.config.gateway.tls_cert_path.clone();
@@ -1314,4 +1352,31 @@ async fn build_storage_wiring(
     };
 
     (object_store, Some(staging))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// O flag ligado tem de impedir o boot, e a mensagem tem de nomear a
+    /// saída — a alternativa (subir com warning) manteria a mentira viva para
+    /// quem não lê log.
+    #[test]
+    fn inert_auth_flag_refuses_to_boot() {
+        let mut config = AppConfig::default();
+        config.gateway.session_tokens_required = true;
+
+        let err = refuse_inert_auth_flag(&config).expect_err("flag ligado deve recusar");
+        let msg = err.to_string();
+        assert!(msg.contains("session_tokens_required"), "msg = {msg}");
+        assert!(msg.contains("NOT implemented"), "msg = {msg}");
+        // A saída de uma linha tem de estar na própria mensagem.
+        assert!(msg.contains("remove the flag"), "msg = {msg}");
+    }
+
+    /// Quem roda hoje (default `false`) não pode ser afetado.
+    #[test]
+    fn default_config_boots() {
+        assert!(refuse_inert_auth_flag(&AppConfig::default()).is_ok());
+    }
 }

--- a/docs/hardening-gateway.md
+++ b/docs/hardening-gateway.md
@@ -44,7 +44,9 @@ gateway:
   # Valor LITERAL no arquivo (não há interpolação de env no config —
   # gere com `openssl rand -hex 32` e proteja o arquivo com chmod 0600):
   api_key: "<token-forte-aqui>"
-  session_tokens_required: true   # exige token de sessão nas rotas /api/*
+  # NÃO adicione `session_tokens_required: true`: o flag NÃO está implementado
+  # (nenhuma rota HTTP valida token de sessão hoje) e o gateway RECUSA subir
+  # com ele ligado, em vez de fingir proteção. Ver "Limitações conhecidas" §2.
   session_ttl_secs: 86400         # validade do token (1 dia)
   session_idle_secs: 3600         # corte por inatividade (1h)
   allowed_origins:                # vazio = allow-all; liste explicitamente
@@ -152,9 +154,15 @@ Arquivo completo comentado, validado com `garra config check`:
 1. `gateway.api_key` só aceita valor literal no arquivo — não há
    interpolação de env no config (a linha `GARRAIA_API_KEY` do
    `.env.example` é aspiracional; suportá-la de verdade é follow-up).
-2. Auth do gateway local é **opt-in** hoje (`api_key`/
-   `session_tokens_required` desligados por default) — endurecer esse
-   default está no roadmap.
+2. Auth do gateway local: **só o WebSocket `/ws` tem gate hoje**, e só
+   quando `gateway.api_key` está definido. As rotas REST (`/api/*`,
+   `/v1/chat/completions`, `/v1/messages`, `/a2a/*`) não têm autenticação
+   por api_key — proteja-as por topologia (loopback, firewall, reverse
+   proxy). `session_tokens_required` **não está implementado**: o
+   middleware nunca foi ligado ao router, e desde a investigação da
+   issue #930 o gateway recusa subir com o flag em `true` em vez de
+   afirmar uma proteção inexistente. Endurecer esses defaults está no
+   roadmap.
 3. "Controle de aplicativos" (GUI/automação de apps) não existe como
    tool — ver a nota em mcp-capacidades.md.
 4. TLS embutido exige build com `--features garraia-gateway/tls`; binários release


### PR DESCRIPTION
## Descrição

Primeiro PR da Trilha A do lote #928–#930. Como nos dois lotes anteriores, **a verificação desmentiu o diagnóstico** — e desta vez encontrou um problema de segurança sem issue, mais grave que o relato.

### #930 — o relato está causalmente errado

`gateway.api_key` é lido por **exatamente um** gate em todo o gateway: o handshake do WebSocket `/ws` (`ws.rs:38-63`). Nenhuma rota REST o consulta — `X-API-Key` aparece no código só como chave de bucket de rate limit (dentro de um extractor `#[deprecated]`), nunca comparado com config.

E `api_key: null` é a saída **normal** do `garra init`: `model.rs` não tem nenhum `skip_serializing_if`, então todo `Option::None` serializa como `null` no YAML. Não é corrupção; é o default.

**Preencher o campo não destravaria REST nenhum e quebraria todo cliente WebSocket existente** — o webchat manda a chave como query param `token` no upgrade (`webchat.html:3863`). A causa provável do sintoma real do relator é outra: `llm.<nome>.api_key: null` (provider pulado no boot em `bootstrap/mod.rs:76-95` → 503 no `/v1/chat/completions`) ou script batendo em rota `/v1/*` do REST v1, que exige `Principal`/JWT.

### O achado sem issue: um flag de hardening que não faz nada

> `require_session_auth` (`session_auth.rs:91`) é **código morto** — nunca é passado a `.layer()`. Logo `gateway.session_tokens_required: true` era um **no-op** para HTTP, enquanto `docs/hardening-gateway.md:47`, os dois READMEs e o próprio `config.hardened.example.yml` afirmavam que ele exige token nas rotas `/api/*`.

Quem seguiu o guia de hardening acreditava estar protegido e não estava. O detalhe que fecha o argumento: **o exemplo oficial de config endurecida ligava o flag** — ou seja, o artefato que o projeto oferece para "fazer certo" instalava a falsa segurança.

### A decisão: falhar alto, não wirear agora

Wirear o middleware de verdade ligaria auth de surpresa em quem hoje depende do acesso aberto — a surpresa oposta, entregue a outras pessoas (inclusive a integração local do próprio relator). Em vez disso:

1. **O boot recusa subir** com o flag em `true` (`refuse_inert_auth_flag`, `server.rs`). A mensagem nomeia a saída de uma linha: remover o flag muda **zero** no comportamento real — só para de afirmar uma proteção que não existe. Função livre e pura, testada nos dois sentidos (recusa com `true`, default sobe intocado).
2. **`garraia config check` ganha um Error** para a mesma condição, no molde do #925. Error e não Warning deliberadamente: o `garra start` recusa exatamente essa config, e um check verde numa config que não sobe seria uma segunda mentira.
3. **As seis afirmações falsas corrigidas**: `docs/hardening-gateway.md` (o yaml de exemplo e a seção "Limitações conhecidas", que agora documenta o escopo real da `api_key` — só o `/ws`; a superfície REST depende de topologia), `README.md`, `README.pt-BR.md` (2×) e `config.hardened.example.yml`.

**Desvio do plano, deliberado:** sem finding "Info" para o escopo da `api_key` — `Severity` só tem Error/Warning, e um aviso incondicional em toda execução (o `null` é default do wizard) seria ruído, não diagnóstico. O esclarecimento foi para as docs, onde o operador da #930 teria procurado.

**Registrado sem consertar** (ampliaria o PR sem decisão do dono): `/ws/parrot` (`router.rs:202`) não tem auth **nenhuma** — nem a `api_key` que o `/ws` irmão exige.

Closes #930

## Tipo de mudança

- [x] `fix`: Correção de bug
- [x] `docs`: Documentação apenas
- [x] `test`: Adição ou correção de testes

## Classe de Risco

- [x] **Classe C (Alto Risco)**: Mudanças de auth ou postura de segurança.

Vale ser preciso sobre a direção: o PR **não adiciona nem remove autenticação de rota nenhuma**. Ele muda o que acontece com uma config que afirma uma proteção inexistente: antes subia em silêncio, agora recusa com instrução. Quem roda o default (`false`) não é afetado — há teste para isso.

## Checklist de Segurança e Qualidade

- [x] `cargo fmt --check` executado e limpo
- [x] `cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings` sem erros
- [x] `cargo test --workspace --exclude garraia-desktop` — **2250 passando**, 1 falha ambiental (a de sempre: `migration_001` sem `/var/run/docker.sock`; o job `Test (ubuntu-latest)` valida)
- [x] Nenhum `unwrap()` em código de produção
- [x] Nenhum segredo commitado
- [x] Nenhuma migração Postgres

## Mudanças na API pública e Schema

- Nenhuma rota, nenhum campo de config novo, nenhuma migration.
- **Mudança de comportamento**: `garra start` com `gateway.session_tokens_required: true` passa de "sobe fingindo" para "recusa com instrução". É o ponto do PR.
- `config check` ganha um finding Error condicional (campo `gateway.session_tokens_required`). O shape do `--json` não muda.

## Como testar

```bash
cargo +1.95 test -p garraia-gateway --lib server::tests   # 2 novos: recusa + default sobe
cargo +1.95 test -p garraia-config check::                # 54 (1 novo: inert_session_tokens_flag_is_error)

# Fim a fim:
printf 'gateway:\n  session_tokens_required: true\n' >> ~/.config/garraia/config.yml
garraia config check     # Error nomeando o flag
garraia start            # recusa, com a saída de uma linha na mensagem
```

## Plano de Rollback

Commit único (`ff4375c`). Reverter restaura o comportamento antigo — o flag volta a ser aceito em silêncio — e as seis afirmações falsas voltam às docs. Se só a recusa de boot incomodar, o corte mínimo é remover a chamada a `refuse_inert_auth_flag` em `run()`: o Error do `config check` e as docs corrigidas ficam, e o operador ainda descobre a verdade pelas duas outras vias.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF

---
_Generated by [Claude Code](https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF)_