### PR TITLE
fix: Telegram channel reconnects on boot failure instead of staying silent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [0.3.9] - 2026-09-05
 
-Segundo lote de retorno de campo do mesmo usuario da v0.3.6/v0.3.7 (Samsung
-A16 / Android 13 / Termux, agora na v0.3.8): issues #920-#925.
+Dois lotes de retorno de campo do mesmo usuario da v0.3.6/v0.3.7 (Samsung
+A16 / Android 13 / Termux, com o Garra orquestrado pelo Hermes via MCP):
+issues #920-#925 (4 PRs: #926/#927/#931/#932) e #928-#930 (#945/#946), mais
+a persona da Hera (#966). Como nos lotes anteriores, a verificacao mudou o
+diagnostico da maioria dos relatos — o detalhe esta no corpo de cada PR — e
+achou um bug de seguranca que ninguem reportou (#945).
 
 ### Added
 - **Wrapper `garra-mcp-server-linker` no Termux (#920).** "O exec falha no
@@ -33,6 +37,26 @@ A16 / Android 13 / Termux, agora na v0.3.8): issues #920-#925.
   receita do `linker64` pronta para colar. `TermuxItem.next_step` passa de
   `&'static str` para `String` para poder nomear o caminho real; a forma
   serializada de `doctor --json` nao muda.
+- **Tool `telegram_send` de envio proativo (#921).** O agente pode *iniciar*
+  uma mensagem no Telegram (lembrete agendado, "o backup terminou", resposta
+  de tarefa longa) em vez de so responder. Deny-by-default: responder no chat
+  corrente nao pede config; mandar para um chat que o modelo *nomeia* exige o
+  id em `channels.telegram.proactive_chat_ids` — lista separada de proposito
+  do allowlist de usuarios (que tem modo `open`, perigoso demais para decidir
+  quem o bot pode procurar sozinho). Vazia = recusa tudo; lida a cada envio
+  (revogacao sem restart). Rate limit de 5 mensagens/conversa/minuto
+  (`SendBudget`); recusa nao consome cota. Documentada em `docs/channels.md`.
+
+  De quebra, a investigacao achou que **a entrega Telegram de tarefas
+  agendadas estava silenciosamente quebrada** — nada no repo escrevia
+  `telegram_chat_id` no metadata que `Channel::send_message` exige — e o
+  mesmo caminho novo de enderecamento (`ProactiveTargets`/
+  `with_channel_address`) conserta os heartbeats.
+- **Persona: o Garra conhece a Hera e a Forja (#966).** Port do plan 0274
+  adaptado ao `agent_router`/`NamedAgentConfig`; a persona explica que a
+  conversa direta entre agentes ainda nao esta disponivel (issue #965).
+  `docs/configuration.md` corrige o exemplo de `agents:` para o formato real
+  e `docs/hera-persona.md` entra na doc.
 
 ### Fixed
 - **O aviso de secret de auth ausente passa a ser acionavel (#925).** Ele dizia
@@ -57,6 +81,52 @@ A16 / Android 13 / Termux, agora na v0.3.8): issues #920-#925.
   cofre ser tambem o ultimo fallback do JWT — entao quem rodou o `garraia init`
   e escolheu o cofre pode ja ter um secret sem saber. `docs/index.md` nao
   linkava esse documento de lugar nenhum; passa a linkar.
+- **`file_read`/`file_write` resolvem caminhos como o usuario espera (#923).**
+  Nao era sandbox (producao roda com `allowed_directories: None`): nao havia
+  expansao de `~`/`$HOME` em lugar nenhum, o `working_dir` da sessao era
+  ignorado e o erro nao nomeava o caminho tentado — foi assim que o agente
+  disse ao usuario que um arquivo existente "nao existia". Novos resolvers
+  puros (`expand_home` + `resolve_tool_path`, com `PathOrigin` dizendo qual
+  regra decidiu), e o erro agora carrega o caminho resolvido + o pedido +
+  a dica. `..` continua rejeitado no input cru, antes de qualquer expansao.
+- **Tools MCP nao congelam mais no snapshot do boot (#924).** A lista de
+  tools do `AgentRuntime` era escrita uma vez no boot e congelava num `Arc`:
+  servidor que conectasse depois (reconexao do health monitor, admin API)
+  aparecia `connected` com N tools e o LLM nao conseguia chamar nenhuma —
+  `garraia mcp call` funcionava, o que disfarcava o bug de capacidade como
+  bug de contador. Agora `tools: RwLock<Vec<RegisteredTool>>` com
+  `ToolSource` (`native` vs `mcp{server}`), sync a cada tick do health
+  monitor, e `GET /api/mcp/tools` expoe o breakdown +
+  `runtime_in_sync_with_manager` no `/api/mcp/health` para isso ser
+  checavel de fora.
+- **Continuidade de conversa no WS e no REST mobile (#922).** Dois bugs: o
+  handler REST passava `&[]` como historico sob um comentario falso ("history
+  already hydrated into runtime session" — o runtime nao guarda historico), e
+  o `/ws` so retomava sessao durável com token *presente*, nao *verificado*
+  (`token_verified` ≠ `token_ok`). O webchat passa a persistir e reenviar o
+  `session_token`. Teste-guarda varre o fonte do handler para o `&[]` nao
+  voltar.
+- **`gateway.session_tokens_required: true` recusa o boot em vez de mentir
+  (#945, achado de verificacao — sem issue).** `require_session_auth` era
+  codigo morto (nunca ia a `.layer()`), entao o flag era no-op para HTTP —
+  e tres documentos, incluindo o guia de hardening e o
+  `config.hardened.example.yml` oficial, afirmavam o contrario. Quem seguiu
+  o guia acreditava estar protegido e nao estava. Agora o boot falha alto
+  nomeando a saida em uma linha, `config check` reporta Error, e os seis
+  lugares que mentiam foram corrigidos (`gateway.api_key` protege so o
+  `/ws`; docs dizem exatamente isso).
+- **Telegram reconecta no boot em vez de emudecer para sempre (#946/#928).**
+  `TelegramChannel::connect()` nao tinha retry: 5s de rede movel ruim na
+  hora errada custavam o canal ate restart manual — enquanto o *polling* do
+  teloxide ja reconectava para sempre (1s→64s). Falha de boot agora vira
+  retry em background (exponencial 2s→cap 60s, a forma do OpenClaw), sem
+  teto de tentativas de proposito, registrando o canal quando conectar.
+  O resto do relato da #928 (strings de log do CPython, unit systemd
+  `portao-despachante`) nao e deste repositorio — detalhe no PR e na issue.
+- **Ancora #115 do ledger CodeQL reapontada (#932).** O shift de +54 linhas
+  do #921 em `session_store.rs` moveu a linha ancorada; o fix reaponta linha
+  e referencias internas sem tocar o `sink_snippet` (que o script proibe
+  editar para "passar").
 
 ## [0.3.8] - 2026-09-04
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3187,7 +3187,7 @@ dependencies = [
 
 [[package]]
 name = "garraia"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -3233,7 +3233,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-agents"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "async-trait",
  "axum",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-auth"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-channels"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "async-trait",
  "axum",
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-common"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-config"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "dirs 6.0.0",
  "garraia-common",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-db"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3374,7 +3374,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-desktop"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -3391,7 +3391,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-embeddings"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "async-trait",
  "serde",
@@ -3405,7 +3405,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-gateway"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3491,7 +3491,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-learning"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "garraia-common",
  "garraia-skills",
@@ -3505,7 +3505,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-media"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "base64 0.23.1",
  "bytes",
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-plugins"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3555,7 +3555,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-security"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "base64 0.23.1",
  "garraia-common",
@@ -3571,7 +3571,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-skills"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "garraia-common",
  "reqwest 0.12.28",
@@ -3584,7 +3584,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-storage"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3611,7 +3611,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-telemetry"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "axum",
@@ -3647,7 +3647,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-voice"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -3661,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "garraia-workspace"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.8"
+version = "0.3.9"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/michelbr84/GarraRUST"

--- a/TODO.md
+++ b/TODO.md
@@ -5,14 +5,30 @@ Status operacional do backlog do GarraIA/GarraRUST. Este arquivo complementa
 foi concluído, o que ficou parcial ou adiado, decisões tomadas e próximos passos
 curtos para a próxima sessão autônoma.
 
-**Atualizado:** 2026-09-04 (America/New_York)
+**Atualizado:** 2026-09-05 (America/New_York)
 
 > O Linear foi descontinuado em 2026-08-18; o planejamento vive no tracker
 > interno. Menções a "Done in Linear", "In Review" ou "issues Linear" nas seções
 > históricas abaixo são registro da época, não estado atual. IDs `GAR-xxx`
 > permanecem como identificadores históricos.
 
-## Em andamento 2026-09-04 — segundo lote de campo (#920-#925), 4 PRs
+## Em andamento 2026-09-05 — pós-v0.3.9: Trilha B (épico #944) e novo lote de memória
+
+A v0.3.9 fecha os dois lotes de campo (#920-#925 e #928-#930). Estado:
+
+| Trilha | Estado |
+| --- | --- |
+| A operacional (#928-#930) | **fechada** — #945 e #946 merged; **#947 (a2a_send) fechado sem merge pelo dono** — a direção de conversa entre agentes migrou para a #965 (agentes nomeados via `agent_router`, não URL); #929 segue aberta aguardando essa direção |
+| B — épico #944 Terminal UX v2 | Fase 1 em voo: **B-PR1 (#933, sinks de tracing + `--verbose`)** pronto em `claude/6-issues-strategy-5mufs3-b1`; **B-PR2 (#936, spinner com janela de aparição + cronômetro)** pronto em `…-b2`; PRs abrem após o corte da v0.3.9. Depois: B-PR3 (#934+#935), ADR 0017 antes do #942 |
+| C — memória semântica (novo) | 18 issues novas do dono (#948-#964 embeddings/memória + #965 A2A nomeado) abertas em 2026-09-05, **fora do plano aprovado** — prioridade entre B e C é decisão do dono |
+
+Pendências registradas sem issue: `/ws/parrot` sem auth; rotas A2A do
+servidor sem auth (loopback é a única proteção); `server.rs` >1500 linhas
+(candidato a refactor); `timeouts.channels` (só se o retry do #946 não
+bastar); `openclaw_bridge.rs` morto no disco; #928 aguarda journal do
+binário Rust do relator.
+
+## Concluído 2026-09-04/05 — segundo lote de campo (#920-#925), 4 PRs
 
 Seis issues novas do mesmo relator (Samsung A16 / Android 13 / Termux, v0.3.8
 de release, Garra em produção orquestrado pelo Hermes via MCP). Como no lote
@@ -23,10 +39,10 @@ Ordem escolhida (há duas dependências reais de código, não é preferência):
 
 | PR | Issues | Estado |
 | --- | --- | --- |
-| 1 | #920 + #925 | **entregue** — instalador, doctor, docs |
-| 2 | #923 + #924 | a fazer — superfície de tools do agente |
-| 3 | #921 | a fazer — depende do PR2 |
-| 4 | #922 | a fazer — depende do PR3 |
+| 1 | #920 + #925 | **entregue** (#926) — instalador, doctor, docs |
+| 2 | #923 + #924 | **entregue** (#927) — superfície de tools do agente |
+| 3 | #921 | **entregue** (#931) — telegram_send + entrega agendada |
+| 4 | #922 | **entregue** (#932) — continuidade WS/REST + âncora CodeQL |
 
 PR2 antes do PR3 porque corrigir a #924 direito torna a lista de tools do
 runtime mutável, o que elimina a janela de `Arc::get_mut` em `server.rs:252` —

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -40,7 +40,9 @@ metrics = "0.24"
 # Telegram (for voice handler)
 teloxide = { workspace = true }
 
-tokio = { workspace = true }
+# Issue #928: `test-util` dá o `start_paused` dos testes do retry de canal —
+# o backoff exponencial é inobservável contra relógio real.
+tokio = { workspace = true, features = ["test-util"] }
 dotenvy = { workspace = true }
 axum = { workspace = true }
 tower = { workspace = true }

--- a/crates/garraia-gateway/src/server.rs
+++ b/crates/garraia-gateway/src/server.rs
@@ -37,6 +37,66 @@ pub struct GatewayServer {
     telemetry_config: Option<garraia_telemetry::TelemetryConfig>,
 }
 
+/// Keep trying to connect a channel that failed at boot (issue #928).
+///
+/// The asymmetry this fixes: once connected, the Telegram polling loop
+/// already survives network loss — teloxide retries `getUpdates` forever
+/// with 1s→64s exponential backoff. Only the *first* connect had no second
+/// chance, so a transient failure in exactly the wrong five seconds left
+/// the channel silent until a human restarted the gateway. Slack, OpenClaw
+/// and iMessage all reconnect; Telegram was the odd one out.
+///
+/// Retries forever, like the polling loop it hands over to: the operator's
+/// intent in configuring the channel is "be on Telegram when the network
+/// allows", and there is no correct number of failures after which that
+/// intent expires. The cap keeps the pressure constant (one attempt per
+/// minute) instead of growing unbounded.
+fn spawn_channel_connect_retry(
+    state: Arc<AppState>,
+    mut channel: Box<dyn garraia_channels::Channel>,
+) {
+    tokio::spawn(async move {
+        let mut attempt: u32 = 0;
+        loop {
+            let delay = channel_retry_delay(attempt);
+            tokio::time::sleep(delay).await;
+            match channel.connect().await {
+                Ok(()) => {
+                    info!(
+                        channel = channel.channel_type(),
+                        attempts = attempt + 1,
+                        "channel connected after boot-time retry"
+                    );
+                    state.channels.write().await.register(channel);
+                    return;
+                }
+                Err(e) => {
+                    warn!(
+                        channel = channel.channel_type(),
+                        attempt = attempt + 1,
+                        next_retry_secs = channel_retry_delay(attempt + 1).as_secs(),
+                        "channel reconnect failed: {e}"
+                    );
+                    attempt = attempt.saturating_add(1);
+                }
+            }
+        }
+    });
+}
+
+/// Backoff for [`spawn_channel_connect_retry`]: 2s, 4s, 8s, … capped at 60s.
+///
+/// Same shape as the OpenClaw client's reconnect loop
+/// (`openclaw/client.rs`), which is the most complete of the three channel
+/// reconnect implementations. Pure so the boundary cases (growth, the cap,
+/// and no overflow at absurd attempt counts) are testable without a clock.
+fn channel_retry_delay(attempt: u32) -> std::time::Duration {
+    const BASE_SECS: u64 = 2;
+    const CAP_SECS: u64 = 60;
+    let exp = 2u64.saturating_pow(attempt.min(32));
+    std::time::Duration::from_secs(BASE_SECS.saturating_mul(exp).min(CAP_SECS))
+}
+
 /// Refuse to boot while `gateway.session_tokens_required` is set.
 ///
 /// Security finding from the #930 investigation: the middleware that was
@@ -664,13 +724,22 @@ impl GatewayServer {
             }
         });
 
-        // Start configured Telegram channels
+        // Start configured Telegram channels.
+        //
+        // Issue #928: a boot-time connect failure used to be terminal — one
+        // `warn!` and the channel stayed mute until a manual restart, while a
+        // failure *during* polling gets teloxide's own infinite exponential
+        // backoff. Five seconds of bad mobile network at boot cost the whole
+        // channel. Now the failed channel keeps retrying in the background
+        // with the same backoff shape the OpenClaw client uses.
         let telegram_channels = build_telegram_channels(&state.config, &state);
         for mut channel in telegram_channels {
-            if let Err(e) = channel.connect().await {
-                warn!("telegram channel failed to connect: {e}");
-            } else {
-                state.channels.write().await.register(channel);
+            match channel.connect().await {
+                Ok(()) => state.channels.write().await.register(channel),
+                Err(e) => {
+                    warn!("telegram channel failed to connect: {e}; retrying in background");
+                    spawn_channel_connect_retry(Arc::clone(&state), channel);
+                }
             }
         }
 
@@ -1357,6 +1426,79 @@ async fn build_storage_wiring(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// A borda que importa: cresce exponencialmente, satura no teto, e não
+    /// estoura com contagens absurdas de tentativa.
+    #[test]
+    fn retry_delay_grows_and_caps() {
+        assert_eq!(channel_retry_delay(0).as_secs(), 2);
+        assert_eq!(channel_retry_delay(1).as_secs(), 4);
+        assert_eq!(channel_retry_delay(3).as_secs(), 16);
+        assert_eq!(channel_retry_delay(5).as_secs(), 60, "teto");
+        assert_eq!(channel_retry_delay(u32::MAX).as_secs(), 60, "sem overflow");
+    }
+
+    /// Canal que falha N vezes e então conecta — o cenário da #928 em
+    /// miniatura: rede ruim nos primeiros segundos do boot.
+    struct FlakyChannel {
+        fails_left: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl garraia_channels::Channel for FlakyChannel {
+        fn channel_type(&self) -> &str {
+            "flaky-telegram"
+        }
+        fn display_name(&self) -> &str {
+            "Flaky"
+        }
+        async fn connect(&mut self) -> Result<()> {
+            if self.fails_left.fetch_sub(1, Ordering::SeqCst) > 1 {
+                Err(garraia_common::Error::Channel("network down".into()))
+            } else {
+                Ok(())
+            }
+        }
+        async fn disconnect(&mut self) -> Result<()> {
+            Ok(())
+        }
+        async fn send_message(&self, _m: &Message) -> Result<()> {
+            Ok(())
+        }
+        fn status(&self) -> garraia_channels::ChannelStatus {
+            garraia_channels::ChannelStatus::Connected
+        }
+    }
+
+    /// O comportamento que a #928 pedia sem saber: uma falha transitória de
+    /// boot não pode mais custar o canal — o retry de fundo acaba
+    /// registrando-o no `ChannelRegistry`, de onde `send_message` o alcança.
+    #[tokio::test(start_paused = true)]
+    async fn boot_retry_eventually_registers_the_channel() {
+        let state = Arc::new(AppState::new(
+            AppConfig::default(),
+            Arc::new(garraia_agents::AgentRuntime::new()),
+            garraia_channels::ChannelRegistry::new(),
+        ));
+
+        // Falha 3 vezes (2s + 4s + 8s de backoff), conecta na 4ª.
+        let channel = FlakyChannel {
+            fails_left: Arc::new(AtomicUsize::new(4)),
+        };
+        spawn_channel_connect_retry(Arc::clone(&state), Box::new(channel));
+
+        // Com o relógio pausado, cada advance dispara o sleep pendente.
+        for _ in 0..8 {
+            tokio::time::advance(std::time::Duration::from_secs(60)).await;
+            tokio::task::yield_now().await;
+        }
+
+        assert!(
+            state.channels.read().await.get("flaky-telegram").is_some(),
+            "canal deveria ter sido registrado após os retries"
+        );
+    }
 
     /// O flag ligado tem de impedir o boot, e a mensagem tem de nomear a
     /// saída — a alternativa (subir com warning) manteria a mentira viva para


### PR DESCRIPTION
## Descrição

Closes #928

Implementa retry automático em background para canais Telegram que falham na conexão durante o boot. Antes, uma falha transitória de rede (5s de mobile ruim no momento exato) deixava o canal mudo até restart manual — enquanto o polling do teloxide já reconectava para sempre com backoff exponencial. Agora a falha de boot dispara retry em background com a mesma estratégia (exponencial 2s→cap 60s, sem teto de tentativas), registrando o canal no `ChannelRegistry` quando conectar.

A assimetria que isto corrige: o polling loop já sobrevive perda de rede (teloxide retenta `getUpdates` para sempre com 1s→64s exponencial). Só a *primeira* conexão não tinha segunda chance. Slack, OpenClaw e iMessage já reconectam; Telegram era o outlier.

## Tipo de mudança

- [x] `fix`: Correção de bug

## Classe de Risco

- [x] **Classe B (Médio Risco)**: Refatoração interna com novo comportamento de retry, sem alteração de API pública ou schema.

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo fmt --check` executado e limpo
- [x] `cargo clippy --workspace --exclude garraia-desktop -- -D warnings` sem erros
- [x] `cargo test --workspace --exclude garraia-desktop` passando localmente
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo, API key, token ou credencial commitada
- [x] Nenhuma migração Postgres com operações destrutivas

## Mudanças na API pública e Schema

- Nenhuma mudança na API pública
- Nenhuma mudança em schema

## Como testar

1. Executar `cargo test --package garraia-gateway` — novo teste `boot_retry_eventually_registers_the_channel` valida que um canal que falha 3 vezes no boot eventualmente se registra após retries com backoff exponencial (2s, 4s, 8s).
2. Teste unitário `retry_delay_grows_and_caps` valida que o backoff cresce exponencialmente (2s, 4s, 8s, 16s, …) e satura no teto de 60s sem overflow em contagens absurdas de tentativa.
3. Integração: simular falha de rede no boot de um canal Telegram (ex.: desligar rede por 10s) e verificar que o canal se conecta automaticamente quando a rede volta, sem restart manual.

## Plano de Rollback

Reverter o commit remove a função `spawn_channel_connect_retry()` e volta o handler de boot para o comportamento anterior (falha de conexão = warn + sem retry). Canais que falharem no boot voltarão a exigir restart manual, mas nenhum estado persistente é afetado.

## Detalhes técnicos

- **`spawn_channel_connect_retry()`**: task assíncrona que retenta conexão com backoff exponencial (2s base, cap 60s). Retenta para sempre (sem teto) porque a intenção do operador em configurar o canal é "estar no Telegram quando a rede permitir", e não há número correto de falhas após o qual essa intenção expira.
- **`channel_retry_delay()`**: função pura que calcula delay com base no número de tentativa. Exponencial 2^attempt capeado em 60s, sem overflow em `u32::MAX`.
- **Novo feature `tokio/test-util`** em `Cargo.toml`: necessário para `#[tokio::test(start_paused = true)]` que permite testar o backoff exponencial sem relógio real.
- **Logging**: warn a cada

https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF