### PR TITLE
fix(db): fecha a divida da auditoria do #971 (TOCTOU, atomicidade, #960)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ Trilha C, o lote de memoria semantica (#948-#965) priorizado pelo dono em
   outro tenant nunca volta pelo KNN.
 
 ### Fixed
+- **Limpeza do indice vetorial: janela de corrida fechada e delecao atomica
+  (divida da auditoria do #971).** `compact` e `delete_session_memory`
+  coletavam os ids condenados e deletavam sob guards diferentes do mutex: uma
+  insercao concorrente que casasse a condicao era apagada sem entrar na lista
+  de limpeza, deixando vetor orfao no indice. Os dois passos passam a dividir
+  um guard so. `VectorStore::delete_embeddings` ganhou transacao — as N
+  tabelas `vec_embeddings_*` e o `vec_id_map` mudam juntos ou nao mudam; sem
+  ela, falhar no meio deixava vetor sem mapeamento, invisivel ate para o
+  `integrity_report`. `insert_embedding` tambem virou transacional: um vetor
+  recusado pelo vec0 por dimensao divergente (#961) deixava o mapeamento ja
+  gravado para tras, criando orfao instantaneo.
 - **Recall filtra por `embedding_model` (#954).** Cosseno entre espacos
   vetoriais de modelos diferentes nao significa nada, mesmo com a mesma
   dimensao. `RecallQuery` ganha `embedding_model` (o runtime envia o modelo
@@ -37,6 +48,16 @@ Trilha C, o lote de memoria semantica (#948-#965) priorizado pelo dono em
   (`_info`/`_chunks`/`_rowids`), que um LIKE ingenuo pegaria junto.
 
 ### Added
+- **`IntegrityReport.entries_missing_model` e o teste de dimensao divergente
+  fecham a #960.** O contador conta entradas COM vetor e SEM
+  `embedding_model` — o legado de antes do #954, que perde o eixo semantico
+  (0.7 do score) sempre que o recall chega com modelo definido, sem nenhum
+  aviso no caminho SQL; um `debug!` por recall complementa, contando os
+  candidatos rebaixados por modelo divergente. A reindexacao (#953) zera essa
+  fila. O teste novo garante que vetor de tamanho diferente do da tabela nao
+  entra e que a recusa nao deixa rastro no `vec_id_map` — com ele, os quatro
+  testes de integridade que a issue propos estao no lugar (os outros tres
+  vieram no #971).
 - **`MemoryStore::integrity_report()` (#960).** Conta entradas com/sem
   embedding (a fila de reindexacao do #953), linhas por tabela vetorial e
   mapeamentos orfaos — a verificacao que em 2026-09-05 precisou de script
@@ -46,6 +67,12 @@ Trilha C, o lote de memoria semantica (#948-#965) priorizado pelo dono em
   idempotencia da delecao.
 
 ### Changed
+- **Quatro testes de KNN deixam de passar em vazio (divida da auditoria do
+  #971).** Eles faziam `return` silencioso quando o sqlite-vec nao carregava —
+  inclusive os dois de isolamento de tenant, que assim jamais exercitariam o
+  caminho que existem para proteger. Agora afirmam `knn_enabled()`: o
+  sqlite-vec e compilado no binario (`rusqlite` com `bundled`), entao ausencia
+  dele e defeito de build, nao ambiente aceitavel.
 - **O console interativo fica limpo por default (#933).** O subscriber unico
   escrevia o mesmo fluxo em `garraia.log` e no stderr, entao todo INFO de
   registro de provider/tools/sessao competia com o spinner e com a resposta

--- a/crates/garraia-db/src/memory_store.rs
+++ b/crates/garraia-db/src/memory_store.rs
@@ -112,12 +112,18 @@ pub struct CompactionReport {
 /// Íntegro quando: `map_rows == entries_with_embedding` (com KNN ligado),
 /// cada tabela `vec_embeddings_*` soma o mesmo total e `orphan_map_entries`
 /// está vazio. `entries_without_embedding > 0` não é corrupção — é a fila de
-/// reindexação (#953).
+/// reindexação (#953), e `entries_missing_model > 0` é a fila legada.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IntegrityReport {
     pub entries_total: usize,
     pub entries_with_embedding: usize,
     pub entries_without_embedding: usize,
+    /// Entradas COM vetor gravado mas **sem** `embedding_model` — legado de
+    /// antes do #954. Elas perdem o eixo semântico do score (0.7) sempre que
+    /// o recall chega com um modelo definido, e o caminho SQL não avisa nada:
+    /// este contador é o único sinal que o operador tem. Zera com reindex
+    /// (#953).
+    pub entries_missing_model: usize,
     /// Linhas em `vec_id_map`.
     pub map_rows: usize,
     /// `(tabela, linhas)` por tabela `vec_embeddings_*` existente.
@@ -222,7 +228,7 @@ impl MemoryStore {
     /// tabelas `vec_embeddings_*` (#960). Não conserta nada — conta e nomeia
     /// divergências para o operador (e para a CLI `garra memory stats`).
     pub fn integrity_report(&self) -> Result<IntegrityReport> {
-        let (entries_total, entries_with_embedding, live_ids) = {
+        let (entries_total, entries_with_embedding, entries_missing_model, live_ids) = {
             let conn = self.connection()?;
             let total: i64 = conn
                 .query_row("SELECT count(*) FROM memory_entries", [], |row| row.get(0))
@@ -234,6 +240,16 @@ impl MemoryStore {
                     |row| row.get(0),
                 )
                 .map_err(|e| Error::Database(format!("failed to count embedded entries: {e}")))?;
+            let missing_model: i64 = conn
+                .query_row(
+                    "SELECT count(*) FROM memory_entries
+                     WHERE embedding IS NOT NULL AND embedding_model IS NULL",
+                    [],
+                    |row| row.get(0),
+                )
+                .map_err(|e| {
+                    Error::Database(format!("failed to count entries missing model: {e}"))
+                })?;
             let mut stmt = conn
                 .prepare("SELECT id FROM memory_entries")
                 .map_err(|e| Error::Database(format!("failed to prepare id scan: {e}")))?;
@@ -242,7 +258,12 @@ impl MemoryStore {
                 .map_err(|e| Error::Database(format!("failed to scan entry ids: {e}")))?
                 .collect::<std::result::Result<Vec<_>, _>>()
                 .map_err(|e| Error::Database(format!("failed to collect entry ids: {e}")))?;
-            (total as usize, with_embedding as usize, ids)
+            (
+                total as usize,
+                with_embedding as usize,
+                missing_model as usize,
+                ids,
+            )
         };
 
         let (map_rows, vec_rows_by_table, orphan_map_entries) = match &self.vector_store {
@@ -259,6 +280,7 @@ impl MemoryStore {
             entries_total,
             entries_with_embedding,
             entries_without_embedding: entries_total - entries_with_embedding,
+            entries_missing_model,
             map_rows,
             vec_rows_by_table,
             orphan_map_entries,
@@ -315,9 +337,12 @@ impl MemoryStore {
     }
 
     pub async fn compact(&self, before: DateTime<Utc>) -> Result<CompactionReport> {
-        // Coletar os ids ANTES de deletar: são eles que limpam o índice
-        // vetorial (#960 — deletar entrada não pode deixar vetor órfão).
-        let doomed = {
+        // Coletar os ids ANTES de deletar (são eles que limpam o índice
+        // vetorial, #960) e SOB O MESMO guard do DELETE: soltar o mutex entre
+        // os dois abriria uma janela TOCTOU em que uma inserção concorrente
+        // casando a condição seria deletada sem entrar na lista de limpeza
+        // (achado M1 da auditoria).
+        let (doomed, deleted) = {
             let conn = self.connection()?;
             let mut stmt = conn
                 .prepare("SELECT id FROM memory_entries WHERE datetime(created_at) < datetime(?)")
@@ -327,16 +352,15 @@ impl MemoryStore {
                 .map_err(|e| Error::Database(format!("failed to scan compact targets: {e}")))?
                 .collect::<std::result::Result<Vec<_>, _>>()
                 .map_err(|e| Error::Database(format!("failed to collect compact targets: {e}")))?;
-            ids
-        };
+            drop(stmt);
 
-        let deleted = {
-            let conn = self.connection()?;
-            conn.execute(
-                "DELETE FROM memory_entries WHERE datetime(created_at) < datetime(?)",
-                params![before.to_rfc3339()],
-            )
-            .map_err(|e| Error::Database(format!("failed to compact memory entries: {e}")))?
+            let deleted = conn
+                .execute(
+                    "DELETE FROM memory_entries WHERE datetime(created_at) < datetime(?)",
+                    params![before.to_rfc3339()],
+                )
+                .map_err(|e| Error::Database(format!("failed to compact memory entries: {e}")))?;
+            (ids, deleted)
         };
 
         self.cleanup_vectors(&doomed);
@@ -348,7 +372,8 @@ impl MemoryStore {
     }
 
     pub async fn delete_session_memory(&self, session_id: &str) -> Result<usize> {
-        let doomed = {
+        // SELECT e DELETE sob o mesmo guard — ver o comentário em `compact`.
+        let (doomed, deleted) = {
             let conn = self.connection()?;
             let mut stmt = conn
                 .prepare("SELECT id FROM memory_entries WHERE session_id = ?")
@@ -358,16 +383,15 @@ impl MemoryStore {
                 .map_err(|e| Error::Database(format!("failed to scan delete targets: {e}")))?
                 .collect::<std::result::Result<Vec<_>, _>>()
                 .map_err(|e| Error::Database(format!("failed to collect delete targets: {e}")))?;
-            ids
-        };
+            drop(stmt);
 
-        let deleted = {
-            let conn = self.connection()?;
-            conn.execute(
-                "DELETE FROM memory_entries WHERE session_id = ?",
-                params![session_id],
-            )
-            .map_err(|e| Error::Database(format!("failed to delete session memory: {e}")))?
+            let deleted = conn
+                .execute(
+                    "DELETE FROM memory_entries WHERE session_id = ?",
+                    params![session_id],
+                )
+                .map_err(|e| Error::Database(format!("failed to delete session memory: {e}")))?;
+            (ids, deleted)
         };
 
         self.cleanup_vectors(&doomed);
@@ -509,12 +533,22 @@ impl MemoryStore {
         query: &RecallQuery,
         limit: usize,
     ) -> Result<Vec<MemoryEntry>> {
+        // Quantos candidatos perderam o eixo semântico por modelo divergente.
+        // Entrada legada (modelo NULL) cai aqui e some do ranking sem nenhum
+        // outro aviso — o contador durável está no `integrity_report`.
+        let mut demoted_other_model = 0usize;
+
         let mut scored: Vec<(f32, MemoryEntry)> = candidates
             .into_iter()
             .map(|entry| {
                 // Cosseno entre modelos diferentes não significa nada (#954):
                 // com filtro de modelo na query, entrada de outro modelo pontua
                 // 0.0 no eixo semântico e compete só por texto/recência.
+                // `(None, _) => true` e deliberado: query sem modelo declarado
+                // e chamada legada ou so-texto, e ali o comportamento antigo
+                // (comparar com o que houver) vale mais que recusar tudo. Quem
+                // manda o modelo — todo recall do runtime desde o #954 — cai
+                // nos dois primeiros bracos e fica protegido.
                 let same_model = match (&query.embedding_model, &entry.embedding_model) {
                     (Some(wanted), Some(got)) => wanted == got,
                     (Some(_), None) => false,
@@ -524,7 +558,12 @@ impl MemoryStore {
                     (Some(needle), Some(candidate)) if same_model => {
                         cosine_similarity(needle, candidate)
                     }
-                    _ => 0.0,
+                    _ => {
+                        if !same_model && entry.embedding.is_some() {
+                            demoted_other_model += 1;
+                        }
+                        0.0
+                    }
                 };
                 let text_score = text_match_score(query.query_text.as_deref(), &entry.content);
                 let recency_score = recency_score(entry.created_at);
@@ -538,6 +577,15 @@ impl MemoryStore {
                 (score, entry)
             })
             .collect();
+
+        if demoted_other_model > 0 {
+            tracing::debug!(
+                demoted = demoted_other_model,
+                model = query.embedding_model.as_deref().unwrap_or("<nenhum>"),
+                "recall: candidatos com vetor de outro modelo (ou legado sem \
+                 modelo) pontuaram 0.0 no eixo semantico"
+            );
+        }
 
         scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(Ordering::Equal));
 
@@ -1056,10 +1104,12 @@ mod tests {
     async fn knn_recall_never_leaks_other_tenants() {
         let store =
             MemoryStore::in_memory_with_vectors().expect("failed to create in-memory store");
-        if !store.knn_enabled() {
-            eprintln!("sqlite-vec not available, skipping KNN isolation test");
-            return;
-        }
+        assert!(
+            store.knn_enabled(),
+            "o sqlite-vec e compilado no binario (rusqlite bundled): sem ele \
+             este teste de isolamento nao exercitaria o caminho KNN e passaria \
+             em vazio"
+        );
 
         let mut ours = entry(
             "session-a",
@@ -1107,10 +1157,10 @@ mod tests {
     async fn knn_recall_respects_session_filter() {
         let store =
             MemoryStore::in_memory_with_vectors().expect("failed to create in-memory store");
-        if !store.knn_enabled() {
-            eprintln!("sqlite-vec not available, skipping KNN session test");
-            return;
-        }
+        assert!(
+            store.knn_enabled(),
+            "sem sqlite-vec este teste nao exercitaria o caminho KNN"
+        );
 
         store
             .remember(entry(
@@ -1157,10 +1207,10 @@ mod tests {
     async fn delete_session_memory_removes_vectors_and_mapping() {
         let store =
             MemoryStore::in_memory_with_vectors().expect("failed to create in-memory store");
-        if !store.knn_enabled() {
-            eprintln!("sqlite-vec not available, skipping orphan test");
-            return;
-        }
+        assert!(
+            store.knn_enabled(),
+            "sem sqlite-vec nao ha indice para ficar orfao — teste em vazio"
+        );
 
         store
             .remember(entry(
@@ -1197,10 +1247,10 @@ mod tests {
     async fn compact_removes_vectors_too() {
         let store =
             MemoryStore::in_memory_with_vectors().expect("failed to create in-memory store");
-        if !store.knn_enabled() {
-            eprintln!("sqlite-vec not available, skipping compact orphan test");
-            return;
-        }
+        assert!(
+            store.knn_enabled(),
+            "sem sqlite-vec nao ha indice para o compact limpar — teste em vazio"
+        );
 
         store
             .remember(entry(
@@ -1268,6 +1318,55 @@ mod tests {
             let report = store.integrity_report().expect("report");
             assert_eq!(report.orphan_map_entries, vec!["fantasma".to_string()]);
         }
+    }
+
+    /// M2 da auditoria: entrada legada (vetor gravado antes do #954, sem
+    /// modelo registrado) perde o eixo semântico em silêncio quando o recall
+    /// chega com modelo. O relatório conta essa fila para o operador.
+    #[tokio::test]
+    async fn integrity_report_counts_legacy_entries_without_model() {
+        let store = MemoryStore::in_memory().expect("failed to create in-memory memory store");
+
+        let mut legada = entry(
+            "session-a",
+            None,
+            "vetor sem modelo",
+            MemoryRole::User,
+            Some(vec![1.0, 0.0, 0.0]),
+        );
+        legada.embedding_model = None;
+        store.remember(legada).await.expect("remember");
+
+        store
+            .remember(entry(
+                "session-a",
+                None,
+                "vetor com modelo",
+                MemoryRole::User,
+                Some(vec![0.0, 1.0, 0.0]),
+            ))
+            .await
+            .expect("remember");
+
+        store
+            .remember(entry(
+                "session-a",
+                None,
+                "sem vetor nenhum",
+                MemoryRole::User,
+                None,
+            ))
+            .await
+            .expect("remember");
+
+        let report = store.integrity_report().expect("report");
+        assert_eq!(report.entries_total, 3);
+        assert_eq!(report.entries_with_embedding, 2);
+        assert_eq!(report.entries_without_embedding, 1);
+        assert_eq!(
+            report.entries_missing_model, 1,
+            "só a entrada com vetor E sem modelo conta como legado"
+        );
     }
 
     #[tokio::test]

--- a/crates/garraia-db/src/vector_store.rs
+++ b/crates/garraia-db/src/vector_store.rs
@@ -142,18 +142,24 @@ impl VectorStore {
             return Ok(());
         }
 
-        let conn = self.connection()?;
+        let mut conn = self.connection()?;
         let table_name = format!("vec_embeddings_{dimensions}");
         let blob = embedding_to_blob(embedding);
 
-        // Upsert into the ID mapping table
-        conn.execute(
+        // Transação: sem ela, um vetor recusado pelo vec0 (dimensão divergente,
+        // #961) deixaria o mapeamento já gravado para trás — órfão instantâneo
+        // no `vec_id_map`, exatamente o que o #960 cobra.
+        let tx = conn
+            .transaction()
+            .map_err(|e| Error::Database(format!("failed to begin vec insert tx: {e}")))?;
+
+        tx.execute(
             "INSERT OR IGNORE INTO vec_id_map (entry_id) VALUES (?)",
             params![id],
         )
         .map_err(|e| Error::Database(format!("failed to insert vec id mapping: {e}")))?;
 
-        let rowid: i64 = conn
+        let rowid: i64 = tx
             .query_row(
                 "SELECT rowid FROM vec_id_map WHERE entry_id = ?",
                 params![id],
@@ -161,11 +167,14 @@ impl VectorStore {
             )
             .map_err(|e| Error::Database(format!("failed to get vec rowid: {e}")))?;
 
-        conn.execute(
+        tx.execute(
             &format!("INSERT OR REPLACE INTO [{table_name}] (rowid, embedding) VALUES (?, ?)"),
             params![rowid, blob],
         )
         .map_err(|e| Error::Database(format!("failed to insert vec embedding: {e}")))?;
+
+        tx.commit()
+            .map_err(|e| Error::Database(format!("failed to commit vec insert tx: {e}")))?;
 
         Ok(())
     }
@@ -181,20 +190,26 @@ impl VectorStore {
             return Ok(0);
         }
 
-        let conn = self.connection()?;
+        let mut conn = self.connection()?;
+        // Transação: as N tabelas dimensionais e o vec_id_map mudam juntos —
+        // falhar no meio deixaria vetor sem mapeamento, invisível até para o
+        // integrity_report (achado L3 da auditoria).
+        let tx = conn
+            .transaction()
+            .map_err(|e| Error::Database(format!("failed to begin vec delete tx: {e}")))?;
 
         let placeholders: String = ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
-        let mut stmt = conn
-            .prepare(&format!(
-                "SELECT rowid FROM vec_id_map WHERE entry_id IN ({placeholders})"
-            ))
-            .map_err(|e| Error::Database(format!("failed to prepare vec rowid lookup: {e}")))?;
-        let rowids: Vec<i64> = stmt
-            .query_map(rusqlite::params_from_iter(ids.iter()), |row| row.get(0))
-            .map_err(|e| Error::Database(format!("failed to look up vec rowids: {e}")))?
-            .collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(|e| Error::Database(format!("failed to collect vec rowids: {e}")))?;
-        drop(stmt);
+        let rowids: Vec<i64> = {
+            let mut stmt = tx
+                .prepare(&format!(
+                    "SELECT rowid FROM vec_id_map WHERE entry_id IN ({placeholders})"
+                ))
+                .map_err(|e| Error::Database(format!("failed to prepare vec rowid lookup: {e}")))?;
+            stmt.query_map(rusqlite::params_from_iter(ids.iter()), |row| row.get(0))
+                .map_err(|e| Error::Database(format!("failed to look up vec rowids: {e}")))?
+                .collect::<std::result::Result<Vec<_>, _>>()
+                .map_err(|e| Error::Database(format!("failed to collect vec rowids: {e}")))?
+        };
 
         if rowids.is_empty() {
             return Ok(0);
@@ -208,20 +223,23 @@ impl VectorStore {
         // Identificadores de tabela vêm do próprio sqlite_master (origem
         // fechada, padrão vec_embeddings_<n> criado por ensure_vec_table);
         // os valores (rowids) são inteiros nossos, não input externo.
-        for table in vec_table_names(&conn)? {
-            conn.execute(
+        for table in vec_table_names(&tx)? {
+            tx.execute(
                 &format!("DELETE FROM [{table}] WHERE rowid IN ({rowid_list})"),
                 [],
             )
             .map_err(|e| Error::Database(format!("failed to delete vec rows: {e}")))?;
         }
 
-        let removed = conn
+        let removed = tx
             .execute(
                 &format!("DELETE FROM vec_id_map WHERE entry_id IN ({placeholders})"),
                 rusqlite::params_from_iter(ids.iter()),
             )
             .map_err(|e| Error::Database(format!("failed to delete vec id mappings: {e}")))?;
+
+        tx.commit()
+            .map_err(|e| Error::Database(format!("failed to commit vec delete tx: {e}")))?;
 
         Ok(removed)
     }
@@ -430,5 +448,40 @@ mod tests {
 
         // Idempotente: repetir não erra nem remove nada.
         assert_eq!(store.delete_embeddings(&["dim2"]).unwrap(), 0);
+    }
+
+    /// #960 item 2: vetor com dimensão diferente da tabela não entra — e a
+    /// recusa não pode deixar rastro. É a rede que segura o #961 (provider
+    /// que troca de modelo e devolve outra dimensão) no nível do índice.
+    #[test]
+    fn wrong_dimension_rejected() {
+        let store = VectorStore::in_memory().expect("should open in-memory vector store");
+        assert!(
+            store.vec_enabled(),
+            "o sqlite-vec e compilado no binario (rusqlite bundled): sem ele \
+             este teste passaria em vazio"
+        );
+
+        store.ensure_vec_table(3).unwrap();
+        store
+            .insert_embedding("certo", &[1.0, 0.0, 0.0], 3)
+            .unwrap();
+
+        let recusado = store.insert_embedding("torto", &[1.0, 0.0], 3);
+        assert!(
+            recusado.is_err(),
+            "vetor de 2 dimensoes nao pode entrar numa tabela float[3]: {recusado:?}"
+        );
+
+        // E o indice segue integro: nem vetor meio-gravado, nem mapeamento orfao.
+        let inventory = store.index_inventory().unwrap();
+        assert_eq!(
+            inventory.map_rows, 1,
+            "a recusa nao pode deixar mapeamento para tras: {inventory:?}"
+        );
+        assert!(
+            store.orphan_map_entries(&["certo"]).unwrap().is_empty(),
+            "nenhum mapeamento sobra alem do insert valido"
+        );
     }
 }


### PR DESCRIPTION
## Descrição

O [#971](https://github.com/michelbr84/GarraRUST/pull/971) mergeou **antes** de as correções da auditoria de segurança que ele mesmo motivou serem aplicadas — elas ficaram na árvore de trabalho quando o PR foi aberto e mergeado pela UI. Este PR fecha essa dívida. Branch novo a partir da `main`, já que o `…-c1` mergeou.

O que a `main` carregava até agora:

| Achado | O que acontecia | Correção |
| --- | --- | --- |
| **M1 — TOCTOU** | `compact()` e `delete_session_memory()` coletavam os ids condenados e deletavam sob **guards diferentes** do mutex. Uma inserção concorrente que casasse a condição era apagada pelo DELETE sem entrar na lista de limpeza do índice — vetor órfão garantido. | SELECT e DELETE dividem um guard só. |
| **L3 — deleção não atômica** | `delete_embeddings` mexia nas N tabelas `vec_embeddings_*` e no `vec_id_map` sem transação. Falhar no meio deixava vetor sem mapeamento — invisível até para o `integrity_report`, que só enxerga o que está mapeado. | Transação envolvendo tudo. |
| **Extra (descoberto ao escrever o teste)** | `insert_embedding` tinha o mesmo buraco na direção oposta: o `INSERT OR IGNORE` no `vec_id_map` acontecia antes do insert no vec0, então um vetor recusado por dimensão divergente (#961) deixava o mapeamento gravado — órfão instantâneo. | `insert_embedding` também virou transacional. |
| **M2 — legado sem sinal** | Entrada com vetor e **sem** `embedding_model` (gravada antes do #954) perde o eixo semântico — 0.7 do score — sempre que o recall chega com modelo definido. Nada no caminho SQL avisa. | `IntegrityReport.entries_missing_model` conta a fila; um `debug!` por recall conta os candidatos rebaixados. |
| **L1 — testes em vazio** | Quatro testes de KNN faziam `return` silencioso quando o sqlite-vec não carregava — **incluindo os dois de isolamento de tenant**, que assim jamais exercitariam o caminho que existem para proteger. | Passam a afirmar `knn_enabled()`. O sqlite-vec é compilado no binário (`rusqlite` com `bundled`), então ausência dele é defeito de build, não ambiente aceitável. |

**Fecha a #960** com o quarto teste que a issue propôs e o #971 não entregou: `wrong_dimension_rejected` — vetor de tamanho diferente do da tabela não entra, e a recusa não deixa rastro no `vec_id_map`.

**L2 da auditoria** (o scan O(N) de ids no `integrity_report`) fica registrado como otimização futura: é custo, não defeito, e a leitura cruza duas conexões por desenho.

## Auditoria

`@security-auditor` rodou sobre o diff antes de abrir — **9/10, nenhum achado bloqueante**. Verificado como correto:

- **TOCTOU fechado:** o `MutexGuard` atravessa SELECT e DELETE sem ser solto, e não há `.await` dentro do bloco crítico. `cleanup_vectors` roda fora do guard, sobre o mutex **separado** do `VectorStore` — a lista já está fixada, e uma inserção concorrente durante a limpeza grava vetor cuja entrada não foi deletada, então não vira órfão.
- **Transações corretas em rusqlite 0.32:** o `return Ok(0)` com transação aberta em `delete_embeddings` acontece antes de qualquer escrita — rollback implícito no drop é no-op. `tx.commit()` cobre o único caminho de sucesso completo. `Transaction` faz `Deref<Target = Connection>`, então `vec_table_names(&tx)` coage corretamente.
- **Log sem PII (regra absoluta 6):** só saem contagem (`usize`) e nome do modelo — constante de configuração. Nenhum `tenant_id`, `session_id`, `user_id` ou conteúdo de memória.
- **SQL:** todo valor por bind. Os três identificadores interpolados têm origem fechada — `vec_embeddings_{usize}`, nomes vindos de `sqlite_master` filtrados por `CREATE VIRTUAL TABLE`, e `rowid_list` de `i64::to_string()`.
- **Asserts seguros no CI:** sqlite-vec é linkado estaticamente e o `verify_vec_extension` faz `SELECT vec_version()` de verdade; não há cenário de falha nas três plataformas da matriz.

Observação da auditoria acatada: o braço `(None, _) => true` do `same_model` (query sem modelo declarado compara com o que houver) é legado intencional e agora está anotado no código.

## Tipo de mudança

- [x] `fix`: Correção de bug
- [x] `test`: Adição ou correção de testes

## Classe de Risco

- [x] **Classe C (Alto)**: mexe em código de isolamento de tenant e de integridade do índice vetorial. Auditoria de segurança rodou antes de abrir.

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo fmt --check` executado e limpo
- [x] `cargo clippy --workspace --exclude garraia-desktop -- -D warnings` sem erros
- [x] `cargo test --workspace --exclude garraia-desktop` passando localmente — única falha é a ambiental conhecida `migration_001_applies_and_schema_is_sane`, que exige `docker.sock`; o CI valida
- [x] Nenhum `unwrap()` adicionado em código de produção (os novos estão só em teste)
- [x] Nenhum segredo, API key, token ou credencial commitada
- [x] Nenhuma migração Postgres — este PR não toca schema

### Para alterações de Alto Risco (Classe C)

- [x] Testes de autorização cross-tenant: os dois que já existiam (`knn_recall_never_leaks_other_tenants`, `knn_recall_respects_session_filter`) **deixam de poder passar em vazio** — era exatamente o risco de um teste de isolamento que se auto-desliga
- [ ] Verificação de políticas RLS `USING`/`WITH CHECK` — não se aplica: a memória é SQLite local (`garraia-db`), sem RLS; o isolamento aqui é o filtro de `tenant_id` no fetch dos candidatos
- [x] Auditoria de eventos sem PII na metadata: o `debug!` novo emite só contagem e nome de modelo — verificado pelo `@security-auditor`

## Mudanças na API pública e Schema

- `IntegrityReport` ganha o campo público `entries_missing_model`. Struct nova de ontem (#971), sem consumidor externo ainda — o primeiro será o `garra memory stats` (#950).
- Sem mudança de schema, sem migração.

## Como testar

```bash
cargo +1.95 test -p garraia-db memory   # 14 testes, inclui o contador de legado
cargo +1.95 test -p garraia-db vector   # 4 testes, inclui wrong_dimension_rejected
```

Os testes de isolamento agora falham — em vez de passar calados — se o sqlite-vec não estiver ativo.

## Plano de Rollback

Commit único, sem migração e sem estado persistido novo. Reverter restaura o comportamento do #971: a janela TOCTOU e a deleção não atômica voltam, os quatro testes voltam a poder passar em vazio, e o `entries_missing_model` some do relatório.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF

---
_Generated by [Claude Code](https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF)_