### PR TITLE
feat(cli): console limpo por default + flag --verbose (#933)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+Inicio da Trilha B — epico #944 (Garra Terminal UX v2), Fase 1.
+
+### Changed
+- **O console interativo fica limpo por default (#933).** O subscriber unico
+  escrevia o mesmo fluxo em `garraia.log` e no stderr, entao todo INFO de
+  registro de provider/tools/sessao competia com o spinner e com a resposta
+  streamada do chat. Agora sao dois layers com filtros independentes: o
+  arquivo segue com tudo no nivel pedido (`--log-level`, elevado por
+  `--debug`) e o stderr mostra so WARN+ — `--verbose` (flag global nova) traz
+  o INFO operacional conciso e `--debug` espelha o arquivo. `RUST_LOG` setado
+  e valido continua vencendo os dois lados, como sempre (GAR-138). A redacao
+  (regra absoluta 6) permanece nos dois caminhos, com teste que varre o fonte
+  para impedir a regressao de redigir so uma metade.
+
+  Ficam **fora** do console limpo, por serem canal de log e nao console:
+  `start`/`restart` (journald le o stderr do foreground) e `mcp-server` (o
+  host MCP loga o stderr do filho — `docs/cli-mcp-server.md` §Stdio
+  invariants). Esses espelham o arquivo como antes.
+
 ## [0.3.9] - 2026-09-05
 
 Dois lotes de retorno de campo do mesmo usuario da v0.3.6/v0.3.7 (Samsung

--- a/crates/garraia-cli/src/cli_args.rs
+++ b/crates/garraia-cli/src/cli_args.rs
@@ -144,6 +144,7 @@ mod tests {
         assert_injects(&["garra", "-m", "qwen3.8"]);
         assert_injects(&["garra", "--model=qwen3.8"]);
         assert_injects(&["garra", "--debug"]);
+        assert_injects(&["garra", "--verbose"]);
         assert_injects(&["garra", "--log-level", "debug"]);
         assert_injects(&["garra", "--log-level=debug"]);
         assert_injects(&["garra", "--provider", "ollama", "--model", "qwen3.8"]);

--- a/crates/garraia-cli/src/main.rs
+++ b/crates/garraia-cli/src/main.rs
@@ -14,6 +14,7 @@ mod migrate_workspace;
 mod repo_workflow;
 mod spinner;
 mod team;
+mod tracing_setup;
 mod update;
 mod verify;
 mod wizard;
@@ -25,7 +26,7 @@ use clap::{ArgAction, CommandFactory, Parser, Subcommand};
 use garraia_security::{RedactingMakeWriter, RedactingWriter};
 use tracing_appender::rolling;
 use tracing_subscriber::EnvFilter;
-use tracing_subscriber::fmt::writer::MakeWriterExt;
+use tracing_subscriber::util::SubscriberInitExt;
 
 /// Initialize OpenTelemetry tracing + Prometheus metrics if enabled.
 ///
@@ -57,11 +58,15 @@ struct Cli {
     #[command(subcommand)]
     command: Commands,
 
-    /// Log level (trace, debug, info, warn, error)
+    /// Log level for the persistent log file (trace, debug, info, warn, error)
     #[arg(long, default_value = "info", global = true)]
     log_level: String,
 
-    /// Enable debug mode (shortcut for --log-level debug with verbose output)
+    /// Show concise operational info (provider, model, tools) on the console
+    #[arg(long, global = true)]
+    verbose: bool,
+
+    /// Enable debug mode: full tracing on the console and in the log file
     #[arg(long, global = true)]
     debug: bool,
 }
@@ -849,6 +854,18 @@ fn kill_and_wait(pid: u32) -> bool {
 /// Derived from the clap tree rather than hand-written so it cannot drift:
 /// the union of value-taking *global* args and the value-taking args of the
 /// injected subcommand — exactly the flags that may legally precede it.
+/// Subcomandos cujo stderr é canal de log, não console interativo (#933):
+/// `start`/`restart` rodam o gateway em foreground com o journal do systemd
+/// preso ao stderr, e o host MCP loga o stderr do `mcp-server`
+/// (`docs/cli-mcp-server.md` §Stdio invariants). Eles seguem espelhando o
+/// arquivo; só os comandos interativos/one-shot ganham o console limpo.
+fn stderr_is_log_channel(command: &Commands) -> bool {
+    matches!(
+        command,
+        Commands::Start { .. } | Commands::Restart { .. } | Commands::McpServer
+    )
+}
+
 fn value_taking_flags() -> Vec<String> {
     fn push(out: &mut Vec<String>, arg: &clap::Arg) {
         if !matches!(arg.get_action(), ArgAction::Set | ArgAction::Append) {
@@ -896,7 +913,14 @@ fn main() -> Result<()> {
     }
 
     // Init tracing for non-daemon mode (daemon reconfigures after fork)
-    let init_tracing = |level: &str| {
+    let console = if stderr_is_log_channel(&cli.command) {
+        // Espelha o arquivo, como antes do #933: journald / host MCP leem o
+        // stderr desses subcomandos como log operacional.
+        tracing_setup::ConsoleMode::Debug
+    } else {
+        tracing_setup::console_mode(cli.debug, cli.verbose)
+    };
+    let init_tracing = move |level: &str| {
         let log_dir = garraia_dir();
         std::fs::create_dir_all(&log_dir).unwrap_or_else(|e| {
             eprintln!("Warning: failed to create log directory: {}", e);
@@ -912,22 +936,21 @@ fn main() -> Result<()> {
         //   RUST_LOG=garraia_gateway=debug,garraia_voice=trace
         //   RUST_LOG=garraia_agents::tools=debug
         // GAR-214: GARRAIA_LOG_FORMAT=json emits structured JSON lines (stdout/file)
-        let env_filter =
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(level));
-        if std::env::var("GARRAIA_LOG_FORMAT").as_deref() == Ok("json") {
-            tracing_subscriber::fmt()
-                .json()
-                .with_env_filter(env_filter)
-                .with_writer(file_appender.and(RedactingWriter::stderr()))
-                .with_ansi(false)
-                .init();
-        } else {
-            tracing_subscriber::fmt()
-                .with_env_filter(env_filter)
-                .with_writer(file_appender.and(RedactingWriter::stderr()))
-                .with_ansi(false)
-                .init();
-        }
+        // #933: arquivo e stderr são layers com filtros independentes — o
+        // arquivo fica com tudo no nível pedido, o console com WARN+ por
+        // default (--verbose = INFO operacional, --debug = espelha o arquivo).
+        let rust_log = std::env::var("RUST_LOG").ok();
+        let (file_dirs, stderr_dirs) =
+            tracing_setup::filter_directives(rust_log.as_deref(), level, console);
+        let json = std::env::var("GARRAIA_LOG_FORMAT").as_deref() == Ok("json");
+        tracing_setup::build_subscriber(
+            file_appender,
+            RedactingWriter::stderr(),
+            &file_dirs,
+            &stderr_dirs,
+            json,
+        )
+        .init();
     };
 
     // GAR-379 / plan 0035 — `config check` must survive an unparseable config
@@ -1696,7 +1719,9 @@ async fn async_main(
             yes,
         } => {
             // Without a tracing subscriber, --debug/RUST_LOG silently produce
-            // nothing in chat mode (logs go to file + stderr, like Ask).
+            // nothing in chat mode. Since #933 the file gets everything while
+            // stderr stays WARN+ unless --verbose/--debug asks for more — the
+            // interactive console no longer competes with INFO records.
             init_tracing(&effective_level);
             chat::run_chat(config, provider, model, url, timeout_secs, yes).await?;
         }
@@ -1711,9 +1736,9 @@ async fn async_main(
             yes,
         } => {
             // GAR-579: ask is non-interactive; tracing init kept off the
-            // stdout/stderr path (`init_tracing` writes to file + stderr
-            // and would pollute machine-readable output when --json is on).
-            // We still initialize because other crates may log warnings.
+            // stdout path. Since #933 stderr only carries WARN+ by default,
+            // so machine-readable --json output on stdout stays clean while
+            // real warnings from other crates remain visible.
             init_tracing(&effective_level);
             let code = ask::run_ask(
                 config,
@@ -1744,7 +1769,9 @@ async fn async_main(
         Commands::McpServer => {
             // GAR-583: MCP server over stdio exposing `garra_ask` tool.
             // Tracing init writes to stderr (RedactingWriter), keeping
-            // stdout reserved for the JSON-RPC channel (rmcp's job).
+            // stdout reserved for the JSON-RPC channel (rmcp's job). O
+            // stderr daqui é canal de log do host MCP, então fica fora do
+            // console limpo do #933 — ver `stderr_is_log_channel`.
             init_tracing(&effective_level);
             mcp_server::run_mcp_server(config).await?;
         }

--- a/crates/garraia-cli/src/tracing_setup.rs
+++ b/crates/garraia-cli/src/tracing_setup.rs
@@ -1,0 +1,284 @@
+//! Saídas do tracing do CLI — arquivo sempre completo, console limpo (#933).
+//!
+//! Até a v0.3.8 havia um subscriber único escrevendo em
+//! `file_appender.and(RedactingWriter::stderr())`: o mesmo `EnvFilter`
+//! alimentava o arquivo e o console, então todo INFO de registro de provider,
+//! tools e sessão competia com o spinner e com a resposta streamada no chat
+//! interativo. A separação é em dois layers com filtros independentes:
+//!
+//! - **arquivo** (`garraia.log`): continua recebendo tudo no nível pedido
+//!   (`--log-level`, elevado por `--debug`). É o registro que se lê depurando
+//!   incidente, então não perde nada.
+//! - **stderr**: WARN+ por default (erro visível, ruído não); `--verbose`
+//!   mostra o INFO operacional (provider, modelo, tools); `--debug` mostra o
+//!   mesmo que o arquivo.
+//!
+//! `RUST_LOG` setado e válido vence os dois lados, como sempre venceu — quem
+//! exporta `RUST_LOG=garraia_agents=trace` está depurando e espera ver o
+//! resultado no console (comportamento legado de GAR-138).
+//!
+//! Invariante de segurança (regra absoluta 6): os DOIS caminhos continuam
+//! embrulhados em redação — `RedactingMakeWriter` no arquivo,
+//! `RedactingWriter::stderr()` no console. Já houve o bug de redigir só uma
+//! metade (comentário em `main.rs` sobre 2026-08-29); o teste
+//! `both_sinks_stay_redacted_in_main` varre o fonte para impedir regressão.
+
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::fmt;
+use tracing_subscriber::fmt::writer::MakeWriter;
+use tracing_subscriber::layer::SubscriberExt;
+
+/// O que o console (stderr) mostra. O arquivo não é afetado por isto.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum ConsoleMode {
+    /// Default: só WARN+ chega ao terminal.
+    Normal,
+    /// `--verbose`: INFO operacional conciso (provider, modelo, tools).
+    Verbose,
+    /// `--debug`: o console espelha o arquivo.
+    Debug,
+}
+
+/// `--debug` vence `--verbose` quando ambos vêm no argv.
+pub(crate) fn console_mode(debug: bool, verbose: bool) -> ConsoleMode {
+    if debug {
+        ConsoleMode::Debug
+    } else if verbose {
+        ConsoleMode::Verbose
+    } else {
+        ConsoleMode::Normal
+    }
+}
+
+/// Deriva as diretivas de filtro `(arquivo, stderr)`.
+///
+/// Pura: `RUST_LOG` entra como parâmetro, nunca é lido aqui. Um valor setado
+/// mas vazio ou inválido é tratado como ausente — o mesmo fallback que o
+/// `try_from_default_env().unwrap_or_else(...)` antigo fazia.
+pub(crate) fn filter_directives(
+    rust_log: Option<&str>,
+    file_level: &str,
+    mode: ConsoleMode,
+) -> (String, String) {
+    if let Some(spec) = rust_log
+        && !spec.trim().is_empty()
+        && EnvFilter::try_new(spec).is_ok()
+    {
+        return (spec.to_string(), spec.to_string());
+    }
+    let stderr_level = match mode {
+        ConsoleMode::Debug => file_level,
+        ConsoleMode::Verbose => "info",
+        ConsoleMode::Normal => "warn",
+    };
+    (file_level.to_string(), stderr_level.to_string())
+}
+
+/// Monta o subscriber de dois layers. Os writers chegam já redigidos — este
+/// módulo não conhece segredos, só filtros e formato.
+///
+/// Boxed porque o braço JSON e o braço texto têm tipos concretos diferentes;
+/// `Box<dyn Subscriber>` é o menor denominador que `with_default` (testes) e
+/// `init` (produção) aceitam igualmente.
+pub(crate) fn build_subscriber<F, E>(
+    file_writer: F,
+    stderr_writer: E,
+    file_directives: &str,
+    stderr_directives: &str,
+    json: bool,
+) -> Box<dyn tracing::Subscriber + Send + Sync>
+where
+    F: for<'a> MakeWriter<'a> + Send + Sync + 'static,
+    E: for<'a> MakeWriter<'a> + Send + Sync + 'static,
+{
+    // As diretivas vêm de filter_directives (válidas por construção) ou de um
+    // nível fixo; o fallback é cinto de segurança, não caminho esperado.
+    let file_filter =
+        EnvFilter::try_new(file_directives).unwrap_or_else(|_| EnvFilter::new("info"));
+    let stderr_filter =
+        EnvFilter::try_new(stderr_directives).unwrap_or_else(|_| EnvFilter::new("warn"));
+
+    use tracing_subscriber::Layer;
+    let registry = tracing_subscriber::registry();
+    if json {
+        Box::new(
+            registry
+                .with(
+                    fmt::layer()
+                        .json()
+                        .with_writer(file_writer)
+                        .with_ansi(false)
+                        .with_filter(file_filter),
+                )
+                .with(
+                    fmt::layer()
+                        .json()
+                        .with_writer(stderr_writer)
+                        .with_ansi(false)
+                        .with_filter(stderr_filter),
+                ),
+        )
+    } else {
+        Box::new(
+            registry
+                .with(
+                    fmt::layer()
+                        .with_writer(file_writer)
+                        .with_ansi(false)
+                        .with_filter(file_filter),
+                )
+                .with(
+                    fmt::layer()
+                        .with_writer(stderr_writer)
+                        .with_ansi(false)
+                        .with_filter(stderr_filter),
+                ),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+    use std::sync::{Arc, Mutex};
+
+    /// MakeWriter afirmável: cada layer escreve num `Vec<u8>` compartilhado.
+    #[derive(Clone, Default)]
+    struct Sink(Arc<Mutex<Vec<u8>>>);
+
+    impl Sink {
+        fn contents(&self) -> String {
+            String::from_utf8_lossy(&self.0.lock().expect("sink poisoned")).into_owned()
+        }
+    }
+
+    impl io::Write for Sink {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().expect("sink poisoned").extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for Sink {
+        type Writer = Sink;
+        fn make_writer(&'a self) -> Sink {
+            self.clone()
+        }
+    }
+
+    /// Emite um probe em cada nível sob o subscriber de dois layers e devolve
+    /// o que cada sink capturou.
+    fn capture(rust_log: Option<&str>, file_level: &str, mode: ConsoleMode) -> (String, String) {
+        let file = Sink::default();
+        let stderr = Sink::default();
+        let (file_dirs, stderr_dirs) = filter_directives(rust_log, file_level, mode);
+        let sub = build_subscriber(
+            file.clone(),
+            stderr.clone(),
+            &file_dirs,
+            &stderr_dirs,
+            false,
+        );
+        tracing::subscriber::with_default(sub, || {
+            tracing::debug!("debug-probe");
+            tracing::info!("info-probe");
+            tracing::warn!("warn-probe");
+        });
+        (file.contents(), stderr.contents())
+    }
+
+    #[test]
+    fn normal_mode_keeps_info_off_the_console_but_in_the_file() {
+        let (file, stderr) = capture(None, "info", ConsoleMode::Normal);
+        assert!(file.contains("info-probe"), "file must keep INFO: {file:?}");
+        assert!(file.contains("warn-probe"));
+        assert!(!file.contains("debug-probe"), "file level is info");
+        assert!(
+            !stderr.contains("info-probe"),
+            "console must stay clean of INFO: {stderr:?}"
+        );
+        assert!(!stderr.contains("debug-probe"));
+        assert!(
+            stderr.contains("warn-probe"),
+            "warnings must stay visible: {stderr:?}"
+        );
+    }
+
+    #[test]
+    fn verbose_mode_shows_info_on_the_console() {
+        let (file, stderr) = capture(None, "info", ConsoleMode::Verbose);
+        assert!(file.contains("info-probe"));
+        assert!(stderr.contains("info-probe"));
+        assert!(stderr.contains("warn-probe"));
+        assert!(!stderr.contains("debug-probe"), "verbose is not debug");
+    }
+
+    #[test]
+    fn debug_mode_mirrors_the_file_on_the_console() {
+        let (file, stderr) = capture(None, "debug", ConsoleMode::Debug);
+        for probe in ["debug-probe", "info-probe", "warn-probe"] {
+            assert!(file.contains(probe), "file missing {probe}: {file:?}");
+            assert!(stderr.contains(probe), "stderr missing {probe}: {stderr:?}");
+        }
+    }
+
+    #[test]
+    fn rust_log_still_wins_both_sinks() {
+        // Escape hatch legado (GAR-138): RUST_LOG explícito é pedido de
+        // depuração e vale para console e arquivo, como antes da separação.
+        let (file, stderr) = capture(Some("trace"), "info", ConsoleMode::Normal);
+        assert!(file.contains("debug-probe"));
+        assert!(stderr.contains("debug-probe"));
+    }
+
+    #[test]
+    fn empty_or_invalid_rust_log_falls_back_to_the_flags() {
+        for bad in [Some(""), Some("   "), Some("not==valid==filter")] {
+            let (file_dirs, stderr_dirs) = filter_directives(bad, "info", ConsoleMode::Normal);
+            assert_eq!(file_dirs, "info", "RUST_LOG={bad:?}");
+            assert_eq!(stderr_dirs, "warn", "RUST_LOG={bad:?}");
+        }
+    }
+
+    #[test]
+    fn debug_flag_beats_verbose() {
+        assert_eq!(console_mode(true, true), ConsoleMode::Debug);
+        assert_eq!(console_mode(false, true), ConsoleMode::Verbose);
+        assert_eq!(console_mode(false, false), ConsoleMode::Normal);
+    }
+
+    #[test]
+    fn log_level_flag_keeps_governing_the_file_only() {
+        // `--log-level debug` sem `--debug`: o arquivo desce a debug, o
+        // console continua limpo — quem quer console barulhento pede --debug.
+        let (file, stderr) = capture(None, "debug", ConsoleMode::Normal);
+        assert!(file.contains("debug-probe"));
+        assert!(!stderr.contains("debug-probe"));
+        assert!(!stderr.contains("info-probe"));
+    }
+
+    /// Regra absoluta 6: redação nos DOIS caminhos. O wiring vive em
+    /// `main.rs`, então o guard varre o fonte — o mesmo padrão do
+    /// `spinner.rs` para invariantes invisíveis a testes de comportamento.
+    #[test]
+    fn both_sinks_stay_redacted_in_main() {
+        let main_src = include_str!("main.rs");
+        assert!(
+            main_src.contains("RedactingMakeWriter::new("),
+            "o appender de arquivo deve continuar embrulhado em redação"
+        );
+        assert!(
+            main_src.contains("RedactingWriter::stderr()"),
+            "o stderr deve continuar embrulhado em redação"
+        );
+        assert!(
+            !main_src.contains(".and(RedactingWriter::stderr())"),
+            "a composição antiga de sink único não deve voltar — os dois \
+             layers têm filtros independentes (#933)"
+        );
+    }
+}


### PR DESCRIPTION
## Descrição

Primeiro PR da **Trilha B — épico #944 (Garra Terminal UX v2), Fase 1**, conforme o plano aprovado. Independente do B-PR2 (#936, spinner) — arquivos disjuntos fora do CHANGELOG.

### O problema (#933)

O subscriber era único: `file_appender.and(RedactingWriter::stderr())` com um só `EnvFilter`. Todo INFO de registro de provider/tools/sessão ia junto para o console interativo, competindo com o spinner e com a resposta streamada.

### A correção

Novo módulo `tracing_setup` (funções puras + builder testável) separa os dois destinos em layers com filtros independentes:

| Destino | Default | `--verbose` (flag global **nova**) | `--debug` |
| --- | --- | --- | --- |
| `garraia.log` | tudo no nível pedido (`--log-level`) | idem | tudo em debug |
| stderr | **só WARN+** | INFO operacional (provider, modelo, tools) | espelha o arquivo |

`RUST_LOG` setado e válido segue vencendo os dois lados, como sempre (GAR-138) — quem exporta `RUST_LOG=…=trace` está depurando e espera ver no console.

**Carve-out deliberado — stderr que é canal de log, não console** (`stderr_is_log_channel`): `start`/`restart` (journald lê o stderr do foreground — silenciá-lo prejudicaria exatamente o operador da #928) e `mcp-server` (o host MCP loga o stderr do filho; `docs/cli-mcp-server.md` §Stdio invariants afirma "logged to stderr at startup"). Esses espelham o arquivo como antes.

### Invariante de segurança preservado (regra absoluta 6)

Redação nos **dois** caminhos: `RedactingMakeWriter` no arquivo, `RedactingWriter::stderr()` no console. Já houve o bug de redigir só metade (2026-08-29); o teste `both_sinks_stay_redacted_in_main` varre o fonte (padrão do `spinner.rs`) e também proíbe a volta da composição antiga `.and(...)` de sink único.

## Tipo de mudança

- [x] `feat`: Nova funcionalidade
- [x] `test`: Adição ou correção de testes

## Classe de Risco

- [x] **Classe B (Médio Risco)**: muda o que aparece no console por default; nenhum dado deixa de ser logado (o arquivo continua completo).

## Checklist de Segurança e Qualidade

- [x] `cargo fmt --check` limpo
- [x] `cargo clippy -p garraia --all-targets -- -D warnings` sem erros
- [x] `cargo test -p garraia` — 287 passando (8 novos em `tracing_setup`)
- [x] Nenhum `unwrap()` em produção
- [x] Nenhum segredo commitado; redação preservada nos dois sinks com teste
- [x] Nenhuma migração

## Mudanças na API pública e Schema

- **Flag global nova**: `--verbose` (booleana; `--debug` vence quando ambas). `--log-level` passa a governar explicitamente o arquivo (help text atualizado).
- Nenhuma mudança de API de biblioteca — tudo privado do binário `garraia`.

## Como testar

```bash
cargo +1.95 test -p garraia tracing_setup   # 8 testes: 3 modos + RUST_LOG + guard de redação
garraia                                     # console limpo (WARN+); garraia.log com INFO
garraia --verbose                           # INFO operacional no console
garraia --debug                             # tudo no console
garraia 2>/dev/null | cat                   # não-TTY: stdout intocado, script-safe
```

## Plano de Rollback

Commit único. Reverter restaura o subscriber único (console barulhento de volta, nada além disso). Sem estado persistido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF

---
_Generated by [Claude Code](https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF)_