### PR TITLE
fix(memory): ruído para de poluir a busca semântica (#952)

### DIFF
--- a/changelog.d/fixed/952-ruido-na-ingestao-da-memoria.md
+++ b/changelog.d/fixed/952-ruido-na-ingestao-da-memoria.md
@@ -1,0 +1,17 @@
+- **Turno curto ou puramente social deixa de poluir a busca semantica (#952).**
+  `"oi"`, `"ok"`, `"kkkk"` e `"bom dia"` eram embeddados como qualquer outra
+  mensagem e disputavam o top-K com memoria de verdade — texto curto tem
+  cosseno alto com quase tudo. Numa base de ~7.100 entradas, "quem e Michel"
+  trazia entradas `"oi"` entre os primeiros resultados. Agora a ingestao
+  decide se vale gastar um vetor: a entrada **continua gravada** e achavel
+  pelo recall textual, so nao entra no indice vetorial. A regra de frase so
+  casa com o conteudo **inteiro** (`"obrigado"` e ruido, `"obrigado pela
+  ajuda com o deploy"` nao), e nada e apagado nem retroativo — vetor de ruido
+  ja indexado continua onde esta. Configuravel em `memory.ingestion`
+  (`filter_noise`, `min_chars`, `extra_noise_phrases`), validado pelo
+  `garra config check`, documentado em `docs/src/memory-ingestion.md`.
+  `garra memory reindex` usa a **mesma** politica — com politicas divergentes
+  ele reembeddaria uma por uma as entradas que a ingestao acabou de pular — e
+  passa a separar no relatorio o que seria reindexado do que fica sem vetor
+  de proposito, para que o total de "sem vetor" do `stats` pare de parecer
+  defeito.

--- a/crates/garraia-agents/src/lib.rs
+++ b/crates/garraia-agents/src/lib.rs
@@ -11,6 +11,7 @@ pub mod embeddings;
 pub mod execution_budget;
 pub mod llama_cpp;
 pub mod memory_extractor;
+pub mod memory_noise;
 pub mod memory_reindex;
 pub mod modes;
 pub mod multi_agent;
@@ -36,8 +37,10 @@ pub use embeddings::{
 };
 pub use execution_budget::ExecutionBudget;
 pub use llama_cpp::{KvCacheType, LlamaCppConfig, LlamaCppProvider};
+pub use memory_noise::{DEFAULT_MIN_CHARS, DEFAULT_NOISE_PHRASES, MIN_CHARS_MAX, NoisePolicy};
 pub use memory_reindex::{
-    DEFAULT_REINDEX_BATCH_SIZE, ReindexOptions, ReindexReport, reindex_missing_embeddings,
+    DEFAULT_REINDEX_BATCH_SIZE, ReindexOptions, ReindexReport, preview_reindex,
+    reindex_missing_embeddings,
 };
 pub use modes::{
     AgentMode, ModeContext, ModeEngine, ModeLimits, ModeLlmConfig, ModeProfile, ToolPolicy,

--- a/crates/garraia-agents/src/memory_noise.rs
+++ b/crates/garraia-agents/src/memory_noise.rs
@@ -1,0 +1,479 @@
+//! Politica de ruido na ingestao da memoria semantica (#952).
+//!
+//! O sintoma relatado: numa base de ~7.100 entradas, a consulta "quem e
+//! Michel" trazia entradas `"oi"` no top-K. Vetor de texto curto tem cosseno
+//! alto com quase tudo, entao "oi" competia com memoria de verdade — e a
+//! proporcao ruido/sinal so cresce com o tempo.
+//!
+//! # O que esta politica faz, e o que ela NAO faz
+//!
+//! Ela decide **se vale gastar um vetor** com um conteudo. Nada mais.
+//!
+//! - A entrada **continua sendo gravada**. O historico nao perde nada, e o
+//!   caminho textual do recall continua achando-a.
+//! - Nada e apagado. Desligar a politica e reindexar devolve o vetor.
+//! - Vetores de ruido que ja estao no indice **ficam**: isto e um filtro de
+//!   ingestao, nao uma limpeza retroativa. Quem quiser limpar o passado usa
+//!   `garra memory compact` / TTL (#956, #959), que apagam de verdade e por
+//!   isso pedem decisao explicita do operador.
+//!
+//! # Por que ela e conservadora
+//!
+//! Errar para o lado de embeddar ruido custa ranking. Errar para o outro lado
+//! custa **memoria que o agente deveria ter e nao tem** — e o usuario nao tem
+//! como saber que perdeu. Por isso a regra de frase so casa quando a frase e
+//! o **conteudo inteiro**: `"obrigado"` e ruido, `"obrigado pela ajuda com o
+//! deploy do gateway"` nao e.
+
+/// Conteudo que nao merece vetor.
+///
+/// Construida a partir da config (`memory.ingestion`) no bootstrap; o
+/// `garraia-agents` nao depende de `garraia-config`, entao a politica chega
+/// como dado puro.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NoisePolicy {
+    enabled: bool,
+    min_chars: usize,
+    /// Frases que, sozinhas, sao o conteudo inteiro de uma entrada de ruido.
+    /// Ja normalizadas na construcao.
+    phrases: Vec<String>,
+}
+
+/// Piso de caracteres uteis abaixo do qual o conteudo nao ganha vetor.
+///
+/// Quatro, e nao os 10 ou 12 que pegariam "bom dia" por comprimento: a lista
+/// de frases faz esse trabalho com precisao, e um piso alto derrubaria junto
+/// um fato curto de verdade ("moro em SP" tem 10). O piso cobre o caso que a
+/// issue relata — `oi`, `ok`, `ta`, `sim`, `nao`, `kkk` — sem apostar em
+/// tamanho como proxy de conteudo.
+pub const DEFAULT_MIN_CHARS: usize = 4;
+
+/// Faixa aceita para `memory.ingestion.min_chars`.
+///
+/// Zero desliga o piso sem desligar a politica (a lista de frases segue
+/// valendo). O teto de 40 nao e arbitrario: acima disso o numero deixa de ser
+/// "filtro de ruido" e vira uma politica de o que lembrar, que ninguem
+/// consegue prever pelo nome da chave.
+pub const MIN_CHARS_MAX: usize = 40;
+
+/// Frases que sao ruido quando sao o conteudo **inteiro**.
+///
+/// PT primeiro porque e a lingua do projeto; o punhado de EN cobre o teclado
+/// de quem alterna. Cada uma esta aqui por ser um ato de fala sem conteudo
+/// proprio — saudacao, confirmacao, agradecimento, despedida. Nenhuma delas
+/// diz nada que o agente queira lembrar seis meses depois.
+pub const DEFAULT_NOISE_PHRASES: &[&str] = &[
+    // saudacao / despedida
+    "oi",
+    "ola",
+    "opa",
+    "e ai",
+    "eai",
+    "fala",
+    "bom dia",
+    "boa tarde",
+    "boa noite",
+    "ate mais",
+    "ate logo",
+    "tchau",
+    "falou",
+    "abraco",
+    "abracos",
+    // confirmacao / negacao
+    "ok",
+    "okay",
+    "ta",
+    "ta bom",
+    "tabom",
+    "ta bem",
+    "tudo bem",
+    "tudo certo",
+    "certo",
+    "claro",
+    "sim",
+    "nao",
+    "pode ser",
+    "pode sim",
+    "isso",
+    "isso mesmo",
+    "exato",
+    "beleza",
+    "blz",
+    "show",
+    "perfeito",
+    "otimo",
+    "legal",
+    "entendi",
+    "entendido",
+    "saquei",
+    "uhum",
+    "aham",
+    "hmm",
+    "hm",
+    // agradecimento / cortesia
+    "obrigado",
+    "obrigada",
+    "obg",
+    "vlw",
+    "valeu",
+    "de nada",
+    "por nada",
+    "imagina",
+    "por favor",
+    "pfv",
+    "desculpa",
+    "desculpe",
+    // EN de teclado alternado
+    "hi",
+    "hello",
+    "hey",
+    "yes",
+    "no",
+    "yep",
+    "nope",
+    "sure",
+    "thanks",
+    "thank you",
+    "thx",
+    "cool",
+    "nice",
+    "great",
+    "got it",
+    "bye",
+];
+
+impl Default for NoisePolicy {
+    fn default() -> Self {
+        Self::new(true, DEFAULT_MIN_CHARS, &[])
+    }
+}
+
+impl NoisePolicy {
+    /// `extras` sao acrescentadas a [`DEFAULT_NOISE_PHRASES`], nunca a
+    /// substituem: a config e aditiva de proposito, para que uma lista
+    /// escrita a mao nao apague silenciosamente a cobertura padrao numa
+    /// atualizacao.
+    pub fn new(enabled: bool, min_chars: usize, extras: &[String]) -> Self {
+        let mut phrases: Vec<String> = DEFAULT_NOISE_PHRASES
+            .iter()
+            .map(|p| normalize(p))
+            .filter(|p| !p.is_empty())
+            .collect();
+        phrases.extend(
+            extras
+                .iter()
+                .map(|p| normalize(p))
+                .filter(|p| !p.is_empty()),
+        );
+        phrases.sort();
+        phrases.dedup();
+        Self {
+            enabled,
+            min_chars,
+            phrases,
+        }
+    }
+
+    /// Politica que nunca filtra nada — o comportamento anterior ao #952.
+    pub fn disabled() -> Self {
+        Self::new(false, 0, &[])
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub fn min_chars(&self) -> usize {
+        self.min_chars
+    }
+
+    /// `true` quando o conteudo nao deve receber vetor.
+    ///
+    /// Com a politica desligada devolve `false` para **tudo**, inclusive para
+    /// conteudo vazio: quem desliga o filtro pediu o comportamento anterior
+    /// inteiro, e a recusa de conteudo vazio ja e do `MemoryStore`.
+    pub fn is_noise(&self, content: &str) -> bool {
+        if !self.enabled {
+            return false;
+        }
+
+        let normalizado = normalize(content);
+
+        // Conteudo que some na normalizacao e so pontuacao ou emoji: "?!",
+        // "...", "👍". Nao ha o que embeddar.
+        if normalizado.is_empty() {
+            return true;
+        }
+        if normalizado.chars().count() < self.min_chars {
+            return true;
+        }
+        if self.phrases.iter().any(|p| p == &normalizado) {
+            return true;
+        }
+        e_so_risada(&normalizado)
+    }
+}
+
+/// Reduz o conteudo ao que interessa para comparar: minusculas, sem acento,
+/// sem pontuacao nem emoji, espacos colapsados.
+///
+/// Nao e normalizacao Unicode completa (nao ha `unicode-normalization` na
+/// arvore e nao vale uma dependencia para isto): cobre a faixa latina que o
+/// portugues usa, que e o alfabeto em que o ruido deste projeto e escrito.
+fn normalize(s: &str) -> String {
+    let mut saida = String::with_capacity(s.len());
+    let mut espaco_pendente = false;
+
+    for c in s.chars() {
+        let c = sem_acento(c.to_lowercase().next().unwrap_or(c));
+        if c.is_alphanumeric() {
+            if espaco_pendente && !saida.is_empty() {
+                saida.push(' ');
+            }
+            espaco_pendente = false;
+            saida.push(c);
+        } else {
+            // Pontuacao, emoji e espaco viram o mesmo separador: "ok!!!" e
+            // "ok" precisam colidir, e "bom-dia" tambem.
+            espaco_pendente = true;
+        }
+    }
+
+    saida
+}
+
+fn sem_acento(c: char) -> char {
+    match c {
+        'á' | 'à' | 'â' | 'ã' | 'ä' | 'å' => 'a',
+        'é' | 'è' | 'ê' | 'ë' => 'e',
+        'í' | 'ì' | 'î' | 'ï' => 'i',
+        'ó' | 'ò' | 'ô' | 'õ' | 'ö' => 'o',
+        'ú' | 'ù' | 'û' | 'ü' => 'u',
+        'ç' => 'c',
+        'ñ' => 'n',
+        outro => outro,
+    }
+}
+
+/// `true` quando o conteudo inteiro e risada.
+///
+/// `kkkkkk`, `hahaha`, `rsrsrs` e `hehe` sao o ruido mais comum de chat em
+/// portugues e passariam pelo piso de caracteres por serem longos. So casa a
+/// **string inteira**: "kkkk pode ser" nao e risada pura e nao entra aqui —
+/// a lista de frases e o piso ja tiveram a chance deles.
+fn e_so_risada(normalizado: &str) -> bool {
+    let compacto: String = normalizado.chars().filter(|c| !c.is_whitespace()).collect();
+    if compacto.chars().count() < 3 {
+        return false;
+    }
+
+    if compacto.chars().all(|c| c == 'k') {
+        return true;
+    }
+
+    // Repeticao de silaba: hahaha, hehe, rsrsrs, huehue.
+    //
+    // Daqui para baixo o codigo conta **bytes** (`len`, `chunks`) e nao
+    // caracteres, e isso e seguro por uma razao que vale escrever: todas as
+    // silabas sao ASCII, e todo byte de um caractere UTF-8 multi-byte tem o
+    // bit alto ligado (>= 0x80). Nenhum pedaco de texto grego, cirilico ou
+    // CJK pode entao casar com uma silaba, mesmo que o comprimento em bytes
+    // seja multiplo de `n` — os bytes nao coincidem. `chunks(n)` com `n >= 1`
+    // tambem nunca entra em panico. Se um dia entrar aqui uma silaba
+    // nao-ASCII, esta invariante cai e a comparacao precisa passar a ser por
+    // caractere.
+    for silaba in ["ha", "he", "hi", "rs", "hue"] {
+        let n = silaba.len();
+        if compacto.len() >= n * 2
+            && compacto.len().is_multiple_of(n)
+            && compacto
+                .as_bytes()
+                .chunks(n)
+                .all(|ch| ch == silaba.as_bytes())
+        {
+            return true;
+        }
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn padrao() -> NoisePolicy {
+        NoisePolicy::default()
+    }
+
+    #[test]
+    fn o_ruido_relatado_na_issue_e_filtrado() {
+        let p = padrao();
+        for ruido in ["oi", "ok", "kkk", "tá", "Oi!", "OK.", "ok!!!", "  ok  "] {
+            assert!(p.is_noise(ruido), "deveria ser ruido: {ruido:?}");
+        }
+    }
+
+    #[test]
+    fn saudacao_e_agradecimento_inteiros_sao_ruido() {
+        let p = padrao();
+        for ruido in [
+            "bom dia",
+            "Bom dia!",
+            "boa noite",
+            "obrigado",
+            "Obrigada :)",
+            "valeu",
+            "de nada",
+            "beleza",
+            "entendi",
+            "tudo bem",
+            "thanks",
+            "got it",
+        ] {
+            assert!(p.is_noise(ruido), "deveria ser ruido: {ruido:?}");
+        }
+    }
+
+    /// O ponto mais importante do modulo: a frase so e ruido quando e o
+    /// conteudo **inteiro**. Uma regra de substring apagaria o eixo semantico
+    /// de memoria de verdade.
+    #[test]
+    fn frase_de_ruido_dentro_de_conteudo_real_nao_filtra() {
+        let p = padrao();
+        for real in [
+            "obrigado pela ajuda com o deploy do gateway",
+            "bom dia, preciso do relatorio de vendas de marco",
+            "ok, entao vamos usar Postgres em vez de SQLite",
+            "beleza mas o teste de RLS ainda falha no CI",
+            "sim, meu nome e Michel e eu moro na Florida",
+        ] {
+            assert!(!p.is_noise(real), "nao deveria ser ruido: {real:?}");
+        }
+    }
+
+    #[test]
+    fn fato_curto_de_verdade_sobrevive() {
+        let p = padrao();
+        for fato in ["moro em SP", "uso Rust", "sou o Michel", "prefiro pt-BR"] {
+            assert!(!p.is_noise(fato), "nao deveria ser ruido: {fato:?}");
+        }
+    }
+
+    #[test]
+    fn risada_inteira_e_ruido_mas_risada_com_conteudo_nao_e() {
+        let p = padrao();
+        for risada in ["kkkk", "kkkkkkkkkk", "hahaha", "hehe", "rsrsrs", "huehue"] {
+            assert!(p.is_noise(risada), "deveria ser ruido: {risada:?}");
+        }
+        for real in [
+            "kkkk pode ser, mas o build quebrou",
+            "hahaha esse teste passou de primeira",
+        ] {
+            assert!(!p.is_noise(real), "nao deveria ser ruido: {real:?}");
+        }
+    }
+
+    /// Palavra que apenas *comeca* com uma silaba de risada nao pode casar.
+    #[test]
+    fn palavra_que_parece_risada_nao_e_risada() {
+        let p = padrao();
+        for real in ["hardware", "heroku", "historico", "hierarquia"] {
+            assert!(!p.is_noise(real), "nao deveria ser ruido: {real:?}");
+        }
+    }
+
+    /// Ancora a invariante documentada em `e_so_risada`: texto nao-ASCII com
+    /// comprimento em bytes multiplo do tamanho de uma silaba nao pode ser
+    /// confundido com risada. Apontada pela auditoria do #952.
+    #[test]
+    fn texto_nao_ascii_nao_vira_risada_por_coincidencia_de_bytes() {
+        let p = padrao();
+        for texto in [
+            "ключевое",   // cirilico, 2 bytes/char
+            "αβγδεζ",     // grego, 2 bytes/char
+            "日本語です", // CJK, 3 bytes/char
+            "한국어입니다",
+        ] {
+            assert!(
+                !p.is_noise(texto),
+                "texto nao-ASCII classificado como risada: {texto:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn so_pontuacao_ou_emoji_e_ruido() {
+        let p = padrao();
+        for vazio in ["?!", "...", "👍", "🙂🙂", "   ", "!!!"] {
+            assert!(p.is_noise(vazio), "deveria ser ruido: {vazio:?}");
+        }
+    }
+
+    #[test]
+    fn desligada_nao_filtra_nada() {
+        let p = NoisePolicy::disabled();
+        for qualquer in ["oi", "ok", "kkkk", "?!", "", "bom dia"] {
+            assert!(
+                !p.is_noise(qualquer),
+                "filtrou com a politica desligada: {qualquer:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn min_chars_zero_desliga_o_piso_e_mantem_as_frases() {
+        let p = NoisePolicy::new(true, 0, &[]);
+        // "eh" passa: nao esta na lista e o piso esta desligado.
+        assert!(!p.is_noise("eh"));
+        // A lista continua valendo.
+        assert!(p.is_noise("bom dia"));
+        assert!(p.is_noise("ok"));
+    }
+
+    #[test]
+    fn extras_somam_e_nao_substituem_a_lista_padrao() {
+        let p = NoisePolicy::new(true, DEFAULT_MIN_CHARS, &["salve familia".to_string()]);
+        assert!(p.is_noise("Salve, familia!"), "extra nao entrou");
+        assert!(p.is_noise("bom dia"), "extra apagou a lista padrao");
+    }
+
+    #[test]
+    fn extras_sao_normalizadas_como_o_conteudo() {
+        let p = NoisePolicy::new(true, DEFAULT_MIN_CHARS, &["  ATÉ  Mais!! ".to_string()]);
+        assert!(p.is_noise("ate mais"));
+        assert!(p.is_noise("Até mais."));
+    }
+
+    #[test]
+    fn extra_vazia_e_ignorada_e_nao_engole_conteudo_normal() {
+        // Uma entrada em branco na config nao pode virar uma frase que casa
+        // com tudo que normaliza para vazio — isso ja e coberto pelo ramo de
+        // string vazia, mas a lista nao pode ganhar um elemento fantasma.
+        let p = NoisePolicy::new(
+            true,
+            DEFAULT_MIN_CHARS,
+            &["".to_string(), "   ".to_string()],
+        );
+        assert!(!p.is_noise("preciso lembrar do deploy de sexta"));
+    }
+
+    #[test]
+    fn normalize_colapsa_espaco_e_pontuacao() {
+        assert_eq!(normalize("Bom   dia!!!"), "bom dia");
+        assert_eq!(normalize("bom-dia"), "bom dia");
+        assert_eq!(normalize("  OK  "), "ok");
+        assert_eq!(normalize("Até logo…"), "ate logo");
+        assert_eq!(normalize("ção"), "cao");
+        assert_eq!(normalize("👍"), "");
+    }
+
+    /// Acento nao pode mudar a decisao: `tá` e `ta` sao a mesma coisa.
+    #[test]
+    fn acento_nao_muda_a_decisao() {
+        let p = padrao();
+        assert_eq!(p.is_noise("tá"), p.is_noise("ta"));
+        assert_eq!(p.is_noise("está tudo bem"), p.is_noise("esta tudo bem"));
+        assert_eq!(p.is_noise("ótimo"), p.is_noise("otimo"));
+    }
+}

--- a/crates/garraia-agents/src/memory_reindex.rs
+++ b/crates/garraia-agents/src/memory_reindex.rs
@@ -12,6 +12,7 @@ use garraia_db::MemoryStore;
 use tracing::{info, warn};
 
 use crate::embeddings::EmbeddingProvider;
+use crate::memory_noise::NoisePolicy;
 
 /// Quantas entradas por ida ao provider.
 ///
@@ -26,8 +27,14 @@ pub struct ReindexOptions {
     pub batch_size: usize,
     /// Teto de entradas a processar. `None` = ate acabar a fila.
     pub max_entries: Option<usize>,
-    /// So conta o que seria feito, sem chamar o provider nem gravar.
-    pub dry_run: bool,
+    /// #952: a **mesma** politica de ruido da ingestao.
+    ///
+    /// Tem que ser a mesma, e nao um default local: uma entrada que a
+    /// ingestao pulou por ser ruido fica com `embedding IS NULL`, que e
+    /// exatamente o que este comando procura. Com politicas diferentes, o
+    /// `garra memory reindex` reembeddaria "oi" e "bom dia" um por um,
+    /// desfazendo o filtro e pagando provider por isso.
+    pub noise: NoisePolicy,
 }
 
 impl Default for ReindexOptions {
@@ -35,7 +42,7 @@ impl Default for ReindexOptions {
         Self {
             batch_size: DEFAULT_REINDEX_BATCH_SIZE,
             max_entries: None,
-            dry_run: false,
+            noise: NoisePolicy::default(),
         }
     }
 }
@@ -51,9 +58,80 @@ pub struct ReindexReport {
     pub reindexed: usize,
     /// Entradas que sumiram entre listar e gravar — nao e erro.
     pub vanished: usize,
+    /// #952: entradas que ficam sem vetor de proposito, por serem ruido.
+    ///
+    /// Elas continuam com `embedding IS NULL`, entao continuam contadas em
+    /// `pending_before` e no `garra memory stats`. Este numero e o que
+    /// explica por que aquele total nao vai a zero.
+    pub skipped_noise: usize,
+    /// Quantas entradas **seriam** reindexadas. So preenchido em `dry_run`.
+    pub would_reindex: usize,
     /// `true` quando o provider falhou e a reindexacao parou no meio.
     pub stopped_early: bool,
     pub dry_run: bool,
+}
+
+/// Conta o que uma reindexacao faria, sem provider e sem gravar (#952).
+///
+/// Nao precisa de `EmbeddingProvider` **e a assinatura diz isso**: em dry-run
+/// nenhum vetor e pedido, entao exigir um provider seria recusar a pergunta
+/// "quanto tem para fazer?" justamente a quem ainda nao configurou um.
+///
+/// Antes do #952 esta resposta era so `entries_without_embedding`, e agora
+/// esse numero passou a incluir entradas que ficam sem vetor **de proposito**.
+/// Sem separar as duas coisas, o total nunca vai a zero e o operador nao tem
+/// como saber se isso e saude ou defeito.
+pub fn preview_reindex(store: &MemoryStore, options: &ReindexOptions) -> Result<ReindexReport> {
+    let pending_before = store.integrity_report()?.entries_without_embedding;
+    let mut report = ReindexReport {
+        pending_before,
+        index_repaired: 0,
+        reindexed: 0,
+        vanished: 0,
+        skipped_noise: 0,
+        would_reindex: 0,
+        stopped_early: false,
+        dry_run: true,
+    };
+    if pending_before == 0 {
+        return Ok(report);
+    }
+
+    let batch_size = options.batch_size.max(1);
+    // Em dry-run nada sai da fila, entao o cursor avanca sobre **tudo** que
+    // foi olhado — senao a mesma pagina se repetiria para sempre.
+    let mut cursor: Option<(chrono::DateTime<chrono::Utc>, String)> = None;
+    let mut examinadas = 0usize;
+
+    loop {
+        let restante = match options.max_entries {
+            Some(teto) => teto.saturating_sub(examinadas),
+            None => batch_size,
+        };
+        if restante == 0 {
+            break;
+        }
+
+        let lote = store.entries_missing_embeddings_after(
+            batch_size.min(restante),
+            cursor.as_ref().map(|(ts, id)| (*ts, id.as_str())),
+        )?;
+        let Some(ultima) = lote.last() else {
+            break;
+        };
+        cursor = Some((ultima.created_at, ultima.id.clone()));
+
+        for entrada in &lote {
+            if options.noise.is_noise(&entrada.content) {
+                report.skipped_noise += 1;
+            } else {
+                report.would_reindex += 1;
+            }
+            examinadas += 1;
+        }
+    }
+
+    Ok(report)
 }
 
 /// Reprocessa entradas gravadas sem vetor.
@@ -76,19 +154,23 @@ pub async fn reindex_missing_embeddings(
         index_repaired: 0,
         reindexed: 0,
         vanished: 0,
+        skipped_noise: 0,
+        would_reindex: 0,
         stopped_early: false,
-        dry_run: options.dry_run,
+        dry_run: false,
     };
-
-    if options.dry_run {
-        return Ok(report);
-    }
 
     // Reparo barato primeiro: reinserir no indice um vetor que ja esta na
     // coluna nao custa chamada de provider nenhuma, e sem isso o `reindex`
     // deixaria de fora justamente as entradas que o `remember_sync` gravou
     // enquanto o sqlite-vec estava fora — elas nao aparecem em
     // `entries_missing_embeddings`, que procura `embedding IS NULL`.
+    //
+    // A politica de ruido do #952 nao se aplica a este reparo, de proposito:
+    // estas entradas **ja tem** o vetor na coluna, gravado antes de a politica
+    // existir ou com ela desligada. Deixa-las fora do indice seria uma
+    // limpeza retroativa disfarcada de reparo, e apagar passado e decisao do
+    // operador (`garra memory compact`), nunca efeito colateral de reindexar.
     report.index_repaired =
         store.reindex_missing_index_rows(options.max_entries.unwrap_or(usize::MAX))?;
     if report.index_repaired > 0 {
@@ -104,18 +186,49 @@ pub async fn reindex_missing_embeddings(
 
     let batch_size = options.batch_size.max(1);
 
+    // Onde a fila parou. Chave da ultima linha vista, nao um `OFFSET`: o
+    // `memory_retention_worker` do gateway apaga entradas em paralelo, e um
+    // ponteiro numerico se desloca quando uma linha some antes dele — o lote
+    // seguinte pularia uma entrada legitima, que ficaria sem vetor ate a
+    // proxima reindexacao manual. Ver `entries_missing_embeddings_after`.
+    let mut cursor: Option<(chrono::DateTime<chrono::Utc>, String)> = None;
+    // Tudo que ja foi olhado — reindexado, sumido ou pulado. E o que o teto
+    // de `--limit` limita: pular ruido tambem e trabalho, e sem contar aqui
+    // um `--limit 10` numa base so de ruido varreria a base inteira.
+    let mut examinadas = 0usize;
+
     loop {
         let restante = match options.max_entries {
-            Some(teto) => teto.saturating_sub(report.reindexed + report.vanished),
+            Some(teto) => teto.saturating_sub(examinadas),
             None => batch_size,
         };
         if restante == 0 {
             break;
         }
 
-        let lote = store.entries_missing_embeddings(batch_size.min(restante))?;
-        if lote.is_empty() {
+        let lote = store.entries_missing_embeddings_after(
+            batch_size.min(restante),
+            cursor.as_ref().map(|(ts, id)| (*ts, id.as_str())),
+        )?;
+        let Some(ultima) = lote.last() else {
             break;
+        };
+        // O cursor avanca sobre o lote **inteiro**, antes de qualquer
+        // gravacao: toda linha daqui ja foi decidida, e nenhuma precisa ser
+        // olhada de novo nesta execucao.
+        cursor = Some((ultima.created_at, ultima.id.clone()));
+        examinadas += lote.len();
+
+        // `partition` preserva a ordem relativa dentro de cada metade, o que
+        // mantem o pareamento texto <-> vetor mais abaixo.
+        let (ruido, lote): (Vec<_>, Vec<_>) = lote
+            .into_iter()
+            .partition(|e| options.noise.is_noise(&e.content));
+        report.skipped_noise += ruido.len();
+        if lote.is_empty() {
+            // Lote inteiro era ruido. Nao ha o que mandar ao provider, e o
+            // cursor ja avancou: a proxima volta olha adiante.
+            continue;
         }
 
         let textos: Vec<String> = lote.iter().map(|e| e.content.clone()).collect();
@@ -149,29 +262,25 @@ pub async fn reindex_missing_embeddings(
             break;
         }
 
-        let mut gravou_algo = false;
         for (entrada, vetor) in lote.iter().zip(vetores) {
             if store.set_embedding(&entrada.id, &vetor, &model)? {
                 report.reindexed += 1;
-                gravou_algo = true;
             } else {
                 report.vanished += 1;
             }
         }
 
-        // Sem isto, um lote que nao grava nada devolveria as mesmas linhas
-        // para sempre — a fila vem do banco, e o que nao foi gravado continua
-        // nela.
-        if !gravou_algo {
-            report.stopped_early = true;
-            break;
-        }
+        // O guard antigo ("se nao gravou nada, para") saiu junto com o
+        // #952: um lote inteiro de ruido nao grava nada e nao e motivo para
+        // parar. O progresso e garantido pelo cursor, que avanca sobre o lote
+        // inteiro antes de qualquer decisao — nenhuma linha ja olhada volta.
     }
 
     info!(
         index_repaired = report.index_repaired,
         reindexed = report.reindexed,
         vanished = report.vanished,
+        skipped_noise = report.skipped_noise,
         pending_before = report.pending_before,
         "reindexacao da memoria concluida"
     );
@@ -294,6 +403,166 @@ mod tests {
         assert_eq!(depois.entries_with_embedding, 8, "as 3 antigas seguem la");
     }
 
+    /// O ponto do #952 no reindex: o comando NAO pode desfazer o filtro da
+    /// ingestao. Sem isto, `garra memory reindex` reembeddaria "oi" e "bom
+    /// dia" um por um, pagando provider para reintroduzir o ruido.
+    #[tokio::test]
+    async fn reindex_nao_reembedda_o_ruido_que_a_ingestao_pulou() {
+        let store = MemoryStore::in_memory_with_vectors().expect("store");
+        for ruido in ["oi", "ok", "bom dia", "kkkk", "obrigado"] {
+            store
+                .remember(entrada(ruido, None))
+                .await
+                .expect("remember");
+        }
+        for real in ["meu nome e Michel e eu moro na Florida", "prefiro Postgres"] {
+            store.remember(entrada(real, None)).await.expect("remember");
+        }
+
+        let provider = FakeProvider::new(3);
+        let report = reindex_missing_embeddings(&store, &provider, ReindexOptions::default())
+            .await
+            .expect("reindex");
+
+        assert_eq!(report.pending_before, 7);
+        assert_eq!(report.reindexed, 2, "so as duas de verdade");
+        assert_eq!(report.skipped_noise, 5);
+        assert!(!report.stopped_early, "ruido nao e motivo para parar");
+
+        // O ruido continua gravado e continua sem vetor — nada foi apagado.
+        let depois = store.integrity_report().expect("report");
+        assert_eq!(depois.entries_without_embedding, 5);
+        assert_eq!(depois.entries_with_embedding, 2);
+    }
+
+    /// O caso que trava um loop ingenuo: entrada pulada continua com
+    /// `embedding IS NULL`, ou seja, continua na fila. Sem o offset, o lote
+    /// seguinte devolveria as mesmas linhas para sempre.
+    #[tokio::test]
+    async fn ruido_no_comeco_da_fila_nao_bloqueia_o_que_vem_depois() {
+        let store = MemoryStore::in_memory_with_vectors().expect("store");
+        // Um lote inteiro de ruido antes de qualquer conteudo real.
+        for _ in 0..4 {
+            store.remember(entrada("ok", None)).await.expect("remember");
+        }
+        store
+            .remember(entrada("o deploy de sexta usa a imagem 1.2.3", None))
+            .await
+            .expect("remember");
+
+        let report = reindex_missing_embeddings(
+            &store,
+            &FakeProvider::new(3),
+            ReindexOptions {
+                batch_size: 2,
+                ..ReindexOptions::default()
+            },
+        )
+        .await
+        .expect("reindex");
+
+        assert_eq!(report.skipped_noise, 4);
+        assert_eq!(report.reindexed, 1, "a entrada real do fim da fila entrou");
+    }
+
+    /// Com a politica desligada o comando volta a ser o de antes do #952:
+    /// reembedda tudo, inclusive o que hoje seria ruido. E a saida de quem
+    /// discorda do filtro.
+    #[tokio::test]
+    async fn politica_desligada_reembedda_tudo() {
+        let store = MemoryStore::in_memory_with_vectors().expect("store");
+        for ruido in ["oi", "ok", "bom dia"] {
+            store
+                .remember(entrada(ruido, None))
+                .await
+                .expect("remember");
+        }
+
+        let report = reindex_missing_embeddings(
+            &store,
+            &FakeProvider::new(3),
+            ReindexOptions {
+                noise: NoisePolicy::disabled(),
+                ..ReindexOptions::default()
+            },
+        )
+        .await
+        .expect("reindex");
+
+        assert_eq!(report.skipped_noise, 0);
+        assert_eq!(report.reindexed, 3);
+    }
+
+    /// O dry-run separa "vai ser reindexada" de "fica sem vetor de proposito".
+    /// Sem essa separacao o total de `stats` nunca chega a zero e o operador
+    /// nao tem como saber se isso e saude ou defeito.
+    #[tokio::test]
+    async fn dry_run_separa_o_que_seria_feito_do_que_e_ruido() {
+        let store = MemoryStore::in_memory_with_vectors().expect("store");
+        for ruido in ["oi", "valeu", "kkkkk"] {
+            store
+                .remember(entrada(ruido, None))
+                .await
+                .expect("remember");
+        }
+        for i in 0..2 {
+            store
+                .remember(entrada(&format!("fato de verdade numero {i}"), None))
+                .await
+                .expect("remember");
+        }
+
+        let report = preview_reindex(
+            &store,
+            &ReindexOptions {
+                batch_size: 2,
+                ..ReindexOptions::default()
+            },
+        )
+        .expect("preview");
+
+        assert!(report.dry_run);
+        assert_eq!(report.pending_before, 5);
+        assert_eq!(report.would_reindex, 2);
+        assert_eq!(report.skipped_noise, 3);
+
+        // Dry-run nao grava: a fila continua inteira.
+        assert_eq!(
+            store
+                .integrity_report()
+                .expect("r")
+                .entries_without_embedding,
+            5
+        );
+    }
+
+    /// `--limit` conta o que foi **olhado**, nao so o que foi gravado: sem
+    /// isso, um `--limit 10` numa base cheia de ruido varreria a base toda.
+    #[tokio::test]
+    async fn limite_conta_o_ruido_pulado_como_trabalho() {
+        let store = MemoryStore::in_memory_with_vectors().expect("store");
+        for _ in 0..20 {
+            store.remember(entrada("ok", None)).await.expect("remember");
+        }
+
+        let report = reindex_missing_embeddings(
+            &store,
+            &FakeProvider::new(3),
+            ReindexOptions {
+                batch_size: 4,
+                max_entries: Some(8),
+                ..ReindexOptions::default()
+            },
+        )
+        .await
+        .expect("reindex");
+
+        assert_eq!(
+            report.skipped_noise, 8,
+            "parou no teto, nao na base inteira"
+        );
+    }
+
     /// A entrada reindexada passa a ser encontravel pela busca semantica —
     /// que e o ponto inteiro do #953.
     #[tokio::test]
@@ -310,20 +579,19 @@ mod tests {
         assert!(depois.orphan_map_entries.is_empty());
     }
 
+    /// Depois da auditoria do #952 o dry-run deixou de ser uma flag de
+    /// `ReindexOptions`: `reindex_missing_embeddings` exigia um provider e o
+    /// descartava, e a assinatura mentia para quem chamasse a API. Quem quer
+    /// so contar chama `preview_reindex`, que nao pede provider nenhum.
     #[tokio::test]
     async fn dry_run_touches_nothing() {
         let store = store_com(3, 0).await;
-        let options = ReindexOptions {
-            dry_run: true,
-            ..ReindexOptions::default()
-        };
 
-        let report = reindex_missing_embeddings(&store, &FakeProvider::new(3), options)
-            .await
-            .expect("reindex");
+        let report = preview_reindex(&store, &ReindexOptions::default()).expect("preview");
 
         assert_eq!(report.pending_before, 3);
         assert_eq!(report.reindexed, 0);
+        assert_eq!(report.would_reindex, 3);
         assert!(report.dry_run);
         assert_eq!(
             store

--- a/crates/garraia-agents/src/runtime.rs
+++ b/crates/garraia-agents/src/runtime.rs
@@ -13,7 +13,7 @@ use garraia_common::{Error, Result};
 use garraia_db::{MemoryEntry, MemoryProvider, MemoryRole, NewMemoryEntry, RecallQuery};
 use tokio::sync::mpsc;
 use tokio::time::timeout;
-use tracing::{info, instrument, warn};
+use tracing::{debug, info, instrument, warn};
 
 use crate::context_policy::ContextPolicy;
 use crate::embeddings::EmbeddingProvider;
@@ -184,6 +184,8 @@ pub struct AgentRuntime {
     /// Model to use when tools are available and the default model may not support function calling.
     /// Overrides model_override for any request that has tools registered.
     tools_model: RwLock<Option<String>>,
+    /// #952: o que nao merece vetor. Ver `crate::memory_noise`.
+    noise_policy: crate::memory_noise::NoisePolicy,
 }
 
 impl AgentRuntime {
@@ -205,6 +207,7 @@ impl AgentRuntime {
             fallback_providers_list: RwLock::new(Vec::new()),
             context_policy: ContextPolicy::default(),
             tools_model: RwLock::new(None),
+            noise_policy: crate::memory_noise::NoisePolicy::default(),
         }
     }
 
@@ -252,6 +255,18 @@ impl AgentRuntime {
     /// GAR-208: Return a reference to the current context policy.
     pub fn context_policy(&self) -> &ContextPolicy {
         &self.context_policy
+    }
+
+    /// #952: define o que nao merece vetor na ingestao.
+    pub fn set_noise_policy(&mut self, policy: crate::memory_noise::NoisePolicy) {
+        self.noise_policy = policy;
+    }
+
+    /// #952: a politica em vigor. A CLI precisa dela para reindexar com o
+    /// **mesmo** criterio da ingestao — sem isso o `garra memory reindex`
+    /// reembeddaria exatamente o ruido que a ingestao acabou de pular.
+    pub fn noise_policy(&self) -> &crate::memory_noise::NoisePolicy {
+        &self.noise_policy
     }
 
     /// GAR-210: Set the ordered fallback provider list (tried on 429/5xx).
@@ -445,7 +460,7 @@ impl AgentRuntime {
         }
 
         if !user_input.trim().is_empty() {
-            let user_embedding = self.embed_document(user_input).await;
+            let user_embedding = self.embed_turn_unless_noise(user_input, "user").await;
             let user_embedding_model = self.embedding_model_for(&user_embedding);
             memory
                 .remember(NewMemoryEntry {
@@ -464,7 +479,9 @@ impl AgentRuntime {
         }
 
         if !assistant_output.trim().is_empty() {
-            let assistant_embedding = self.embed_document(assistant_output).await;
+            let assistant_embedding = self
+                .embed_turn_unless_noise(assistant_output, "assistant")
+                .await;
             let assistant_embedding_model = self.embedding_model_for(&assistant_embedding);
             memory
                 .remember(NewMemoryEntry {
@@ -1906,6 +1923,29 @@ impl AgentRuntime {
         Ok(())
     }
 
+    /// Embedding de um turno, a menos que a politica de ruido recuse (#952).
+    ///
+    /// A entrada e gravada de qualquer jeito: o que se decide aqui e se ela
+    /// entra no indice vetorial. Recusar cedo tambem poupa uma ida ao
+    /// provider por "ok" — que numa conversa longa nao e pouco.
+    ///
+    /// Vale so para turno. Fato extraido (`[FACT] ...`) nao passa por aqui:
+    /// ele ja e sinal filtrado por um LLM com limiar de confianca, e o texto
+    /// que se grava e sempre longo.
+    async fn embed_turn_unless_noise(&self, text: &str, papel: &str) -> Option<Vec<f32>> {
+        if self.noise_policy.is_noise(text) {
+            debug!(
+                papel,
+                chars = text.chars().count(),
+                "memoria: turno gravado sem vetor por ser ruido para a busca \
+                 semantica (#952); a entrada continua no historico e no recall \
+                 textual. Ajuste em `memory.ingestion`."
+            );
+            return None;
+        }
+        self.embed_document(text).await
+    }
+
     async fn embed_document(&self, text: &str) -> Option<Vec<f32>> {
         let provider = self.embeddings.as_ref()?;
         match provider.embed_documents(&[text.to_string()]).await {
@@ -1997,6 +2037,162 @@ impl Default for AgentRuntime {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ─── #952: ruido nao merece vetor ─────────────────────────────────────
+
+    /// Provider de embeddings que conta quantas vezes foi chamado.
+    ///
+    /// O contador e metade do teste: a politica nao so evita gravar o vetor,
+    /// ela evita **pedir** o vetor. Numa conversa longa, uma ida ao provider
+    /// por "ok" nao e pouco.
+    struct ContandoEmbeddings(std::sync::atomic::AtomicUsize);
+
+    #[async_trait]
+    impl crate::embeddings::EmbeddingProvider for ContandoEmbeddings {
+        fn provider_id(&self) -> &str {
+            "contando"
+        }
+        fn model(&self) -> &str {
+            "modelo-de-teste"
+        }
+        async fn embed_documents(&self, texts: &[String]) -> garraia_common::Result<Vec<Vec<f32>>> {
+            self.0
+                .fetch_add(texts.len(), std::sync::atomic::Ordering::SeqCst);
+            Ok(texts.iter().map(|_| vec![0.25, 0.5, 0.75]).collect())
+        }
+        async fn embed_query(&self, _text: &str) -> garraia_common::Result<Vec<f32>> {
+            Ok(vec![0.25, 0.5, 0.75])
+        }
+        async fn health_check(&self) -> garraia_common::Result<bool> {
+            Ok(true)
+        }
+    }
+
+    async fn runtime_com_memoria(
+        policy: crate::memory_noise::NoisePolicy,
+    ) -> (
+        AgentRuntime,
+        Arc<garraia_db::MemoryStore>,
+        Arc<ContandoEmbeddings>,
+    ) {
+        let store = Arc::new(garraia_db::MemoryStore::in_memory_with_vectors().expect("store"));
+        let embeddings = Arc::new(ContandoEmbeddings(std::sync::atomic::AtomicUsize::new(0)));
+        let mut rt = AgentRuntime::new();
+        rt.set_memory_provider(store.clone());
+        rt.set_embedding_provider(embeddings.clone());
+        rt.set_noise_policy(policy);
+        (rt, store, embeddings)
+    }
+
+    fn chamadas(e: &ContandoEmbeddings) -> usize {
+        e.0.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    /// O sintoma da issue: "oi" era gravado **com** vetor e disputava o
+    /// top-K com memoria de verdade.
+    #[tokio::test]
+    async fn turno_de_ruido_e_gravado_sem_vetor_e_sem_ida_ao_provider() {
+        let (rt, store, embeddings) =
+            runtime_com_memoria(crate::memory_noise::NoisePolicy::default()).await;
+
+        rt.remember_turn("s1", None, None, "oi", "bom dia")
+            .await
+            .expect("remember_turn");
+
+        assert_eq!(chamadas(&embeddings), 0, "pediu vetor para ruido");
+        let r = store.integrity_report().expect("report");
+        assert_eq!(r.entries_with_embedding, 0);
+        assert_eq!(r.entries_without_embedding, 2, "as duas seguem gravadas");
+    }
+
+    /// O outro lado da moeda, e o que impede o filtro de virar perda de
+    /// memoria: conteudo de verdade continua ganhando vetor.
+    #[tokio::test]
+    async fn turno_de_verdade_continua_ganhando_vetor() {
+        let (rt, store, embeddings) =
+            runtime_com_memoria(crate::memory_noise::NoisePolicy::default()).await;
+
+        rt.remember_turn(
+            "s1",
+            None,
+            None,
+            "meu nome e Michel e eu moro na Florida",
+            "anotado: voce se chama Michel e mora na Florida",
+        )
+        .await
+        .expect("remember_turn");
+
+        assert_eq!(chamadas(&embeddings), 2);
+        let r = store.integrity_report().expect("report");
+        assert_eq!(r.entries_with_embedding, 2);
+        assert_eq!(r.map_rows, 2, "as duas entraram no indice vetorial");
+    }
+
+    /// Um turno pode ter uma metade de ruido e outra de conteudo. Elas sao
+    /// decididas separadamente — a pergunta "ok" nao pode derrubar a resposta
+    /// que veio depois dela.
+    #[tokio::test]
+    async fn as_duas_metades_do_turno_sao_decididas_em_separado() {
+        let (rt, store, embeddings) =
+            runtime_com_memoria(crate::memory_noise::NoisePolicy::default()).await;
+
+        rt.remember_turn(
+            "s1",
+            None,
+            None,
+            "ok",
+            "o gateway sobe na porta 3888 e le a config de ~/.garraia",
+        )
+        .await
+        .expect("remember_turn");
+
+        assert_eq!(chamadas(&embeddings), 1);
+        let r = store.integrity_report().expect("report");
+        assert_eq!(r.entries_with_embedding, 1);
+        assert_eq!(r.entries_without_embedding, 1);
+    }
+
+    /// Desligar a politica devolve o comportamento anterior ao #952, inteiro.
+    #[tokio::test]
+    async fn politica_desligada_embedda_ate_o_ruido() {
+        let (rt, store, embeddings) =
+            runtime_com_memoria(crate::memory_noise::NoisePolicy::disabled()).await;
+
+        rt.remember_turn("s1", None, None, "oi", "bom dia")
+            .await
+            .expect("remember_turn");
+
+        assert_eq!(chamadas(&embeddings), 2);
+        assert_eq!(
+            store
+                .integrity_report()
+                .expect("report")
+                .entries_with_embedding,
+            2
+        );
+    }
+
+    /// A coluna `embedding_model` descreve o vetor. Uma entrada pulada por
+    /// ruido nao tem vetor, entao nao pode sair dizendo por qual modelo foi
+    /// indexada — foi essa mentira que o #948 corrigiu, e o filtro novo nao
+    /// pode reintroduzi-la.
+    #[tokio::test]
+    async fn entrada_pulada_nao_finge_ter_modelo() {
+        let (rt, store, _) = runtime_com_memoria(crate::memory_noise::NoisePolicy::default()).await;
+
+        rt.remember_turn("s1", None, None, "ok", "valeu")
+            .await
+            .expect("remember_turn");
+
+        for entrada in store.recent_entries(10).expect("recent") {
+            assert!(entrada.embedding.is_none());
+            assert!(
+                entrada.embedding_model.is_none(),
+                "linha sem vetor anunciando modelo: {:?}",
+                entrada.embedding_model
+            );
+        }
+    }
 
     // ─── issue #924: o inventario de tools nao pode congelar no boot ───────
 

--- a/crates/garraia-cli/src/memory_cmd.rs
+++ b/crates/garraia-cli/src/memory_cmd.rs
@@ -504,7 +504,11 @@ pub async fn run_reindex(
 
     // No dry-run nao ha chamada de provider, entao exigir um seria recusar a
     // pergunta "quanto tem para fazer?" justamente a quem ainda nao configurou.
-    let provider = garraia_gateway::bootstrap::build_embedding_provider(config);
+    let provider = if dry_run {
+        None
+    } else {
+        garraia_gateway::bootstrap::build_embedding_provider(config)
+    };
     if provider.is_none() && !dry_run {
         eprintln!(
             "error: nenhum provider de embeddings configurado — sem ele nao ha como\n\
@@ -517,23 +521,20 @@ pub async fn run_reindex(
     let options = ReindexOptions {
         batch_size,
         max_entries: limit,
-        dry_run,
+        // A **mesma** politica da ingestao, construida da mesma config (#952).
+        // Um default local aqui reembeddaria justamente o ruido que a
+        // ingestao pulou.
+        noise: garraia_gateway::bootstrap::noise_policy_from_config(config),
     };
 
     let report = match &provider {
+        // Dry-run nao chama provider: a fila vem do banco e a politica de
+        // ruido responde o resto. Por isso `preview_reindex` nao pede um —
+        // exigi-lo so para descarta-lo seria uma assinatura que mente.
+        None => garraia_agents::preview_reindex(&store, &options)?,
         Some(p) => reindex_missing_embeddings(&store, p.as_ref(), options)
             .await
             .context("reindex failed")?,
-        // Dry-run sem provider: a fila e derivada do banco, e o relatorio de
-        // integridade responde sozinho.
-        None => garraia_agents::ReindexReport {
-            pending_before: store.integrity_report()?.entries_without_embedding,
-            index_repaired: 0,
-            reindexed: 0,
-            vanished: 0,
-            stopped_early: false,
-            dry_run: true,
-        },
     };
 
     if json {
@@ -542,6 +543,8 @@ pub async fn run_reindex(
             "index_repaired": report.index_repaired,
             "reindexed": report.reindexed,
             "vanished": report.vanished,
+            "skipped_noise": report.skipped_noise,
+            "would_reindex": report.would_reindex,
             "stopped_early": report.stopped_early,
             "dry_run": report.dry_run,
         });
@@ -549,13 +552,29 @@ pub async fn run_reindex(
     } else if report.dry_run {
         println!(
             "{} entrada(s) sem vetor seriam reprocessadas (dry-run: nada foi gravado).",
-            report.pending_before
+            report.would_reindex
         );
+        if report.skipped_noise > 0 {
+            println!(
+                "Outras {} ficam sem vetor de proposito, por serem ruido para a\n\
+                 busca semantica (#952) — elas seguem contadas em `stats` como\n\
+                 \"sem vetor\".\n\
+                 Ajuste ou desligue em `memory.ingestion`.",
+                report.skipped_noise
+            );
+        }
     } else {
         println!(
             "Fila inicial: {} | reindexadas: {} | sumiram no caminho: {}",
             report.pending_before, report.reindexed, report.vanished
         );
+        if report.skipped_noise > 0 {
+            println!(
+                "{} entrada(s) foram puladas por serem ruido (#952) e continuam\n\
+                 sem vetor de proposito. Ajuste ou desligue em `memory.ingestion`.",
+                report.skipped_noise
+            );
+        }
         if report.index_repaired > 0 {
             println!(
                 "Alem dessas, {} entrada(s) ja tinham vetor na coluna e voltaram \

--- a/crates/garraia-config/src/check.rs
+++ b/crates/garraia-config/src/check.rs
@@ -618,6 +618,7 @@ fn validate(config: &AppConfig) -> Vec<Finding> {
     // knobs. Secret env vars remain enforced at AuthConfig::from_env.
     validate_auth(&config.auth, &mut findings, &push_err, &push_warn);
     validate_retention(&config.memory, &mut findings, &push_err, &push_warn);
+    validate_ingestion(&config.memory, &mut findings, &push_err, &push_warn);
 
     // Channels: warn when a channel is enabled but its well-known token
     // env var is not set and no inline credential is present. This helps
@@ -727,6 +728,82 @@ fn validate_retention(
                 r.max_age_days,
                 u64::from(r.max_age_days) * 24
             ),
+        );
+    }
+}
+
+/// Filtro de ruido na ingestao (#952).
+///
+/// Ao contrario da retencao, nada aqui apaga dado — o pior caso e uma
+/// entrada gravada sem vetor. Por isso as checagens sao sobre coerencia e
+/// surpresa, nao sobre perda: o operador precisa saber quando escreveu uma
+/// chave que nao tem efeito, e quando escolheu um piso que vai engolir
+/// conteudo de verdade.
+fn validate_ingestion(
+    memory: &crate::model::MemoryConfig,
+    findings: &mut Vec<Finding>,
+    push_err: &impl Fn(&mut Vec<Finding>, &str, String),
+    push_warn: &impl Fn(&mut Vec<Finding>, &str, String),
+) {
+    use crate::model::INGESTION_MIN_CHARS_MAX;
+
+    let i = &memory.ingestion;
+
+    if i.min_chars > INGESTION_MIN_CHARS_MAX {
+        push_err(
+            findings,
+            "memory.ingestion.min_chars",
+            format!(
+                "memory.ingestion.min_chars ({}) must be in [0, {INGESTION_MIN_CHARS_MAX}]",
+                i.min_chars
+            ),
+        );
+    }
+
+    // Um piso alto nao e erro de sintaxe, e uma escolha com consequencia que
+    // so aparece meses depois, quando o agente nao lembra de algo curto. So
+    // avisa dentro da faixa: com o valor ja recusado acima, repetir a mesma
+    // chave como aviso e ruido em cima de um erro que o operador ja leu.
+    if i.filter_noise && i.min_chars > 12 && i.min_chars <= INGESTION_MIN_CHARS_MAX {
+        push_warn(
+            findings,
+            "memory.ingestion.min_chars",
+            format!(
+                "memory.ingestion.min_chars ({}) is high; short facts like \"moro em SP\" \
+                 (10 chars) stop getting an embedding and become findable only by text search",
+                i.min_chars
+            ),
+        );
+    }
+
+    // Chave escrita com o filtro desligado nao tem efeito nenhum. Silencio
+    // aqui vira "configurei e nao funcionou".
+    let piso_padrao = crate::model::IngestionConfig::default().min_chars;
+    if !i.filter_noise && (!i.extra_noise_phrases.is_empty() || i.min_chars != piso_padrao) {
+        push_warn(
+            findings,
+            "memory.ingestion.filter_noise",
+            "memory.ingestion.filter_noise=false; min_chars and extra_noise_phrases have no effect"
+                .into(),
+        );
+    }
+
+    // Frase em branco na lista nao casa com nada util e quase sempre e um
+    // item sobrando do YAML.
+    if i.extra_noise_phrases.iter().any(|p| p.trim().is_empty()) {
+        push_warn(
+            findings,
+            "memory.ingestion.extra_noise_phrases",
+            "memory.ingestion.extra_noise_phrases contains an empty entry; it is ignored".into(),
+        );
+    }
+
+    if i.filter_noise && !memory.enabled {
+        push_warn(
+            findings,
+            "memory.ingestion.filter_noise",
+            "memory.ingestion.filter_noise=true but memory.enabled=false; nothing is ingested"
+                .into(),
         );
     }
 }
@@ -1094,6 +1171,95 @@ mod tests {
             std::process::id(),
             nanos
         ))
+    }
+
+    // ─── #952: filtro de ruido na ingestao ────────────────────────────────
+
+    fn achados_de(config: &AppConfig, campo: &str) -> Vec<Finding> {
+        validate(config)
+            .into_iter()
+            .filter(|f| f.field == campo)
+            .collect()
+    }
+
+    #[test]
+    fn ingestao_default_nao_produz_achado() {
+        let config = AppConfig::default();
+        assert!(
+            validate(&config)
+                .iter()
+                .all(|f| !f.field.starts_with("memory.ingestion")),
+            "a config default nao pode reclamar de si mesma"
+        );
+    }
+
+    #[test]
+    fn min_chars_acima_do_teto_e_erro() {
+        let mut config = AppConfig::default();
+        config.memory.ingestion.min_chars = crate::model::INGESTION_MIN_CHARS_MAX + 1;
+        let achados = achados_de(&config, "memory.ingestion.min_chars");
+        assert!(
+            achados.iter().any(|f| f.severity == Severity::Error),
+            "{achados:?}"
+        );
+    }
+
+    /// Piso alto nao e erro de sintaxe — e uma escolha cuja consequencia so
+    /// aparece meses depois, quando o agente nao lembra de algo curto.
+    #[test]
+    fn min_chars_alto_avisa_sem_barrar() {
+        let mut config = AppConfig::default();
+        config.memory.ingestion.min_chars = 20;
+        let achados = achados_de(&config, "memory.ingestion.min_chars");
+        assert!(achados.iter().any(|f| f.severity == Severity::Warning));
+        assert!(!achados.iter().any(|f| f.severity == Severity::Error));
+    }
+
+    /// Chave escrita com o filtro desligado nao faz nada. Silencio aqui vira
+    /// "configurei e nao funcionou".
+    /// Valor fora da faixa ja e erro; repetir a mesma chave como aviso e
+    /// ruido em cima de um erro que o operador acabou de ler.
+    #[test]
+    fn valor_fora_da_faixa_nao_vem_com_aviso_redundante() {
+        let mut config = AppConfig::default();
+        config.memory.ingestion.min_chars = 999;
+        let achados = achados_de(&config, "memory.ingestion.min_chars");
+        assert_eq!(achados.len(), 1, "{achados:?}");
+        assert_eq!(achados[0].severity, Severity::Error);
+    }
+
+    #[test]
+    fn chave_sem_efeito_com_o_filtro_desligado_avisa() {
+        let mut config = AppConfig::default();
+        config.memory.ingestion.filter_noise = false;
+        config.memory.ingestion.extra_noise_phrases = vec!["salve".to_string()];
+        let achados = achados_de(&config, "memory.ingestion.filter_noise");
+        assert!(achados.iter().any(|f| f.severity == Severity::Warning));
+    }
+
+    /// Desligar o filtro sem escrever mais nada e uma escolha legitima e
+    /// silenciosa — o aviso acima nao pode disparar aqui.
+    #[test]
+    fn filtro_desligado_sozinho_nao_avisa() {
+        let mut config = AppConfig::default();
+        config.memory.ingestion.filter_noise = false;
+        assert!(achados_de(&config, "memory.ingestion.filter_noise").is_empty());
+    }
+
+    #[test]
+    fn frase_em_branco_na_lista_avisa() {
+        let mut config = AppConfig::default();
+        config.memory.ingestion.extra_noise_phrases = vec!["  ".to_string()];
+        let achados = achados_de(&config, "memory.ingestion.extra_noise_phrases");
+        assert!(achados.iter().any(|f| f.severity == Severity::Warning));
+    }
+
+    #[test]
+    fn filtro_ligado_com_memoria_desligada_avisa() {
+        let mut config = AppConfig::default();
+        config.memory.enabled = false;
+        let achados = achados_de(&config, "memory.ingestion.filter_noise");
+        assert!(achados.iter().any(|f| f.severity == Severity::Warning));
     }
 
     #[test]

--- a/crates/garraia-config/src/model.rs
+++ b/crates/garraia-config/src/model.rs
@@ -451,6 +451,10 @@ pub struct MemoryConfig {
     /// Politica de retencao da memoria do agente (#956, #959).
     #[serde(default)]
     pub retention: RetentionConfig,
+
+    /// O que merece vetor na ingestao (#952).
+    #[serde(default)]
+    pub ingestion: IngestionConfig,
 }
 
 impl Default for MemoryConfig {
@@ -460,8 +464,67 @@ impl Default for MemoryConfig {
             embedding_provider: None,
             shared_continuity: false,
             retention: RetentionConfig::default(),
+            ingestion: IngestionConfig::default(),
         }
     }
+}
+
+/// Filtro de ruido na ingestao da memoria semantica (#952).
+///
+/// **Ligado por padrao**, ao contrario da retencao — e a diferenca e o que
+/// esta em jogo. A retencao **apaga** memoria, entao so roda quando o
+/// operador pede. Este filtro nao apaga nada: a entrada continua gravada,
+/// continua no historico e continua achavel pelo recall textual; o que ela
+/// nao ganha e um vetor. Desligar a chave e reindexar devolve o vetor.
+///
+/// O que ele nao faz: limpar o que ja esta no indice. Vetor de "oi" gravado
+/// antes desta versao continua la. Isto e um filtro de ingestao, e limpar o
+/// passado apaga dado — decisao do operador, via `garra memory compact`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IngestionConfig {
+    /// `false` restaura o comportamento anterior ao #952: todo turno nao
+    /// vazio recebe vetor.
+    #[serde(default = "default_filter_noise")]
+    pub filter_noise: bool,
+
+    /// Piso de caracteres uteis (ja sem acento, pontuacao e emoji) abaixo do
+    /// qual o conteudo nao recebe vetor. `0` desliga so o piso; a lista de
+    /// frases segue valendo. Faixa aceita (0..=40) cobrada pelo
+    /// `garra config check`.
+    #[serde(default = "default_ingestion_min_chars")]
+    pub min_chars: usize,
+
+    /// Frases que, sozinhas, sao o conteudo inteiro de uma entrada de ruido.
+    /// **Somam** a lista embutida, nunca a substituem: uma lista escrita a
+    /// mao nao pode apagar a cobertura padrao numa atualizacao.
+    #[serde(default)]
+    pub extra_noise_phrases: Vec<String>,
+}
+
+impl Default for IngestionConfig {
+    fn default() -> Self {
+        Self {
+            filter_noise: default_filter_noise(),
+            min_chars: default_ingestion_min_chars(),
+            extra_noise_phrases: Vec::new(),
+        }
+    }
+}
+
+/// Faixa aceita para `memory.ingestion.min_chars`. O teto nao e arbitrario:
+/// acima disso a chave deixa de ser "filtro de ruido" e vira uma politica de
+/// o que lembrar, que ninguem consegue prever pelo nome.
+pub const INGESTION_MIN_CHARS_MAX: usize = 40;
+
+fn default_filter_noise() -> bool {
+    true
+}
+
+/// Quatro. O mesmo default do `garraia-agents::memory_noise`, e a razao esta
+/// documentada la: a lista de frases faz o trabalho de precisao, entao o piso
+/// pode ficar baixo o bastante para nao derrubar um fato curto de verdade.
+fn default_ingestion_min_chars() -> usize {
+    4
 }
 
 /// Quando o gateway apaga memoria velha sozinho (#956).

--- a/crates/garraia-db/src/memory_store.rs
+++ b/crates/garraia-db/src/memory_store.rs
@@ -518,6 +518,37 @@ impl MemoryStore {
     /// em lotes sucessivos avança de forma previsível em vez de reprocessar
     /// as mesmas linhas.
     pub fn entries_missing_embeddings(&self, limit: usize) -> Result<Vec<MemoryEntry>> {
+        self.entries_missing_embeddings_after(limit, None)
+    }
+
+    /// A mesma fila, retomada **depois** de uma posicao conhecida.
+    ///
+    /// Existe por causa do #952: a reindexacao pula entradas que a politica
+    /// de ruido recusa, e uma entrada pulada **continua** com
+    /// `embedding IS NULL` — ou seja, continua na fila. Sem avancar, o lote
+    /// seguinte devolveria as mesmas linhas para sempre.
+    ///
+    /// A posicao e a **chave** da ultima linha vista (`created_at`, `id`), e
+    /// nao um `OFFSET` numerico. A diferenca importa porque a fila muda
+    /// debaixo do laco: o `memory_retention_worker` do gateway roda em
+    /// paralelo e apaga entradas vencidas. Com `OFFSET`, uma delecao entre
+    /// dois lotes encolhe a fila **antes** do ponteiro e o lote seguinte
+    /// pula uma entrada legitima — que ficaria sem vetor sem ninguem
+    /// perceber, ate a proxima reindexacao manual. Um cursor por chave nao
+    /// se move quando outra linha some, e ainda troca o custo O(offset) do
+    /// `OFFSET` do SQLite por uma comparacao.
+    ///
+    /// A ordenacao inclui `id` de proposito: `created_at` tem granularidade
+    /// de segundo e empata com facilidade, e sob empate a ordem entre duas
+    /// linhas seria indefinida entre uma consulta e a proxima. Com
+    /// `(created_at, id)` a ordem e total, estavel, e a comparacao do cursor
+    /// usa **a mesma** expressao `datetime(created_at)` da ordenacao — se
+    /// usasse outra, o corte e a ordem discordariam nos empates.
+    pub fn entries_missing_embeddings_after(
+        &self,
+        limit: usize,
+        after: Option<(DateTime<Utc>, &str)>,
+    ) -> Result<Vec<MemoryEntry>> {
         let conn = self.connection()?;
         let mut stmt = conn
             .prepare(
@@ -530,13 +561,23 @@ impl MemoryStore {
                    -- que a proxima compactacao apaga e chamada de provider
                    -- paga por trabalho que vai para o lixo (#959).
                    AND (ttl_expires_at IS NULL OR datetime(ttl_expires_at) > datetime('now'))
-                 ORDER BY datetime(created_at) ASC
-                 LIMIT ?",
+                   -- Cursor: NULL na primeira pagina (o ramo `?2 IS NULL`
+                   -- devolve a fila inteira).
+                   AND (?2 IS NULL
+                        OR datetime(created_at) > datetime(?2)
+                        OR (datetime(created_at) = datetime(?2) AND id > ?3))
+                 ORDER BY datetime(created_at) ASC, id ASC
+                 LIMIT ?1",
             )
             .map_err(|e| Error::Database(format!("failed to prepare reindex scan: {e}")))?;
 
+        let (cursor_ts, cursor_id) = match after {
+            Some((ts, id)) => (Some(ts.to_rfc3339()), Some(id.to_string())),
+            None => (None, None),
+        };
+
         let rows = stmt
-            .query_map(params![limit as i64], row_to_entry)
+            .query_map(params![limit as i64, cursor_ts, cursor_id], row_to_entry)
             .map_err(|e| Error::Database(format!("failed to scan entries to reindex: {e}")))?;
 
         rows.collect::<std::result::Result<Vec<_>, _>>()
@@ -1743,6 +1784,96 @@ mod tests {
         let fila = store.entries_missing_embeddings(10).expect("fila");
         assert_eq!(fila.len(), 1, "a vencida entrou na fila: {fila:?}");
         assert_eq!(fila[0].content, "vigente");
+    }
+
+    /// O cursor da fila e uma **chave**, nao um `OFFSET` numerico — e a
+    /// diferenca so aparece quando alguem apaga uma linha no meio.
+    ///
+    /// Achado pela auditoria de seguranca do #952: o gateway roda um
+    /// `memory_retention_worker` em paralelo, e o `garra memory reindex`
+    /// pagina a fila. Com `OFFSET`, uma delecao **antes** do ponteiro encolhe
+    /// a fila e a pagina seguinte comeca uma linha adiante — uma entrada
+    /// legitima ficaria sem vetor sem ninguem perceber, ate a proxima
+    /// reindexacao manual. Este teste reproduz exatamente essa corrida.
+    #[tokio::test]
+    async fn cursor_da_fila_sobrevive_a_delecao_concorrente() {
+        let store = MemoryStore::in_memory().expect("store");
+        for i in 0..6 {
+            store
+                .remember(entry(
+                    "s1",
+                    None,
+                    &format!("entrada {i}"),
+                    MemoryRole::User,
+                    None,
+                ))
+                .await
+                .expect("insere");
+        }
+
+        // A ordem da fila e `(datetime(created_at), id)`. Como as seis
+        // nascem no mesmo segundo, quem manda e o `id` (UUID) — entao o
+        // teste pergunta ao banco qual e a ordem em vez de supor.
+        let ordem = store.entries_missing_embeddings(10).expect("ordem");
+        assert_eq!(ordem.len(), 6);
+
+        // Primeira pagina: duas entradas.
+        let pagina1 = store.entries_missing_embeddings(2).expect("pagina 1");
+        assert_eq!(pagina1.len(), 2);
+        let ultima = pagina1.last().expect("ultima");
+        let cursor = (ultima.created_at, ultima.id.clone());
+
+        // A retencao apaga uma entrada JA VISTA, atras do cursor. Com
+        // `OFFSET 2` a fila teria encolhido e a pagina 2 comecaria uma linha
+        // adiante, pulando `ordem[2]` para sempre.
+        assert!(store.delete_entry(&pagina1[0].id).expect("apaga"));
+
+        let pagina2 = store
+            .entries_missing_embeddings_after(2, Some((cursor.0, cursor.1.as_str())))
+            .expect("pagina 2");
+        assert_eq!(pagina2.len(), 2);
+        assert_eq!(
+            pagina2[0].id, ordem[2].id,
+            "a delecao atras do cursor deslocou a pagina e pulou uma entrada"
+        );
+        assert_eq!(pagina2[1].id, ordem[3].id);
+    }
+
+    /// A fila e percorrida ate o fim sem repetir nem pular, mesmo com o lote
+    /// menor que o total e com `created_at` empatado no segundo — que e o
+    /// caso normal, ja que varias entradas nascem no mesmo segundo.
+    #[tokio::test]
+    async fn cursor_percorre_a_fila_inteira_sem_repetir_nem_pular() {
+        let store = MemoryStore::in_memory().expect("store");
+        for i in 0..7 {
+            store
+                .remember(entry(
+                    "s1",
+                    None,
+                    &format!("entrada {i}"),
+                    MemoryRole::User,
+                    None,
+                ))
+                .await
+                .expect("insere");
+        }
+
+        let mut vistas: Vec<String> = Vec::new();
+        let mut cursor: Option<(chrono::DateTime<chrono::Utc>, String)> = None;
+        loop {
+            let lote = store
+                .entries_missing_embeddings_after(3, cursor.as_ref().map(|(t, i)| (*t, i.as_str())))
+                .expect("lote");
+            let Some(ultima) = lote.last() else { break };
+            cursor = Some((ultima.created_at, ultima.id.clone()));
+            vistas.extend(lote.iter().map(|e| e.content.clone()));
+        }
+
+        assert_eq!(vistas.len(), 7, "repetiu ou pulou: {vistas:?}");
+        let mut unicas = vistas.clone();
+        unicas.sort();
+        unicas.dedup();
+        assert_eq!(unicas.len(), 7, "houve repeticao: {vistas:?}");
     }
 
     #[tokio::test]

--- a/crates/garraia-gateway/src/bootstrap/mod.rs
+++ b/crates/garraia-gateway/src/bootstrap/mod.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 use garraia_agents::tools::Tool;
 use garraia_agents::{
     AgentRuntime, AnthropicProvider, BashTool, CohereEmbeddingProvider, EmbeddingProvider,
-    FileReadTool, FileWriteTool, LlamaCppProvider, McpManager, OllamaEmbeddingProvider,
-    OllamaProvider, OpenAiEmbeddingProvider, OpenAiProvider, ResilientEmbeddingProvider,
-    WebFetchTool, WebSearchTool,
+    FileReadTool, FileWriteTool, LlamaCppProvider, McpManager, NoisePolicy,
+    OllamaEmbeddingProvider, OllamaProvider, OpenAiEmbeddingProvider, OpenAiProvider,
+    ResilientEmbeddingProvider, WebFetchTool, WebSearchTool,
 };
 use garraia_config::{AppConfig, provider_key_env};
 use garraia_db::MemoryStore;
@@ -651,6 +651,23 @@ pub fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
         runtime.set_context_policy(policy);
     }
 
+    // #952: o que nao merece vetor na ingestao.
+    {
+        let policy = noise_policy_from_config(config);
+        if policy.is_enabled() {
+            info!(
+                min_chars = policy.min_chars(),
+                extras = config.memory.ingestion.extra_noise_phrases.len(),
+                "filtro de ruido da memoria ativo: turno curto ou puramente \
+                 social e gravado sem vetor (#952). Desligue em \
+                 `memory.ingestion.filter_noise` se quiser embeddar tudo."
+            );
+        } else {
+            info!("filtro de ruido da memoria desligado por config (#952)");
+        }
+        runtime.set_noise_policy(policy);
+    }
+
     // Wire tools_model: model override used when tools are present (e.g. avoids openrouter/free
     // which may not support function calling).
     if let Some(ref tm) = config.agent.tools_model {
@@ -1078,6 +1095,17 @@ pub async fn build_mcp_tools(
 /// Devolve `None` quando `memory.embedding_provider` nao aponta para nenhuma
 /// entrada de `embeddings:`, ou quando o provider apontado nao pode ser
 /// construido (sem credencial contra endpoint oficial, tipo desconhecido).
+/// A politica de ruido da ingestao (#952), a partir da config.
+///
+/// Publica pela mesma razao que [`build_embedding_provider`]: o `garra memory
+/// reindex` precisa da **mesma** politica que a ingestao usou. Com politicas
+/// divergentes, o reindex reembeddaria exatamente as entradas que a ingestao
+/// acabou de pular — e o operador pagaria provider para desfazer o filtro.
+pub fn noise_policy_from_config(config: &AppConfig) -> NoisePolicy {
+    let i = &config.memory.ingestion;
+    NoisePolicy::new(i.filter_noise, i.min_chars, &i.extra_noise_phrases)
+}
+
 pub fn build_embedding_provider(config: &AppConfig) -> Option<Arc<dyn EmbeddingProvider>> {
     let embed_name = config.memory.embedding_provider.as_ref()?;
     let embed_config = config.embeddings.get(embed_name)?;
@@ -1268,5 +1296,60 @@ mod tests {
         );
         // Should not panic — unknown providers are logged and skipped
         let _runtime = build_agent_runtime(&config);
+    }
+
+    // ─── #952: a politica de ruido, config <-> agents ─────────────────────
+
+    /// `garraia-agents` nao depende de `garraia-config` (de proposito: a
+    /// politica chega la como dado puro), entao o piso de caracteres e a
+    /// faixa aceita existem escritos **duas vezes**. Este crate e o unico
+    /// que ve os dois lados, e este teste e o que impede os dois numeros de
+    /// divergirem em silencio — o sintoma seria um `config check` aceitando
+    /// um valor que a politica trata de outro jeito.
+    #[test]
+    fn os_dois_lados_da_politica_de_ruido_concordam_nos_numeros() {
+        assert_eq!(
+            garraia_agents::DEFAULT_MIN_CHARS,
+            garraia_config::model::IngestionConfig::default().min_chars,
+            "default do piso divergiu entre garraia-agents e garraia-config"
+        );
+        assert_eq!(
+            garraia_agents::MIN_CHARS_MAX,
+            garraia_config::model::INGESTION_MIN_CHARS_MAX,
+            "teto do piso divergiu entre garraia-agents e garraia-config"
+        );
+    }
+
+    /// A config default tem que produzir a politica default. Se o bootstrap
+    /// deixasse de ler alguma chave, o gateway rodaria com uma politica e o
+    /// `garra memory reindex` com outra — e o reindex desfaria o filtro.
+    #[test]
+    fn config_default_produz_a_politica_default() {
+        let config = AppConfig::default();
+        assert_eq!(
+            noise_policy_from_config(&config),
+            garraia_agents::NoisePolicy::default()
+        );
+    }
+
+    #[test]
+    fn filter_noise_false_desliga_a_politica() {
+        let mut config = AppConfig::default();
+        config.memory.ingestion.filter_noise = false;
+        let policy = noise_policy_from_config(&config);
+        assert!(!policy.is_enabled());
+        assert!(!policy.is_noise("oi"));
+    }
+
+    #[test]
+    fn extras_da_config_chegam_na_politica() {
+        let mut config = AppConfig::default();
+        config.memory.ingestion.extra_noise_phrases = vec!["salve familia".to_string()];
+        let policy = noise_policy_from_config(&config);
+        assert!(policy.is_noise("Salve, familia!"));
+        assert!(
+            policy.is_noise("bom dia"),
+            "a lista padrao continua valendo"
+        );
     }
 }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -42,6 +42,7 @@
   - [Checklist de Segurança](./security/checklist.md)
 - [Memória e Contexto](./memory.md)
 - [Backup e restauração da memória](./memory-backup.md)
+- [Filtro de ruído na ingestão](./memory-ingestion.md)
 - [Modos de Operação](./modes.md)
 - [Modos de Continuação](./continue-modes.md)
 

--- a/docs/src/memory-ingestion.md
+++ b/docs/src/memory-ingestion.md
@@ -1,0 +1,123 @@
+# Filtro de ruído na ingestão da memória
+
+> Fecha o [#952](https://github.com/michelbr84/GarraRUST/issues/952).
+
+Nem todo turno de conversa merece um vetor. `"oi"`, `"ok"`, `"kkkk"` e
+`"bom dia"` são gravados como qualquer outra mensagem, mas como **vetor** eles
+só atrapalham: texto curto tem cosseno alto com quase tudo, então competem no
+top-K com memória de verdade. Numa base de ~7.100 entradas, a consulta
+*"quem é Michel"* trazia entradas `"oi"` entre os primeiros resultados.
+
+O gateway agora decide, na ingestão, se vale gastar um vetor com aquele
+conteúdo.
+
+## O que o filtro faz — e o que ele não faz
+
+**Faz:** decide se o conteúdo entra no índice vetorial.
+
+**Não faz:**
+
+- **Não apaga nada.** A entrada continua gravada, continua no histórico e
+  continua achável pelo recall textual. O que ela não ganha é um vetor.
+- **Não é retroativo.** Vetor de `"oi"` gravado antes desta versão continua no
+  índice. Limpar o passado apaga dado, e isso é decisão explícita do operador
+  — `garra memory compact` e a política de TTL existem para isso.
+- **Não é irreversível.** Desligue o filtro, rode `garra memory reindex`, e os
+  vetores voltam.
+
+## Configuração
+
+```yaml
+memory:
+  ingestion:
+    filter_noise: true          # padrão
+    min_chars: 4                # padrão
+    extra_noise_phrases:        # somam à lista embutida
+      - "salve família"
+```
+
+| Chave | Padrão | O que faz |
+| --- | --- | --- |
+| `filter_noise` | `true` | `false` restaura o comportamento anterior: todo turno não vazio recebe vetor. |
+| `min_chars` | `4` | Piso de caracteres **úteis** (já sem acento, pontuação e emoji). `0` desliga só o piso; a lista de frases segue valendo. Faixa aceita: `0`–`40`. |
+| `extra_noise_phrases` | `[]` | Frases que, sozinhas, são o conteúdo inteiro de uma entrada de ruído. **Somam** à lista embutida, nunca a substituem. |
+
+`garra config check` valida a faixa de `min_chars`, avisa quando um piso alto
+vai engolir conteúdo curto de verdade, e avisa quando você escreveu chaves que
+não têm efeito porque `filter_noise` está `false`.
+
+### Por que ligado por padrão
+
+Ao contrário da política de retenção — que fica **desligada** por padrão
+porque apaga memória —, este filtro não apaga nada. O pior caso é uma entrada
+gravada sem vetor, e isso se desfaz com um `reindex`. Deixá-lo desligado por
+padrão significaria que ninguém recebe a correção do bug.
+
+### Por que o piso é baixo
+
+Quatro caracteres, e não os dez ou doze que pegariam `"bom dia"` por
+comprimento. A lista de frases faz o trabalho de precisão; um piso alto
+derrubaria junto um fato curto de verdade, como `"moro em SP"` (10
+caracteres). Errar embeddando ruído custa ranking; errar do outro lado custa
+**memória que o agente deveria ter e não tem** — e o usuário não tem como
+saber que perdeu.
+
+## O que conta como ruído
+
+Nesta ordem:
+
+1. **Conteúdo que some na normalização.** `"?!"`, `"..."`, `"👍"` — só
+   pontuação ou emoji, não há o que embeddar.
+2. **Abaixo de `min_chars`** caracteres úteis.
+3. **Frase inteira** na lista: saudações, confirmações, agradecimentos,
+   despedidas (`oi`, `ok`, `bom dia`, `obrigado`, `valeu`, `beleza`,
+   `entendi`, `thanks`, `got it`, …).
+4. **Risada pura:** `kkkk`, `hahaha`, `rsrsrs`, `hehe`.
+
+A regra de frase só casa quando a frase é o **conteúdo inteiro**:
+
+| Conteúdo | Ganha vetor? |
+| --- | --- |
+| `obrigado` | não |
+| `obrigado pela ajuda com o deploy do gateway` | **sim** |
+| `bom dia` | não |
+| `bom dia, preciso do relatório de vendas de março` | **sim** |
+| `kkkk` | não |
+| `kkkk pode ser, mas o build quebrou` | **sim** |
+
+Acento e pontuação não mudam a decisão: `"tá"`, `"ta"` e `"Tá!"` são a mesma
+coisa. Fato extraído (`[FACT] …`) nunca passa pelo filtro — já é sinal
+filtrado por um LLM com limiar de confiança.
+
+## Efeito no `garra memory`
+
+Uma entrada pulada fica com `embedding IS NULL`, exatamente como uma entrada
+cujo embedding **falhou**. Duas consequências práticas:
+
+**O total de "sem vetor" em `garra memory stats` não vai mais a zero.** Parte
+dele é proposital. O `reindex` separa as duas coisas:
+
+```console
+$ garra memory reindex --dry-run
+12 entrada(s) sem vetor seriam reprocessadas (dry-run: nada foi gravado).
+Outras 340 ficam sem vetor de proposito, por serem ruido para a busca
+semantica (#952) — elas seguem contadas em `stats` como "sem vetor".
+Ajuste ou desligue em `memory.ingestion`.
+```
+
+**O `reindex` usa a mesma política da ingestão.** Se usasse outra, ele
+reembeddaria uma por uma exatamente as entradas que a ingestão acabou de
+pular — pagando provider para desfazer o filtro. Os dois lados leem a mesma
+seção `memory.ingestion` da mesma config.
+
+## Discordo do filtro. Como volto ao comportamento anterior?
+
+```yaml
+memory:
+  ingestion:
+    filter_noise: false
+```
+
+Reinicie o gateway e rode `garra memory reindex`. Toda entrada que ficou sem
+vetor por causa da política recebe um — inclusive as que foram puladas antes
+de você mudar a chave.


### PR DESCRIPTION
## Descrição

Numa base de ~7.100 entradas, a consulta *"quem é Michel"* trazia entradas `"oi"` entre os primeiros resultados. Não era ranking ruim: `"oi"`, `"ok"`, `"kkkk"` e `"bom dia"` eram embeddados como qualquer outra mensagem, e **vetor de texto curto tem cosseno alto com quase tudo**. A proporção ruído/sinal só cresce com o tempo.

A ingestão passa a decidir se vale gastar um vetor com aquele conteúdo.

## O que o filtro **não** faz

Isto é o desenho, não uma limitação:

- **Não apaga nada.** A entrada continua gravada, continua no histórico e continua achável pelo recall textual. O que ela não ganha é o vetor.
- **Não é retroativo.** Vetor de `"oi"` já indexado continua onde está. Limpar o passado apaga dado, e isso é decisão do operador — `garra memory compact` e o TTL existem para isso.
- **Não é irreversível.** `filter_noise: false` + `garra memory reindex` devolve os vetores, inclusive das entradas puladas antes de você mudar a chave.

## As regras, e por que são conservadoras

Quatro, nesta ordem: conteúdo que some na normalização (só pontuação ou emoji), piso de caracteres úteis, frase inteira numa lista curada, e risada pura.

A regra de frase só casa quando a frase é o conteúdo **inteiro**:

| Conteúdo | Ganha vetor? |
| --- | --- |
| `obrigado` | não |
| `obrigado pela ajuda com o deploy do gateway` | **sim** |
| `bom dia` | não |
| `bom dia, preciso do relatório de vendas de março` | **sim** |
| `kkkk` | não |
| `kkkk pode ser, mas o build quebrou` | **sim** |

Uma regra de substring apagaria o eixo semântico de memória de verdade.

O piso é **4**, e não os 10 ou 12 que pegariam "bom dia" por comprimento. A lista faz o trabalho de precisão; um piso alto derrubaria junto um fato curto de verdade — `"moro em SP"` tem 10 caracteres. Errar embeddando ruído custa ranking; errar do outro lado custa **memória que o agente deveria ter e não tem**, e o usuário não tem como saber que perdeu.

**Ligado por padrão**, ao contrário da política de retenção. A diferença é o que está em jogo: a retenção apaga memória, esta política não apaga nada. Deixá-la desligada por padrão significaria que ninguém recebe a correção do bug.

## A reindexação usa a **mesma** política

Este é o ponto que faz o PR ser mais do que um `if` na ingestão.

Uma entrada pulada fica com `embedding IS NULL` — exatamente o que o `garra memory reindex` procura. Com políticas divergentes, ele reembeddaria **uma por uma** as entradas que a ingestão acabou de pular, pagando provider para desfazer o filtro.

Os dois lados leem a mesma seção `memory.ingestion` pelo mesmo `noise_policy_from_config`. E como o `garraia-agents` não depende do `garraia-config` (de propósito — a política chega lá como dado puro), o piso e a faixa existem escritos duas vezes: um teste no `garraia-gateway`, o único crate que vê os dois lados, trava os números.

Consequência honesta: **o total de "sem vetor" do `stats` não vai mais a zero.** Parte dele é proposital. O `--dry-run` passou a separar as duas coisas:

```console
$ garra memory reindex --dry-run
3 entrada(s) sem vetor seriam reprocessadas (dry-run: nada foi gravado).
Outras 7 ficam sem vetor de proposito, por serem ruido para a
busca semantica (#952) — elas seguem contadas em `stats` como
"sem vetor".
Ajuste ou desligue em `memory.ingestion`.
```

## Auditoria

`@security-auditor` rodou antes de abrir — **8.5/10, nenhum achado de segurança**. Os dois MÉDIO eram de corretude e viraram código; o BAIXO restante virou comentário e teste.

### MÉDIO — corrida entre o worker de retenção e a paginação da fila

O achado que mais importa. A fila era paginada por `OFFSET`, e o gateway roda um `memory_retention_worker` em paralelo (`server.rs:538`) que apaga entradas vencidas.

Uma deleção entre dois lotes encolhe a fila **antes** do ponteiro, e o lote seguinte começa uma linha adiante: **uma entrada legítima ficaria sem vetor sem ninguém perceber**, até a próxima reindexação manual.

A fila passou a um cursor por chave `(created_at, id)`, que não se move quando outra linha some. De brinde, troca o `O(offset)` do `OFFSET` do SQLite por uma comparação — que era o outro achado (BAIXO-2) da mesma auditoria. Dois findings, uma mudança.

Tem teste que reproduz a corrida: página 1, deleção **atrás** do cursor, página 2 — e a entrada que o `OFFSET` pularia está lá. O teste pergunta ao banco qual é a ordem em vez de supor, porque com `created_at` empatado no segundo quem manda é o `id` (UUID).

### MÉDIO — `dry_run` fazia a assinatura mentir

`dry_run` era campo de `ReindexOptions`, então `reindex_missing_embeddings` **exigia** um `&dyn EmbeddingProvider` e o descartava. Quem chamasse a API pública passaria um provider real sem saber que ele é ignorado. Além disso o `integrity_report` era calculado duas vezes.

`dry_run` saiu das options. Quem quer só contar chama `preview_reindex`, que não pede provider nenhum — porque nunca pediu vetor nenhum.

### BAIXO — `e_so_risada` conta bytes

A auditoria verificou que é seguro e eu concordo, mas o motivo não estava escrito. Agora está, no código: toda sílaba é ASCII e todo byte de um caractere UTF-8 multi-byte tem o bit alto ligado, então texto grego, cirílico ou CJK não pode casar por coincidência de comprimento em bytes. Com teste que ancora a invariante — se um dia entrar uma sílaba não-ASCII, ele quebra.

### O que a auditoria confirmou como correto

Nenhum conteúdo de memória vai para o `tracing` (o `debug!` emite o papel e a **contagem** de caracteres, não o texto); SQL só por `params!`; nenhum `unwrap()` novo em produção; `extra_noise_phrases` aditiva e não substitutiva; e a lista `DEFAULT_NOISE_PHRASES` revisada palavra por palavra sem falso-positivo real, porque a regra do conteúdo inteiro é o que a torna segura.

## Tipo de mudança

- [x] `fix`: Correção de bug
- [x] `feat`: Nova chave de config (`memory.ingestion`)
- [x] `docs`: Documentação
- [x] `test`: Adição de testes

## Classe de Risco

- [x] **Classe C (Alto Risco)**: muda **o que entra no índice vetorial**, ou seja, o que o agente consegue lembrar por busca semântica. Não apaga dado, não toca auth, RLS nem schema — mas mudar o que é lembrado é o critério que importa. Auditoria rodou antes de abrir.

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo +1.95 fmt --all` executado e limpo
- [x] `cargo +1.95 clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings` sem erros
- [x] `cargo +1.95 test --workspace --exclude garraia-desktop` passando — única falha é a ambiental conhecida `migration_001_applies_and_schema_is_sane`, que exige `docker.sock`; o CI valida
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo, API key, token ou credencial commitada
- [x] Nenhuma migração — este PR não toca schema

### Para alterações de Alto Risco (Classe C)

- [x] A entrada **nunca** é apagada nem deixa de ser gravada — só não ganha vetor, com teste
- [x] Frase de ruído dentro de conteúdo real não filtra, com teste
- [x] Fato curto de verdade sobrevive, com teste
- [x] Desligar a política restaura o comportamento anterior **inteiro**, com teste nos dois caminhos (ingestão e reindexação)
- [x] Entrada pulada não finge ter modelo — a coluna `embedding_model` descreve o vetor (regra do #948), com teste
- [x] Nenhum conteúdo de memória chega ao `tracing`
- [ ] Verificação de políticas RLS — não se aplica: SQLite local, sem RLS

## Mudanças na API pública e Schema

- **`garraia-agents`:** módulo novo `memory_noise` (`NoisePolicy`, `DEFAULT_MIN_CHARS`, `MIN_CHARS_MAX`, `DEFAULT_NOISE_PHRASES`); `AgentRuntime::{set_noise_policy, noise_policy}`; `preview_reindex`; `ReindexOptions` ganha `noise` e **perde** `dry_run`; `ReindexReport` ganha `skipped_noise` e `would_reindex`.
- **`garraia-db`:** `entries_missing_embeddings_after(limit, after)` substitui a paginação por offset; `entries_missing_embeddings(limit)` inalterado.
- **`garraia-config`:** `memory.ingestion` (`filter_noise`, `min_chars`, `extra_noise_phrases`) + `INGESTION_MIN_CHARS_MAX` + 5 validações no `config check`.
- **`garraia-gateway`:** `bootstrap::noise_policy_from_config` público (a CLI precisa da mesma política).
- **CLI:** `garra memory reindex` reporta `skipped_noise` / `would_reindex`; `--dry-run` não exige mais provider.
- Sem mudança de schema, sem migração.

## Como testar

```bash
cargo +1.95 test -p garraia-agents memory_noise      # 15: as 4 regras, acento, nao-ASCII, extras
cargo +1.95 test -p garraia-agents memory_reindex    # 11: coerencia com a ingestao, limite, dry-run
cargo +1.95 test -p garraia-agents runtime::tests    # ingestao: sem vetor E sem ida ao provider
cargo +1.95 test -p garraia-db cursor                # a corrida com a delecao concorrente
cargo +1.95 test -p garraia-gateway --lib bootstrap  # os dois lados da politica concordam
cargo +1.95 test -p garraia-config check::tests      # as 5 validacoes
```

Fim a fim, exercitado nesta sessão contra um `memory.db` real com 7 entradas de ruído e 3 de conteúdo:

```bash
garra memory reindex --dry-run --json         # skipped_noise: 7, would_reindex: 3
garra memory reindex --dry-run --limit 4 --batch-size 2 --json   # 2 + 2: o limite conta o ruido
# com filter_noise: false                     # skipped_noise: 0, would_reindex: 10
# com min_chars: 999                          # config check: 1 erro, nao 1 erro + 1 aviso redundante
```

## Plano de Rollback

Reverter o merge, ou só escrever `memory.ingestion.filter_noise: false` e rodar `garra memory reindex` — nada foi apagado, então tudo volta. O que se perde é a proteção do índice contra o ruído novo.

## O que fica para o próximo PR

**#957** (métricas `garraia_memory_*` no `/metrics`). Ela nasce daqui — a métrica que interessa é ingeridas vs. descartadas, e o gancho é o filtro que este PR introduz. Fica em diff próprio porque são seis métricas novas e um ponto de atualização de gauge no gateway, que é superfície de observabilidade e merece ser lida sozinha.

Closes #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF

---
_Generated by [Claude Code](https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF)_