### PR TITLE
feat(cli): garra memory — inspecao, busca e reindexacao (#950, #953)

### DIFF
--- a/changelog.d/added/950-953-cli-garra-memory.md
+++ b/changelog.d/added/950-953-cli-garra-memory.md
@@ -1,0 +1,19 @@
+- **`garra memory` inspeciona, repara e limpa a memoria semantica (#950, #953).**
+  Ate aqui a memoria era caixa-preta: nao havia como saber quantas entradas
+  existiam, quantas tinham vetor, se o indice estava consistente, nem como
+  consertar as que a cadeia de perda silenciosa (#948, #951, #962) deixou sem
+  embedding — e o `docs/src/memory.md` chegava a documentar seis subcomandos
+  que nunca existiram. Agora sao seis de verdade: `stats` mostra o relatorio de
+  integridade do #960 (inclusive a fila legada de vetor sem modelo), `list`
+  lista as entradas recentes ou so a fila de reindexacao, `search` roda o mesmo
+  recall do agente e diz se foi semantico ou textual, `reindex` reprocessa as
+  entradas gravadas sem vetor, `delete` apaga uma entrada com o vetor dela e
+  `compact` apaga tudo anterior a N dias. Os dois destrutivos exigem confirmacao
+  e, sem terminal, exigem `--yes` explicito. `stats`, `list`, `search` e
+  `reindex` tem `--json` para script. O reindex para no primeiro lote que falha
+  em vez de insistir: a fila e derivada do banco, entao rodar de novo depois
+  continua de onde parou. A CLI abre o **mesmo** `memory.db` do gateway
+  (`AppConfig::memory_db_path`, agora fonte unica) e pede o **mesmo** provider
+  de embeddings (`bootstrap::build_embedding_provider`, extraido de
+  `build_agent_runtime`) — o que o `reindex` grava e exatamente o que o recall
+  do agente le de volta.

--- a/changelog.d/added/950-953-cli-garra-memory.md
+++ b/changelog.d/added/950-953-cli-garra-memory.md
@@ -17,3 +17,13 @@
   de embeddings (`bootstrap::build_embedding_provider`, extraido de
   `build_agent_runtime`) — o que o `reindex` grava e exatamente o que o recall
   do agente le de volta.
+
+- **`garra memory reindex` tambem repara o indice, sem custo de provider (#950).**
+  O `remember_sync` grava a linha e insere no indice em best-effort: com o
+  sqlite-vec fora do ar por um momento, a entrada fica com vetor na coluna e
+  **fora** da busca semantica, e o reindex normal nao a alcanca porque ele
+  procura `embedding IS NULL`. O reparo agora roda antes, sem chamar provider
+  nenhum — o vetor ja existe, so falta indexa-lo — e aparece como
+  `index_repaired` no relatorio. Na mesma linha, `set_embedding` virou
+  fail-closed: se o indice recusar o vetor, a coluna volta a NULL, para a
+  entrada continuar na fila em vez de sair dela sem ter sido indexada.

--- a/crates/garraia-agents/src/lib.rs
+++ b/crates/garraia-agents/src/lib.rs
@@ -11,6 +11,7 @@ pub mod embeddings;
 pub mod execution_budget;
 pub mod llama_cpp;
 pub mod memory_extractor;
+pub mod memory_reindex;
 pub mod modes;
 pub mod multi_agent;
 pub mod ollama;
@@ -35,6 +36,9 @@ pub use embeddings::{
 };
 pub use execution_budget::ExecutionBudget;
 pub use llama_cpp::{KvCacheType, LlamaCppConfig, LlamaCppProvider};
+pub use memory_reindex::{
+    DEFAULT_REINDEX_BATCH_SIZE, ReindexOptions, ReindexReport, reindex_missing_embeddings,
+};
 pub use modes::{
     AgentMode, ModeContext, ModeEngine, ModeLimits, ModeLlmConfig, ModeProfile, ToolPolicy,
 };

--- a/crates/garraia-agents/src/memory_reindex.rs
+++ b/crates/garraia-agents/src/memory_reindex.rs
@@ -1,0 +1,390 @@
+//! Reindexacao da memoria semantica (#953).
+//!
+//! Mora **aqui** e nao no `MemoryStore`, que e onde a issue propunha, por uma
+//! razao de camada: o `EmbeddingProvider` e deste crate, e `garraia-agents` ja
+//! depende de `garraia-db`. Pedir ao store que receba um provider exigiria a
+//! dependencia inversa, e o ciclo nao fecha. As primitivas ficaram no store
+//! (`entries_missing_embeddings`, `set_embedding`); o que precisa dos dois
+//! lados fica aqui.
+
+use garraia_common::Result;
+use garraia_db::MemoryStore;
+use tracing::{info, warn};
+
+use crate::embeddings::EmbeddingProvider;
+
+/// Quantas entradas por ida ao provider.
+///
+/// O lote do Ollama ja e paralelo internamente (#962), entao este numero e
+/// sobre o tamanho da transacao logica, nao sobre concorrencia: pequeno o
+/// bastante para que uma interrupcao no meio de uma base de milhares perca
+/// pouco trabalho, grande o bastante para nao virar uma ida por entrada.
+pub const DEFAULT_REINDEX_BATCH_SIZE: usize = 32;
+
+#[derive(Debug, Clone)]
+pub struct ReindexOptions {
+    pub batch_size: usize,
+    /// Teto de entradas a processar. `None` = ate acabar a fila.
+    pub max_entries: Option<usize>,
+    /// So conta o que seria feito, sem chamar o provider nem gravar.
+    pub dry_run: bool,
+}
+
+impl Default for ReindexOptions {
+    fn default() -> Self {
+        Self {
+            batch_size: DEFAULT_REINDEX_BATCH_SIZE,
+            max_entries: None,
+            dry_run: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReindexReport {
+    /// Entradas sem vetor antes de comecar.
+    pub pending_before: usize,
+    pub reindexed: usize,
+    /// Entradas que sumiram entre listar e gravar — nao e erro.
+    pub vanished: usize,
+    /// `true` quando o provider falhou e a reindexacao parou no meio.
+    pub stopped_early: bool,
+    pub dry_run: bool,
+}
+
+/// Reprocessa entradas gravadas sem vetor.
+///
+/// Para no primeiro lote que falha, de proposito: uma falha de provider quase
+/// sempre significa que ele esta fora, e insistir lote apos lote so demora
+/// para dar a mesma noticia. O relatorio diz quanto foi feito, e rodar de novo
+/// depois continua de onde parou — a fila e derivada do banco, nao de estado
+/// em memoria.
+pub async fn reindex_missing_embeddings(
+    store: &MemoryStore,
+    provider: &dyn EmbeddingProvider,
+    options: ReindexOptions,
+) -> Result<ReindexReport> {
+    let pending_before = store.integrity_report()?.entries_without_embedding;
+    let model = provider.model().to_string();
+
+    let mut report = ReindexReport {
+        pending_before,
+        reindexed: 0,
+        vanished: 0,
+        stopped_early: false,
+        dry_run: options.dry_run,
+    };
+
+    if options.dry_run || pending_before == 0 {
+        return Ok(report);
+    }
+
+    let batch_size = options.batch_size.max(1);
+
+    loop {
+        let restante = match options.max_entries {
+            Some(teto) => teto.saturating_sub(report.reindexed + report.vanished),
+            None => batch_size,
+        };
+        if restante == 0 {
+            break;
+        }
+
+        let lote = store.entries_missing_embeddings(batch_size.min(restante))?;
+        if lote.is_empty() {
+            break;
+        }
+
+        let textos: Vec<String> = lote.iter().map(|e| e.content.clone()).collect();
+        let vetores = match provider.embed_documents(&textos).await {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(
+                    provider = provider.provider_id(),
+                    model = model.as_str(),
+                    reindexed = report.reindexed,
+                    "reindexacao interrompida: o provider de embeddings falhou. \
+                     Rode de novo quando ele voltar — a fila continua de onde parou: {e}"
+                );
+                report.stopped_early = true;
+                break;
+            }
+        };
+
+        // Um provider que devolve menos vetores do que textos quebraria o
+        // pareamento por indice e gravaria o vetor errado na entrada errada.
+        if vetores.len() != lote.len() {
+            warn!(
+                provider = provider.provider_id(),
+                esperados = lote.len(),
+                recebidos = vetores.len(),
+                "reindexacao interrompida: o provider devolveu um numero de vetores \
+                 diferente do numero de textos, e parear por indice gravaria vetor \
+                 na entrada errada"
+            );
+            report.stopped_early = true;
+            break;
+        }
+
+        let mut gravou_algo = false;
+        for (entrada, vetor) in lote.iter().zip(vetores) {
+            if store.set_embedding(&entrada.id, &vetor, &model)? {
+                report.reindexed += 1;
+                gravou_algo = true;
+            } else {
+                report.vanished += 1;
+            }
+        }
+
+        // Sem isto, um lote que nao grava nada devolveria as mesmas linhas
+        // para sempre — a fila vem do banco, e o que nao foi gravado continua
+        // nela.
+        if !gravou_algo {
+            report.stopped_early = true;
+            break;
+        }
+    }
+
+    info!(
+        reindexed = report.reindexed,
+        vanished = report.vanished,
+        pending_before = report.pending_before,
+        "reindexacao da memoria concluida"
+    );
+
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::embeddings::EmbeddingProvider;
+    use async_trait::async_trait;
+    use garraia_common::Error;
+    use garraia_db::{MemoryRole, NewMemoryEntry};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct FakeProvider {
+        dims: usize,
+        fail_after: Option<usize>,
+        calls: AtomicUsize,
+    }
+
+    impl FakeProvider {
+        fn new(dims: usize) -> Self {
+            Self {
+                dims,
+                fail_after: None,
+                calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn failing_after(dims: usize, batches: usize) -> Self {
+            Self {
+                dims,
+                fail_after: Some(batches),
+                calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl EmbeddingProvider for FakeProvider {
+        fn provider_id(&self) -> &str {
+            "fake"
+        }
+
+        fn model(&self) -> &str {
+            "fake-model"
+        }
+
+        async fn embed_documents(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+            let n = self.calls.fetch_add(1, Ordering::SeqCst);
+            if let Some(limite) = self.fail_after
+                && n >= limite
+            {
+                return Err(Error::Agent("provider fora do ar".into()));
+            }
+            Ok(texts.iter().map(|_| vec![0.5; self.dims]).collect())
+        }
+
+        async fn embed_query(&self, _text: &str) -> Result<Vec<f32>> {
+            Ok(vec![0.5; self.dims])
+        }
+
+        async fn health_check(&self) -> Result<bool> {
+            Ok(true)
+        }
+    }
+
+    async fn store_com(sem_vetor: usize, com_vetor: usize) -> MemoryStore {
+        let store = MemoryStore::in_memory_with_vectors().expect("store");
+        for i in 0..sem_vetor {
+            store
+                .remember(entrada(&format!("sem vetor {i}"), None))
+                .await
+                .expect("remember");
+        }
+        for i in 0..com_vetor {
+            store
+                .remember(entrada(
+                    &format!("com vetor {i}"),
+                    Some(vec![0.1, 0.2, 0.3]),
+                ))
+                .await
+                .expect("remember");
+        }
+        store
+    }
+
+    fn entrada(content: &str, embedding: Option<Vec<f32>>) -> NewMemoryEntry {
+        NewMemoryEntry {
+            tenant_id: "default".to_string(),
+            session_id: "s".to_string(),
+            channel_id: None,
+            user_id: None,
+            continuity_key: None,
+            role: MemoryRole::User,
+            content: content.to_string(),
+            embedding_model: embedding.as_ref().map(|_| "antigo".to_string()),
+            embedding,
+            metadata: serde_json::json!({}),
+        }
+    }
+
+    #[tokio::test]
+    async fn reindexes_only_the_entries_without_a_vector() {
+        let store = store_com(5, 3).await;
+        let provider = FakeProvider::new(3);
+
+        let report = reindex_missing_embeddings(&store, &provider, ReindexOptions::default())
+            .await
+            .expect("reindex");
+
+        assert_eq!(report.pending_before, 5);
+        assert_eq!(report.reindexed, 5);
+        assert!(!report.stopped_early);
+
+        let depois = store.integrity_report().expect("report");
+        assert_eq!(depois.entries_without_embedding, 0);
+        assert_eq!(depois.entries_with_embedding, 8, "as 3 antigas seguem la");
+    }
+
+    /// A entrada reindexada passa a ser encontravel pela busca semantica —
+    /// que e o ponto inteiro do #953.
+    #[tokio::test]
+    async fn reindexed_entries_enter_the_vector_index() {
+        let store = store_com(4, 0).await;
+        assert_eq!(store.integrity_report().expect("r").map_rows, 0);
+
+        reindex_missing_embeddings(&store, &FakeProvider::new(3), ReindexOptions::default())
+            .await
+            .expect("reindex");
+
+        let depois = store.integrity_report().expect("report");
+        assert_eq!(depois.map_rows, 4, "as quatro entraram no indice");
+        assert!(depois.orphan_map_entries.is_empty());
+    }
+
+    #[tokio::test]
+    async fn dry_run_touches_nothing() {
+        let store = store_com(3, 0).await;
+        let options = ReindexOptions {
+            dry_run: true,
+            ..ReindexOptions::default()
+        };
+
+        let report = reindex_missing_embeddings(&store, &FakeProvider::new(3), options)
+            .await
+            .expect("reindex");
+
+        assert_eq!(report.pending_before, 3);
+        assert_eq!(report.reindexed, 0);
+        assert!(report.dry_run);
+        assert_eq!(
+            store
+                .integrity_report()
+                .expect("r")
+                .entries_without_embedding,
+            3,
+            "dry-run nao pode gravar"
+        );
+    }
+
+    /// Provider que cai no meio nao pode fazer a reindexacao girar em falso:
+    /// ela para, relata o que fez, e rodar de novo continua de onde parou.
+    #[tokio::test]
+    async fn stops_when_the_provider_fails_and_keeps_what_was_done() {
+        let store = store_com(10, 0).await;
+        let provider = FakeProvider::failing_after(3, 1);
+        let options = ReindexOptions {
+            batch_size: 4,
+            ..ReindexOptions::default()
+        };
+
+        let report = reindex_missing_embeddings(&store, &provider, options.clone())
+            .await
+            .expect("reindex");
+
+        assert_eq!(report.reindexed, 4, "o primeiro lote passou");
+        assert!(report.stopped_early);
+        assert_eq!(
+            store
+                .integrity_report()
+                .expect("r")
+                .entries_without_embedding,
+            6
+        );
+
+        // Provider de volta: a fila continua de onde parou, sem estado em memoria.
+        let report = reindex_missing_embeddings(&store, &FakeProvider::new(3), options)
+            .await
+            .expect("reindex");
+        assert_eq!(report.pending_before, 6);
+        assert_eq!(report.reindexed, 6);
+        assert_eq!(
+            store
+                .integrity_report()
+                .expect("r")
+                .entries_without_embedding,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn max_entries_caps_the_work() {
+        let store = store_com(10, 0).await;
+        let options = ReindexOptions {
+            batch_size: 3,
+            max_entries: Some(5),
+            ..ReindexOptions::default()
+        };
+
+        let report = reindex_missing_embeddings(&store, &FakeProvider::new(3), options)
+            .await
+            .expect("reindex");
+
+        assert_eq!(report.reindexed, 5, "para no teto, nao no fim da fila");
+        assert_eq!(
+            store
+                .integrity_report()
+                .expect("r")
+                .entries_without_embedding,
+            5
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_queue_is_a_no_op() {
+        let store = store_com(0, 2).await;
+
+        let report =
+            reindex_missing_embeddings(&store, &FakeProvider::new(3), ReindexOptions::default())
+                .await
+                .expect("reindex");
+
+        assert_eq!(report.pending_before, 0);
+        assert_eq!(report.reindexed, 0);
+        assert!(!report.stopped_early);
+    }
+}

--- a/crates/garraia-agents/src/memory_reindex.rs
+++ b/crates/garraia-agents/src/memory_reindex.rs
@@ -44,6 +44,10 @@ impl Default for ReindexOptions {
 pub struct ReindexReport {
     /// Entradas sem vetor antes de comecar.
     pub pending_before: usize,
+    /// Entradas que ja tinham vetor na coluna e faltavam no indice, e foram
+    /// reinseridas sem custo de provider. E o estado que o `remember_sync`
+    /// produz quando o sqlite-vec falha na ingestao.
+    pub index_repaired: usize,
     pub reindexed: usize,
     /// Entradas que sumiram entre listar e gravar — nao e erro.
     pub vanished: usize,
@@ -69,13 +73,32 @@ pub async fn reindex_missing_embeddings(
 
     let mut report = ReindexReport {
         pending_before,
+        index_repaired: 0,
         reindexed: 0,
         vanished: 0,
         stopped_early: false,
         dry_run: options.dry_run,
     };
 
-    if options.dry_run || pending_before == 0 {
+    if options.dry_run {
+        return Ok(report);
+    }
+
+    // Reparo barato primeiro: reinserir no indice um vetor que ja esta na
+    // coluna nao custa chamada de provider nenhuma, e sem isso o `reindex`
+    // deixaria de fora justamente as entradas que o `remember_sync` gravou
+    // enquanto o sqlite-vec estava fora — elas nao aparecem em
+    // `entries_missing_embeddings`, que procura `embedding IS NULL`.
+    report.index_repaired =
+        store.reindex_missing_index_rows(options.max_entries.unwrap_or(usize::MAX))?;
+    if report.index_repaired > 0 {
+        info!(
+            reparadas = report.index_repaired,
+            "vetores que ja estavam na coluna voltaram para o indice"
+        );
+    }
+
+    if pending_before == 0 {
         return Ok(report);
     }
 
@@ -146,6 +169,7 @@ pub async fn reindex_missing_embeddings(
     }
 
     info!(
+        index_repaired = report.index_repaired,
         reindexed = report.reindexed,
         vanished = report.vanished,
         pending_before = report.pending_before,

--- a/crates/garraia-cli/src/main.rs
+++ b/crates/garraia-cli/src/main.rs
@@ -10,6 +10,7 @@ mod doctor;
 mod glob_cmd;
 mod max_power;
 mod mcp_server;
+mod memory_cmd;
 mod migrate;
 mod migrate_workspace;
 mod repo_workflow;
@@ -245,6 +246,16 @@ enum Commands {
         yes: bool,
     },
 
+    /// Inspect, repair, and prune the semantic memory (#950).
+    ///
+    /// Opens the same `memory.db` the gateway uses (`AppConfig::memory_db_path`)
+    /// and, when a subcommand needs one, the same embedding provider — so what
+    /// `reindex` writes is exactly what the agent's recall reads back.
+    Memory {
+        #[command(subcommand)]
+        action: MemoryCommands,
+    },
+
     /// Inspect, validate, and diagnose the effective configuration
     Config {
         #[command(subcommand)]
@@ -311,6 +322,79 @@ enum Commands {
         /// Defaults to the current working directory.
         #[arg(long, value_name = "DIR")]
         workspace: Option<std::path::PathBuf>,
+    },
+}
+
+#[derive(Subcommand)]
+enum MemoryCommands {
+    /// Counts plus the vector-index integrity report (#960).
+    Stats {
+        /// Emit machine-readable JSON instead of the human-friendly report.
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// List the most recent entries, newest first.
+    List {
+        #[arg(long, default_value_t = 20)]
+        limit: usize,
+
+        /// Only entries stored without a vector — the `reindex` queue.
+        #[arg(long)]
+        no_embedding: bool,
+
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Search the memory through the same recall the agent uses.
+    ///
+    /// Semantic when an embedding provider is configured; textual otherwise.
+    /// The output says which of the two ran.
+    Search {
+        query: String,
+
+        #[arg(long, default_value_t = 10)]
+        limit: usize,
+
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Re-embed the entries stored without a vector (#953).
+    Reindex {
+        /// Cap on how many entries to process. Omit to drain the queue.
+        #[arg(long)]
+        limit: Option<usize>,
+
+        #[arg(long, default_value_t = garraia_agents::DEFAULT_REINDEX_BATCH_SIZE)]
+        batch_size: usize,
+
+        /// Report what would be done without calling the provider or writing.
+        #[arg(long)]
+        dry_run: bool,
+
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Delete one entry by id, along with its vector.
+    Delete {
+        id: String,
+
+        /// Skip the confirmation prompt (required when stdin is not a TTY).
+        #[arg(long, short = 'y')]
+        yes: bool,
+    },
+
+    /// Delete every entry older than N days, along with their vectors.
+    Compact {
+        #[arg(long, default_value_t = 90)]
+        older_than_days: i64,
+
+        /// Skip the confirmation prompt (required when stdin is not a TTY).
+        #[arg(long, short = 'y')]
+        yes: bool,
     },
 }
 
@@ -1760,6 +1844,40 @@ async fn async_main(
                 yes,
             )
             .await?;
+            if code != 0 {
+                std::process::exit(code);
+            }
+        }
+        Commands::Memory { action } => {
+            // O console limpo do #933 vale aqui: a saida do subcomando e o
+            // relatorio, e o tracing so entra quando o operador pede.
+            if cli.verbose || cli.debug {
+                init_tracing(&effective_level);
+            }
+            let code = match action {
+                MemoryCommands::Stats { json } => memory_cmd::run_stats(&config, json).await?,
+                MemoryCommands::List {
+                    limit,
+                    no_embedding,
+                    json,
+                } => memory_cmd::run_list(&config, limit, no_embedding, json).await?,
+                MemoryCommands::Search { query, limit, json } => {
+                    memory_cmd::run_search(&config, query, limit, json).await?
+                }
+                MemoryCommands::Reindex {
+                    limit,
+                    batch_size,
+                    dry_run,
+                    json,
+                } => memory_cmd::run_reindex(&config, limit, batch_size, dry_run, json).await?,
+                MemoryCommands::Delete { id, yes } => {
+                    memory_cmd::run_delete(&config, id, yes).await?
+                }
+                MemoryCommands::Compact {
+                    older_than_days,
+                    yes,
+                } => memory_cmd::run_compact(&config, older_than_days, yes).await?,
+            };
             if code != 0 {
                 std::process::exit(code);
             }

--- a/crates/garraia-cli/src/memory_cmd.rs
+++ b/crates/garraia-cli/src/memory_cmd.rs
@@ -95,7 +95,11 @@ pub(crate) fn cutoff_from_days(now: DateTime<Utc>, days: i64) -> Option<DateTime
     if days < 0 {
         return None;
     }
-    now.checked_sub_signed(Duration::days(days))
+    // `Duration::days` entra em **panico** acima de ~106 bilhoes de dias, e
+    // `--older-than-days` e um `i64` que o operador digita: sem o `try_`, um
+    // numero grande derruba o processo antes de o `checked_sub_signed` ter
+    // chance de recusar.
+    now.checked_sub_signed(Duration::try_days(days)?)
 }
 
 /// Uma entrada em JSON. O conteudo vai inteiro — quem pediu `--json` esta
@@ -113,19 +117,28 @@ fn entry_json(entry: &MemoryEntry) -> serde_json::Value {
     })
 }
 
-/// Uma entrada em uma linha de terminal.
-fn entry_line(entry: &MemoryEntry) -> String {
+/// Uma entrada em duas linhas de terminal: cabecalho e previa do conteudo.
+///
+/// A distancia, quando ha, vai no **cabecalho** e nao depois da previa: o
+/// conteudo e truncado, e pendurar um numero no fim de um texto cortado
+/// confunde os dois.
+fn entry_line(entry: &MemoryEntry, distancia: Option<f64>) -> String {
     let vetor = match (&entry.embedding, &entry.embedding_model) {
         (None, _) => "sem vetor".to_string(),
         (Some(_), None) => "vetor sem modelo".to_string(),
         (Some(_), Some(m)) => m.clone(),
     };
+    let distancia = match distancia {
+        Some(d) => format!("  d={d:.4}"),
+        None => String::new(),
+    };
     format!(
-        "{}  {}  [{}]  ({})\n    {}",
+        "{}  {}  [{}]  ({}){}\n    {}",
         entry.created_at.format("%Y-%m-%d %H:%M:%SZ"),
         entry.id,
         vetor,
         role_str(entry),
+        distancia,
         preview(&entry.content, PREVIEW_CHARS),
     )
 }
@@ -161,6 +174,9 @@ pub async fn run_stats(config: &AppConfig, json: bool) -> Result<i32> {
     let report = store
         .integrity_report()
         .context("failed to build integrity report")?;
+    let breakdown = store
+        .embedding_breakdown()
+        .context("failed to build per-model breakdown")?;
     let knn = store.knn_enabled();
 
     if json {
@@ -178,6 +194,7 @@ pub async fn run_stats(config: &AppConfig, json: bool) -> Result<i32> {
                 .map(|(t, n)| serde_json::json!({ "table": t, "rows": n }))
                 .collect::<Vec<_>>(),
             "orphan_map_entries": report.orphan_map_entries,
+            "by_model": breakdown,
         });
         println!("{}", serde_json::to_string_pretty(&payload)?);
         return Ok(EXIT_OK);
@@ -199,6 +216,22 @@ pub async fn run_stats(config: &AppConfig, json: bool) -> Result<i32> {
     println!("Linhas no mapa:     {}", report.map_rows);
     for (table, rows) in &report.vec_rows_by_table {
         println!("  {table}: {rows}");
+    }
+
+    // "Com o que este indice foi construido?" e a pergunta que decide se uma
+    // troca de modelo exige reindexar tudo (#954) — e ela nao se responde
+    // com um agregado.
+    if !breakdown.is_empty() {
+        println!("\nPor modelo:");
+        for linha in &breakdown {
+            let rotulo = match (&linha.embedding_model, linha.embedding_dimensions) {
+                (Some(m), Some(d)) => format!("{m} ({d} dimensoes)"),
+                (Some(m), None) => format!("{m} (dimensao nao registrada)"),
+                (None, Some(d)) => format!("sem modelo registrado ({d} dimensoes)"),
+                (None, None) => "sem vetor".to_string(),
+            };
+            println!("  {rotulo}: {}", linha.entries);
+        }
     }
 
     if !report.orphan_map_entries.is_empty() {
@@ -284,7 +317,7 @@ pub async fn run_list(
     }
 
     for entry in &entries {
-        println!("{}", entry_line(entry));
+        println!("{}", entry_line(entry, None));
     }
     Ok(EXIT_OK)
 }
@@ -341,6 +374,19 @@ pub async fn run_search(
 
     let semantica = query_embedding.is_some();
 
+    // Distancias cruas do indice, so para anotar o que o recall devolver.
+    // A ordem da lista continua sendo a do score hibrido do recall — que
+    // combina distancia, recencia e casamento textual —, entao ela nao e
+    // monotona na distancia, e o rotulo diz "d=" em vez de "rank".
+    let distancias: std::collections::HashMap<String, f64> = match &query_embedding {
+        Some(vetor) => store
+            .knn_distances(vetor, limit.saturating_mul(4))
+            .unwrap_or_default()
+            .into_iter()
+            .collect(),
+        None => std::collections::HashMap::new(),
+    };
+
     let results = store
         .recall(RecallQuery {
             tenant_id: None,
@@ -357,7 +403,22 @@ pub async fn run_search(
     if json {
         let payload = serde_json::json!({
             "semantic": semantica,
-            "results": results.iter().map(entry_json).collect::<Vec<_>>(),
+            "results": results
+                .iter()
+                .map(|entry| {
+                    let mut valor = entry_json(entry);
+                    if let Some(objeto) = valor.as_object_mut() {
+                        objeto.insert(
+                            "distance".to_string(),
+                            match distancias.get(&entry.id) {
+                                Some(d) => serde_json::json!(d),
+                                None => serde_json::Value::Null,
+                            },
+                        );
+                    }
+                    valor
+                })
+                .collect::<Vec<_>>(),
         });
         println!("{}", serde_json::to_string_pretty(&payload)?);
         return Ok(EXIT_OK);
@@ -372,7 +433,7 @@ pub async fn run_search(
     };
     println!("Busca {modo} — {} resultado(s)\n", results.len());
     for entry in &results {
-        println!("{}", entry_line(entry));
+        println!("{}", entry_line(entry, distancias.get(&entry.id).copied()));
     }
 
     // O caminho textual do recall e um `LIKE '%frase inteira%'`: uma consulta
@@ -441,6 +502,7 @@ pub async fn run_reindex(
         // integridade responde sozinho.
         None => garraia_agents::ReindexReport {
             pending_before: store.integrity_report()?.entries_without_embedding,
+            index_repaired: 0,
             reindexed: 0,
             vanished: 0,
             stopped_early: false,
@@ -451,6 +513,7 @@ pub async fn run_reindex(
     if json {
         let payload = serde_json::json!({
             "pending_before": report.pending_before,
+            "index_repaired": report.index_repaired,
             "reindexed": report.reindexed,
             "vanished": report.vanished,
             "stopped_early": report.stopped_early,
@@ -467,6 +530,13 @@ pub async fn run_reindex(
             "Fila inicial: {} | reindexadas: {} | sumiram no caminho: {}",
             report.pending_before, report.reindexed, report.vanished
         );
+        if report.index_repaired > 0 {
+            println!(
+                "Alem dessas, {} entrada(s) ja tinham vetor na coluna e voltaram \
+                 para o indice sem custo de provider.",
+                report.index_repaired
+            );
+        }
         if report.stopped_early {
             println!(
                 "\nA reindexacao parou no meio: o provider de embeddings falhou.\n\
@@ -591,6 +661,16 @@ mod tests {
     #[test]
     fn cutoff_recusa_dias_negativos() {
         assert!(cutoff_from_days(Utc::now(), -1).is_none());
+    }
+
+    /// `Duration::days` entra em panico acima de ~106 bilhoes de dias, e
+    /// `--older-than-days` e um numero que o operador digita: sem o `try_`,
+    /// `garra memory compact --older-than-days 999999999999999` derrubava o
+    /// processo com backtrace em vez de recusar o argumento.
+    #[test]
+    fn cutoff_recusa_dias_absurdos_em_vez_de_entrar_em_panico() {
+        assert!(cutoff_from_days(Utc::now(), i64::MAX).is_none());
+        assert!(cutoff_from_days(Utc::now(), 999_999_999_999_999).is_none());
     }
 
     #[test]

--- a/crates/garraia-cli/src/memory_cmd.rs
+++ b/crates/garraia-cli/src/memory_cmd.rs
@@ -1,0 +1,762 @@
+//! `garra memory` — inspeciona, repara e limpa a memoria semantica (#950).
+//!
+//! Ate aqui a memoria era uma caixa-preta: o operador nao tinha como saber
+//! quantas entradas existiam, quantas tinham vetor, se o indice estava
+//! consistente, nem como consertar as que a cadeia de perda silenciosa
+//! (#948/#951/#962) deixou sem embedding. O `docs/src/memory.md` chegava a
+//! documentar seis subcomandos que nunca existiram.
+//!
+//! Codigos de saida (sysexits, iguais aos do `garra config check`):
+//!
+//! - `0`  — ok.
+//! - `2`  — `EX_USAGE`: argumento invalido, id inexistente, confirmacao negada.
+//! - `69` — `EX_UNAVAILABLE`: a operacao exige um provider de embeddings e nao
+//!   ha nenhum configurado.
+//! - `74` — `EX_IOERR`: o banco existe mas nao abre.
+//!
+//! Sobre conteudo: as entradas sao dados do proprio operador, no terminal do
+//! proprio operador — listar e o objetivo da ferramenta. O que **nao** pode
+//! acontecer e conteudo de memoria virar log estruturado, entao nada aqui vai
+//! para o `tracing`; tudo sai por `stdout`.
+
+use std::io::IsTerminal;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Duration, Utc};
+use garraia_agents::{ReindexOptions, reindex_missing_embeddings};
+use garraia_config::AppConfig;
+use garraia_db::{MemoryEntry, MemoryStore, RecallQuery};
+
+/// Tudo certo.
+const EXIT_OK: i32 = 0;
+/// `EX_USAGE` — argumento invalido, id inexistente, confirmacao negada.
+const EXIT_USAGE: i32 = 2;
+/// `EX_UNAVAILABLE` — a operacao precisa de um provider de embeddings.
+const EXIT_UNAVAILABLE: i32 = 69;
+/// `EX_IOERR` — o arquivo existe mas nao abre.
+const EXIT_IOERR: i32 = 74;
+
+/// Quanto do conteudo aparece numa listagem humana.
+///
+/// Corta por **caractere**, nao por byte: memoria em portugues e cheia de
+/// acento, e cortar no meio de um `ç` entrega mojibake ou entra em panico.
+const PREVIEW_CHARS: usize = 110;
+
+/// O que aconteceu ao tentar abrir o banco.
+enum Opened {
+    Store(Box<MemoryStore>, PathBuf),
+    /// Nao ha banco ainda. Nao e erro: cada subcomando decide o que dizer.
+    Absent(PathBuf),
+    /// Existe e nao abre. A mensagem ja foi para `stderr`.
+    Failed,
+}
+
+/// Abre o banco de memoria, sem cria-lo.
+///
+/// `MemoryStore::open` cria o arquivo se ele nao existir — util no boot do
+/// gateway, ruim aqui: `garra memory stats` numa instalacao que nunca
+/// conversou criaria um banco vazio como efeito colateral de uma leitura.
+fn open_store(config: &AppConfig) -> Opened {
+    let path = config.memory_db_path();
+    if !path.exists() {
+        return Opened::Absent(path);
+    }
+    match MemoryStore::open(&path) {
+        Ok(store) => Opened::Store(Box::new(store), path),
+        Err(e) => {
+            eprintln!(
+                "error: o banco de memoria existe mas nao abre ({}): {e}",
+                path.display()
+            );
+            Opened::Failed
+        }
+    }
+}
+
+/// Mensagem unica para o caso "o banco ainda nao existe".
+fn report_no_store(path: &Path) {
+    println!("Nenhuma memoria ainda: {} nao existe.", path.display());
+    println!("Ela e criada na primeira conversa com `memory.enabled: true` na config.");
+}
+
+/// Corta o conteudo para caber numa linha, respeitando limites de caractere.
+pub(crate) fn preview(content: &str, max_chars: usize) -> String {
+    let mut out: String = content.chars().take(max_chars).collect();
+    // `chars().count()` so e pago quando o corte pode ter acontecido.
+    if out.chars().count() < content.chars().count() {
+        out.push('…');
+    }
+    out.replace('\n', " ")
+}
+
+/// Instante de corte para o `compact`, a partir de uma idade em dias.
+pub(crate) fn cutoff_from_days(now: DateTime<Utc>, days: i64) -> Option<DateTime<Utc>> {
+    if days < 0 {
+        return None;
+    }
+    now.checked_sub_signed(Duration::days(days))
+}
+
+/// Uma entrada em JSON. O conteudo vai inteiro — quem pediu `--json` esta
+/// scriptando, e truncar ali silenciosamente corromperia o dado.
+fn entry_json(entry: &MemoryEntry) -> serde_json::Value {
+    serde_json::json!({
+        "id": entry.id,
+        "session_id": entry.session_id,
+        "role": role_str(entry),
+        "content": entry.content,
+        "created_at": entry.created_at.to_rfc3339(),
+        "has_embedding": entry.embedding.is_some(),
+        "embedding_model": entry.embedding_model,
+        "embedding_dimensions": entry.embedding_dimensions,
+    })
+}
+
+/// Uma entrada em uma linha de terminal.
+fn entry_line(entry: &MemoryEntry) -> String {
+    let vetor = match (&entry.embedding, &entry.embedding_model) {
+        (None, _) => "sem vetor".to_string(),
+        (Some(_), None) => "vetor sem modelo".to_string(),
+        (Some(_), Some(m)) => m.clone(),
+    };
+    format!(
+        "{}  {}  [{}]  ({})\n    {}",
+        entry.created_at.format("%Y-%m-%d %H:%M:%SZ"),
+        entry.id,
+        vetor,
+        role_str(entry),
+        preview(&entry.content, PREVIEW_CHARS),
+    )
+}
+
+fn role_str(entry: &MemoryEntry) -> &'static str {
+    match entry.role {
+        garraia_db::MemoryRole::User => "user",
+        garraia_db::MemoryRole::Assistant => "assistant",
+        garraia_db::MemoryRole::System => "system",
+        garraia_db::MemoryRole::Tool => "tool",
+    }
+}
+
+/// `garra memory stats` — contagens e integridade do indice vetorial (#960).
+pub async fn run_stats(config: &AppConfig, json: bool) -> Result<i32> {
+    let (store, path) = match open_store(config) {
+        Opened::Store(store, path) => (*store, path),
+        Opened::Absent(path) => {
+            if json {
+                let payload = serde_json::json!({
+                    "db_path": path.display().to_string(),
+                    "exists": false,
+                });
+                println!("{}", serde_json::to_string_pretty(&payload)?);
+            } else {
+                report_no_store(&path);
+            }
+            return Ok(EXIT_OK);
+        }
+        Opened::Failed => return Ok(EXIT_IOERR),
+    };
+
+    let report = store
+        .integrity_report()
+        .context("failed to build integrity report")?;
+    let knn = store.knn_enabled();
+
+    if json {
+        let payload = serde_json::json!({
+            "db_path": path.display().to_string(),
+            "exists": true,
+            "knn_enabled": knn,
+            "entries_total": report.entries_total,
+            "entries_with_embedding": report.entries_with_embedding,
+            "entries_without_embedding": report.entries_without_embedding,
+            "entries_missing_model": report.entries_missing_model,
+            "map_rows": report.map_rows,
+            "vec_rows_by_table": report.vec_rows_by_table
+                .iter()
+                .map(|(t, n)| serde_json::json!({ "table": t, "rows": n }))
+                .collect::<Vec<_>>(),
+            "orphan_map_entries": report.orphan_map_entries,
+        });
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+        return Ok(EXIT_OK);
+    }
+
+    println!("Banco:              {}", path.display());
+    println!(
+        "Busca vetorial:     {}",
+        if knn {
+            "ativa (sqlite-vec)"
+        } else {
+            "DESLIGADA — o recall cai para o caminho textual"
+        }
+    );
+    println!("Entradas:           {}", report.entries_total);
+    println!("  com vetor:        {}", report.entries_with_embedding);
+    println!("  sem vetor:        {}", report.entries_without_embedding);
+    println!("  vetor sem modelo: {}", report.entries_missing_model);
+    println!("Linhas no mapa:     {}", report.map_rows);
+    for (table, rows) in &report.vec_rows_by_table {
+        println!("  {table}: {rows}");
+    }
+
+    if !report.orphan_map_entries.is_empty() {
+        println!(
+            "\nOrfaos no indice: {} (vetor mapeado sem entrada correspondente)",
+            report.orphan_map_entries.len()
+        );
+        for id in report.orphan_map_entries.iter().take(10) {
+            println!("  {id}");
+        }
+        if report.orphan_map_entries.len() > 10 {
+            println!("  … e mais {}", report.orphan_map_entries.len() - 10);
+        }
+    }
+
+    if report.entries_without_embedding > 0 {
+        println!(
+            "\n{} entrada(s) sem vetor. Elas so entram no recall pelo caminho textual;\n\
+             `garra memory reindex` repovoa o indice.",
+            report.entries_without_embedding
+        );
+    }
+    if report.entries_missing_model > 0 {
+        println!(
+            "\n{} entrada(s) tem vetor mas nao registram o modelo que o produziu (legado\n\
+             de antes do #954). Elas perdem o eixo semantico do score sempre que o recall\n\
+             chega com um modelo definido — `garra memory reindex` tambem conserta isso.",
+            report.entries_missing_model
+        );
+    }
+
+    Ok(EXIT_OK)
+}
+
+/// `garra memory list` — as entradas mais recentes, ou so a fila de reindex.
+pub async fn run_list(
+    config: &AppConfig,
+    limit: usize,
+    only_missing: bool,
+    json: bool,
+) -> Result<i32> {
+    if limit == 0 {
+        eprintln!("error: --limit precisa ser maior que zero");
+        return Ok(EXIT_USAGE);
+    }
+
+    let store = match open_store(config) {
+        Opened::Store(store, _) => *store,
+        Opened::Absent(path) => {
+            if json {
+                println!("[]");
+            } else {
+                report_no_store(&path);
+            }
+            return Ok(EXIT_OK);
+        }
+        Opened::Failed => return Ok(EXIT_IOERR),
+    };
+
+    let entries = if only_missing {
+        store
+            .entries_missing_embeddings(limit)
+            .context("failed to list entries without embedding")?
+    } else {
+        store
+            .recent_entries(limit)
+            .context("failed to list recent entries")?
+    };
+
+    if json {
+        let payload: Vec<_> = entries.iter().map(entry_json).collect();
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+        return Ok(EXIT_OK);
+    }
+
+    if entries.is_empty() {
+        if only_missing {
+            println!("Nenhuma entrada sem vetor — a fila de reindexacao esta vazia.");
+        } else {
+            println!("Nenhuma entrada na memoria.");
+        }
+        return Ok(EXIT_OK);
+    }
+
+    for entry in &entries {
+        println!("{}", entry_line(entry));
+    }
+    Ok(EXIT_OK)
+}
+
+/// `garra memory search` — recall pelo mesmo caminho que o agente usa.
+///
+/// Com provider configurado a busca e semantica (KNN + score hibrido, com o
+/// filtro de modelo do #954); sem provider, cai para o caminho textual — o
+/// mesmo fallback do gateway, e o subcomando diz qual dos dois rodou para o
+/// operador nao confundir "nao achou" com "nao havia como achar".
+pub async fn run_search(
+    config: &AppConfig,
+    query: String,
+    limit: usize,
+    json: bool,
+) -> Result<i32> {
+    if query.trim().is_empty() {
+        eprintln!("error: a busca precisa de um termo");
+        return Ok(EXIT_USAGE);
+    }
+    if limit == 0 {
+        eprintln!("error: --limit precisa ser maior que zero");
+        return Ok(EXIT_USAGE);
+    }
+
+    let store = match open_store(config) {
+        Opened::Store(store, _) => *store,
+        Opened::Absent(path) => {
+            if json {
+                println!("[]");
+            } else {
+                report_no_store(&path);
+            }
+            return Ok(EXIT_OK);
+        }
+        Opened::Failed => return Ok(EXIT_IOERR),
+    };
+
+    let provider = garraia_gateway::bootstrap::build_embedding_provider(config);
+
+    let (query_embedding, embedding_model) = match &provider {
+        Some(p) => match p.embed_query(&query).await {
+            Ok(vetor) => (Some(vetor), Some(p.model().to_string())),
+            Err(e) => {
+                eprintln!(
+                    "aviso: o provider de embeddings falhou ({e}); \
+                     caindo para a busca textual"
+                );
+                (None, None)
+            }
+        },
+        None => (None, None),
+    };
+
+    let semantica = query_embedding.is_some();
+
+    let results = store
+        .recall(RecallQuery {
+            tenant_id: None,
+            query_text: Some(query.clone()),
+            query_embedding,
+            embedding_model,
+            session_id: None,
+            continuity_key: None,
+            limit,
+        })
+        .await
+        .context("recall failed")?;
+
+    if json {
+        let payload = serde_json::json!({
+            "semantic": semantica,
+            "results": results.iter().map(entry_json).collect::<Vec<_>>(),
+        });
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+        return Ok(EXIT_OK);
+    }
+
+    // "Caiu para textual porque nao ha provider" e "caiu porque o provider
+    // esta fora" levam a acoes diferentes; o cabecalho diz qual dos dois foi.
+    let modo = match (semantica, provider.is_some()) {
+        (true, _) => "semantica",
+        (false, true) => "textual (o provider de embeddings falhou)",
+        (false, false) => "textual (sem provider de embeddings)",
+    };
+    println!("Busca {modo} — {} resultado(s)\n", results.len());
+    for entry in &results {
+        println!("{}", entry_line(entry));
+    }
+
+    // O caminho textual do recall e um `LIKE '%frase inteira%'`: uma consulta
+    // de duas palavras so casa se as duas aparecerem grudadas, na ordem. Sem
+    // este aviso, "nao achou" e indistinguivel de "nao havia como achar".
+    if !semantica && results.is_empty() && query.split_whitespace().count() > 1 {
+        println!(
+            "A busca textual casa a frase inteira, nao palavras soltas — tente um termo unico."
+        );
+        if provider.is_none() {
+            println!(
+                "Configurar `memory.embedding_provider` liga a busca semantica, que nao \
+                 depende de casamento literal."
+            );
+        }
+    }
+
+    Ok(EXIT_OK)
+}
+
+/// `garra memory reindex` — repovoa os vetores que faltam (#953).
+pub async fn run_reindex(
+    config: &AppConfig,
+    limit: Option<usize>,
+    batch_size: usize,
+    dry_run: bool,
+    json: bool,
+) -> Result<i32> {
+    if batch_size == 0 {
+        eprintln!("error: --batch-size precisa ser maior que zero");
+        return Ok(EXIT_USAGE);
+    }
+
+    let store = match open_store(config) {
+        Opened::Store(store, _) => *store,
+        Opened::Absent(path) => {
+            report_no_store(&path);
+            return Ok(EXIT_OK);
+        }
+        Opened::Failed => return Ok(EXIT_IOERR),
+    };
+
+    // No dry-run nao ha chamada de provider, entao exigir um seria recusar a
+    // pergunta "quanto tem para fazer?" justamente a quem ainda nao configurou.
+    let provider = garraia_gateway::bootstrap::build_embedding_provider(config);
+    if provider.is_none() && !dry_run {
+        eprintln!(
+            "error: nenhum provider de embeddings configurado — sem ele nao ha como\n\
+             produzir os vetores. Aponte `memory.embedding_provider` para uma entrada\n\
+             de `embeddings:` na config (`garra config check` mostra o efetivo)."
+        );
+        return Ok(EXIT_UNAVAILABLE);
+    }
+
+    let options = ReindexOptions {
+        batch_size,
+        max_entries: limit,
+        dry_run,
+    };
+
+    let report = match &provider {
+        Some(p) => reindex_missing_embeddings(&store, p.as_ref(), options)
+            .await
+            .context("reindex failed")?,
+        // Dry-run sem provider: a fila e derivada do banco, e o relatorio de
+        // integridade responde sozinho.
+        None => garraia_agents::ReindexReport {
+            pending_before: store.integrity_report()?.entries_without_embedding,
+            reindexed: 0,
+            vanished: 0,
+            stopped_early: false,
+            dry_run: true,
+        },
+    };
+
+    if json {
+        let payload = serde_json::json!({
+            "pending_before": report.pending_before,
+            "reindexed": report.reindexed,
+            "vanished": report.vanished,
+            "stopped_early": report.stopped_early,
+            "dry_run": report.dry_run,
+        });
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+    } else if report.dry_run {
+        println!(
+            "{} entrada(s) sem vetor seriam reprocessadas (dry-run: nada foi gravado).",
+            report.pending_before
+        );
+    } else {
+        println!(
+            "Fila inicial: {} | reindexadas: {} | sumiram no caminho: {}",
+            report.pending_before, report.reindexed, report.vanished
+        );
+        if report.stopped_early {
+            println!(
+                "\nA reindexacao parou no meio: o provider de embeddings falhou.\n\
+                 Rode de novo quando ele voltar — a fila continua de onde parou."
+            );
+        }
+    }
+
+    // Parar no meio nao e sucesso: quem chamou de um script precisa saber.
+    if report.stopped_early {
+        return Ok(EXIT_UNAVAILABLE);
+    }
+    Ok(EXIT_OK)
+}
+
+/// `garra memory delete` — apaga uma entrada pelo id, junto do vetor.
+pub async fn run_delete(config: &AppConfig, id: String, yes: bool) -> Result<i32> {
+    let store = match open_store(config) {
+        Opened::Store(store, _) => *store,
+        Opened::Absent(path) => {
+            report_no_store(&path);
+            return Ok(EXIT_OK);
+        }
+        Opened::Failed => return Ok(EXIT_IOERR),
+    };
+
+    if !confirm(&format!("Apagar a entrada {id} (e o vetor dela)?"), yes)? {
+        return Ok(EXIT_USAGE);
+    }
+
+    if store.delete_entry(&id).context("failed to delete entry")? {
+        println!("Entrada {id} apagada.");
+        Ok(EXIT_OK)
+    } else {
+        eprintln!("error: nenhuma entrada com o id {id}");
+        Ok(EXIT_USAGE)
+    }
+}
+
+/// `garra memory compact` — apaga tudo anterior a N dias.
+pub async fn run_compact(config: &AppConfig, older_than_days: i64, yes: bool) -> Result<i32> {
+    let Some(cutoff) = cutoff_from_days(Utc::now(), older_than_days) else {
+        eprintln!("error: --older-than-days precisa ser um numero de dias nao-negativo");
+        return Ok(EXIT_USAGE);
+    };
+
+    let store = match open_store(config) {
+        Opened::Store(store, _) => *store,
+        Opened::Absent(path) => {
+            report_no_store(&path);
+            return Ok(EXIT_OK);
+        }
+        Opened::Failed => return Ok(EXIT_IOERR),
+    };
+
+    let antes = store.integrity_report()?.entries_total;
+    let pergunta = format!(
+        "Apagar toda memoria anterior a {} ({} dia(s))? {} entrada(s) no banco hoje.",
+        cutoff.format("%Y-%m-%d %H:%M:%SZ"),
+        older_than_days,
+        antes
+    );
+    if !confirm(&pergunta, yes)? {
+        return Ok(EXIT_USAGE);
+    }
+
+    let report = store.compact(cutoff).await.context("compaction failed")?;
+    println!(
+        "{} entrada(s) apagadas (anteriores a {}).",
+        report.deleted_entries,
+        report.before.format("%Y-%m-%d %H:%M:%SZ")
+    );
+    Ok(EXIT_OK)
+}
+
+/// Confirmacao para operacoes destrutivas.
+///
+/// Sem TTY nao ha como perguntar, e assumir "sim" apagaria dado de quem so
+/// esbarrou no comando dentro de um script: o caminho nao-interativo exige
+/// `--yes` explicito.
+fn confirm(prompt: &str, yes: bool) -> Result<bool> {
+    if yes {
+        return Ok(true);
+    }
+    if !std::io::stdin().is_terminal() {
+        eprintln!("error: operacao destrutiva sem terminal para confirmar — use --yes");
+        return Ok(false);
+    }
+    let answer = dialoguer::Confirm::new()
+        .with_prompt(prompt)
+        .default(false)
+        .interact()
+        .context("failed to read confirmation")?;
+    if !answer {
+        println!("Cancelado.");
+    }
+    Ok(answer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preview_nao_corta_no_meio_de_caractere() {
+        // "ç" e "ã" ocupam dois bytes: cortar por byte entraria em panico.
+        let conteudo = "coração de leão";
+        let curto = preview(conteudo, 7);
+        assert_eq!(curto, "coração…");
+    }
+
+    #[test]
+    fn preview_nao_marca_o_que_nao_cortou() {
+        assert_eq!(preview("curto", 40), "curto");
+    }
+
+    #[test]
+    fn preview_achata_quebras_de_linha() {
+        assert_eq!(preview("uma\nlinha", 40), "uma linha");
+    }
+
+    #[test]
+    fn cutoff_recusa_dias_negativos() {
+        assert!(cutoff_from_days(Utc::now(), -1).is_none());
+    }
+
+    #[test]
+    fn cutoff_de_zero_dias_e_agora() {
+        let agora = Utc::now();
+        assert_eq!(cutoff_from_days(agora, 0), Some(agora));
+    }
+
+    /// `AppConfig` minima apontando o `data_dir` para um diretorio de teste.
+    fn config_em(dir: &Path) -> AppConfig {
+        AppConfig {
+            data_dir: Some(dir.to_path_buf()),
+            ..Default::default()
+        }
+    }
+
+    fn entrada(conteudo: &str) -> garraia_db::NewMemoryEntry {
+        garraia_db::NewMemoryEntry {
+            tenant_id: "default".to_string(),
+            session_id: "sessao-de-teste".to_string(),
+            channel_id: None,
+            user_id: None,
+            continuity_key: None,
+            role: garraia_db::MemoryRole::User,
+            content: conteudo.to_string(),
+            embedding: None,
+            embedding_model: None,
+            metadata: serde_json::Value::Null,
+        }
+    }
+
+    /// A leitura nao pode ter efeito colateral: `stats` numa instalacao que
+    /// nunca conversou nao cria um `memory.db` vazio.
+    #[tokio::test]
+    async fn stats_sem_banco_nao_cria_o_arquivo() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = config_em(dir.path());
+
+        let code = run_stats(&config, false).await.expect("stats");
+
+        assert_eq!(code, EXIT_OK);
+        assert!(
+            !config.memory_db_path().exists(),
+            "uma leitura criou o banco"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_com_limite_zero_e_erro_de_uso() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let code = run_list(&config_em(dir.path()), 0, false, false)
+            .await
+            .expect("list");
+        assert_eq!(code, EXIT_USAGE);
+    }
+
+    #[tokio::test]
+    async fn delete_de_id_inexistente_e_erro_de_uso() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = config_em(dir.path());
+        MemoryStore::open(&config.memory_db_path()).expect("cria o banco");
+
+        let code = run_delete(&config, "nao-existe".to_string(), true)
+            .await
+            .expect("delete");
+
+        assert_eq!(code, EXIT_USAGE);
+    }
+
+    #[tokio::test]
+    async fn delete_apaga_a_entrada() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = config_em(dir.path());
+        let id = {
+            let store = MemoryStore::open(&config.memory_db_path()).expect("cria o banco");
+            store
+                .remember(entrada("lembrar disto"))
+                .await
+                .expect("insere")
+        };
+
+        let code = run_delete(&config, id.clone(), true).await.expect("delete");
+        assert_eq!(code, EXIT_OK);
+
+        let store = MemoryStore::open(&config.memory_db_path()).expect("reabre");
+        assert_eq!(store.integrity_report().expect("report").entries_total, 0);
+
+        // Apagar de novo o mesmo id ja nao acha nada.
+        assert_eq!(
+            run_delete(&config, id, true).await.expect("delete"),
+            EXIT_USAGE
+        );
+    }
+
+    /// Perguntar "quanto tem para fazer?" nao exige provider — recusar o
+    /// dry-run seria negar a resposta justamente a quem ainda nao configurou.
+    #[tokio::test]
+    async fn reindex_dry_run_dispensa_provider() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = config_em(dir.path());
+        {
+            let store = MemoryStore::open(&config.memory_db_path()).expect("cria o banco");
+            store.remember(entrada("sem vetor")).await.expect("insere");
+        }
+
+        let code = run_reindex(&config, None, 32, true, false)
+            .await
+            .expect("reindex");
+
+        assert_eq!(code, EXIT_OK);
+        // Dry-run nao grava: a fila continua de pe.
+        let store = MemoryStore::open(&config.memory_db_path()).expect("reabre");
+        assert_eq!(
+            store
+                .integrity_report()
+                .expect("report")
+                .entries_without_embedding,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn reindex_sem_provider_e_indisponivel() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = config_em(dir.path());
+        MemoryStore::open(&config.memory_db_path()).expect("cria o banco");
+
+        let code = run_reindex(&config, None, 32, false, false)
+            .await
+            .expect("reindex");
+
+        assert_eq!(code, EXIT_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn batch_size_zero_e_erro_de_uso() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let code = run_reindex(&config_em(dir.path()), None, 0, true, false)
+            .await
+            .expect("reindex");
+        assert_eq!(code, EXIT_USAGE);
+    }
+
+    /// Sem TTY e sem `--yes` nada e apagado — um script que esbarre no
+    /// comando nao pode levar o banco junto.
+    #[tokio::test]
+    async fn compact_sem_confirmacao_nao_apaga() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config = config_em(dir.path());
+        {
+            let store = MemoryStore::open(&config.memory_db_path()).expect("cria o banco");
+            store.remember(entrada("fica")).await.expect("insere");
+        }
+
+        // `cargo test` roda sem TTY em stdin, entao este e o caminho real.
+        let code = run_compact(&config, 0, false).await.expect("compact");
+
+        assert_eq!(code, EXIT_USAGE);
+        let store = MemoryStore::open(&config.memory_db_path()).expect("reabre");
+        assert_eq!(store.integrity_report().expect("report").entries_total, 1);
+    }
+
+    #[test]
+    fn cutoff_anda_para_tras() {
+        let agora = Utc::now();
+        let corte = cutoff_from_days(agora, 30).expect("30 dias cabem no calendario");
+        assert_eq!((agora - corte).num_days(), 30);
+    }
+}

--- a/crates/garraia-config/src/model.rs
+++ b/crates/garraia-config/src/model.rs
@@ -419,6 +419,25 @@ pub struct EmbeddingProviderConfig {
     pub extra: HashMap<String, serde_json::Value>,
 }
 
+impl AppConfig {
+    /// Diretorio de dados efetivo: o configurado, ou `<config_dir>/data`.
+    pub fn resolved_data_dir(&self) -> std::path::PathBuf {
+        self.data_dir
+            .clone()
+            .unwrap_or_else(|| crate::ConfigLoader::default_config_dir().join("data"))
+    }
+
+    /// Caminho do banco da memoria semantica.
+    ///
+    /// Fonte **unica**: o gateway e a CLI (`garra memory`) precisam abrir
+    /// exatamente o mesmo arquivo. Duas copias desta resolucao divergiriam no
+    /// dia em que uma delas mudasse, e o sintoma seria o pior possivel — a CLI
+    /// relatando uma memoria vazia enquanto o agente conversa com outra.
+    pub fn memory_db_path(&self) -> std::path::PathBuf {
+        self.resolved_data_dir().join("memory.db")
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MemoryConfig {
     #[serde(default = "default_memory_enabled")]

--- a/crates/garraia-db/src/lib.rs
+++ b/crates/garraia-db/src/lib.rs
@@ -16,8 +16,8 @@ pub use chat_sync::{
 };
 pub use db_trait::GarraDb;
 pub use memory_store::{
-    CompactionReport, IntegrityReport, MemoryEntry, MemoryProvider, MemoryRole, MemoryStore,
-    NewMemoryEntry, RecallQuery, SessionContext,
+    CompactionReport, EmbeddingBreakdownRow, IntegrityReport, MemoryEntry, MemoryProvider,
+    MemoryRole, MemoryStore, NewMemoryEntry, RecallQuery, SessionContext,
 };
 pub use project_store::{DataRetentionRecord, Project, ProjectFile, ProjectTemplate};
 pub use session_store::{MobileUser, ScheduledTask, SessionStore, StoredMessage};

--- a/crates/garraia-db/src/memory_store.rs
+++ b/crates/garraia-db/src/memory_store.rs
@@ -416,6 +416,97 @@ impl MemoryStore {
         }
     }
 
+    /// Entradas gravadas **sem vetor** — a fila de reindexação (#953).
+    ///
+    /// O critério é só `embedding IS NULL`. A issue propunha exigir também
+    /// `embedding_model IS NULL`, mas isso perderia exatamente as entradas
+    /// mais antigas: até o #948 o modelo era gravado mesmo sem vetor, então
+    /// as linhas legadas têm um modelo que mente. Filtrar por ele deixaria
+    /// justamente elas de fora da reindexação.
+    ///
+    /// Ordena da mais antiga para a mais nova: numa base grande, reindexar
+    /// em lotes sucessivos avança de forma previsível em vez de reprocessar
+    /// as mesmas linhas.
+    pub fn entries_missing_embeddings(&self, limit: usize) -> Result<Vec<MemoryEntry>> {
+        let conn = self.connection()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, tenant_id, session_id, channel_id, user_id, continuity_key, role,
+                        content, embedding, embedding_model, embedding_dimensions, metadata,
+                        created_at
+                 FROM memory_entries
+                 WHERE embedding IS NULL
+                 ORDER BY datetime(created_at) ASC
+                 LIMIT ?",
+            )
+            .map_err(|e| Error::Database(format!("failed to prepare reindex scan: {e}")))?;
+
+        let rows = stmt
+            .query_map(params![limit as i64], row_to_entry)
+            .map_err(|e| Error::Database(format!("failed to scan entries to reindex: {e}")))?;
+
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(|e| Error::Database(format!("failed to collect entries to reindex: {e}")))
+    }
+
+    /// Grava o vetor de uma entrada que estava sem, e a indexa (#953).
+    ///
+    /// Devolve `false` quando o id não existe — a entrada pode ter sido
+    /// apagada entre a listagem e a gravação, e isso não é erro.
+    ///
+    /// O modelo é gravado **junto** com o vetor, nunca antes: é a mesma regra
+    /// que o #948 estabeleceu na ingestão, e ela vale aqui pelo mesmo motivo
+    /// — a coluna descreve o vetor.
+    pub fn set_embedding(&self, id: &str, embedding: &[f32], model: &str) -> Result<bool> {
+        let blob = embedding_to_blob(embedding);
+        let dims = embedding.len();
+
+        let updated = {
+            let conn = self.connection()?;
+            conn.execute(
+                "UPDATE memory_entries
+                 SET embedding = ?, embedding_model = ?, embedding_dimensions = ?
+                 WHERE id = ?",
+                params![blob, model, dims as i64, id],
+            )
+            .map_err(|e| Error::Database(format!("failed to write embedding: {e}")))?
+        };
+
+        if updated == 0 {
+            return Ok(false);
+        }
+
+        if let Some(vs) = &self.vector_store {
+            vs.ensure_vec_table(dims)?;
+            vs.insert_embedding(id, embedding, dims)?;
+        }
+
+        Ok(true)
+    }
+
+    /// Entradas mais recentes, sem filtro de sessão — o que a CLI lista.
+    pub fn recent_entries(&self, limit: usize) -> Result<Vec<MemoryEntry>> {
+        self.query_candidates_with_tenant_sync(None, None, None, None, limit)
+    }
+
+    /// Apaga uma entrada pelo id, junto do vetor e do mapeamento.
+    ///
+    /// Devolve `false` se o id não existia.
+    pub fn delete_entry(&self, id: &str) -> Result<bool> {
+        let deleted = {
+            let conn = self.connection()?;
+            conn.execute("DELETE FROM memory_entries WHERE id = ?", params![id])
+                .map_err(|e| Error::Database(format!("failed to delete entry: {e}")))?
+        };
+
+        if deleted == 0 {
+            return Ok(false);
+        }
+
+        self.cleanup_vectors(&[id.to_string()]);
+        Ok(true)
+    }
+
     fn remember_sync(&self, entry: NewMemoryEntry) -> Result<String> {
         if entry.content.trim().is_empty() {
             return Err(Error::Database("memory content cannot be empty".into()));

--- a/crates/garraia-db/src/memory_store.rs
+++ b/crates/garraia-db/src/memory_store.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use chrono::{DateTime, NaiveDateTime, Utc};
 use garraia_common::{Error, Result};
-use rusqlite::{Connection, params};
+use rusqlite::{Connection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::path::Path;
@@ -130,6 +130,18 @@ pub struct IntegrityReport {
     pub vec_rows_by_table: Vec<(String, usize)>,
     /// Ids mapeados no índice sem entrada correspondente em `memory_entries`.
     pub orphan_map_entries: Vec<String>,
+}
+
+/// Uma linha do agrupamento por modelo do `garra memory stats` (#950).
+///
+/// `embedding_model: None` com `embedding_dimensions: None` é a fila de
+/// reindexação; `None` com dimensão preenchida é o legado de antes do #954 —
+/// vetor gravado sem registrar quem o produziu.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmbeddingBreakdownRow {
+    pub embedding_model: Option<String>,
+    pub embedding_dimensions: Option<usize>,
+    pub entries: usize,
 }
 
 #[async_trait]
@@ -476,12 +488,186 @@ impl MemoryStore {
             return Ok(false);
         }
 
-        if let Some(vs) = &self.vector_store {
-            vs.ensure_vec_table(dims)?;
-            vs.insert_embedding(id, embedding, dims)?;
+        // A coluna e o indice vivem em conexoes diferentes (por desenho:
+        // o `VectorStore` tem a sua), entao nao ha transacao que cubra os
+        // dois. Se o indice recusar o vetor, a coluna volta a NULL: caso
+        // contrario a entrada sairia da fila do reindex (`embedding IS NULL`)
+        // sem ter entrado no indice, e ficaria invisivel para a busca
+        // semantica **sem nenhum caminho de reparo**. Melhor continuar na
+        // fila e ser tentada de novo.
+        if let Some(vs) = &self.vector_store
+            && let Err(e) = vs
+                .ensure_vec_table(dims)
+                .and_then(|()| vs.insert_embedding(id, embedding, dims))
+        {
+            self.clear_embedding_columns(id);
+            return Err(e);
         }
 
         Ok(true)
+    }
+
+    /// Desfaz a escrita da coluna quando o indice recusou o vetor.
+    ///
+    /// Best-effort de propria natureza: se este UPDATE tambem falhar, o
+    /// banco fica no estado que a chamada tentava evitar — e ai o `warn!` e
+    /// o unico sinal, porque o proximo `garra memory stats` so mostra a
+    /// divergencia agregada (`map_rows` menor que `entries_with_embedding`).
+    fn clear_embedding_columns(&self, id: &str) {
+        let Ok(conn) = self.connection() else {
+            tracing::warn!("nao foi possivel reverter a coluna de embedding: lock envenenado");
+            return;
+        };
+        if let Err(e) = conn.execute(
+            "UPDATE memory_entries
+             SET embedding = NULL, embedding_model = NULL, embedding_dimensions = NULL
+             WHERE id = ?",
+            params![id],
+        ) {
+            tracing::warn!(
+                "o indice recusou o vetor e a coluna nao pode ser revertida; a entrada \
+                 ficou marcada como indexada sem estar: {e}"
+            );
+        }
+    }
+
+    /// Reinsere no indice os vetores que ja estao na coluna mas nao no mapa.
+    ///
+    /// Este e o estado que o `remember_sync` produz na operacao normal: ele
+    /// grava a linha e insere no indice em best-effort, com `warn!`, entao um
+    /// sqlite-vec momentaneamente indisponivel deixa entradas com vetor na
+    /// coluna e fora da busca semantica — e o `reindex` por si so nao as
+    /// alcanca, porque ele procura `embedding IS NULL`.
+    ///
+    /// Nao chama provider nenhum: o vetor ja existe, so falta indexa-lo. Por
+    /// isso roda sempre, inclusive sem provider configurado.
+    ///
+    /// Devolve quantas foram reindexadas. `Ok(0)` quando o KNN esta desligado
+    /// — sem indice nao ha o que reparar.
+    pub fn reindex_missing_index_rows(&self, limit: usize) -> Result<usize> {
+        let Some(vs) = &self.vector_store else {
+            return Ok(0);
+        };
+        if !vs.vec_enabled() {
+            return Ok(0);
+        }
+
+        // O conjunto de indexados vem da conexão do próprio `VectorStore`:
+        // em produção ele é o mesmo arquivo, mas em memória é um segundo
+        // banco, e um `JOIN` daqui não enxergaria o `vec_id_map`.
+        let mapeados: std::collections::HashSet<String> = vs.mapped_ids()?.into_iter().collect();
+
+        // Só os ids primeiro (barato), e o blob depois, apenas das que estão
+        // realmente fora do índice: numa base de milhares, carregar todo
+        // vetor para descobrir que quase nenhum falta seria o custo errado.
+        let faltantes: Vec<String> = {
+            let conn = self.connection()?;
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id FROM memory_entries
+                     WHERE embedding IS NOT NULL
+                     ORDER BY datetime(created_at) ASC",
+                )
+                .map_err(|e| Error::Database(format!("failed to prepare index repair: {e}")))?;
+
+            let rows = stmt
+                .query_map([], |row| row.get::<_, String>(0))
+                .map_err(|e| Error::Database(format!("failed to scan index repair: {e}")))?;
+
+            let mut out = Vec::new();
+            for row in rows {
+                let id =
+                    row.map_err(|e| Error::Database(format!("failed to read entry id: {e}")))?;
+                if !mapeados.contains(&id) {
+                    out.push(id);
+                    if out.len() >= limit {
+                        break;
+                    }
+                }
+            }
+            out
+        };
+
+        let mut reparadas = 0usize;
+        for id in faltantes {
+            let vetor = {
+                let conn = self.connection()?;
+                let blob: Option<Vec<u8>> = conn
+                    .query_row(
+                        "SELECT embedding FROM memory_entries WHERE id = ?",
+                        params![id],
+                        |row| row.get(0),
+                    )
+                    .optional()
+                    .map_err(|e| Error::Database(format!("failed to read embedding: {e}")))?
+                    .flatten();
+                match blob {
+                    Some(b) => blob_to_embedding(&b)?,
+                    // A entrada sumiu (ou perdeu o vetor) entre a listagem e
+                    // aqui: não é erro, é concorrência.
+                    None => continue,
+                }
+            };
+
+            let dims = vetor.len();
+            vs.ensure_vec_table(dims)?;
+            vs.insert_embedding(&id, &vetor, dims)?;
+            reparadas += 1;
+        }
+        Ok(reparadas)
+    }
+
+    /// Quantas entradas por `(modelo, dimensoes)` do vetor gravado (#950).
+    ///
+    /// `(None, None)` é a fila de reindexação; `(None, Some(d))` é uma linha
+    /// com vetor e sem modelo — o legado de antes do #954 que o
+    /// `IntegrityReport` conta agregado e que aqui aparece com a dimensão.
+    ///
+    /// Ordena por contagem decrescente: numa base misturada, o modelo que
+    /// domina é o que responde "com o que este índice foi construído?".
+    pub fn embedding_breakdown(&self) -> Result<Vec<EmbeddingBreakdownRow>> {
+        let conn = self.connection()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT embedding_model, embedding_dimensions, count(*)
+                 FROM memory_entries
+                 GROUP BY embedding_model, embedding_dimensions
+                 ORDER BY count(*) DESC",
+            )
+            .map_err(|e| Error::Database(format!("failed to prepare breakdown: {e}")))?;
+
+        let rows = stmt
+            .query_map([], |row| {
+                let model: Option<String> = row.get(0)?;
+                let dims: Option<i64> = row.get(1)?;
+                let total: i64 = row.get(2)?;
+                Ok(EmbeddingBreakdownRow {
+                    embedding_model: model,
+                    embedding_dimensions: dims.map(|d| d as usize),
+                    entries: total as usize,
+                })
+            })
+            .map_err(|e| Error::Database(format!("failed to run breakdown: {e}")))?;
+
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(|e| Error::Database(format!("failed to collect breakdown: {e}")))
+    }
+
+    /// Distâncias cruas dos vizinhos mais próximos, para a CLI mostrar (#950).
+    ///
+    /// Existe **só** para anotar o resultado do [`Self::recall`], nunca para
+    /// substituí-lo: o índice vec0 não conhece tenant, sessão nem modelo, e
+    /// ler dele direto foi exatamente o bypass de isolamento que o #971
+    /// fechou. Por isso devolve `(id, distância)` e não entradas — quem chama
+    /// já tem as linhas que passaram pelo escopo e usa isto para enriquecer o
+    /// que já ganhou.
+    ///
+    /// Vazio quando o KNN está desligado.
+    pub fn knn_distances(&self, embedding: &[f32], limit: usize) -> Result<Vec<(String, f64)>> {
+        match &self.vector_store {
+            Some(vs) if vs.vec_enabled() => vs.search_nearest(embedding, embedding.len(), limit),
+            _ => Ok(Vec::new()),
+        }
     }
 
     /// Entradas mais recentes, sem filtro de sessão — o que a CLI lista.
@@ -1006,6 +1192,121 @@ mod tests {
             embedding_model: Some("unit-test".to_string()),
             metadata: serde_json::json!({}),
         }
+    }
+
+    /// O `remember_sync` grava a linha e insere no indice em best-effort:
+    /// com o sqlite-vec fora do ar por um momento, a entrada fica com vetor
+    /// na coluna e **fora** da busca semantica. O `reindex` normal nao a
+    /// alcanca, porque ele procura `embedding IS NULL` — quem repara e este
+    /// caminho, e sem custo de provider, porque o vetor ja existe.
+    #[tokio::test]
+    async fn reindex_missing_index_rows_devolve_ao_indice_o_vetor_orfao_de_coluna() {
+        let store = MemoryStore::in_memory_with_vectors().expect("store com vetores");
+        assert!(
+            store.knn_enabled(),
+            "sqlite-vec e compilado no binario; sem ele este teste nao afirma nada"
+        );
+
+        let id = store
+            .remember(entry(
+                "s1",
+                None,
+                "entrada que perdeu o indice",
+                MemoryRole::User,
+                None,
+            ))
+            .await
+            .expect("insere sem vetor");
+
+        // Estado que o best-effort do `remember_sync` produz: coluna escrita,
+        // indice intocado.
+        {
+            let conn = store.connection().expect("lock");
+            conn.execute(
+                "UPDATE memory_entries
+                 SET embedding = ?, embedding_model = 'unit-test', embedding_dimensions = 4
+                 WHERE id = ?",
+                rusqlite::params![super::embedding_to_blob(&[0.1, 0.2, 0.3, 0.4]), id],
+            )
+            .expect("simula a coluna escrita sem indice");
+        }
+
+        let antes = store.integrity_report().expect("report");
+        assert_eq!(antes.entries_with_embedding, 1);
+        assert_eq!(antes.map_rows, 0, "o indice ainda nao conhece a entrada");
+
+        let reparadas = store.reindex_missing_index_rows(100).expect("reparo");
+        assert_eq!(reparadas, 1);
+
+        let depois = store.integrity_report().expect("report");
+        assert_eq!(depois.map_rows, 1);
+
+        // E agora ela e alcancavel pelo caminho KNN.
+        let achados = store
+            .recall(RecallQuery {
+                tenant_id: None,
+                query_text: None,
+                query_embedding: Some(vec![0.1, 0.2, 0.3, 0.4]),
+                embedding_model: Some("unit-test".to_string()),
+                session_id: None,
+                continuity_key: None,
+                limit: 5,
+            })
+            .await
+            .expect("recall");
+        assert_eq!(achados.len(), 1);
+        assert_eq!(achados[0].id, id);
+    }
+
+    /// Rodar o reparo com o indice ja consistente nao e erro nem trabalho.
+    #[tokio::test]
+    async fn reindex_missing_index_rows_e_no_op_quando_tudo_esta_indexado() {
+        let store = MemoryStore::in_memory_with_vectors().expect("store com vetores");
+        assert!(store.knn_enabled());
+
+        store
+            .remember(entry(
+                "s1",
+                None,
+                "ja indexada",
+                MemoryRole::User,
+                Some(vec![0.5, 0.5, 0.5, 0.5]),
+            ))
+            .await
+            .expect("insere com vetor");
+
+        assert_eq!(store.reindex_missing_index_rows(100).expect("reparo"), 0);
+    }
+
+    /// A ordem e da mais antiga para a mais nova e o teto e respeitado: numa
+    /// base grande, reparar em fatias precisa avancar, nao repetir.
+    #[tokio::test]
+    async fn reindex_missing_index_rows_respeita_o_teto() {
+        let store = MemoryStore::in_memory_with_vectors().expect("store com vetores");
+        assert!(store.knn_enabled());
+
+        for i in 0..3 {
+            let id = store
+                .remember(entry(
+                    "s1",
+                    None,
+                    &format!("entrada {i}"),
+                    MemoryRole::User,
+                    None,
+                ))
+                .await
+                .expect("insere");
+            let conn = store.connection().expect("lock");
+            conn.execute(
+                "UPDATE memory_entries SET embedding = ?, embedding_dimensions = 4 WHERE id = ?",
+                rusqlite::params![super::embedding_to_blob(&[0.1, 0.2, 0.3, 0.4]), id],
+            )
+            .expect("simula coluna sem indice");
+        }
+
+        assert_eq!(store.reindex_missing_index_rows(2).expect("reparo"), 2);
+        assert_eq!(store.reindex_missing_index_rows(2).expect("reparo"), 1);
+        assert_eq!(store.reindex_missing_index_rows(2).expect("reparo"), 0);
     }
 
     #[test]

--- a/crates/garraia-db/src/vector_store.rs
+++ b/crates/garraia-db/src/vector_store.rs
@@ -275,21 +275,30 @@ impl VectorStore {
     /// Base do relatório de órfãos: o chamador (MemoryStore) passa os ids
     /// vivos de `memory_entries`.
     pub fn orphan_map_entries(&self, live_ids: &[&str]) -> Result<Vec<String>> {
-        let conn = self.connection()?;
-        let mut stmt = conn
-            .prepare("SELECT entry_id FROM vec_id_map")
-            .map_err(|e| Error::Database(format!("failed to prepare orphan scan: {e}")))?;
-        let all: Vec<String> = stmt
-            .query_map([], |row| row.get(0))
-            .map_err(|e| Error::Database(format!("failed to scan vec_id_map: {e}")))?
-            .collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(|e| Error::Database(format!("failed to collect vec_id_map: {e}")))?;
-
+        let all = self.mapped_ids()?;
         let live: std::collections::HashSet<&str> = live_ids.iter().copied().collect();
         Ok(all
             .into_iter()
             .filter(|id| !live.contains(id.as_str()))
             .collect())
+    }
+
+    /// Todos os `entry_id` presentes no `vec_id_map`.
+    ///
+    /// A pergunta "quais entradas estão indexadas?" só pode ser feita a esta
+    /// conexão: em produção o índice mora no mesmo arquivo, mas nos testes
+    /// (`MemoryStore::in_memory_with_vectors`) ele é um segundo banco em
+    /// memória, e um `JOIN` a partir da conexão da memória não enxergaria a
+    /// tabela.
+    pub fn mapped_ids(&self) -> Result<Vec<String>> {
+        let conn = self.connection()?;
+        let mut stmt = conn
+            .prepare("SELECT entry_id FROM vec_id_map")
+            .map_err(|e| Error::Database(format!("failed to prepare vec_id_map scan: {e}")))?;
+        stmt.query_map([], |row| row.get(0))
+            .map_err(|e| Error::Database(format!("failed to scan vec_id_map: {e}")))?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(|e| Error::Database(format!("failed to collect vec_id_map: {e}")))
     }
 
     /// KNN search: find the nearest `limit` embeddings to `query`.

--- a/crates/garraia-gateway/src/bootstrap/mod.rs
+++ b/crates/garraia-gateway/src/bootstrap/mod.rs
@@ -577,166 +577,26 @@ pub fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
 
     // --- Memory ---
     if config.memory.enabled {
-        let data_dir = config
-            .data_dir
-            .clone()
-            .unwrap_or_else(|| garraia_config::ConfigLoader::default_config_dir().join("data"));
+        let data_dir = config.resolved_data_dir();
 
         if let Err(e) = std::fs::create_dir_all(&data_dir) {
             warn!("failed to create data directory: {e}");
         }
 
-        let memory_db_path = data_dir.join("memory.db");
+        // Mesma resolucao que a CLI usa (`garra memory`) — ver
+        // `AppConfig::memory_db_path`.
+        let memory_db_path = config.memory_db_path();
         match MemoryStore::open(&memory_db_path) {
             Ok(store) => {
                 let store = Arc::new(store);
                 runtime.set_memory_provider(store);
                 info!("memory store opened at {}", memory_db_path.display());
 
-                // Attach embedding provider if configured
-                if let Some(embed_name) = &config.memory.embedding_provider
-                    && let Some(embed_config) = config.embeddings.get(embed_name)
-                {
-                    // Timeout proprio, nao mais o do LLM (#962): 120s para uma
-                    // chamada que responde em milissegundos significava que um
-                    // Ollama travado segurava o turno inteiro do agente, que
-                    // espera o `query_embedding` para montar o recall.
-                    let embed_client = reqwest::Client::builder()
-                        .timeout(std::time::Duration::from_secs(
-                            config.timeouts.embeddings.default_secs,
-                        ))
-                        .build()
-                        .unwrap_or_default();
-
-                    let built: Option<Arc<dyn EmbeddingProvider>> =
-                        match embed_config.provider.as_str() {
-                            // =====================================
-                            // COHERE
-                            // =====================================
-                            "cohere" => {
-                                let api_key = resolve_api_key(
-                                    embed_config.api_key.as_deref(),
-                                    "COHERE_API_KEY",
-                                    "COHERE_API_KEY",
-                                );
-
-                                if let Some(key) = api_key {
-                                    Some(Arc::new(
-                                        CohereEmbeddingProvider::new(
-                                            key,
-                                            embed_config.model.clone(),
-                                            embed_config.base_url.clone(),
-                                        )
-                                        .with_client(embed_client.clone()),
-                                    ))
-                                } else {
-                                    warn!("skipping cohere embedding provider: no API key");
-                                    None
-                                }
-                            }
-
-                            // =====================================
-                            // OLLAMA (ADICIONE ESTE BLOCO)
-                            // =====================================
-                            "ollama" => Some(Arc::new(
-                                OllamaEmbeddingProvider::new(
-                                    embed_config.model.clone(),
-                                    embed_config.base_url.clone(),
-                                )
-                                .with_client(embed_client.clone()),
-                            )),
-
-                            // =====================================
-                            // OPENAI-COMPATIBLE (LM Studio, OpenAI, etc.)
-                            // =====================================
-                            "openai" => {
-                                // Antes daqui saia o literal "no-key" para qualquer
-                                // endpoint. Contra a OpenAI oficial isso e um 401 em
-                                // toda chamada — e o erro era engolido logo adiante
-                                // (#948), entao a memoria simplesmente parava de ser
-                                // indexada sem ninguem saber. E a chave nem era
-                                // procurada no ambiente, so no arquivo de config.
-                                let api_key = resolve_api_key(
-                                    embed_config.api_key.as_deref(),
-                                    KEY_ENV_VAR_OPENAI,
-                                    KEY_ENV_VAR_OPENAI,
-                                );
-                                let self_hosted = is_self_hosted_openai_endpoint(
-                                    embed_config.base_url.as_deref(),
-                                );
-
-                                match (api_key, self_hosted) {
-                                    (Some(key), _) => Some(Arc::new(
-                                        OpenAiEmbeddingProvider::new(
-                                            key,
-                                            embed_config.model.clone(),
-                                            embed_config.base_url.clone(),
-                                        )
-                                        .with_client(embed_client.clone()),
-                                    )),
-                                    // LM Studio, vLLM, gateway interno: nao pedem
-                                    // credencial, e mandar um bearer vazio faz alguns
-                                    // recusarem. O provider omite o header nesse caso.
-                                    (None, true) => {
-                                        info!(
-                                            "openai embedding provider '{embed_name}': endpoint \
-                                         proprio sem credencial configurada, seguindo sem \
-                                         autenticacao"
-                                        );
-                                        Some(Arc::new(
-                                            OpenAiEmbeddingProvider::new(
-                                                String::new(),
-                                                embed_config.model.clone(),
-                                                embed_config.base_url.clone(),
-                                            )
-                                            .with_client(embed_client.clone()),
-                                        ))
-                                    }
-                                    (None, false) => {
-                                        warn!(
-                                            "skipping openai embedding provider '{embed_name}': \
-                                         sem chave no config, no cofre nem no ambiente, e o \
-                                         endpoint e o oficial da OpenAI — subir assim daria \
-                                         401 em toda chamada de embedding"
-                                        );
-                                        None
-                                    }
-                                }
-                            }
-
-                            // =====================================
-                            // UNKNOWN
-                            // =====================================
-                            other => {
-                                warn!("unknown embedding provider type: {other}");
-                                None
-                            }
-                        };
-
-                    if let Some(inner) = built {
-                        let provider_id = inner.provider_id().to_string();
-                        let model = inner.model().to_string();
-
-                        // Toda saida de embeddings passa a ter retry com backoff
-                        // e validacao de dimensao (#962, #961) — um envelope so
-                        // para os tres providers, em vez de tres copias da mesma
-                        // logica.
-                        let resilient = ResilientEmbeddingProvider::new(inner)
-                            .with_expected_dimensions(embed_config.dimensions);
-                        runtime.set_embedding_provider(Arc::new(resilient));
-
-                        match embed_config.dimensions {
-                            Some(dims) => info!(
-                                "configured {provider_id} embedding provider: {embed_name} \
-                                 (modelo {model}, {dims} dimensoes validadas)"
-                            ),
-                            None => info!(
-                                "configured {provider_id} embedding provider: {embed_name} \
-                                 (modelo {model}; sem `dimensions` na config, o vetor \
-                                 devolvido nao e validado — ver #961)"
-                            ),
-                        }
-                    }
+                // Attach embedding provider if configured. A construcao mora
+                // em `build_embedding_provider` para a CLI reusar o mesmo
+                // provider sem subir um runtime (#953).
+                if let Some(provider) = build_embedding_provider(config) {
+                    runtime.set_embedding_provider(provider);
                 }
             }
             Err(e) => {
@@ -1204,6 +1064,156 @@ pub async fn build_mcp_tools(
 }
 
 /// Build a voice handler for Telegram that processes voice messages.
+/// Constroi o provider de embeddings declarado na config, ja envelopado no
+/// [`ResilientEmbeddingProvider`] (#962, #961).
+///
+/// Extraido de [`build_agent_runtime`] para que a CLI possa pedir **o mesmo**
+/// provider que o gateway usa sem subir um runtime inteiro (e sem abrir uma
+/// segunda conexao no `memory.db`) — `garra memory reindex` (#953) grava
+/// vetores que o recall do gateway vai ler, entao os dois lados precisam
+/// concordar na resolucao da chave, no timeout proprio e na dimensao validada.
+/// Construir um segundo provider por fora era exatamente a divergencia
+/// silenciosa que este projeto ja pagou caro.
+///
+/// Devolve `None` quando `memory.embedding_provider` nao aponta para nenhuma
+/// entrada de `embeddings:`, ou quando o provider apontado nao pode ser
+/// construido (sem credencial contra endpoint oficial, tipo desconhecido).
+pub fn build_embedding_provider(config: &AppConfig) -> Option<Arc<dyn EmbeddingProvider>> {
+    let embed_name = config.memory.embedding_provider.as_ref()?;
+    let embed_config = config.embeddings.get(embed_name)?;
+
+    let embed_client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(
+            config.timeouts.embeddings.default_secs,
+        ))
+        .build()
+        .unwrap_or_default();
+
+    let built: Option<Arc<dyn EmbeddingProvider>> = match embed_config.provider.as_str() {
+        // =====================================
+        // COHERE
+        // =====================================
+        "cohere" => {
+            let api_key = resolve_api_key(
+                embed_config.api_key.as_deref(),
+                "COHERE_API_KEY",
+                "COHERE_API_KEY",
+            );
+
+            if let Some(key) = api_key {
+                Some(Arc::new(
+                    CohereEmbeddingProvider::new(
+                        key,
+                        embed_config.model.clone(),
+                        embed_config.base_url.clone(),
+                    )
+                    .with_client(embed_client.clone()),
+                ))
+            } else {
+                warn!("skipping cohere embedding provider: no API key");
+                None
+            }
+        }
+
+        // =====================================
+        // OLLAMA (ADICIONE ESTE BLOCO)
+        // =====================================
+        "ollama" => Some(Arc::new(
+            OllamaEmbeddingProvider::new(embed_config.model.clone(), embed_config.base_url.clone())
+                .with_client(embed_client.clone()),
+        )),
+
+        // =====================================
+        // OPENAI-COMPATIBLE (LM Studio, OpenAI, etc.)
+        // =====================================
+        "openai" => {
+            // Antes daqui saia o literal "no-key" para qualquer
+            // endpoint. Contra a OpenAI oficial isso e um 401 em
+            // toda chamada — e o erro era engolido logo adiante
+            // (#948), entao a memoria simplesmente parava de ser
+            // indexada sem ninguem saber. E a chave nem era
+            // procurada no ambiente, so no arquivo de config.
+            let api_key = resolve_api_key(
+                embed_config.api_key.as_deref(),
+                KEY_ENV_VAR_OPENAI,
+                KEY_ENV_VAR_OPENAI,
+            );
+            let self_hosted = is_self_hosted_openai_endpoint(embed_config.base_url.as_deref());
+
+            match (api_key, self_hosted) {
+                (Some(key), _) => Some(Arc::new(
+                    OpenAiEmbeddingProvider::new(
+                        key,
+                        embed_config.model.clone(),
+                        embed_config.base_url.clone(),
+                    )
+                    .with_client(embed_client.clone()),
+                )),
+                // LM Studio, vLLM, gateway interno: nao pedem
+                // credencial, e mandar um bearer vazio faz alguns
+                // recusarem. O provider omite o header nesse caso.
+                (None, true) => {
+                    info!(
+                        "openai embedding provider '{embed_name}': endpoint \
+                         proprio sem credencial configurada, seguindo sem \
+                         autenticacao"
+                    );
+                    Some(Arc::new(
+                        OpenAiEmbeddingProvider::new(
+                            String::new(),
+                            embed_config.model.clone(),
+                            embed_config.base_url.clone(),
+                        )
+                        .with_client(embed_client.clone()),
+                    ))
+                }
+                (None, false) => {
+                    warn!(
+                        "skipping openai embedding provider '{embed_name}': \
+                         sem chave no config, no cofre nem no ambiente, e o \
+                         endpoint e o oficial da OpenAI — subir assim daria \
+                         401 em toda chamada de embedding"
+                    );
+                    None
+                }
+            }
+        }
+
+        // =====================================
+        // UNKNOWN
+        // =====================================
+        other => {
+            warn!("unknown embedding provider type: {other}");
+            None
+        }
+    };
+
+    let inner = built?;
+    let provider_id = inner.provider_id().to_string();
+    let model = inner.model().to_string();
+
+    // Toda saida de embeddings passa a ter retry com backoff
+    // e validacao de dimensao (#962, #961) — um envelope so
+    // para os tres providers, em vez de tres copias da mesma
+    // logica.
+    let resilient =
+        ResilientEmbeddingProvider::new(inner).with_expected_dimensions(embed_config.dimensions);
+
+    match embed_config.dimensions {
+        Some(dims) => info!(
+            "configured {provider_id} embedding provider: {embed_name} \
+             (modelo {model}, {dims} dimensoes validadas)"
+        ),
+        None => info!(
+            "configured {provider_id} embedding provider: {embed_name} \
+             (modelo {model}; sem `dimensions` na config, o vetor \
+             devolvido nao e validado — ver #961)"
+        ),
+    }
+
+    Some(Arc::new(resilient))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Descrição

A memória semântica era caixa-preta. Não havia como saber quantas entradas existiam, quantas tinham vetor, se o índice estava consistente, nem como consertar as que a cadeia de perda silenciosa (#948, #951, #962) deixou sem embedding — e o `docs/src/memory.md` ainda documenta seis subcomandos que nunca existiram. Este PR entrega seis de verdade.

| Subcomando | O que faz |
| --- | --- |
| `stats` | O relatório de integridade do #960: total, com/sem vetor, **vetor sem modelo** (a fila legada de antes do #954), linhas no mapa, linhas por tabela `vec_embeddings_*` e órfãos, mais o agrupamento por `(modelo, dimensões)`. |
| `list` | As entradas mais recentes, ou só a fila de reindexação (`--no-embedding`). |
| `search <termo>` | O **mesmo** recall que o agente usa, com a distância de cada resultado, dizendo no cabeçalho se foi semântico ou textual — e, quando textual, se foi por falta de provider ou porque ele falhou. |
| `reindex` | Reprocessa as entradas gravadas sem vetor (`--dry-run`, `--limit`, `--batch-size`). |
| `delete <id>` | Apaga uma entrada e o vetor dela. |
| `compact` | Apaga tudo anterior a N dias (`--older-than-days`, default 90). |

Os dois destrutivos pedem confirmação e, **sem TTY, exigem `--yes` explícito**: um script que esbarre no comando não pode levar o banco junto. Códigos de saída sysexits, iguais aos do `garra config check` — `0` ok, `2` uso/id inexistente/confirmação negada, `69` sem provider ou reindexação interrompida, `74` banco existe e não abre. `stats`, `list`, `search` e `reindex` têm `--json`.

### Uma fonte só para o caminho do banco e para o provider

Duas extrações deliberadas, porque a alternativa era duplicar:

- **`AppConfig::memory_db_path()`** (`garraia-config`) vira a fonte única que gateway e CLI usam. Duplicar a resolução faria a CLI reindexar um `memory.db` que o gateway nunca lê — o tipo de divergência silenciosa que este projeto já pagou caro.
- **`bootstrap::build_embedding_provider(config)`** sai de dentro do `build_agent_runtime` — refactor puro, corpo idêntico, agora devolvendo o `Arc<dyn EmbeddingProvider>` em vez de chamá-lo no runtime. A CLI pede o **mesmo** provider (mesma resolução de chave, mesmo timeout próprio de embeddings do #962, mesma validação de dimensão do #961) sem subir um runtime nem abrir uma segunda conexão no banco. O que o `reindex` grava é exatamente o que o recall do agente lê de volta.

### Duas correções ao que as issues propunham

1. **A reindexação mora em `garraia-agents`, não no `MemoryStore`** (#953 propunha o store). O `EmbeddingProvider` é daquele crate e `garraia-agents` já depende de `garraia-db`: pedir ao store que receba um provider exigiria a dependência inversa, e o ciclo não fecha. As primitivas ficaram no store; o que precisa dos dois lados fica no `memory_reindex`.
2. **`entries_missing_embeddings` filtra por `embedding IS NULL` e não também por `embedding_model IS NULL`**, como a issue propunha. As linhas de antes do #948 carregam um modelo que **mente** sobre um vetor que não existe; exigir as duas condições deixaria justamente elas de fora da reindexação — as que mais precisam dela.

### Segurança da reindexação

- Para no **primeiro** lote que falha, de propósito: falha de provider quase sempre significa que ele está fora, e insistir lote após lote só demora para dar a mesma notícia. A fila é derivada do banco, então rodar de novo depois continua de onde parou. Sai com `69`, não com `0` — quem chamou de um script precisa saber.
- **Aborta se o provider devolver um número de vetores diferente do de textos.** O pareamento é por índice; sem essa guarda, um provider que pula um item grava vetor na entrada errada — e o erro seria invisível, porque a linha ficaria "reindexada".
- Interrompe se um lote inteiro não gravar nada, para não girar em falso sobre uma fila que não anda.

## Auditoria

`@security-auditor` rodou sobre o diff antes de abrir — **8/10**, dois achados genuínos, ambos corrigidos no segundo commit.

| Severidade | Achado | Correção |
| --- | --- | --- |
| **MÉDIO** | `set_embedding` deixava estado **irrecuperável**: a coluna e o índice vivem em conexões diferentes (o `VectorStore` tem a sua), então não há transação que cubra os dois. Se o índice recusasse o vetor, a linha ficava com `embedding` preenchido e fora do índice — saindo da fila do reindex (`embedding IS NULL`) sem ter entrado na busca semântica, e sem caminho de reparo. | Fail-closed: a coluna volta a `NULL` e a entrada continua na fila. |
| **BAIXO** | `Duration::days` faz `expect` acima de ~106 bilhões de dias, **antes** de o `checked_sub_signed` ter chance de recusar. `garra memory compact --older-than-days 999999999999999` derrubava o processo com backtrace. | `Duration::try_days`; o comando sai `2` com mensagem. |
| INFO | Corpo de erro de provider 5xx cujo token não case com os prefixos conhecidos do `sanitize_error_body` poderia chegar ao log. Limitação pré-existente do #948, que este PR apenas invoca corretamente. | Registrado, sem ação. |

A auditoria confirmou como corretos: SQL todo por bind nas primitivas novas; nenhum `unwrap()` em produção; `confirm()` recusando sem TTY e sem `--yes`; a guarda de pareamento por índice no reindex; as três saídas do `loop` (teto, fila vazia, lote que não grava nada) fechando o risco de loop infinito; e o refactor do `build_embedding_provider` como semântica-preservante.

### O que a correção do MÉDIO expôs

O mesmo estado que o `set_embedding` podia deixar **já é produzido pelo `remember_sync` na operação normal** — ele insere no índice em best-effort com `warn!`, então um sqlite-vec momentaneamente fora do ar deixa entradas com vetor na coluna e fora da busca semântica. E o `reindex` não as alcançava, porque procura `embedding IS NULL`.

Uma ferramenta de reparo que não repara o caso mais provável não serve, então o `reindex` ganhou um primeiro passo **de graça**: `reindex_missing_index_rows` reinsere no índice o vetor que já está na coluna, sem chamada de provider nenhuma. Sai no relatório como `index_repaired`, roda antes do lote pago, e funciona mesmo sem provider configurado.

O conjunto de ids indexados vem da conexão do próprio `VectorStore`, não de um `JOIN` a partir da memória: em produção os dois são o mesmo arquivo, mas em `in_memory_with_vectors` o índice é um segundo banco em memória e o `JOIN` não enxergaria o `vec_id_map` — os testes pegaram isso na primeira execução.

### Duas lacunas da #950, fechadas depois de reler a issue

- **`stats` agrupa por `(modelo, dimensões)`.** A issue pedia "por modelo, dimensões", e "com o que este índice foi construído?" — a pergunta que decide se uma troca de modelo exige reindexar tudo (#954) — não se responde com um agregado.
- **`search` mostra a distância de cada resultado.** Vem do `MemoryStore::knn_distances`, que existe **só para anotar** o que o recall devolveu: ler o índice direto foi exatamente o bypass de isolamento que o #971 fechou, então ele devolve `(id, distância)` e nunca entradas. A ordem da lista continua sendo a do score híbrido do recall, não a da distância — por isso o rótulo é `d=`, não um ranking.

A issue também propunha `reindex --model`. Fica de fora **de propósito**: o modelo do vetor precisa ser o mesmo com que o recall vai consultar, e isso vem da config. Um override de linha de comando produziria vetores que o filtro de modelo do #954 exclui do próprio recall — trabalho pago para gerar dado inútil.

## Tipo de mudança

- [x] `feat`: Nova funcionalidade
- [x] `refactor`: Refatoração sem mudança de comportamento (extração do `build_embedding_provider`)
- [x] `test`: Adição ou correção de testes

## Classe de Risco

- [x] **Classe B (Médio Risco)**: refatoração interna sem mudança de schema, mais uma superfície nova de CLI. Não toca auth, RLS, migrations nem rota REST. Ainda assim a auditoria rodou antes de abrir, porque o PR **apaga dado do usuário** (`delete`, `compact`) e mexe na integridade do índice vetorial.

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo +1.95 fmt --all` executado e limpo
- [x] `cargo +1.95 clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings` sem erros
- [x] `cargo +1.95 test --workspace --exclude garraia-desktop` passando — única falha é a ambiental conhecida `migration_001_applies_and_schema_is_sane`, que exige `docker.sock`; o CI valida
- [x] Nenhum `unwrap()` adicionado em código de produção (os novos estão só em teste)
- [x] Nenhum segredo, API key, token ou credencial commitada
- [x] Nenhuma migração Postgres — este PR não toca schema

## Mudanças na API pública e Schema

- **CLI:** subcomando novo `garra memory` com seis ações. Nenhum comando existente muda.
- **`garraia-config`:** `AppConfig::resolved_data_dir()` e `AppConfig::memory_db_path()` (métodos novos, nada removido).
- **`garraia-gateway`:** `bootstrap::build_embedding_provider(&AppConfig)` passa a ser público. `build_agent_runtime` mantém o comportamento — a diferença é de onde o provider vem.
- **`garraia-db`:** `MemoryStore` ganha `entries_missing_embeddings`, `set_embedding`, `recent_entries`, `delete_entry`, `embedding_breakdown`, `knn_distances` e `reindex_missing_index_rows`; struct nova `EmbeddingBreakdownRow`; `VectorStore::mapped_ids` (extraído do scan que o `orphan_map_entries` já fazia).
- **`garraia-agents`:** `reindex_missing_embeddings`, `ReindexOptions`, `ReindexReport` (com o campo `index_repaired`), `DEFAULT_REINDEX_BATCH_SIZE`.
- Sem mudança de schema, sem migração. O `memory.db` de uma instalação existente é lido como está.

## Como testar

```bash
cargo +1.95 test -p garraia-agents memory_reindex     # 6 testes
cargo +1.95 test -p garraia --bin garra memory_cmd    # 15 testes
cargo +1.95 test -p garraia-db reindex_missing        # 3 testes do reparo de indice
```

Fim a fim, com um endpoint OpenAI-compatível local (o `is_self_hosted_openai_endpoint` do #948 dispensa credencial fora do `api.openai.com`):

```yaml
# ~/.config/garraia/config.yml
memory: { enabled: true, embedding_provider: fake }
embeddings:
  fake: { provider: openai, model: fake-embed, base_url: http://127.0.0.1:8799, dimensions: 8 }
```

```bash
garra memory stats            # N entradas, 0 com vetor, 0 linhas no mapa
garra memory reindex --json   # {"pending_before": N, "index_repaired": 0, "reindexed": N}
garra memory stats            # N com vetor, vec_embeddings_8 com N linhas
garra memory search "..."     # "Busca semantica" — achou pelo caminho KNN, com d=
```

Exercitado nesta sessão, incluindo os caminhos de falha: com o provider derrubado no meio, `reindex` reporta `stopped_early` e sai `69`; `search` avisa que caiu para o textual em vez de mentir que não achou nada; e com uma entrada gravada com vetor na coluna e fora do índice, `reindex` a devolve ao índice sem chamar provider (`index_repaired: 1`) e a busca semântica passa a encontrá-la.

## Limitação registrada, não corrigida aqui

O caminho **textual** do recall é um `LIKE '%frase inteira%'` (`memory_store.rs`, `query_candidates_with_tenant_sync`): uma consulta de duas palavras só casa se as duas aparecerem grudadas, na ordem. Isso é comportamento pré-existente do recall do agente, não algo que este PR introduz — mudá-lo alteraria o que o agente lembra, e merece issue própria. O que este PR faz é parar de deixar o operador confundir "não achou" com "não havia como achar": quando a busca textual volta vazia com mais de uma palavra, ela diz isso.

## Plano de Rollback

Reverter o merge. Não há migração, estado persistido novo nem mudança de schema: o `memory.db` continua legível pela versão anterior, inclusive os vetores que o `reindex` tiver gravado (a coluna e o índice já existiam). O que se perde é o subcomando e a extração do `build_embedding_provider` — o `build_agent_runtime` volta a construir o provider inline, com o mesmo resultado.

Closes #950
Closes #953

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF

---
_Generated by [Claude Code](https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF)_