### PR TITLE
feat(cli): layout de conversa e cabecalho compacto (#934, #935)

### DIFF
--- a/crates/garraia-cli/src/banner.rs
+++ b/crates/garraia-cli/src/banner.rs
@@ -52,6 +52,45 @@ pub(crate) fn shorten_path(p: &Path) -> String {
     format!("{head}…{tail}")
 }
 
+/// A marca inteira, sob demanda (#935).
+///
+/// O mascote saiu da abertura do `garra chat`, que passou a ser um cabecalho
+/// de tres linhas — ele ocupava doze linhas de terminal em toda sessao para
+/// dizer o que cabe em duas. Continua aqui, atras de um comando explicito,
+/// porque identidade de produto nao se joga fora: so deixa de ser cobrada de
+/// quem so quer conversar.
+pub fn print_about() {
+    const CYAN: &str = "\x1b[36m";
+    const YELLOW: &str = "\x1b[33m";
+    const GREEN: &str = "\x1b[32m";
+    const BOLD: &str = "\x1b[1m";
+    const DIM: &str = "\x1b[2m";
+    const RESET: &str = "\x1b[0m";
+
+    let version = env!("CARGO_PKG_VERSION");
+
+    println!();
+    println!("{CYAN}{BOLD}╭──────────────────────────────────────────────╮{RESET}");
+    println!("{CYAN}{BOLD}│{RESET}                                              {CYAN}{BOLD}│{RESET}");
+    println!("{CYAN}{BOLD}│{RESET}      {YELLOW}{BOLD}_~^~^~_{RESET}                                {CYAN}{BOLD}│{RESET}");
+    println!(
+        "{CYAN}{BOLD}│{RESET}   {YELLOW}{BOLD}\\) /  o o  \\ (/{RESET}   {GREEN}{BOLD}GarraIA v{version}{RESET}         {CYAN}{BOLD}│{RESET}"
+    );
+    println!("{CYAN}{BOLD}│{RESET}     {YELLOW}{BOLD}'_   -   _'{RESET}    Personal AI Assistant   {CYAN}{BOLD}│{RESET}");
+    println!("{CYAN}{BOLD}│{RESET}     {YELLOW}{BOLD}/ '-----' \\{RESET}                            {CYAN}{BOLD}│{RESET}");
+    println!("{CYAN}{BOLD}│{RESET}                                              {CYAN}{BOLD}│{RESET}");
+    println!("{CYAN}{BOLD}╰──────────────────────────────────────────────╯{RESET}");
+    println!();
+    println!("  {DIM}Assistente de IA pessoal, escrito em Rust.{RESET}");
+    println!("  {DIM}Tudo local: conversas, memoria, config e credenciais.{RESET}");
+    println!();
+    println!("  {BOLD}garra{RESET}          conversar");
+    println!("  {BOLD}garra start{RESET}    subir o gateway");
+    println!("  {BOLD}garra doctor{RESET}   diagnosticar a instalacao");
+    println!("  {BOLD}garra --help{RESET}   todos os comandos");
+    println!();
+}
+
 /// Print the startup banner with Ferris and config summary.
 pub fn print_banner(host: &str, port: u16, config: &AppConfig, config_dir: &Path) {
     let version = env!("CARGO_PKG_VERSION");

--- a/crates/garraia-cli/src/chat.rs
+++ b/crates/garraia-cli/src/chat.rs
@@ -23,82 +23,15 @@ const CYAN: &str = "\x1b[36m";
 const GREEN: &str = "\x1b[32m";
 const YELLOW: &str = "\x1b[33m";
 const DIM: &str = "\x1b[2m";
-const BOLD: &str = "\x1b[1m";
 const RESET: &str = "\x1b[0m";
 
 /// Print the Garra chat banner.
-pub fn print_chat_banner(provider: &str, model: &str, mode: &str) {
-    let version = env!("CARGO_PKG_VERSION");
-    println!();
-    println!("{CYAN}{BOLD}╭──────────────────────────────────────────────╮{RESET}");
-    println!(
-        "{CYAN}{BOLD}│{RESET}                                              {CYAN}{BOLD}│{RESET}"
-    );
-    println!(
-        "{CYAN}{BOLD}│{RESET}      {YELLOW}{BOLD}_~^~^~_{RESET}                                {CYAN}{BOLD}│{RESET}"
-    );
-    println!(
-        "{CYAN}{BOLD}│{RESET}   {YELLOW}{BOLD}\\) /  o o  \\ (/{RESET}   {GREEN}{BOLD}GarraIA v{version}{RESET}         {CYAN}{BOLD}│{RESET}"
-    );
-    println!(
-        "{CYAN}{BOLD}│{RESET}     {YELLOW}{BOLD}'_   -   _'{RESET}    Personal AI Assistant   {CYAN}{BOLD}│{RESET}"
-    );
-    println!(
-        "{CYAN}{BOLD}│{RESET}     {YELLOW}{BOLD}/ '-----' \\{RESET}                            {CYAN}{BOLD}│{RESET}"
-    );
-    println!(
-        "{CYAN}{BOLD}│{RESET}                                              {CYAN}{BOLD}│{RESET}"
-    );
-    println!(
-        "{CYAN}{BOLD}│{RESET}  {DIM}Provider:{RESET} {GREEN}{provider:<15}{RESET} {DIM}Mode:{RESET} {GREEN}{mode:<8}{RESET}  {CYAN}{BOLD}│{RESET}"
-    );
-    println!(
-        "{CYAN}{BOLD}│{RESET}  {DIM}Model:{RESET}    {GREEN}{model:<33}{RESET} {CYAN}{BOLD}│{RESET}"
-    );
-    println!(
-        "{CYAN}{BOLD}│{RESET}                                              {CYAN}{BOLD}│{RESET}"
-    );
-    println!(
-        "{CYAN}{BOLD}│{RESET}  {DIM}/help  /model  /provider  /clear  /exit{RESET}  {CYAN}{BOLD}│{RESET}"
-    );
-    println!("{CYAN}{BOLD}╰──────────────────────────────────────────────╯{RESET}");
-    println!();
-}
 
 /// Scan the current directory for project markers and build a context summary.
 fn scan_directory_context(cwd: &str) -> String {
     let p = Path::new(cwd);
-    let mut markers = Vec::new();
-
-    // Rust
-    if p.join("Cargo.toml").exists() {
-        markers.push("Rust (Cargo)");
-    }
-    // Node.js
-    if p.join("package.json").exists() {
-        markers.push("Node.js");
-    }
-    // Python
-    if p.join("pyproject.toml").exists() || p.join("requirements.txt").exists() {
-        markers.push("Python");
-    }
-    // Flutter/Dart
-    if p.join("pubspec.yaml").exists() {
-        markers.push("Flutter/Dart");
-    }
-    // Go
-    if p.join("go.mod").exists() {
-        markers.push("Go");
-    }
-    // Java/Kotlin
-    if p.join("pom.xml").exists() || p.join("build.gradle").exists() {
-        markers.push("Java/Kotlin");
-    }
-    // Docker
-    if p.join("Dockerfile").exists() || p.join("docker-compose.yml").exists() {
-        markers.push("Docker");
-    }
-    // Git
+    // Mesma tabela que o cabecalho usa (#935) — duas copias divergiriam.
+    let mut markers = crate::conversation::project_markers(p);
     if p.join(".git").exists() {
         markers.push("Git repo");
     }
@@ -986,11 +919,33 @@ pub async fn run_chat(
     // Scan directory for context
     let dir_context = scan_directory_context(&cwd);
 
-    print_chat_banner(&provider_name, &model_name, mode);
-    println!("{DIM}  Diretorio: {cwd}{RESET}");
-    if !dir_context.is_empty() {
-        println!("{DIM}  Projeto:   {dir_context}{RESET}");
-    }
+    // Cabecalho compacto (#935): tres linhas no lugar do quadro de doze com o
+    // mascote — que nao sumiu, so deixou de ser cobrado em toda abertura
+    // (`garra about` mostra ele inteiro). A listagem de arquivos que saia aqui
+    // continua indo para o prompt do sistema, onde serve para alguma coisa, e
+    // a inspecao detalhada virou o `/context`.
+    let style = crate::conversation::Style::detect();
+    let cwd_path = std::path::Path::new(&cwd);
+    let markers = crate::conversation::project_markers(cwd_path);
+    // `openrouter/auto` no lugar de `auto`: modelo sem provider e ambiguo.
+    let model_display = if model_name.contains('/') {
+        model_name.clone()
+    } else {
+        format!("{provider_name}/{model_name}")
+    };
+    let header = crate::conversation::Header {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        model: model_display,
+        mode: mode.to_string(),
+        cwd: crate::banner::shorten_path(cwd_path),
+        branch: crate::conversation::git_branch(cwd_path),
+        project: (!markers.is_empty()).then(|| markers.join(", ")),
+    };
+    println!();
+    print!(
+        "{}",
+        header.render(style, crate::conversation::terminal_width())
+    );
     println!();
 
     // Build runtime with filesystem tools
@@ -1074,7 +1029,7 @@ pub async fn run_chat(
 
     loop {
         // Prompt
-        print!("{GREEN}{BOLD}voce >{RESET} ");
+        print!("{}", style.user_prompt());
         io::stdout().flush()?;
 
         let mut input = String::new();
@@ -1107,7 +1062,23 @@ pub async fn run_chat(
                 println!("  /models            Listar modelos disponiveis");
                 println!("  /clear             Limpar historico");
                 println!("  /history           Mostrar historico");
+                println!("  /context           Diretorio e projeto detectados");
                 println!("  /exit              Sair");
+                continue;
+            }
+            // A inspecao detalhada de diretorio saiu do cabecalho de abertura
+            // (#935) e mora aqui: quem quer ver, pede.
+            "/context" | "/contexto" => {
+                println!("{DIM}Diretorio: {cwd}{RESET}");
+                match crate::conversation::git_branch(std::path::Path::new(&cwd)) {
+                    Some(branch) => println!("{DIM}Ramo:      {branch}{RESET}"),
+                    None => println!("{DIM}Ramo:      (fora de um repositorio git){RESET}"),
+                }
+                if dir_context.is_empty() {
+                    println!("{DIM}Projeto:   nenhum marcador detectado{RESET}");
+                } else {
+                    println!("{DIM}Projeto:   {dir_context}{RESET}");
+                }
                 continue;
             }
             "/history" | "/historico" => {
@@ -1227,7 +1198,7 @@ pub async fn run_chat(
             std::time::Duration::from_secs(timeout_secs),
             &mut stdout,
             spinner,
-            &format!("{CYAN}{BOLD}garra >{RESET} "),
+            &style.assistant_prefix(),
             &cancel,
         )
         .await;

--- a/crates/garraia-cli/src/conversation.rs
+++ b/crates/garraia-cli/src/conversation.rs
@@ -1,0 +1,412 @@
+//! Apresentacao da conversa no terminal (#934) e cabecalho compacto de
+//! abertura (#935).
+//!
+//! Puro de proposito, no mesmo molde do `spinner`: nada aqui escreve no
+//! terminal nem le o relogio. As funcoes recebem o que precisam e devolvem
+//! `String`, o que torna cada linha afirmavel contra um literal em teste —
+//! inclusive os caminhos ASCII e sem cor, que ninguem exercita a mao e por
+//! isso sao justamente os que quebram sem ninguem ver.
+
+use std::io::IsTerminal;
+use std::path::Path;
+
+const CYAN: &str = "\x1b[36m";
+const GREEN: &str = "\x1b[32m";
+const BOLD: &str = "\x1b[1m";
+const DIM: &str = "\x1b[2m";
+const RESET: &str = "\x1b[0m";
+
+/// Largura maxima do cabecalho quando o terminal nao diz a dele.
+pub const DEFAULT_WIDTH: usize = 72;
+
+/// O que este terminal aguenta.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Style {
+    pub unicode: bool,
+    pub color: bool,
+}
+
+impl Style {
+    /// ASCII puro, sem uma unica sequencia de escape. E o que sai quando a
+    /// saida esta redirecionada para arquivo ou pipe.
+    pub const PLAIN: Self = Self {
+        unicode: false,
+        color: false,
+    };
+
+    /// Unicode com cor — o terminal interativo comum.
+    pub const RICH: Self = Self {
+        unicode: true,
+        color: true,
+    };
+
+    /// Deriva do ambiente pela **mesma regra** do `spinner::detect`.
+    ///
+    /// As duas superficies nao podem discordar sobre o que o terminal
+    /// aguenta: se discordassem, um terminal legado ganharia `❯` sem ganhar
+    /// spinner, ou o contrario — e o usuario veria meia interface nova.
+    pub fn detect() -> Self {
+        if !std::io::stdout().is_terminal() {
+            return Self::PLAIN;
+        }
+        if env_is_set("NO_COLOR") {
+            return Self::PLAIN;
+        }
+        if std::env::var("TERM").is_ok_and(|t| t == "dumb") {
+            return Self::PLAIN;
+        }
+        Self::RICH
+    }
+
+    /// Marcador do input do usuario. Substitui o antigo `voce >`.
+    pub fn user_prompt(&self) -> String {
+        let marker = if self.unicode { "❯" } else { ">" };
+        if self.color {
+            format!("{GREEN}{BOLD}{marker}{RESET} ")
+        } else {
+            format!("{marker} ")
+        }
+    }
+
+    /// Rotulo da resposta, escrito uma unica vez imediatamente antes do
+    /// primeiro delta (o contrato do `stream_turn`).
+    ///
+    /// Vai numa linha propria, com uma linha em branco antes: o antigo
+    /// `garra > ` prefixava a resposta na mesma linha, e quando a resposta
+    /// tinha varios paragrafos so a primeira linha ficava identificada. A
+    /// linha em branco tambem absorve a linha que o spinner acabou de limpar.
+    pub fn assistant_prefix(&self) -> String {
+        if self.color {
+            format!("\n{CYAN}{BOLD}Garra{RESET}\n")
+        } else {
+            "\nGarra\n".to_string()
+        }
+    }
+
+    fn separator(&self) -> &'static str {
+        if self.unicode { " · " } else { " | " }
+    }
+
+    fn rule_char(&self) -> char {
+        if self.unicode { '─' } else { '-' }
+    }
+
+    fn ellipsis(&self) -> &'static str {
+        if self.unicode { "…" } else { "..." }
+    }
+}
+
+/// Largura util do terminal, best-effort.
+///
+/// Sem dependencia nova: le `COLUMNS` quando o shell exporta e cai no default
+/// quando nao. Nao e exato, e nem precisa ser — a regua do cabecalho nunca
+/// passa do conteudo, e o `shorten_path` ja limita o caminho em 32 chars,
+/// entao o pior caso cabe em qualquer terminal de largura razoavel. A funcao
+/// existe para o dia em que houver uma fonte melhor: troca-se so ela.
+pub fn terminal_width() -> usize {
+    std::env::var("COLUMNS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|w| *w >= 20)
+        .unwrap_or(DEFAULT_WIDTH)
+}
+
+fn env_is_set(name: &str) -> bool {
+    std::env::var(name).is_ok_and(|v| !v.is_empty())
+}
+
+/// Cabecalho compacto de abertura (#935).
+///
+/// Tres linhas no lugar do quadro de doze com o mascote — que nao sumiu, so
+/// deixou de ser cobrado em toda abertura (`garra about` mostra ele inteiro).
+#[derive(Debug, Clone)]
+pub struct Header {
+    pub version: String,
+    pub model: String,
+    pub mode: String,
+    /// Ja encurtado (ver `banner::shorten_path`).
+    pub cwd: String,
+    pub branch: Option<String>,
+    pub project: Option<String>,
+}
+
+impl Header {
+    pub fn render(&self, style: Style, width: usize) -> String {
+        let sep = style.separator();
+
+        let linha1 = format!(
+            "GarraIA {}{sep}{}{sep}{}",
+            self.version, self.model, self.mode
+        );
+
+        let mut partes2 = vec![self.cwd.clone()];
+        if let Some(branch) = &self.branch {
+            partes2.push(branch.clone());
+        }
+        if let Some(project) = &self.project {
+            partes2.push(project.clone());
+        }
+        let linha2 = partes2.join(sep);
+
+        let linha1 = truncate(&linha1, width, style.ellipsis());
+        let linha2 = truncate(&linha2, width, style.ellipsis());
+
+        // A regua acompanha o conteudo e nunca passa da largura pedida: e o
+        // que impede a borda quebrada em terminal estreito.
+        let largura_regua = linha1
+            .chars()
+            .count()
+            .max(linha2.chars().count())
+            .min(width);
+        let regua: String = std::iter::repeat_n(style.rule_char(), largura_regua).collect();
+
+        if style.color {
+            format!("{BOLD}{linha1}{RESET}\n{DIM}{linha2}{RESET}\n{DIM}{regua}{RESET}\n")
+        } else {
+            format!("{linha1}\n{linha2}\n{regua}\n")
+        }
+    }
+}
+
+/// Corta em `width` caracteres, sinalizando o corte.
+fn truncate(s: &str, width: usize, ellipsis: &str) -> String {
+    if s.chars().count() <= width {
+        return s.to_string();
+    }
+    let reservado = ellipsis.chars().count();
+    let manter = width.saturating_sub(reservado);
+    let cabeca: String = s.chars().take(manter).collect();
+    format!("{cabeca}{ellipsis}")
+}
+
+/// Ramo do git lido direto do `.git/HEAD` — sem subprocesso.
+///
+/// Chamar `git` no boot custaria um fork por abertura de chat, e o dado esta
+/// num arquivo de uma linha. `HEAD` desanexado devolve o sha curto, que e o
+/// que o usuario precisa ver para saber onde esta.
+pub fn git_branch(dir: &Path) -> Option<String> {
+    let git = dir.join(".git");
+
+    // Em worktree e submodulo, `.git` e um arquivo com `gitdir: <caminho>`.
+    let git_dir = if git.is_file() {
+        let conteudo = std::fs::read_to_string(&git).ok()?;
+        let apontado = conteudo.strip_prefix("gitdir:")?.trim();
+        let caminho = Path::new(apontado);
+        if caminho.is_absolute() {
+            caminho.to_path_buf()
+        } else {
+            dir.join(caminho)
+        }
+    } else if git.is_dir() {
+        git
+    } else {
+        return None;
+    };
+
+    let head = std::fs::read_to_string(git_dir.join("HEAD")).ok()?;
+    let head = head.trim();
+
+    if let Some(referencia) = head.strip_prefix("ref: refs/heads/") {
+        return Some(referencia.to_string());
+    }
+
+    // HEAD desanexado: o proprio sha.
+    if head.len() >= 7 && head.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Some(head[..7].to_string());
+    }
+
+    None
+}
+
+/// Marcadores de tipo de projeto no diretorio.
+///
+/// So os marcadores — a listagem de arquivos que acompanhava isso saiu do
+/// cabecalho (#935) e continua indo para o prompt do sistema, onde ela
+/// realmente serve para alguma coisa.
+pub fn project_markers(dir: &Path) -> Vec<&'static str> {
+    let mut markers = Vec::new();
+
+    if dir.join("Cargo.toml").exists() {
+        markers.push("Rust");
+    }
+    if dir.join("package.json").exists() {
+        markers.push("Node.js");
+    }
+    if dir.join("pyproject.toml").exists() || dir.join("requirements.txt").exists() {
+        markers.push("Python");
+    }
+    if dir.join("pubspec.yaml").exists() {
+        markers.push("Flutter/Dart");
+    }
+    if dir.join("go.mod").exists() {
+        markers.push("Go");
+    }
+    if dir.join("pom.xml").exists() || dir.join("build.gradle").exists() {
+        markers.push("Java/Kotlin");
+    }
+    if dir.join("Dockerfile").exists() || dir.join("docker-compose.yml").exists() {
+        markers.push("Docker");
+    }
+
+    markers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn header() -> Header {
+        Header {
+            version: "0.3.9".to_string(),
+            model: "openrouter/auto".to_string(),
+            mode: "cloud".to_string(),
+            cwd: "~/GarraRUST".to_string(),
+            branch: Some("main".to_string()),
+            project: Some("Rust".to_string()),
+        }
+    }
+
+    #[test]
+    fn rich_header_matches_the_mockup_of_the_epic() {
+        let saida = header().render(Style::RICH, DEFAULT_WIDTH);
+        let linhas: Vec<&str> = saida.lines().collect();
+
+        assert_eq!(linhas.len(), 3, "o cabecalho tem tres linhas: {saida:?}");
+        assert!(linhas[0].contains("GarraIA 0.3.9 · openrouter/auto · cloud"));
+        assert!(linhas[1].contains("~/GarraRUST · main · Rust"));
+        assert!(linhas[2].contains('─'));
+    }
+
+    #[test]
+    fn plain_header_has_no_escape_sequence_and_no_unicode() {
+        let saida = header().render(Style::PLAIN, DEFAULT_WIDTH);
+
+        assert!(!saida.contains('\x1b'), "vazou escape ANSI: {saida:?}");
+        assert!(saida.is_ascii(), "vazou caractere nao-ASCII: {saida:?}");
+        assert!(saida.contains("GarraIA 0.3.9 | openrouter/auto | cloud"));
+        assert!(saida.contains("---"));
+    }
+
+    /// Criterio de aceite do #935: terminal estreito nao pode quebrar a borda.
+    #[test]
+    fn narrow_terminal_never_exceeds_the_requested_width() {
+        for largura in [20usize, 24, 32, 40] {
+            let saida = header().render(Style::PLAIN, largura);
+            for linha in saida.lines() {
+                assert!(
+                    linha.chars().count() <= largura,
+                    "largura {largura}: linha com {} chars: {linha:?}",
+                    linha.chars().count()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn header_omits_absent_branch_and_project() {
+        let mut h = header();
+        h.branch = None;
+        h.project = None;
+        let saida = h.render(Style::PLAIN, DEFAULT_WIDTH);
+
+        let linha2 = saida.lines().nth(1).expect("segunda linha");
+        assert_eq!(linha2, "~/GarraRUST", "sem separador solto: {linha2:?}");
+    }
+
+    /// #934: nada de `voce >`, e o fallback continua utilizavel.
+    #[test]
+    fn user_prompt_swaps_marker_but_keeps_ascii_usable() {
+        assert!(Style::RICH.user_prompt().contains('❯'));
+        assert!(!Style::RICH.user_prompt().contains("voce"));
+
+        let plano = Style::PLAIN.user_prompt();
+        assert_eq!(plano, "> ");
+        assert!(!plano.contains('\x1b'));
+    }
+
+    /// O rotulo da resposta vai numa linha propria: resposta de varios
+    /// paragrafos tinha so a primeira linha identificada com `garra > `.
+    #[test]
+    fn assistant_prefix_is_a_block_label_on_its_own_line() {
+        let rico = Style::RICH.assistant_prefix();
+        assert!(rico.starts_with('\n'), "linha em branco antes: {rico:?}");
+        assert!(rico.ends_with('\n'), "resposta comeca na linha seguinte");
+        assert!(rico.contains("Garra"));
+
+        assert_eq!(Style::PLAIN.assistant_prefix(), "\nGarra\n");
+    }
+
+    #[test]
+    fn truncation_marks_the_cut() {
+        assert_eq!(truncate("abcdefgh", 5, "..."), "ab...");
+        assert_eq!(truncate("abc", 5, "..."), "abc");
+        assert_eq!(truncate("abcdefgh", 5, "…"), "abcd…");
+    }
+
+    #[test]
+    fn reads_branch_from_a_plain_git_dir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let git = tmp.path().join(".git");
+        std::fs::create_dir_all(&git).expect("mkdir");
+        std::fs::write(git.join("HEAD"), "ref: refs/heads/claude/algo-longo\n").expect("write");
+
+        assert_eq!(
+            git_branch(tmp.path()),
+            Some("claude/algo-longo".to_string())
+        );
+    }
+
+    #[test]
+    fn detached_head_reports_the_short_sha() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let git = tmp.path().join(".git");
+        std::fs::create_dir_all(&git).expect("mkdir");
+        std::fs::write(git.join("HEAD"), "9f39dfe1b65a1c2d3e4f5061728394a5b6c7d8e9\n")
+            .expect("write");
+
+        assert_eq!(git_branch(tmp.path()), Some("9f39dfe".to_string()));
+    }
+
+    /// Worktree e submodulo tem `.git` como ARQUIVO apontando para outro
+    /// lugar. Sem seguir o ponteiro, quem usa `git worktree` perderia o ramo
+    /// no cabecalho sem entender por que.
+    #[test]
+    fn follows_the_gitdir_pointer_of_a_worktree() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let real = tmp.path().join("real-git-dir");
+        std::fs::create_dir_all(&real).expect("mkdir");
+        std::fs::write(real.join("HEAD"), "ref: refs/heads/feature\n").expect("write");
+
+        let work = tmp.path().join("work");
+        std::fs::create_dir_all(&work).expect("mkdir");
+        std::fs::write(
+            work.join(".git"),
+            format!("gitdir: {}\n", real.display()),
+        )
+        .expect("write");
+
+        assert_eq!(git_branch(&work), Some("feature".to_string()));
+    }
+
+    #[test]
+    fn no_git_no_branch() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert_eq!(git_branch(tmp.path()), None);
+    }
+
+    #[test]
+    fn detects_project_markers_without_listing_files() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join("Cargo.toml"), "[package]").expect("write");
+        std::fs::write(tmp.path().join("Dockerfile"), "FROM scratch").expect("write");
+        std::fs::write(tmp.path().join("segredo.txt"), "nao deve aparecer").expect("write");
+
+        let markers = project_markers(tmp.path());
+
+        assert_eq!(markers, vec!["Rust", "Docker"]);
+        assert!(
+            !markers.iter().any(|m| m.contains("segredo")),
+            "o cabecalho nao lista arquivos (#935)"
+        );
+    }
+}

--- a/crates/garraia-cli/src/main.rs
+++ b/crates/garraia-cli/src/main.rs
@@ -5,6 +5,7 @@ mod capability_prompt;
 mod chat;
 mod cli_args;
 mod config_cmd;
+mod conversation;
 mod doctor;
 mod glob_cmd;
 mod max_power;
@@ -93,6 +94,9 @@ enum Commands {
         #[arg(long)]
         with_voice: bool,
     },
+
+    /// Show the full GarraIA banner and what each command does
+    About,
 
     /// Stop the running daemon
     Stop,
@@ -1159,6 +1163,10 @@ async fn async_main(
                 .with_telemetry_config(Some(telemetry_config));
             server.run().await?;
         }
+        Commands::About => {
+            banner::print_about();
+        }
+
         Commands::Stop => {
             init_tracing(&effective_level);
             stop_daemon(config.gateway.port)?;


### PR DESCRIPTION
## Descrição

Duas issues da Fase 1 do épico #944 que se encontram no mesmo lugar: o que o terminal mostra quando o chat abre e a cada turno.

### #934 — layout da conversa

`voce >` vira `❯`, e `garra > ` vira um rótulo `Garra` em linha própria.

O rótulo na mesma linha da resposta só identificava o **primeiro parágrafo** — numa resposta de cinco parágrafos, os outros quatro ficavam visualmente indistinguíveis do que o usuário digitou. Agora ele identifica o bloco.

Um dos critérios de aceite da issue já estava atendido antes deste PR: "nenhum prompt vazio durante a latência". O #936 mudou o contrato do `stream_turn` para escrever o prefixo **uma única vez, imediatamente antes do primeiro delta** — então aqui foi só trocar o rótulo, sem tocar na mecânica.

### #935 — cabeçalho compacto

Doze linhas de quadro com mascote, mais `Diretorio:` e `Projeto: Arquivos: a, b, c…`, viram três:

```text
GarraIA 0.3.9 · openrouter/auto · cloud
~/GarraRUST · main · Rust
────────────────────────────────────────
```

Nada foi jogado fora, só reposicionado:

| O que era | Onde está agora |
| --- | --- |
| Mascote + branding (12 linhas em toda abertura) | `garra about`, com o resumo dos comandos junto |
| `Diretorio:` + `Projeto:` + lista de arquivos | `/context`, quando o usuário pedir |
| Lista de arquivos do diretório | Continua indo para o **prompt do sistema**, que é onde ela serve para alguma coisa — o agente usa, o usuário não lia |

O modelo aparece como `openrouter/auto` e não `auto`: modelo sem provider é ambíguo.

## Decisões que valem registro

**Novo módulo `conversation.rs`, puro no molde do `spinner`.** Não escreve no terminal nem lê o relógio — recebe o que precisa e devolve `String`. É o que torna afirmável exatamente o que ninguém exercita à mão: o caminho ASCII, o sem cor e o terminal estreito. Um teste fixa que a saída plana não contém **um único** byte de escape ANSI nem caractere não-ASCII.

**`Style::detect` usa a mesma regra do `spinner::detect`.** Se as duas superfícies discordassem sobre o que o terminal aguenta, um terminal legado ganharia `❯` sem ganhar spinner — meia interface nova, que é pior que nenhuma.

**O ramo do git sai do `.git/HEAD`, sem subprocesso.** Um `fork` por abertura de chat para ler um arquivo de uma linha não se paga. Segue o ponteiro `gitdir:` de worktree e submódulo (senão quem usa `git worktree` perderia o ramo sem entender por quê) e devolve o sha curto em `HEAD` desanexado.

**A régua acompanha o conteúdo e nunca passa da largura pedida** — é o que atende ao critério "narrow terminals render without broken borders", com teste de 20 a 40 colunas.

## Tipo de mudança

- [x] `feat`: Nova funcionalidade
- [x] `test`: Adição ou correção de testes

## Classe de Risco

- [x] **Classe A/B (Baixo–Médio)**: só apresentação do CLI interativo. Nenhum caminho de dados, API, auth ou storage tocado. Sem auditoria de segurança — não há superfície para auditar.

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo fmt --check` executado e limpo
- [x] `cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings` sem erros
- [x] `cargo test --workspace --exclude garraia-desktop` passando — **291 testes** no binário `garra`; única falha é a ambiental conhecida `migration_001_applies_and_schema_is_sane`, que exige `docker.sock`
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo, API key, token ou credencial commitada
- [x] Nenhuma migração Postgres

## Mudanças na API pública e Schema

- Novo subcomando `garra about`.
- Novo slash command `/context` no REPL (e `/help` passa a listá-lo).
- `chat::print_chat_banner` deixou de existir; a arte vive em `banner::print_about`.
- Sem mudança de schema, sem migração.

**Este PR estreia o `changelog.d` do #973**: registra a mudança em `changelog.d/changed/934-935-layout-conversa.md` em vez de editar o `CHANGELOG.md`, que é a nova regra do `CLAUDE.md`.

## Como testar

```bash
cargo +1.95 test -p garraia --bin garra conversation   # 12 testes do modulo
cargo +1.95 test -p garraia --bin garra                # 291 no total
cargo +1.95 run -p garraia --bin garra -- about        # o mascote, agora sob demanda
```

Fim a fim: abrir o `garraia` e comparar com o mockup do épico; `/context` para a inspeção detalhada; `NO_COLOR=1 garraia` e `TERM=dumb garraia` para o fallback ASCII; `garraia 2>/dev/null | cat` para o não-TTY.

## Plano de Rollback

Commit único, puramente de apresentação, sem estado persistido. Reverter restaura `voce >`, `garra > `, o quadro de doze linhas com o mascote e o dump de arquivos na abertura; `garra about` e `/context` somem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF

---
_Generated by [Claude Code](https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF)_