### PR TITLE
chore(release): v0.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [0.3.9] - 2026-09-05
 
-Segundo lote de retorno de campo do mesmo usuario da v0.3.6/v0.3.7 (Samsung
-A16 / Android 13 / Termux, agora na v0.3.8): issues #920-#925.
+Dois lotes de retorno de campo do mesmo usuario da v0.3.6/v0.3.7 (Samsung
+A16 / Android 13 / Termux, com o Garra orquestrado pelo Hermes via MCP):
+issues #920-#925 (4 PRs: #926/#927/#931/#932) e #928-#930 (#945/#946), mais
+a persona da Hera (#966). Como nos lotes anteriores, a verificacao mudou o
+diagnostico da maioria dos relatos — o detalhe esta no corpo de cada PR — e
+achou um bug de seguranca que ninguem reportou (#945).
 
 ### Added
 - **Wrapper `garra-mcp-server-linker` no Termux (#920).** "O exec falha no
@@ -33,6 +37,26 @@ A16 / Android 13 / Termux, agora na v0.3.8): issues #920-#925.
   receita do `linker64` pronta para colar. `TermuxItem.next_step` passa de
   `&'static str` para `String` para poder nomear o caminho real; a forma
   serializada de `doctor --json` nao muda.
+- **Tool `telegram_send` de envio proativo (#921).** O agente pode *iniciar*
+  uma mensagem no Telegram (lembrete agendado, "o backup terminou", resposta
+  de tarefa longa) em vez de so responder. Deny-by-default: responder no chat
+  corrente nao pede config; mandar para um chat que o modelo *nomeia* exige o
+  id em `channels.telegram.proactive_chat_ids` — lista separada de proposito
+  do allowlist de usuarios (que tem modo `open`, perigoso demais para decidir
+  quem o bot pode procurar sozinho). Vazia = recusa tudo; lida a cada envio
+  (revogacao sem restart). Rate limit de 5 mensagens/conversa/minuto
+  (`SendBudget`); recusa nao consome cota. Documentada em `docs/channels.md`.
+
+  De quebra, a investigacao achou que **a entrega Telegram de tarefas
+  agendadas estava silenciosamente quebrada** — nada no repo escrevia
+  `telegram_chat_id` no metadata que `Channel::send_message` exige — e o
+  mesmo caminho novo de enderecamento (`ProactiveTargets`/
+  `with_channel_address`) conserta os heartbeats.
+- **Persona: o Garra conhece a Hera e a Forja (#966).** Port do plan 0274
+  adaptado ao `agent_router`/`NamedAgentConfig`; a persona explica que a
+  conversa direta entre agentes ainda nao esta disponivel (issue #965).
+  `docs/configuration.md` corrige o exemplo de `agents:` para o formato real
+  e `docs/hera-persona.md` entra na doc.
 
 ### Fixed
 - **O aviso de secret de auth ausente passa a ser acionavel (#925).** Ele dizia
@@ -57,6 +81,52 @@ A16 / Android 13 / Termux, agora na v0.3.8): issues #920-#925.
   cofre ser tambem o ultimo fallback do JWT — entao quem rodou o `garraia init`
   e escolheu o cofre pode ja ter um secret sem saber. `docs/index.md` nao
   linkava esse documento de lugar nenhum; passa a linkar.
+- **`file_read`/`file_write` resolvem caminhos como o usuario espera (#923).**
+  Nao era sandbox (producao roda com `allowed_directories: None`): nao havia
+  expansao de `~`/`$HOME` em lugar nenhum, o `working_dir` da sessao era
+  ignorado e o erro nao nomeava o caminho tentado — foi assim que o agente
+  disse ao usuario que um arquivo existente "nao existia". Novos resolvers
+  puros (`expand_home` + `resolve_tool_path`, com `PathOrigin` dizendo qual
+  regra decidiu), e o erro agora carrega o caminho resolvido + o pedido +
+  a dica. `..` continua rejeitado no input cru, antes de qualquer expansao.
+- **Tools MCP nao congelam mais no snapshot do boot (#924).** A lista de
+  tools do `AgentRuntime` era escrita uma vez no boot e congelava num `Arc`:
+  servidor que conectasse depois (reconexao do health monitor, admin API)
+  aparecia `connected` com N tools e o LLM nao conseguia chamar nenhuma —
+  `garraia mcp call` funcionava, o que disfarcava o bug de capacidade como
+  bug de contador. Agora `tools: RwLock<Vec<RegisteredTool>>` com
+  `ToolSource` (`native` vs `mcp{server}`), sync a cada tick do health
+  monitor, e `GET /api/mcp/tools` expoe o breakdown +
+  `runtime_in_sync_with_manager` no `/api/mcp/health` para isso ser
+  checavel de fora.
+- **Continuidade de conversa no WS e no REST mobile (#922).** Dois bugs: o
+  handler REST passava `&[]` como historico sob um comentario falso ("history
+  already hydrated into runtime session" — o runtime nao guarda historico), e
+  o `/ws` so retomava sessao durável com token *presente*, nao *verificado*
+  (`token_verified` ≠ `token_ok`). O webchat passa a persistir e reenviar o
+  `session_token`. Teste-guarda varre o fonte do handler para o `&[]` nao
+  voltar.
+- **`gateway.session_tokens_required: true` recusa o boot em vez de mentir
+  (#945, achado de verificacao — sem issue).** `require_session_auth` era
+  codigo morto (nunca ia a `.layer()`), entao o flag era no-op para HTTP —
+  e tres documentos, incluindo o guia de hardening e o
+  `config.hardened.example.yml` oficial, afirmavam o contrario. Quem seguiu
+  o guia acreditava estar protegido e nao estava. Agora o boot falha alto
+  nomeando a saida em uma linha, `config check` reporta Error, e os seis
+  lugares que mentiam foram corrigidos (`gateway.api_key` protege so o
+  `/ws`; docs dizem exatamente isso).
+- **Telegram reconecta no boot em vez de emudecer para sempre (#946/#928).**
+  `TelegramChannel::connect()` nao tinha retry: 5s de rede movel ruim na
+  hora errada custavam o canal ate restart manual — enquanto o *polling* do
+  teloxide ja reconectava para sempre (1s→64s). Falha de boot agora vira
+  retry em background (exponencial 2s→cap 60s, a forma do OpenClaw), sem
+  teto de tentativas de proposito, registrando o canal quando conectar.
+  O resto do relato da #928 (strings de log do CPython, unit systemd
+  `portao-despachante`) nao e deste repositorio — detalhe no PR e na issue.
+- **Ancora #115 do ledger CodeQL reapontada (#932).** O shift de +54 linhas
+  do #921 em `session_store.rs` moveu a linha ancorada; o fix reaponta linha
+  e referencias internas sem tocar o `sink_snippet` (que o script proibe
+  editar para "passar").
 
 ## [0.3.8] - 2026-09-04
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3187,7 +3187,7 @@ dependencies = [
 
 [[package]]
 name = "garraia"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -3233,7 +3233,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-agents"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "async-trait",
  "axum",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-auth"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-channels"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "async-trait",
  "axum",
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-common"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-config"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "dirs 6.0.0",
  "garraia-common",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-db"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-desktop"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -3391,7 +3391,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-embeddings"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "async-trait",
  "serde",
@@ -3405,7 +3405,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-gateway"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3491,7 +3491,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-learning"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "garraia-common",
  "garraia-skills",
@@ -3505,7 +3505,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-media"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "base64 0.23.1",
  "bytes",
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-plugins"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3555,7 +3555,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-security"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "base64 0.23.1",
  "garraia-common",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-skills"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "garraia-common",
  "reqwest 0.12.28",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-storage"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3611,7 +3611,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-telemetry"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "axum",
@@ -3647,7 +3647,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-voice"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3661,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-workspace"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.8"
+version = "0.3.9"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/michelbr84/GarraRUST"

--- a/TODO.md
+++ b/TODO.md
@@ -5,14 +5,30 @@ Status operacional do backlog do GarraIA/GarraRUST. Este arquivo complementa
 foi concluído, o que ficou parcial ou adiado, decisões tomadas e próximos passos
 curtos para a próxima sessão autônoma.
 
-**Atualizado:** 2026-09-04 (America/New_York)
+**Atualizado:** 2026-09-05 (America/New_York)
 
 > O Linear foi descontinuado em 2026-08-18; o planejamento vive no tracker
 > interno. Menções a "Done in Linear", "In Review" ou "issues Linear" nas seções
 > históricas abaixo são registro da época, não estado atual. IDs `GAR-xxx`
 > permanecem como identificadores históricos.
 
-## Em andamento 2026-09-04 — segundo lote de campo (#920-#925), 4 PRs
+## Em andamento 2026-09-05 — pós-v0.3.9: Trilha B (épico #944) e novo lote de memória
+
+A v0.3.9 fecha os dois lotes de campo (#920-#925 e #928-#930). Estado:
+
+| Trilha | Estado |
+| --- | --- |
+| A operacional (#928-#930) | **fechada** — #945 e #946 merged; **#947 (a2a_send) fechado sem merge pelo dono** — a direção de conversa entre agentes migrou para a #965 (agentes nomeados via `agent_router`, não URL); #929 segue aberta aguardando essa direção |
+| B — épico #944 Terminal UX v2 | Fase 1 em voo: **B-PR1 (#933, sinks de tracing + `--verbose`)** pronto em `claude/6-issues-strategy-5mufs3-b1`; **B-PR2 (#936, spinner com janela de aparição + cronômetro)** pronto em `…-b2`; PRs abrem após o corte da v0.3.9. Depois: B-PR3 (#934+#935), ADR 0017 antes do #942 |
+| C — memória semântica (novo) | 18 issues novas do dono (#948-#964 embeddings/memória + #965 A2A nomeado) abertas em 2026-09-05, **fora do plano aprovado** — prioridade entre B e C é decisão do dono |
+
+Pendências registradas sem issue: `/ws/parrot` sem auth; rotas A2A do
+servidor sem auth (loopback é a única proteção); `server.rs` >1500 linhas
+(candidato a refactor); `timeouts.channels` (só se o retry do #946 não
+bastar); `openclaw_bridge.rs` morto no disco; #928 aguarda journal do
+binário Rust do relator.
+
+## Concluído 2026-09-04/05 — segundo lote de campo (#920-#925), 4 PRs
 
 Seis issues novas do mesmo relator (Samsung A16 / Android 13 / Termux, v0.3.8
 de release, Garra em produção orquestrado pelo Hermes via MCP). Como no lote
@@ -23,10 +39,10 @@ Ordem escolhida (há duas dependências reais de código, não é preferência):
 
 | PR | Issues | Estado |
 | --- | --- | --- |
-| 1 | #920 + #925 | **entregue** — instalador, doctor, docs |
-| 2 | #923 + #924 | a fazer — superfície de tools do agente |
-| 3 | #921 | a fazer — depende do PR2 |
-| 4 | #922 | a fazer — depende do PR3 |
+| 1 | #920 + #925 | **entregue** (#926) — instalador, doctor, docs |
+| 2 | #923 + #924 | **entregue** (#927) — superfície de tools do agente |
+| 3 | #921 | **entregue** (#931) — telegram_send + entrega agendada |
+| 4 | #922 | **entregue** (#932) — continuidade WS/REST + âncora CodeQL |
 
 PR2 antes do PR3 porque corrigir a #924 direito torna a lista de tools do
 runtime mutável, o que elimina a janela de `Arc::get_mut` em `server.rs:252` —


### PR DESCRIPTION
## Descrição

Corte da **v0.3.9**, no padrão dos releases anteriores ([#915](https://github.com/michelbr84/GarraRUST/pull/915)/[#919](https://github.com/michelbr84/GarraRUST/pull/919), commits `735394d`/`442233e`): um commit tocando exatamente os 3 arquivos canônicos + um commit de docs atualizando o `TODO.md`.

**Escopo** — tudo em `main` além da tag `v0.3.8`:

- Lote de campo **#920–#925** (PRs [#926](https://github.com/michelbr84/GarraRUST/pull/926), [#927](https://github.com/michelbr84/GarraRUST/pull/927), [#931](https://github.com/michelbr84/GarraRUST/pull/931), [#932](https://github.com/michelbr84/GarraRUST/pull/932)): wrapper linker64, resolução de caminhos das tools, tools MCP sem congelar no boot, `telegram_send` proativo (+ conserto da entrega agendada silenciosamente quebrada), continuidade WS/REST.
- Lote operacional **#928–#930** ([#945](https://github.com/michelbr84/GarraRUST/pull/945), [#946](https://github.com/michelbr84/GarraRUST/pull/946)): `session_tokens_required` inerte recusa o boot em vez de mentir (+ 6 docs corrigidos); Telegram reconecta no boot (2s→60s, sem teto).
- **#966** (dono): persona da Hera/Forja.
- O **[#947](https://github.com/michelbr84/GarraRUST/pull/947) (a2a_send) foi fechado sem merge pelo dono** e não entra — o CHANGELOG e o TODO registram que a direção de conversa entre agentes migrou para a #965.

**Motivo de cortar agora:** #945/#946 mudam comportamento do binário e o wrapper do #920 vive no installer — nada disso alcança o usuário de campo (Termux, v0.3.8) sem release.

O `[Unreleased]` só carregava as entries do PR1 do lote; as dos demais (#921–#924, #945, #946, #966) foram escritas aqui no estilo da casa.

## Tipo de mudança

- [x] `chore`: Release
- [x] `docs`: CHANGELOG + TODO

## Classe de Risco

- [x] **Classe A (Baixo Risco)**: Nenhum código de produção tocado — versão, lockfile e documentação.

## Checklist de Segurança e Qualidade

- [x] `Cargo.toml:29` é a única edição manual de versão (0.3.8 → 0.3.9)
- [x] `Cargo.lock` regenerado por `cargo check` (38 linhas, 19 entradas garraia — mesmo shape dos cortes anteriores)
- [x] Nenhum segredo commitado
- [x] Nenhuma migração

## Mudanças na API pública e Schema

- Nenhuma. Só metadados de versão e documentação.

## Como testar

```bash
grep -n 'version = "0.3.9"' Cargo.toml        # linha 29, única
git diff v0.3.8..HEAD --stat -- Cargo.toml Cargo.lock CHANGELOG.md TODO.md
```

Após o merge, a tag `v0.3.9` no commit de merge dispara o `release.yml` (com a guarda de plataforma do asset Android introduzida na v0.3.8).

## Plano de Rollback

Reverter os dois commits restaura 0.3.8 nos metadados. Nada de runtime muda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF

---
_Generated by [Claude Code](https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF)_