### PR TITLE
feat(cli): eventos de tool no terminal — o agente para de trabalhar no escuro (#937)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3242,6 +3242,7 @@ dependencies = [
  "futures",
  "garraia-common",
  "garraia-db",
+ "garraia-security",
  "libc",
  "reqwest 0.12.28",
  "rmcp",

--- a/changelog.d/added/937-eventos-de-tool-no-terminal.md
+++ b/changelog.d/added/937-eventos-de-tool-no-terminal.md
@@ -1,0 +1,39 @@
+- **O terminal mostra o que o agente esta fazendo, ferramenta por ferramenta
+  (#937).** Ate aqui a execucao de ferramenta era invisivel no `garra chat`:
+  o usuario via o indicador de atividade e, minutos depois, a resposta pronta —
+  sem saber se o agente estava lendo um arquivo, rodando `cargo test` ou parado.
+  Agora cada chamada aparece em duas linhas compactas: `● Bash cargo test` ao
+  comecar e `└─ 148 passed · 6.3s` ao terminar, com glifo e cor diferentes na
+  falha (`× Bash └─ error: exit 101 · 4.2s`). Saida longa **nao** e despejada:
+  vira a primeira linha mais a contagem das outras.
+
+  Por baixo, o `garraia-agents` ganha `TurnEvent` e `TurnSink`. O runtime
+  passa a contar o turno inteiro — texto e ciclo de vida de ferramenta — num
+  canal so, o que preserva a ordem entre os dois (dois canais nao garantiriam,
+  e o agente intercala texto e ferramenta no mesmo turno). Os sete consumidores
+  que so querem texto — Telegram, Slack, Discord, WhatsApp, `openai_api`,
+  `parrot_ws` e o `garra ask` — ficam intactos: num sink de texto os eventos de
+  ferramenta sao descartados na origem.
+
+  O resumo do input e o do output passam por `redact_secrets` **antes** de
+  virar evento, e nao no renderer: qualquer consumidor futuro herda a garantia
+  sem precisar lembrar dela.
+
+- **O indicador de atividade volta depois que a ferramenta termina (#937).**
+  Ele parava no primeiro token e nao voltava mais, entao o tempo em que o
+  modelo pensa **depois** de uma ferramenta era prompt morto de novo. Faltava
+  o evento para ouvir; agora existe. O rotulo `Garra` continua saindo uma vez
+  so por turno.
+
+- **O redactor de segredos aprendeu os segredos de terceiro (#937).** Ate aqui
+  ele so via log, onde aparecem as chaves que o proprio GarraIA usa — Anthropic,
+  OpenAI, Slack, Discord. Com os eventos de ferramenta ele passou a ver
+  **comando que o agente monta**, e ali entra credencial que o usuario deu no
+  contexto. Foram acrescentados: PAT do GitHub (classico e fine-grained), JWT,
+  access key da AWS (fixa e temporaria), token de bot do Telegram e senha
+  embutida em connection string (`postgres://user:senha@host`). Como o
+  `redact_secrets` e o mesmo que o `RedactingWriter` usa, todo log do projeto
+  ganhou a cobertura junto. O que ele continua **nao** cobrindo, e esta escrito
+  no codigo: segredo sem formato reconhecivel, como `--password minhasenha` —
+  um regex que tentasse pegar "o argumento depois de --password" erraria mais
+  do que acertaria.

--- a/crates/garraia-agents/Cargo.toml
+++ b/crates/garraia-agents/Cargo.toml
@@ -7,6 +7,9 @@ description = "LLM agent runtime and orchestration for GarraIA"
 
 [dependencies]
 garraia-common = { workspace = true, features = ["ssrf"] }
+# #937: o resumo de ferramenta passa por `redact_secrets` na origem, para
+# nenhum consumidor de `TurnEvent` precisar lembrar de redigir.
+garraia-security = { workspace = true }
 garraia-db = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/garraia-agents/src/lib.rs
+++ b/crates/garraia-agents/src/lib.rs
@@ -22,6 +22,7 @@ pub mod provider_resilience;
 pub mod providers;
 pub mod runtime;
 pub mod tools;
+pub mod turn_events;
 
 pub use agent_mode::{
     AutoRouter, LlmRouter, ModeProfileExt, ModeSelectionMethod, SessionModeMetadata,
@@ -67,6 +68,7 @@ pub use tools::{
     RepoSearchTool, RunTestsTool, ScheduleHeartbeat, ScheduleRecurring, ScheduledTask, TaskStatus,
     Tool, ToolContext, ToolOutput, TriggerRegistry, WebFetchTool, WebSearchTool, WebhookTrigger,
 };
+pub use turn_events::{TurnEvent, TurnSink, summarize_tool_input, summarize_tool_output};
 
 #[cfg(feature = "mcp")]
 pub use mcp::{McpManager, McpPromptInfo, McpResourceInfo, McpToolInfo};

--- a/crates/garraia-agents/src/runtime.rs
+++ b/crates/garraia-agents/src/runtime.rs
@@ -25,6 +25,7 @@ use crate::providers::{
     StreamEvent, ToolDefinition,
 };
 use crate::tools::{Tool, ToolContext, ToolOutput};
+use crate::turn_events::{TurnSink, summarize_tool_input, summarize_tool_output};
 
 /// Where a registered tool came from. Issue #924: without this the runtime
 /// cannot tell a native tool from an MCP one, so it cannot replace just the
@@ -1273,12 +1274,79 @@ impl AgentRuntime {
             model = tracing::field::Empty,
         )
     )]
+    #[allow(clippy::too_many_arguments)]
     pub async fn process_message_streaming_with_agent_config(
         &self,
         session_id: &str,
         user_text: &str,
         conversation_history: &[ChatMessage],
         delta_tx: mpsc::Sender<String>,
+        continuity_key: Option<&str>,
+        user_id: Option<&str>,
+        provider_id: Option<&str>,
+        model_override: Option<&str>,
+        system_prompt_override: Option<&str>,
+        max_tokens_override: Option<u32>,
+    ) -> Result<String> {
+        self.stream_turn_with_sink(
+            session_id,
+            user_text,
+            conversation_history,
+            TurnSink::Text(delta_tx),
+            continuity_key,
+            user_id,
+            provider_id,
+            model_override,
+            system_prompt_override,
+            max_tokens_override,
+        )
+        .await
+    }
+
+    /// Como [`Self::process_message_streaming`], mas entregando o **fluxo
+    /// completo** do turno: texto e ciclo de vida das ferramentas (#937).
+    ///
+    /// Existe para o `garra chat` poder desenhar o que o agente esta fazendo
+    /// sem ler log. Os outros chamadores continuam no caminho de texto e nao
+    /// pagam nada por isto — ver [`TurnSink`].
+    #[allow(clippy::too_many_arguments)]
+    pub async fn process_message_streaming_with_events(
+        &self,
+        session_id: &str,
+        user_text: &str,
+        conversation_history: &[ChatMessage],
+        events_tx: mpsc::Sender<crate::turn_events::TurnEvent>,
+        continuity_key: Option<&str>,
+        user_id: Option<&str>,
+        provider_id: Option<&str>,
+        model_override: Option<&str>,
+        system_prompt_override: Option<&str>,
+        max_tokens_override: Option<u32>,
+    ) -> Result<String> {
+        self.stream_turn_with_sink(
+            session_id,
+            user_text,
+            conversation_history,
+            TurnSink::Events(events_tx),
+            continuity_key,
+            user_id,
+            provider_id,
+            model_override,
+            system_prompt_override,
+            max_tokens_override,
+        )
+        .await
+    }
+
+    /// O turno em si. Um sink so, entao a ordem entre texto e evento de
+    /// ferramenta e a ordem de emissao (ver `turn_events`).
+    #[allow(clippy::too_many_arguments)]
+    async fn stream_turn_with_sink(
+        &self,
+        session_id: &str,
+        user_text: &str,
+        conversation_history: &[ChatMessage],
+        sink: TurnSink,
         continuity_key: Option<&str>,
         user_id: Option<&str>,
         provider_id: Option<&str>,
@@ -1459,7 +1527,7 @@ impl AgentRuntime {
                         match event? {
                             StreamEvent::TextDelta(text) => {
                                 response_text.push_str(&text);
-                                let _ = delta_tx.send(text).await;
+                                sink.text(text).await;
                             }
                             StreamEvent::ToolUseStart { id, name, .. } => {
                                 current_tool = Some((id, name, String::new()));
@@ -1564,6 +1632,17 @@ impl AgentRuntime {
                             return Err(Error::Agent(format!("tool loop detected: {}", name)));
                         }
 
+                        // #937: este e o caminho de streaming nativo; o de
+                        // fallback tem a instrumentacao equivalente logo
+                        // adiante. Os dois precisam dela — o Ollama, provedor
+                        // padrao do projeto, nao implementa `stream_complete`
+                        // e cai justamente no outro.
+                        if sink.wants_tool_events() {
+                            sink.tool_started(name, summarize_tool_input(name, &input))
+                                .await;
+                        }
+                        let iniciado_em = std::time::Instant::now();
+
                         // executa com timeout
                         let output = match self.find_tool(name) {
                             Some(tool) => {
@@ -1577,6 +1656,17 @@ impl AgentRuntime {
                             }
                             None => ToolOutput::error(format!("unknown tool: {}", name)),
                         };
+
+                        if sink.wants_tool_events() {
+                            let ok = !output.is_error;
+                            sink.tool_finished(
+                                name,
+                                iniciado_em.elapsed(),
+                                ok,
+                                summarize_tool_output(&output.content, ok),
+                            )
+                            .await;
+                        }
 
                         // GAR-187: pause agent loop if tool requires user confirmation
                         if output.requires_confirmation {
@@ -1602,7 +1692,7 @@ impl AgentRuntime {
 
                     // GAR-187: if confirmation needed, send prompt via stream and return
                     if let Some(confirmation_msg) = confirmation_response {
-                        let _ = delta_tx.send(confirmation_msg.clone()).await;
+                        sink.text(confirmation_msg.clone()).await;
                         full_response.push_str(&confirmation_msg);
                         return Ok(full_response);
                     }
@@ -1610,7 +1700,7 @@ impl AgentRuntime {
                     // Add separator between iterations
                     if !full_response.is_empty() {
                         full_response.push_str("\n\n");
-                        let _ = delta_tx.send("\n\n".to_string()).await;
+                        sink.text("\n\n".to_string()).await;
                     }
                 }
                 Err(_) => {
@@ -1633,7 +1723,7 @@ impl AgentRuntime {
 
                     if !has_tool_use {
                         let final_text = extract_text(&response.content);
-                        let _ = delta_tx.send(final_text.clone()).await;
+                        sink.text(final_text.clone()).await;
                         full_response.push_str(&final_text);
 
                         if let Err(e) = self
@@ -1678,6 +1768,15 @@ impl AgentRuntime {
                                 return Err(Error::Agent(format!("tool loop detected: {}", name)));
                             }
 
+                            // #937: o resumo do input so e montado quando alguem
+                            // vai desenha-lo. `summarize_tool_input` ja redige
+                            // segredo na origem.
+                            if sink.wants_tool_events() {
+                                sink.tool_started(name, summarize_tool_input(name, input))
+                                    .await;
+                            }
+                            let iniciado_em = std::time::Instant::now();
+
                             // executa com timeout
                             let output = match self.find_tool(name) {
                                 Some(tool) => {
@@ -1696,6 +1795,17 @@ impl AgentRuntime {
                                 }
                                 None => ToolOutput::error(format!("unknown tool: {}", name)),
                             };
+
+                            if sink.wants_tool_events() {
+                                let ok = !output.is_error;
+                                sink.tool_finished(
+                                    name,
+                                    iniciado_em.elapsed(),
+                                    ok,
+                                    summarize_tool_output(&output.content, ok),
+                                )
+                                .await;
+                            }
 
                             // GAR-187: pause if tool requires user confirmation
                             if output.requires_confirmation {
@@ -1722,7 +1832,7 @@ impl AgentRuntime {
 
                     // GAR-187: if confirmation needed, send prompt via stream and return
                     if let Some(confirmation_msg) = confirmation_response {
-                        let _ = delta_tx.send(confirmation_msg.clone()).await;
+                        sink.text(confirmation_msg.clone()).await;
                         full_response.push_str(&confirmation_msg);
                         return Ok(full_response);
                     }

--- a/crates/garraia-agents/src/turn_events.rs
+++ b/crates/garraia-agents/src/turn_events.rs
@@ -1,0 +1,387 @@
+//! O que o runtime **conta** sobre um turno (#937).
+//!
+//! Nasce da ADR 0017: o `UiEvent` e o `TerminalRenderer` moram no CLI, e o
+//! runtime nao pode depender deles — senao o crate de agentes carregaria
+//! apresentacao junto para todo mundo que o usa (gateway, canais, MCP).
+//! Entao o runtime fala numa linguagem propria, [`TurnEvent`], e quem desenha
+//! traduz.
+//!
+//! # Por que um enum, e nao um segundo canal
+//!
+//! Ate aqui o turno empurrava `mpsc::Sender<String>` — so texto. A alternativa
+//! obvia para carregar ciclo de vida de ferramenta seria um segundo canal, so
+//! para eventos. **Dois canais nao garantem ordem entre si**, e o agente
+//! intercala texto e chamada de ferramenta no mesmo turno: o evento da tool
+//! poderia ser desenhado depois do texto que veio depois dele. Um canal so,
+//! com um enum, preserva a ordem de emissao.
+//!
+//! # E os sete chamadores que so querem texto
+//!
+//! Ficam intactos. O [`TurnSink`] aceita **ou** o `Sender<String>` de hoje
+//! **ou** um `Sender<TurnEvent>`; num sink de texto, os eventos de ferramenta
+//! sao descartados na origem — o Telegram nao tem o que fazer com "Bash
+//! comecou". Quem quer o fluxo inteiro pede pelo
+//! `process_message_streaming_with_events`.
+//!
+//! # Segredo nao sai daqui
+//!
+//! O resumo do input e o do output passam por [`garraia_security::redact_secrets`]
+//! **antes** de virar evento. E deliberado que a redacao esteja na origem, e
+//! nao no renderer: qualquer consumidor futuro (console web, outro canal)
+//! herda a garantia sem precisar lembrar dela. Foi a licao do #948/#974 —
+//! corrigir no ponto onde o dado nasce, nao onde ele e impresso.
+
+use std::time::Duration;
+
+use tokio::sync::mpsc;
+
+/// Quanto de um resumo de ferramenta cabe numa linha de terminal.
+const SUMMARY_MAX_CHARS: usize = 72;
+
+/// Um acontecimento do turno, na linguagem de quem **observa** o agente.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TurnEvent {
+    /// Um pedaco do texto da resposta, como saiu do modelo.
+    TextDelta(String),
+
+    /// Uma ferramenta comecou a rodar.
+    ToolStarted {
+        /// Nome registrado da ferramenta (`bash`, `file_read`, …).
+        name: String,
+        /// O que ela vai fazer, ja redigido e truncado — o `cargo test` de
+        /// `Bash cargo test`. Vazio quando nao ha nada util a dizer.
+        detail: String,
+    },
+
+    /// Uma ferramenta terminou.
+    ToolFinished {
+        name: String,
+        /// Tempo de parede da execucao.
+        duration: Duration,
+        success: bool,
+        /// Uma linha sobre o resultado, ja redigida e truncada. Em falha, o
+        /// trecho mais relevante do erro.
+        summary: String,
+    },
+}
+
+/// Para onde o turno escreve.
+///
+/// `Text` e o que os sete chamadores de hoje usam e mantem o comportamento
+/// exato de antes do #937. `Events` e o fluxo completo.
+#[derive(Debug, Clone)]
+pub enum TurnSink {
+    Text(mpsc::Sender<String>),
+    Events(mpsc::Sender<TurnEvent>),
+}
+
+impl TurnSink {
+    /// Um pedaco de texto da resposta. Chega nos dois tipos de sink.
+    pub async fn text(&self, delta: String) {
+        match self {
+            Self::Text(tx) => {
+                let _ = tx.send(delta).await;
+            }
+            Self::Events(tx) => {
+                let _ = tx.send(TurnEvent::TextDelta(delta)).await;
+            }
+        }
+    }
+
+    /// Ciclo de vida de ferramenta. **Descartado** num sink de texto — e o
+    /// ponto: o canal do Telegram nao ganha ruido por causa de uma feature de
+    /// terminal.
+    pub async fn tool_started(&self, name: &str, detail: String) {
+        if let Self::Events(tx) = self {
+            let _ = tx
+                .send(TurnEvent::ToolStarted {
+                    name: name.to_string(),
+                    detail,
+                })
+                .await;
+        }
+    }
+
+    pub async fn tool_finished(
+        &self,
+        name: &str,
+        duration: Duration,
+        success: bool,
+        summary: String,
+    ) {
+        if let Self::Events(tx) = self {
+            let _ = tx
+                .send(TurnEvent::ToolFinished {
+                    name: name.to_string(),
+                    duration,
+                    success,
+                    summary,
+                })
+                .await;
+        }
+    }
+
+    /// Este sink se importa com eventos de ferramenta? O runtime usa para nao
+    /// pagar o custo de montar resumo que ninguem vai ler.
+    pub fn wants_tool_events(&self) -> bool {
+        matches!(self, Self::Events(_))
+    }
+}
+
+/// O que a ferramenta vai fazer, em uma linha.
+///
+/// Escolhe o campo que interessa por ferramenta — o `command` do bash, o
+/// `path` de leitura e escrita, o `pattern` de busca — porque o schema de cada
+/// uma e conhecimento **do crate de agentes**, nao do renderer. O renderer
+/// recebe texto pronto e decide so como desenhar (ADR 0017).
+///
+/// Redige e trunca sempre. E ferramenta sem caso proprio devolve vazio, em
+/// vez de adivinhar um campo: uma ferramenta nova nao pode vazar segredo so
+/// por ainda nao ter caso proprio aqui.
+///
+/// O caminho de arquivo aparece **inteiro**, de proposito: `Read
+/// ~/.ssh/id_rsa` e exatamente a informacao que a #937 quer dar ao operador —
+/// saber o que o agente leu. O caminho nao e o segredo; o conteudo e, e ele
+/// nao sai daqui.
+pub fn summarize_tool_input(name: &str, input: &serde_json::Value) -> String {
+    let bruto = match name {
+        "bash" => campo(input, "command"),
+        "file_read" | "file_write" => campo(input, "path"),
+        "repo_search" | "web_search" => campo(input, "query").or_else(|| campo(input, "pattern")),
+        "web_fetch" => campo(input, "url"),
+        "git_diff" => campo(input, "path"),
+        // Ferramenta sem caso proprio nao mostra nada.
+        //
+        // A versao anterior pegava o primeiro valor textual do input, e a
+        // auditoria mostrou por que isso e ruim: `serde_json::Map` preserva a
+        // ordem de insercao, entao uma ferramenta nova com
+        // `{"connection_string": "...", "query": "..."}` exibiria a connection
+        // string. "Ferramenta nova nao pode vazar segredo so por ainda nao ter
+        // caso proprio aqui" era a regra que eu mesmo escrevi — e adivinhar o
+        // campo a violava. Ferramenta nova aparece so com o nome ate alguem
+        // dizer qual campo dela e o interessante.
+        _ => None,
+    };
+
+    match bruto {
+        Some(texto) => sanear(&texto),
+        None => String::new(),
+    }
+}
+
+/// Uma linha sobre o que a ferramenta devolveu.
+///
+/// Em sucesso: a primeira linha nao-vazia, ou a contagem de linhas quando a
+/// saida e longa — "nao despejar output grande por padrao" e criterio de
+/// aceite da #937. Em falha: a primeira linha nao-vazia, que e onde as
+/// ferramentas deste projeto poem a causa.
+pub fn summarize_tool_output(content: &str, success: bool) -> String {
+    let linhas: Vec<&str> = content.lines().filter(|l| !l.trim().is_empty()).collect();
+
+    let Some(primeira) = linhas.first() else {
+        return String::new();
+    };
+
+    // Em falha o que importa e a causa, mesmo que a saida seja longa.
+    if success && linhas.len() > 1 {
+        let resumo = sanear(primeira);
+        let restantes = linhas.len() - 1;
+        return format!("{resumo} (+{restantes} linha(s))");
+    }
+
+    sanear(primeira)
+}
+
+fn campo(input: &serde_json::Value, chave: &str) -> Option<String> {
+    input
+        .get(chave)
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+}
+
+/// Redige segredo e trunca — nessa ordem, sempre.
+///
+/// Truncar antes de redigir poderia cortar uma chave ao meio e deixar o
+/// prefixo passar pelo regex sem casar.
+fn sanear(texto: &str) -> String {
+    let redigido = garraia_security::redact_secrets(texto.trim());
+    let uma_linha = redigido.replace(['\n', '\r'], " ");
+    truncar(&uma_linha, SUMMARY_MAX_CHARS)
+}
+
+/// Corta por **caractere**, nunca por byte — comando e caminho carregam
+/// acento, e cortar no meio de um `ç` produz bytes invalidos.
+fn truncar(texto: &str, max: usize) -> String {
+    if texto.chars().count() <= max {
+        return texto.to_string();
+    }
+    let mut out: String = texto.chars().take(max.saturating_sub(1)).collect();
+    out.push('…');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn resume_o_comando_do_bash() {
+        let input = json!({ "command": "cargo test --workspace" });
+        assert_eq!(
+            summarize_tool_input("bash", &input),
+            "cargo test --workspace"
+        );
+    }
+
+    #[test]
+    fn resume_o_caminho_das_ferramentas_de_arquivo() {
+        let input = json!({ "path": "crates/garraia-cli/src/chat.rs" });
+        assert_eq!(
+            summarize_tool_input("file_read", &input),
+            "crates/garraia-cli/src/chat.rs"
+        );
+        assert_eq!(
+            summarize_tool_input("file_write", &input),
+            "crates/garraia-cli/src/chat.rs"
+        );
+    }
+
+    /// Ferramenta sem caso proprio aparece so com o nome — nunca adivinhando
+    /// um campo do input que pode ser o segredo.
+    #[test]
+    fn ferramenta_desconhecida_nao_adivinha_campo() {
+        let input = json!({
+            "connection_string": "postgres://admin:s3cr3tpass@host/db",
+            "query": "SELECT 1"
+        });
+        assert_eq!(summarize_tool_input("ferramenta_nova", &input), "");
+    }
+
+    #[test]
+    fn input_sem_nada_util_vira_vazio() {
+        assert_eq!(summarize_tool_input("bash", &json!({})), "");
+        assert_eq!(summarize_tool_input("bash", &json!(42)), "");
+    }
+
+    /// O criterio de aceite da #937 sobre nao vazar segredo de argumento.
+    #[test]
+    fn segredo_no_comando_e_redigido_na_origem() {
+        let chave = format!("sk-{}", "a".repeat(40));
+        let input = json!({ "command": format!("curl -H 'auth: {chave}' https://x") });
+        let resumo = summarize_tool_input("bash", &input);
+        assert!(!resumo.contains(&chave), "chave vazou: {resumo}");
+        assert!(resumo.contains("[REDACTED]"), "{resumo}");
+    }
+
+    #[test]
+    fn segredo_na_saida_tambem_e_redigido() {
+        let chave = format!("xoxb-{}", "b".repeat(30));
+        let resumo = summarize_tool_output(&format!("token={chave}"), true);
+        assert!(!resumo.contains(&chave), "chave vazou: {resumo}");
+    }
+
+    /// Truncar ANTES de redigir cortaria a chave e deixaria o prefixo passar.
+    #[test]
+    fn redige_antes_de_truncar() {
+        let chave = format!("sk-{}", "c".repeat(120));
+        let resumo = summarize_tool_input("bash", &json!({ "command": chave.clone() }));
+        assert!(
+            !resumo.contains("sk-cccc"),
+            "prefixo de chave sobreviveu: {resumo}"
+        );
+    }
+
+    #[test]
+    fn resumo_longo_e_truncado_sem_quebrar_caractere() {
+        let longo = "ç".repeat(200);
+        let resumo = summarize_tool_input("bash", &json!({ "command": longo }));
+        assert!(resumo.chars().count() <= SUMMARY_MAX_CHARS);
+        assert!(resumo.ends_with('…'));
+    }
+
+    #[test]
+    fn saida_de_uma_linha_sai_inteira() {
+        assert_eq!(summarize_tool_output("148 passed", true), "148 passed");
+    }
+
+    /// "Long tool output is not dumped by default" — criterio de aceite.
+    #[test]
+    fn saida_longa_vira_primeira_linha_mais_contagem() {
+        let saida = "primeira\nsegunda\nterceira\n";
+        assert_eq!(summarize_tool_output(saida, true), "primeira (+2 linha(s))");
+    }
+
+    /// Em falha o que importa e a causa, nao a contagem.
+    #[test]
+    fn falha_mostra_a_primeira_linha_do_erro() {
+        let saida = "error: exit 101\nstack trace...\nmais ruido";
+        assert_eq!(summarize_tool_output(saida, false), "error: exit 101");
+    }
+
+    #[test]
+    fn saida_vazia_vira_resumo_vazio() {
+        assert_eq!(summarize_tool_output("", true), "");
+        assert_eq!(summarize_tool_output("\n\n  \n", true), "");
+    }
+
+    #[tokio::test]
+    async fn sink_de_texto_descarta_evento_de_ferramenta() {
+        let (tx, mut rx) = mpsc::channel::<String>(8);
+        let sink = TurnSink::Text(tx);
+        assert!(!sink.wants_tool_events());
+
+        sink.tool_started("bash", "cargo test".into()).await;
+        sink.text("oi".into()).await;
+        sink.tool_finished("bash", Duration::from_secs(1), true, "ok".into())
+            .await;
+        drop(sink);
+
+        let mut recebidos = Vec::new();
+        while let Some(t) = rx.recv().await {
+            recebidos.push(t);
+        }
+        assert_eq!(recebidos, vec!["oi".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn sink_de_eventos_preserva_a_ordem_de_emissao() {
+        let (tx, mut rx) = mpsc::channel::<TurnEvent>(8);
+        let sink = TurnSink::Events(tx);
+        assert!(sink.wants_tool_events());
+
+        sink.text("antes ".into()).await;
+        sink.tool_started("bash", "cargo test".into()).await;
+        sink.tool_finished(
+            "bash",
+            Duration::from_millis(1500),
+            true,
+            "148 passed".into(),
+        )
+        .await;
+        sink.text("depois".into()).await;
+        drop(sink);
+
+        let mut recebidos = Vec::new();
+        while let Some(e) = rx.recv().await {
+            recebidos.push(e);
+        }
+        assert_eq!(
+            recebidos,
+            vec![
+                TurnEvent::TextDelta("antes ".into()),
+                TurnEvent::ToolStarted {
+                    name: "bash".into(),
+                    detail: "cargo test".into()
+                },
+                TurnEvent::ToolFinished {
+                    name: "bash".into(),
+                    duration: Duration::from_millis(1500),
+                    success: true,
+                    summary: "148 passed".into()
+                },
+                TurnEvent::TextDelta("depois".into()),
+            ]
+        );
+    }
+}

--- a/crates/garraia-cli/src/chat.rs
+++ b/crates/garraia-cli/src/chat.rs
@@ -17,6 +17,7 @@ use garraia_config::AppConfig;
 use tokio::sync::mpsc;
 
 use crate::ui::{TerminalRenderer, UiEvent};
+use garraia_agents::TurnEvent;
 
 use std::path::Path;
 
@@ -779,7 +780,7 @@ enum TurnOutcome<T, E> {
 /// aperta Ctrl+C durante o turno.
 async fn stream_turn<F, T, E>(
     call: F,
-    mut rx: mpsc::Receiver<String>,
+    mut rx: mpsc::Receiver<TurnEvent>,
     timeout: std::time::Duration,
     out: &mut (impl io::Write + ?Sized),
     renderer: &mut TerminalRenderer,
@@ -827,7 +828,7 @@ where
                 renderer.handle(UiEvent::ActivityTick, out);
             }
             maybe = rx.recv(), if rx_open => match maybe {
-                Some(delta) => renderer.handle(UiEvent::TextDelta(&delta), out),
+                Some(evento) => render_turn_event(&evento, renderer, out),
                 None => rx_open = false,
             },
         }
@@ -837,8 +838,8 @@ where
     // a timeout — tokio::pin! would keep it alive and hang the drain below.
     drop(call);
     if rx_open {
-        while let Some(delta) = rx.recv().await {
-            renderer.handle(UiEvent::TextDelta(&delta), out);
+        while let Some(evento) = rx.recv().await {
+            render_turn_event(&evento, renderer, out);
         }
     }
 
@@ -848,6 +849,35 @@ where
     renderer.handle(UiEvent::TurnFinished, out);
 
     result
+}
+
+/// Traduz o que o runtime **contou** para o que o terminal **desenha**.
+///
+/// É a fronteira que a ADR 0017 fixa: `garraia-agents` fala `TurnEvent` e não
+/// conhece renderer nenhum; o `ui` fala `UiEvent` e não conhece runtime. Esta
+/// função de três linhas é toda a ponte, e é de propósito que ela seja
+/// pequena — se um dia precisar de lógica, a lógica está no lado errado.
+fn render_turn_event(
+    evento: &TurnEvent,
+    renderer: &mut TerminalRenderer,
+    out: &mut (impl io::Write + ?Sized),
+) {
+    let ui = match evento {
+        TurnEvent::TextDelta(texto) => UiEvent::TextDelta(texto),
+        TurnEvent::ToolStarted { name, detail } => UiEvent::ToolStarted { name, detail },
+        TurnEvent::ToolFinished {
+            name,
+            duration,
+            success,
+            summary,
+        } => UiEvent::ToolFinished {
+            name,
+            duration: *duration,
+            success: *success,
+            summary,
+        },
+    };
+    renderer.handle(ui, out);
 }
 
 /// Run the interactive chat REPL.
@@ -1157,7 +1187,7 @@ pub async fn run_chat(
         renderer.begin_turn(caps.spinner(turn_index));
         turn_index = turn_index.wrapping_add(1);
 
-        let (tx, rx) = mpsc::channel::<String>(100);
+        let (tx, rx) = mpsc::channel::<TurnEvent>(100);
 
         // The runtime appends the user message on top of the given history
         // (runtime.rs), so `history` must NOT contain it yet — it is pushed
@@ -1166,12 +1196,20 @@ pub async fn run_chat(
         let session_clone = session_id.clone();
         let model_clone = model_name.clone();
 
-        let call = runtime.process_message_streaming(
+        // #937: o chat pede o fluxo completo — texto e ciclo de vida das
+        // ferramentas. Os outros consumidores do runtime seguem no caminho
+        // de texto e nao pagam nada por isto.
+        let call = runtime.process_message_streaming_with_events(
             &session_clone,
             &input,
             &history_clone,
             tx,
+            None,
+            None,
+            None,
             Some(&model_clone),
+            None,
+            None,
         );
         let mut stdout = io::stdout();
         turn_active.store(true, std::sync::atomic::Ordering::SeqCst);
@@ -1656,10 +1694,10 @@ mod tests {
     /// 5s outer timeout turns a regression into a failure instead of a hang.
     #[tokio::test]
     async fn stream_turn_drains_concurrently_without_deadlock() {
-        let (tx, rx) = tokio::sync::mpsc::channel::<String>(2);
+        let (tx, rx) = tokio::sync::mpsc::channel::<TurnEvent>(2);
         let call = async move {
             for i in 0..300 {
-                tx.send(format!("d{i} "))
+                tx.send(TurnEvent::TextDelta(format!("d{i} ")))
                     .await
                     .map_err(|_| "receiver dropped")?;
             }
@@ -1694,9 +1732,9 @@ mod tests {
     /// already-buffered deltas must still be flushed before returning None.
     #[tokio::test]
     async fn stream_turn_times_out_and_flushes_buffered_deltas() {
-        let (tx, rx) = tokio::sync::mpsc::channel::<String>(8);
+        let (tx, rx) = tokio::sync::mpsc::channel::<TurnEvent>(8);
         let call = async move {
-            tx.send("partial ".to_string())
+            tx.send(TurnEvent::TextDelta("partial ".to_string()))
                 .await
                 .map_err(|_| "receiver dropped")?;
             // Never completes: simulates a stalled provider/SSE stream.
@@ -1744,6 +1782,58 @@ mod tests {
             animation: true,
             width: 80,
         }
+    }
+
+    /// A ponte `TurnEvent` -> `UiEvent` no caminho real do `stream_turn`
+    /// (#937): o runtime conta, o renderer desenha, e a ordem entre texto e
+    /// ferramenta e a ordem de emissao — que e o motivo de haver um canal so.
+    #[tokio::test]
+    async fn stream_turn_desenha_texto_e_ferramenta_na_ordem_emitida() {
+        let (tx, rx) = tokio::sync::mpsc::channel::<TurnEvent>(8);
+        let call = async move {
+            tx.send(TurnEvent::TextDelta("vou rodar os testes. ".into()))
+                .await
+                .map_err(|_| "receiver dropped")?;
+            tx.send(TurnEvent::ToolStarted {
+                name: "bash".into(),
+                detail: "cargo test".into(),
+            })
+            .await
+            .map_err(|_| "receiver dropped")?;
+            tx.send(TurnEvent::ToolFinished {
+                name: "bash".into(),
+                duration: std::time::Duration::from_millis(6300),
+                success: true,
+                summary: "148 passed".into(),
+            })
+            .await
+            .map_err(|_| "receiver dropped")?;
+            tx.send(TurnEvent::TextDelta("passou tudo.".into()))
+                .await
+                .map_err(|_| "receiver dropped")?;
+            Ok::<String, &'static str>("pronto".to_string())
+        };
+
+        let mut out: Vec<u8> = Vec::new();
+        let outcome = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            stream_turn(
+                call,
+                rx,
+                std::time::Duration::from_secs(5),
+                &mut out,
+                &mut TerminalRenderer::with_prefix(crate::ui::Capabilities::PLAIN, None, ""),
+                &tokio::sync::Notify::new(),
+            ),
+        )
+        .await
+        .expect("stream_turn nao pode travar");
+
+        assert_eq!(outcome, TurnOutcome::Done(Ok("pronto".to_string())));
+        assert_eq!(
+            String::from_utf8(out).expect("utf8"),
+            "vou rodar os testes. * Bash cargo test\n  |- 148 passed | 6.3s\npassou tudo."
+        );
     }
 
     /// Renderer sem rótulo: estes testes afirmam o texto do modelo e os
@@ -1806,11 +1896,11 @@ mod tests {
     /// é flake garantido; pausado, cada tick cai no instante exato.
     #[tokio::test(start_paused = true)]
     async fn spinner_runs_before_the_first_token() {
-        let (tx, rx) = tokio::sync::mpsc::channel::<String>(8);
+        let (tx, rx) = tokio::sync::mpsc::channel::<TurnEvent>(8);
         let call = async move {
             // Latência de provedor: vários quadros cabem aqui antes do 1o token.
             tokio::time::sleep(std::time::Duration::from_millis(700)).await;
-            tx.send("resposta".to_string())
+            tx.send(TurnEvent::TextDelta("resposta".to_string()))
                 .await
                 .map_err(|_| "receiver dropped")?;
             Ok::<String, &'static str>("resposta".to_string())
@@ -1845,13 +1935,13 @@ mod tests {
     /// depois que a resposta começa a sair.
     #[tokio::test(start_paused = true)]
     async fn spinner_is_cleared_before_streamed_output() {
-        let (tx, rx) = tokio::sync::mpsc::channel::<String>(8);
+        let (tx, rx) = tokio::sync::mpsc::channel::<TurnEvent>(8);
         let call = async move {
             tokio::time::sleep(std::time::Duration::from_millis(700)).await;
-            tx.send("alpha ".to_string())
+            tx.send(TurnEvent::TextDelta("alpha ".to_string()))
                 .await
                 .map_err(|_| "receiver dropped")?;
-            tx.send("beta".to_string())
+            tx.send(TurnEvent::TextDelta("beta".to_string()))
                 .await
                 .map_err(|_| "receiver dropped")?;
             Ok::<String, &'static str>("alpha beta".to_string())
@@ -1890,7 +1980,7 @@ mod tests {
     /// Erro do provedor precisa limpar a animação — nada de spinner órfão.
     #[tokio::test(start_paused = true)]
     async fn spinner_is_cleaned_up_on_provider_error() {
-        let (tx, rx) = tokio::sync::mpsc::channel::<String>(8);
+        let (tx, rx) = tokio::sync::mpsc::channel::<TurnEvent>(8);
         let call = async move {
             tokio::time::sleep(std::time::Duration::from_millis(700)).await;
             drop(tx);
@@ -1921,7 +2011,7 @@ mod tests {
     /// Timeout também limpa.
     #[tokio::test(start_paused = true)]
     async fn spinner_is_cleaned_up_on_timeout() {
-        let (tx, rx) = tokio::sync::mpsc::channel::<String>(8);
+        let (tx, rx) = tokio::sync::mpsc::channel::<TurnEvent>(8);
         let call = async move {
             let _keep = tx;
             std::future::pending::<()>().await;
@@ -1954,7 +2044,7 @@ mod tests {
     /// prompt — sem matar o processo e sem deixar o cursor escondido.
     #[tokio::test(start_paused = true)]
     async fn cancellation_stops_and_cleans_up_the_spinner() {
-        let (tx, rx) = tokio::sync::mpsc::channel::<String>(8);
+        let (tx, rx) = tokio::sync::mpsc::channel::<TurnEvent>(8);
         let call = async move {
             let _keep = tx;
             // Provedor que nunca responde: só o cancelamento tira a gente daqui.
@@ -1997,10 +2087,10 @@ mod tests {
     /// `None` e a saída tem de ser byte a byte igual à de antes do spinner.
     #[tokio::test]
     async fn non_tty_output_contains_no_animation_frames() {
-        let (tx, rx) = tokio::sync::mpsc::channel::<String>(8);
+        let (tx, rx) = tokio::sync::mpsc::channel::<TurnEvent>(8);
         let call = async move {
             tokio::time::sleep(std::time::Duration::from_millis(250)).await;
-            tx.send("resposta limpa".to_string())
+            tx.send(TurnEvent::TextDelta("resposta limpa".to_string()))
                 .await
                 .map_err(|_| "receiver dropped")?;
             Ok::<String, &'static str>("resposta limpa".to_string())
@@ -2035,10 +2125,10 @@ mod tests {
     /// duplicação de linha quando o provedor entrega token a token.
     #[tokio::test]
     async fn prefix_is_written_exactly_once_across_many_deltas() {
-        let (tx, rx) = tokio::sync::mpsc::channel::<String>(4);
+        let (tx, rx) = tokio::sync::mpsc::channel::<TurnEvent>(4);
         let call = async move {
             for i in 0..50 {
-                tx.send(format!("t{i}"))
+                tx.send(TurnEvent::TextDelta(format!("t{i}")))
                     .await
                     .map_err(|_| "receiver dropped")?;
             }
@@ -2064,7 +2154,7 @@ mod tests {
     /// Errors from the call are passed through untouched.
     #[tokio::test]
     async fn stream_turn_propagates_call_error() {
-        let (tx, rx) = tokio::sync::mpsc::channel::<String>(8);
+        let (tx, rx) = tokio::sync::mpsc::channel::<TurnEvent>(8);
         let call = async move {
             drop(tx);
             Err::<String, &'static str>("provider exploded")

--- a/crates/garraia-cli/src/ui/mod.rs
+++ b/crates/garraia-cli/src/ui/mod.rs
@@ -69,7 +69,39 @@ pub enum UiEvent<'a> {
     /// aponta o proximo passo. Sem linha em branco antes, porque ela pertence
     /// a mensagem que acabou de sair.
     Hint(&'a str),
+
+    /// Uma ferramenta comecou (#937). `detail` ja vem redigido e truncado do
+    /// `garraia-agents` — o renderer nao ve input cru de ferramenta.
+    ToolStarted { name: &'a str, detail: &'a str },
+
+    /// Uma ferramenta terminou (#937).
+    ToolFinished {
+        name: &'a str,
+        duration: std::time::Duration,
+        success: bool,
+        /// Uma linha sobre o resultado, ja redigida e truncada.
+        summary: &'a str,
+    },
 }
+
+/// Glifos do ciclo de vida de ferramenta (#937), por estado.
+///
+/// O par Unicode/ASCII anda junto com o resto da interface: num terminal sem
+/// UTF-8 o `●` viraria mojibake exatamente como o `❯` viraria.
+struct ToolGlyphs {
+    ok: &'static str,
+    fail: &'static str,
+}
+
+const TOOL_GLYPHS_UNICODE: ToolGlyphs = ToolGlyphs {
+    ok: "\u{25cf}",
+    fail: "\u{d7}",
+};
+const TOOL_GLYPHS_ASCII: ToolGlyphs = ToolGlyphs { ok: "*", fail: "x" };
+
+/// O ramo da arvore que liga o resultado a linha da ferramenta.
+const BRANCH_UNICODE: &str = "  \u{2514}\u{2500} ";
+const BRANCH_ASCII: &str = "  |- ";
 
 /// O que este terminal aguenta, decidido **uma vez so**.
 ///
@@ -157,7 +189,16 @@ pub struct TerminalRenderer {
     caps: Capabilities,
     spinner: Option<Spinner>,
     assistant_prefix: String,
+    /// O rotulo `Garra` ja saiu neste turno? Uma vez so, sempre.
     prefix_written: bool,
+    /// A linha de atividade pode ser desenhada agora?
+    ///
+    /// Separado do `prefix_written` de proposito (#937): o primeiro token
+    /// entrega a linha para a resposta, mas quando uma **ferramenta termina**
+    /// o modelo volta a pensar e a animacao deve voltar — sem que o rotulo
+    /// seja reimpresso. Era o "retomar o spinner depois da tool" que ficou de
+    /// fora do #936 por nao haver evento para ouvir.
+    animating: bool,
 }
 
 impl TerminalRenderer {
@@ -167,6 +208,7 @@ impl TerminalRenderer {
             caps,
             spinner,
             prefix_written: false,
+            animating: true,
         }
     }
 
@@ -187,6 +229,7 @@ impl TerminalRenderer {
             spinner,
             assistant_prefix: prefix.into(),
             prefix_written: false,
+            animating: true,
         }
     }
 
@@ -195,6 +238,7 @@ impl TerminalRenderer {
     pub fn begin_turn(&mut self, spinner: Option<Spinner>) {
         self.spinner = spinner;
         self.prefix_written = false;
+        self.animating = true;
     }
 
     /// Ha animacao rodando neste turno? O `select!` usa isto para nao armar o
@@ -213,13 +257,20 @@ impl TerminalRenderer {
                 self.write_notice(text, conversation::YELLOW, true, out)
             }
             UiEvent::Hint(text) => self.write_notice(text, conversation::DIM, false, out),
+            UiEvent::ToolStarted { name, detail } => self.write_tool_started(name, detail, out),
+            UiEvent::ToolFinished {
+                name,
+                duration,
+                success,
+                summary,
+            } => self.write_tool_finished(name, duration, success, summary, out),
         }
     }
 
     /// Um quadro da animacao — e so antes do primeiro token: depois disso a
     /// linha pertence a resposta, e um quadro colidiria com ela.
     fn tick(&mut self, out: &mut (impl io::Write + ?Sized)) {
-        if self.prefix_written {
+        if !self.animating {
             return;
         }
         if let Some(s) = self.spinner.as_mut() {
@@ -237,6 +288,8 @@ impl TerminalRenderer {
         }
         let _ = write!(out, "{delta}");
         let _ = out.flush();
+        // A linha agora pertence a resposta.
+        self.animating = false;
     }
 
     /// Fim do turno: limpeza **incondicional**, valendo para sucesso, erro do
@@ -256,6 +309,106 @@ impl TerminalRenderer {
             self.prefix_written = true;
         }
         let _ = out.flush();
+    }
+
+    /// `● Bash cargo test` — a ferramenta comecou.
+    ///
+    /// A animacao e limpa antes, sempre: e o criterio de aceite "spinner is
+    /// cleared before a tool event is rendered" da #937, e sem isso o quadro
+    /// da garra ficaria colado na linha da ferramenta.
+    ///
+    /// O glifo do inicio e o mesmo do sucesso de proposito. A alternativa —
+    /// um `◐` que depois vira `●` na mesma linha — exigiria reescrever uma
+    /// linha ja rolada, e este terminal e de fluxo, nao de tela cheia
+    /// (ADR 0017, opcao B rejeitada). O resultado aparece na linha seguinte.
+    fn write_tool_started(
+        &mut self,
+        name: &str,
+        detail: &str,
+        out: &mut (impl io::Write + ?Sized),
+    ) {
+        if let Some(s) = self.spinner.as_mut() {
+            s.clear(out);
+        }
+        // Enquanto a ferramenta roda, quem ocupa a tela e ela.
+        self.animating = false;
+        let glifo = self.tool_glyphs().ok;
+        let rotulo = tool_label(name);
+        let linha = if detail.is_empty() {
+            format!("{glifo} {rotulo}")
+        } else {
+            format!("{glifo} {rotulo} {detail}")
+        };
+        if self.caps.interactive {
+            let _ = writeln!(out, "{}{linha}{}", conversation::DIM, conversation::RESET);
+        } else {
+            let _ = writeln!(out, "{linha}");
+        }
+        let _ = out.flush();
+    }
+
+    /// `  └─ 148 passed · 6.3s` — o resultado, pendurado na linha anterior.
+    ///
+    /// Em falha, o glifo muda e a linha inteira sai na cor de aviso: e o par
+    /// "estados visualmente distintos" + "falha mostra o trecho mais
+    /// relevante" da #937.
+    fn write_tool_finished(
+        &mut self,
+        name: &str,
+        duration: std::time::Duration,
+        success: bool,
+        summary: &str,
+        out: &mut (impl io::Write + ?Sized),
+    ) {
+        if let Some(s) = self.spinner.as_mut() {
+            s.clear(out);
+        }
+        // Ferramenta terminou: o modelo volta a pensar, entao a animacao volta.
+        self.animating = true;
+        let glifos = self.tool_glyphs();
+        let ramo = if self.caps.unicode {
+            BRANCH_UNICODE
+        } else {
+            BRANCH_ASCII
+        };
+        let separador = if self.caps.unicode { " · " } else { " | " };
+        let tempo = format_duration(duration);
+
+        // Sucesso e so o resultado pendurado; falha repete o nome, porque a
+        // linha de inicio pode estar longe depois de uma saida longa.
+        let (corpo, cor) = if success {
+            let corpo = if summary.is_empty() {
+                tempo.clone()
+            } else {
+                format!("{summary}{separador}{tempo}")
+            };
+            (format!("{ramo}{corpo}"), conversation::DIM)
+        } else {
+            let corpo = if summary.is_empty() {
+                format!("falhou{separador}{tempo}")
+            } else {
+                format!("{summary}{separador}{tempo}")
+            };
+            (
+                format!("{} {} {ramo}{corpo}", glifos.fail, tool_label(name)),
+                conversation::YELLOW,
+            )
+        };
+
+        if self.caps.interactive {
+            let _ = writeln!(out, "{cor}{corpo}{}", conversation::RESET);
+        } else {
+            let _ = writeln!(out, "{corpo}");
+        }
+        let _ = out.flush();
+    }
+
+    fn tool_glyphs(&self) -> ToolGlyphs {
+        if self.caps.unicode {
+            TOOL_GLYPHS_UNICODE
+        } else {
+            TOOL_GLYPHS_ASCII
+        }
     }
 
     /// Aviso, erro ou dica. `blank_line_before` separa a mensagem do que veio
@@ -278,6 +431,42 @@ impl TerminalRenderer {
         }
         let _ = out.flush();
     }
+}
+
+/// Nome da ferramenta como o usuario le: `bash` vira `Bash`, `file_read`
+/// vira `Read`.
+///
+/// Mapa explicito em vez de titlecase automatico: `file_read` viraria
+/// "File Read", e o que o operador reconhece e "Read". Ferramenta sem entrada
+/// aqui aparece com o nome cru — honesto, e o pior caso e feio, nao errado.
+fn tool_label(name: &str) -> String {
+    match name {
+        "bash" => "Bash".to_string(),
+        "file_read" => "Read".to_string(),
+        "file_write" => "Write".to_string(),
+        "repo_search" => "Search".to_string(),
+        "web_search" => "Web".to_string(),
+        "web_fetch" => "Fetch".to_string(),
+        "git_diff" => "Diff".to_string(),
+        "list_dir" => "List".to_string(),
+        "run_tests" => "Tests".to_string(),
+        outro => outro.to_string(),
+    }
+}
+
+/// Duracao em uma casa decimal para segundos, inteiro para milissegundos:
+/// `6.3s`, `840ms`. Acima de um minuto, `1m03s`.
+fn format_duration(d: std::time::Duration) -> String {
+    let ms = d.as_millis();
+    if ms < 1000 {
+        return format!("{ms}ms");
+    }
+    let total_s = d.as_secs();
+    if total_s < 60 {
+        let decimos = (ms / 100) % 10;
+        return format!("{total_s}.{decimos}s");
+    }
+    format!("{}m{:02}s", total_s / 60, total_s % 60)
 }
 
 #[cfg(test)]
@@ -315,6 +504,16 @@ mod tests {
                 UiEvent::ActivityTick,
                 UiEvent::ActivityTick,
                 UiEvent::TextDelta("oi"),
+                UiEvent::ToolStarted {
+                    name: "bash",
+                    detail: "cargo test",
+                },
+                UiEvent::ToolFinished {
+                    name: "bash",
+                    duration: std::time::Duration::from_millis(6300),
+                    success: true,
+                    summary: "148 passed",
+                },
                 UiEvent::Warning("cuidado"),
                 UiEvent::Error("quebrou"),
                 UiEvent::TurnFinished,
@@ -453,6 +652,212 @@ mod tests {
             caps.style().user_prompt().trim_end(),
             "\x1b[32m\x1b[1m>\x1b[0m"
         );
+    }
+
+    // ── #937: ciclo de vida de ferramenta ────────────────────────────────
+
+    /// O formato que a issue desenha: linha de inicio, resultado pendurado.
+    #[test]
+    fn ferramenta_bem_sucedida_desenha_inicio_e_resultado() {
+        let saida = render(
+            Capabilities::PLAIN,
+            &[
+                UiEvent::ToolStarted {
+                    name: "bash",
+                    detail: "cargo test",
+                },
+                UiEvent::ToolFinished {
+                    name: "bash",
+                    duration: std::time::Duration::from_millis(6300),
+                    success: true,
+                    summary: "148 passed",
+                },
+            ],
+        );
+        assert_eq!(saida, "* Bash cargo test\n  |- 148 passed | 6.3s\n");
+    }
+
+    #[test]
+    fn ferramenta_bem_sucedida_em_unicode() {
+        let caps = Capabilities {
+            interactive: false,
+            unicode: true,
+            animation: false,
+            width: 80,
+        };
+        let saida = render(
+            caps,
+            &[
+                UiEvent::ToolStarted {
+                    name: "file_read",
+                    detail: "src/runtime.rs",
+                },
+                UiEvent::ToolFinished {
+                    name: "file_read",
+                    duration: std::time::Duration::from_millis(40),
+                    success: true,
+                    summary: "",
+                },
+            ],
+        );
+        assert_eq!(
+            saida,
+            "\u{25cf} Read src/runtime.rs\n  \u{2514}\u{2500} 40ms\n"
+        );
+    }
+
+    /// Falha muda o glifo E repete o nome: depois de uma saida longa, a linha
+    /// de inicio pode estar fora da tela.
+    #[test]
+    fn ferramenta_que_falha_muda_o_glifo_e_repete_o_nome() {
+        let saida = render(
+            Capabilities::PLAIN,
+            &[UiEvent::ToolFinished {
+                name: "bash",
+                duration: std::time::Duration::from_millis(4200),
+                success: false,
+                summary: "error: exit 101",
+            }],
+        );
+        assert_eq!(saida, "x Bash   |- error: exit 101 | 4.2s\n");
+    }
+
+    #[test]
+    fn falha_sem_resumo_ainda_diz_que_falhou() {
+        let saida = render(
+            Capabilities::PLAIN,
+            &[UiEvent::ToolFinished {
+                name: "bash",
+                duration: std::time::Duration::from_secs(2),
+                success: false,
+                summary: "",
+            }],
+        );
+        assert!(saida.contains("falhou"), "{saida:?}");
+    }
+
+    /// Criterio de aceite da #937: a animacao e limpa antes do evento.
+    #[test]
+    fn animacao_e_limpa_antes_do_evento_de_ferramenta() {
+        let caps = rich();
+        let mut renderer = TerminalRenderer::new(caps, caps.spinner(0));
+        let mut out: Vec<u8> = Vec::new();
+        for _ in 0..10 {
+            renderer.handle(UiEvent::ActivityTick, &mut out);
+        }
+        out.clear();
+        renderer.handle(
+            UiEvent::ToolStarted {
+                name: "bash",
+                detail: "ls",
+            },
+            &mut out,
+        );
+        let saida = String::from_utf8(out).expect("UTF-8");
+        assert!(
+            saida.starts_with("\r\x1b[2K"),
+            "nao limpou a animacao antes: {saida:?}"
+        );
+    }
+
+    /// A animacao para enquanto a ferramenta roda — a tela e dela.
+    #[test]
+    fn animacao_para_enquanto_a_ferramenta_roda() {
+        let caps = rich();
+        let mut renderer = TerminalRenderer::new(caps, caps.spinner(0));
+        let mut out: Vec<u8> = Vec::new();
+        for _ in 0..10 {
+            renderer.handle(UiEvent::ActivityTick, &mut out);
+        }
+        renderer.handle(
+            UiEvent::ToolStarted {
+                name: "bash",
+                detail: "ls",
+            },
+            &mut out,
+        );
+        out.clear();
+        for _ in 0..10 {
+            renderer.handle(UiEvent::ActivityTick, &mut out);
+        }
+        assert!(out.is_empty(), "animou por cima da ferramenta: {out:?}");
+    }
+
+    /// E volta quando ela termina — o "retomar o spinner depois da tool" que
+    /// ficou de fora do #936 por nao haver evento para ouvir.
+    #[test]
+    fn animacao_volta_depois_que_a_ferramenta_termina() {
+        let caps = rich();
+        let mut renderer = TerminalRenderer::new(caps, caps.spinner(0));
+        let mut out: Vec<u8> = Vec::new();
+
+        // Texto primeiro: a linha passa a ser da resposta e a animacao para.
+        renderer.handle(UiEvent::TextDelta("vou rodar os testes"), &mut out);
+        out.clear();
+        for _ in 0..10 {
+            renderer.handle(UiEvent::ActivityTick, &mut out);
+        }
+        assert!(out.is_empty(), "animou por cima da resposta");
+
+        renderer.handle(
+            UiEvent::ToolFinished {
+                name: "bash",
+                duration: std::time::Duration::from_secs(1),
+                success: true,
+                summary: "ok",
+            },
+            &mut out,
+        );
+        out.clear();
+        for _ in 0..10 {
+            renderer.handle(UiEvent::ActivityTick, &mut out);
+        }
+        assert!(
+            !out.is_empty(),
+            "a animacao nao voltou depois da ferramenta"
+        );
+    }
+
+    /// E o rotulo `Garra` continua saindo uma vez so — retomar a animacao
+    /// nao pode reimprimi-lo.
+    #[test]
+    fn retomar_a_animacao_nao_reimprime_o_rotulo() {
+        let saida = render(
+            Capabilities::PLAIN,
+            &[
+                UiEvent::TextDelta("antes "),
+                UiEvent::ToolFinished {
+                    name: "bash",
+                    duration: std::time::Duration::from_secs(1),
+                    success: true,
+                    summary: "ok",
+                },
+                UiEvent::TextDelta("depois"),
+                UiEvent::TurnFinished,
+            ],
+        );
+        assert_eq!(saida.matches("Garra").count(), 1, "{saida:?}");
+    }
+
+    #[test]
+    fn rotulo_de_ferramenta_e_o_que_o_operador_reconhece() {
+        assert_eq!(tool_label("bash"), "Bash");
+        assert_eq!(tool_label("file_read"), "Read");
+        assert_eq!(tool_label("file_write"), "Write");
+        assert_eq!(tool_label("repo_search"), "Search");
+        // Ferramenta sem entrada aparece com o nome cru, nao com um erro.
+        assert_eq!(tool_label("ferramenta_nova"), "ferramenta_nova");
+    }
+
+    #[test]
+    fn duracao_muda_de_unidade_conforme_a_escala() {
+        use std::time::Duration;
+        assert_eq!(format_duration(Duration::from_millis(40)), "40ms");
+        assert_eq!(format_duration(Duration::from_millis(999)), "999ms");
+        assert_eq!(format_duration(Duration::from_millis(1000)), "1.0s");
+        assert_eq!(format_duration(Duration::from_millis(6300)), "6.3s");
+        assert_eq!(format_duration(Duration::from_secs(59)), "59.0s");
+        assert_eq!(format_duration(Duration::from_secs(63)), "1m03s");
     }
 
     #[test]

--- a/crates/garraia-security/src/redaction.rs
+++ b/crates/garraia-security/src/redaction.rs
@@ -67,17 +67,39 @@ where
 }
 
 /// Replace known API key patterns with `[REDACTED]`.
+///
+/// A lista cresceu no #937, e vale registrar por que: ate ali o redactor so
+/// via log, onde o que aparece sao as chaves que o *proprio* GarraIA usa
+/// (Anthropic, OpenAI, Slack, Discord). Com os eventos de ferramenta, o mesmo
+/// redactor passou a ver **comando que o agente monta** — e ali entra
+/// credencial de terceiro que o usuario deu no contexto: PAT do GitHub, JWT,
+/// chave da AWS, senha embutida em connection string. Sao esses os padroes
+/// novos.
+///
+/// O que ele **nao** cobre, e continua sendo verdade: segredo sem formato
+/// reconhecivel. `--password minhasenha` ou `-u admin:123456` nao tem prefixo
+/// nem forma que os distinga de texto comum, e um regex que tentasse pegar
+/// "o argumento depois de --password" erraria mais do que acertaria. Quem
+/// olha a tela ve o comando como o agente o montou.
 pub fn redact_secrets(input: &str) -> String {
-    // Patterns: Anthropic, OpenAI, Slack bot/app tokens, generic sk- prefixed keys
     static PATTERNS: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
         regex::Regex::new(
             r"(?x)
+            # --- credenciais do proprio GarraIA (vistas em log) ---
               sk-ant-api\S{10,}    # Anthropic API keys
             | sk-\S{20,}           # OpenAI-style keys
             | xoxb-\S{10,}         # Slack bot tokens
             | xapp-\S{10,}         # Slack app tokens
             | xoxp-\S{10,}         # Slack user tokens
             | Bot\s+[A-Za-z0-9_\-]{30,}  # Discord bot tokens
+
+            # --- credenciais de terceiro que entram por comando de ferramenta (#937) ---
+            | github_pat_[A-Za-z0-9_]{22,}          # GitHub fine-grained PAT
+            | gh[pousr]_[A-Za-z0-9]{20,}            # GitHub PAT/OAuth/user/server/refresh
+            | eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}  # JWT
+            | (?:AKIA|ASIA)[A-Z0-9]{16}             # AWS access key id (fixa e temporaria)
+            | [0-9]{8,10}:AA[A-Za-z0-9_\-]{32,}    # Telegram bot token
+            | ://[^:@/\s]+:[^@/\s]{4,}@           # senha embutida em connection string
             ",
         )
         .expect("redaction regex should compile")
@@ -89,6 +111,87 @@ pub fn redact_secrets(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #937: o redactor passou a ver comando de ferramenta, entao passou a
+    /// precisar dos segredos de terceiro que aparecem ali.
+    #[test]
+    fn redacts_github_tokens() {
+        let classico = format!("ghp_{}", "a".repeat(36));
+        let fine = format!("github_pat_{}", "b".repeat(82));
+        for token in [&classico, &fine] {
+            let saida = redact_secrets(&format!("curl -H 'Authorization: Bearer {token}'"));
+            assert!(!saida.contains(token.as_str()), "vazou: {saida}");
+            assert!(saida.contains("[REDACTED]"), "{saida}");
+        }
+    }
+
+    #[test]
+    fn redacts_jwt() {
+        // Montado em pedacos de proposito. Um JWT literal aqui e um achado
+        // legitimo do `gitleaks`, e foi o que ele pegou na primeira versao
+        // deste teste. As duas saidas eram alargar a allowlist do
+        // `.gitleaks.toml` ou nao escrever o literal — e trocar a forca de um
+        // gate de seguranca pela legibilidade de um vetor de teste e o lado
+        // errado da troca. **Nao junte estas partes numa string so.**
+        let jwt = format!(
+            "{}.{}.{}",
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+            "eyJzdWIiOiIxMjM0NTY3ODkwIn0",
+            "dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+        );
+        let saida = redact_secrets(&format!("Authorization: Bearer {jwt}"));
+        assert!(!saida.contains(&jwt), "vazou: {saida}");
+    }
+
+    #[test]
+    fn redacts_aws_access_key_id() {
+        for prefixo in ["AKIA", "ASIA"] {
+            let chave = format!("{prefixo}IOSFODNN7EXAMPLE");
+            let saida = redact_secrets(&format!("aws --access-key {chave} s3 ls"));
+            assert!(!saida.contains(&chave), "vazou: {saida}");
+        }
+    }
+
+    #[test]
+    fn redacts_telegram_bot_token() {
+        let token = format!("7654321098:AA{}", "F".repeat(33));
+        let saida = redact_secrets(&format!("https://api.telegram.org/bot{token}/sendMessage"));
+        assert!(!saida.contains(&token), "vazou: {saida}");
+    }
+
+    #[test]
+    fn redacts_password_in_connection_string() {
+        let saida = redact_secrets("psql postgres://admin:s3cr3tpass@db.prod.example.com/mydb");
+        assert!(!saida.contains("s3cr3tpass"), "vazou: {saida}");
+        // O host sobrevive: e diagnostico util e nao e o segredo.
+        assert!(saida.contains("db.prod.example.com"), "{saida}");
+    }
+
+    /// Uma URL comum nao pode ser redigida — o redactor roda em todo log.
+    #[test]
+    fn deixa_url_sem_credencial_em_paz() {
+        for url in [
+            "https://api.github.com/repos/x/y",
+            "https://garraia.org/install.sh",
+            "http://127.0.0.1:11434/api/embeddings",
+            "git@github.com:michelbr84/GarraRUST.git",
+        ] {
+            assert_eq!(redact_secrets(url), url, "redigiu URL inocente: {url}");
+        }
+    }
+
+    /// Texto comum tambem nao pode virar `[REDACTED]`.
+    #[test]
+    fn deixa_texto_comum_em_paz() {
+        for texto in [
+            "cargo test --workspace",
+            "crates/garraia-cli/src/chat.rs",
+            "148 passed em 6.3s",
+            "erro: exit 101",
+        ] {
+            assert_eq!(redact_secrets(texto), texto, "redigiu texto comum: {texto}");
+        }
+    }
 
     #[test]
     fn redacts_anthropic_key() {


### PR DESCRIPTION
## Descrição

Primeira capacidade **nova** sobre a camada que o #942 deixou pronta — e a prova de que ela valeu: isto entra como variantes novas de um enum, não como `println!` espalhado pelo runtime.

Até aqui a execução de ferramenta era invisível no `garra chat`. O usuário via o indicador de atividade e, minutos depois, a resposta — sem saber se o agente estava lendo um arquivo, rodando `cargo test` ou parado.

```text
❯ roda os testes e me diz o que quebrou

Garra
Vou rodar a suíte.

● Bash cargo test
  └─ 148 passed · 6.3s

● Read crates/garraia-db/src/memory_store.rs
  └─ 40ms

× Bash cargo clippy
  └─ error: unused variable `x` · 4.2s
```

Saída longa **não** é despejada: vira a primeira linha mais a contagem das outras. Em falha, a primeira linha inteira — é ali que as ferramentas deste projeto põem a causa.

## Um canal, não dois

Por baixo, `garraia-agents` ganha `TurnEvent` e `TurnSink`, e o runtime passa a contar o turno inteiro — texto e ciclo de vida de ferramenta — num canal só.

A alternativa óbvia era um segundo canal, só para eventos, deixando o de texto intacto. **Dois canais não garantem ordem entre si**, e o agente intercala texto e chamada de ferramenta no mesmo turno: o evento da tool poderia ser desenhado depois do texto que veio depois dele.

## Os sete consumidores de texto ficam intactos

`process_message_streaming` tem **8 chamadores** em três camadas de wrapper. Trocar o tipo do canal em todos seria churn grande e sem retorno: o Telegram não tem o que fazer com "Bash começou".

O `TurnSink` aceita **ou** o `Sender<String>` de hoje **ou** um `Sender<TurnEvent>`; num sink de texto os eventos de ferramenta são descartados na origem. Telegram, Slack, Discord, WhatsApp, `openai_api`, `parrot_ws` e o `garra ask` recebem exatamente o que recebiam antes — o que a auditoria confirmou lendo os quatro caminhos. Nenhum canal externo ganha ruído por causa de uma feature de terminal, e é justamente ali que um vazamento seria pior.

## Os dois laços de execução, não um

`stream_turn_with_sink` tem **duas** execuções de ferramenta: o caminho de streaming nativo e o de fallback. O **Ollama, provedor padrão deste projeto, não implementa `stream_complete`** e cai justamente no segundo. Instrumentar só um teria entregue a feature quebrada para o caso mais comum.

## O spinner volta depois da tool

Ele parava no primeiro token e não voltava, então o tempo em que o modelo pensa **depois** de uma ferramenta era prompt morto de novo. O #936 deixou isso de fora por não haver evento para ouvir; agora há.

`animating` virou estado separado de `prefix_written`: a linha volta a ser da animação quando a ferramenta termina, mas o rótulo `Garra` continua saindo **uma vez só** por turno — com teste para os dois.

## Auditoria

`@security-auditor` rodou antes de abrir — **7/10, um achado ALTO**, corrigido no mesmo commit.

### ALTO — o redactor não cobria o que este PR passou a mostrar

A issue pede literalmente "avoid leaking secrets from command arguments or output", e eu apresentei o `redact_secrets` como a garantia. A auditoria foi ler o regex: **seis padrões, todos chaves que o próprio GarraIA usa** (Anthropic, OpenAI, Slack, Discord) — porque até aqui esse redactor só via log.

Com os eventos de ferramenta ele passou a ver **comando que o agente monta**, e ali entra credencial de terceiro que o usuário deu no contexto. Nenhum destes casava:

| Padrão | Exemplo |
| --- | --- |
| GitHub PAT (clássico e fine-grained) | `curl -H "Authorization: Bearer ghp_…"` |
| JWT | `Authorization: Bearer eyJhbGciOi…` |
| AWS access key (fixa e temporária) | `aws --access-key AKIA…` |
| Token de bot do Telegram | `api.telegram.org/bot7654321:AAF…` |
| Senha em connection string | `psql postgres://admin:senha@db/x` |

Todos acrescentados, com teste por padrão — e **dois testes de não-regressão**, porque o mesmo `redact_secrets` roda em todo log do projeto: URL sem credencial e texto comum não podem virar `[REDACTED]`. O ganho vaza para o bem: o `RedactingWriter` herdou a cobertura.

O que ele continua **não** cobrindo está escrito no código: segredo sem formato reconhecível, como `--password minhasenha`. Um regex que tentasse pegar "o argumento depois de `--password`" erraria mais do que acertaria.

### MÉDIO — o ramo genérico contradizia a minha própria regra

Eu escrevi no módulo que "ferramenta nova não pode vazar segredo só por ainda não ter caso próprio", e logo abaixo fiz o ramo genérico adivinhar o primeiro valor textual do input. `serde_json::Map` preserva ordem de inserção: uma ferramenta com `{"connection_string": …, "query": …}` exibiria a connection string.

Agora devolve vazio. Ferramenta nova aparece só com o nome até alguém dizer qual campo dela interessa.

### BAIXO — caminho de arquivo aparece inteiro

Fica como está, e virou documentação: `Read ~/.ssh/id_rsa` é **exatamente** a informação que a issue quer dar ao operador. O caminho não é o segredo; o conteúdo é, e ele não sai daqui.

### O que a auditoria confirmou como correto

A ordem redigir-depois-truncar (truncar antes cortaria uma chave ao meio e deixaria o prefixo passar); que a expansão de `$TOKEN` acontece no shell **depois** do evento, então a variável aparece literal e não o valor; que nenhum `info!`/`warn!` novo carrega conteúdo de ferramenta; que o refactor `_with_agent_config` → `stream_turn_with_sink` é semântica-preservante nos cinco envios de delta; e que a instrumentação não introduz ponto de bloqueio novo no canal limitado — o pior caso teórico (48 ferramentas sem texto entre elas) enche 96 dos 100 slots e o receptor drena a cada `.await`.

## Tipo de mudança

- [x] `feat`: Nova funcionalidade
- [x] `sec`: Hardening (cobertura do redactor)
- [x] `test`: Adição de testes

## Classe de Risco

- [x] **Classe C (Alto Risco)**: o PR passa a **imprimir na tela** input e output de ferramenta que antes não apareciam em lugar nenhum, e mexe no redactor que todo log do projeto usa. Não toca auth, RLS nem schema, mas exposição nova de dado é o critério que importa. Auditoria rodou antes de abrir.

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo +1.95 fmt --all` executado e limpo
- [x] `cargo +1.95 clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings` sem erros
- [x] `cargo +1.95 test --workspace --exclude garraia-desktop` passando — única falha é a ambiental conhecida `migration_001_applies_and_schema_is_sane`, que exige `docker.sock`; o CI valida
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo, API key, token ou credencial commitada (os dos testes são sintéticos)
- [x] Nenhuma migração — este PR não toca banco

### Para alterações de Alto Risco (Classe C)

- [x] Redação **na origem**, não no renderer: qualquer consumidor futuro de `TurnEvent` herda a garantia sem precisar lembrar dela
- [x] Teste de não-regressão do redactor (URL e texto comum não podem ser redigidos — ele roda em todo log)
- [x] Verificado que nenhum evento de ferramenta escapa para canal externo
- [ ] Verificação de políticas RLS — não se aplica: nada aqui toca banco

## Mudanças na API pública e Schema

- **`garraia-agents`:** `TurnEvent`, `TurnSink`, `summarize_tool_input`, `summarize_tool_output`; método novo `process_message_streaming_with_events`. `process_message_streaming{,_with_context,_with_agent_config}` mantêm a assinatura — delegam para um `stream_turn_with_sink` privado. Dependência nova: `garraia-security`.
- **`garraia-security`:** `redact_secrets` cobre cinco famílias de padrão a mais. Nenhuma mudança de assinatura.
- **CLI:** `UiEvent::ToolStarted` / `ToolFinished`; `stream_turn` passa a receber `Receiver<TurnEvent>` (função privada).
- Sem mudança de schema, sem migração, sem chave de config nova.

## Como testar

```bash
cargo +1.95 test -p garraia-agents turn_events        # 14: resumo, redacao, ordem do sink
cargo +1.95 test -p garraia-security redact           # 12: cada padrao + nao-regressao
cargo +1.95 test -p garraia --bin garra ui::          # 55: estados da ferramenta, ASCII, nao-TTY
cargo +1.95 test -p garraia --bin garra stream_turn   # a ponte TurnEvent -> UiEvent no caminho real
```

Fim a fim, com um provedor que chame ferramenta:

```bash
garra chat                        # "roda os testes" -> as duas linhas por chamada
NO_COLOR=1 garra chat             # sem cor, glifo ASCII
LANG=C garra chat                 # `*` e `|-` no lugar de `●` e `└─`
garra chat 2>/dev/null | cat      # sem escape algum nas linhas de ferramenta
```

## Plano de Rollback

Reverter o merge. Nada persistido, nada de config, nada de schema. O que se perde é a visibilidade e a cobertura nova do redactor — e o `stream_turn` volta a receber `Receiver<String>`. As issues #938 e #941 voltam a não ter onde se apoiar.

## O que fica para o próximo PR

**#938** (sumarização com inspeção explícita do output completo). Este PR já cobre o "não despejar por padrão", que é metade da issue; o que falta é o **mecanismo de inspeção** — onde o output inteiro fica e como o usuário o pede. É superfície nova e merece o seu próprio diff.

Closes #937

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF

---
_Generated by [Claude Code](https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF)_