### PR TITLE
docs(adr): a ADR 0002 passa a dizer o que foi construído (#949, #964)

### DIFF
--- a/changelog.d/changed/949-adr-0002-amendment-sqlite-vec.md
+++ b/changelog.d/changed/949-adr-0002-amendment-sqlite-vec.md
@@ -1,0 +1,15 @@
+- **A ADR 0002 passa a dizer o que foi construido (#949).** Ela decidia
+  "pgvector, 768 dimensoes fixas, mxbai" e ninguem voltou nela quando a memoria
+  do agente foi construida em **sqlite-vec**, com uma tabela `vec_embeddings_{dims}`
+  por dimensao, criada sob demanda a partir do vetor que o provider devolve.
+  Quem lia o ADR de cima a baixo acreditava num sistema que nao existe em
+  instalacao nenhuma. A Amendment de 2026-09-06 registra a divergencia campo a
+  campo, explica por que ela aconteceu (memoria do agente e local-first e
+  mono-usuario; exigir Postgres teria matado o caso de uso principal) e delimita
+  o que do ADR continua valendo — tudo que ele decide para o workspace
+  multi-tenant em Postgres. O status segue `Accepted`: o documento nao estava
+  errado, estava sem escopo. O crate orfao `garraia-embeddings` ganha um aviso
+  no topo dizendo que **nao** e o caminho em uso e apontando para o par que e
+  (`garraia_agents::embeddings` + `garraia_db::vector_store`). Remover ou alinhar
+  o crate fica como decisao propria, com ADR, porque o `CLAUDE.md` o registra
+  como scaffold deliberado da Fase 2.1.

--- a/changelog.d/fixed/964-retriever-doc-mentia.md
+++ b/changelog.d/fixed/964-retriever-doc-mentia.md
@@ -1,0 +1,9 @@
+- **O stub do retriever de skills parava de mentir (#964).** A doc dizia
+  "Returns empty list until then" e o corpo devolvia `Err` — duas frases sobre a
+  mesma funcao, discordando. Quem lesse o comentario escreveria
+  `retrieve(q)?.is_empty()` e levaria um erro em producao. O comportamento que
+  ficou e o `Err`, porque `Ok(vec![])` seria pior: lista vazia e indistinguivel
+  de "procurei e nao achei nada", e o chamador seguiria em frente com um recall
+  que nunca rodou. A doc tambem citava a dependencia errada (`garraia-embeddings`,
+  o crate orfao do #949) e agora aponta o par que de fato funciona na memoria do
+  agente. Nao ha chamador no workspace hoje.

--- a/crates/garraia-embeddings/src/lib.rs
+++ b/crates/garraia-embeddings/src/lib.rs
@@ -1,12 +1,40 @@
 //! GarraIA — Embeddings & vector search.
 //!
+//! # ⚠️ Este crate NÃO é o sistema de embeddings em uso (#949)
+//!
+//! Nada no workspace depende dele: nenhum `Cargo.toml` o declara como
+//! dependência e nenhum `.rs` o referencia. Ele é o scaffold da Fase 2.1
+//! (plan 0145), e o que ele descreve — pgvector, 768 dimensões fixas,
+//! mxbai-embed-large-v1 — **não** é o que roda hoje.
+//!
+//! O caminho vivo é outro, e são dois módulos em dois crates diferentes:
+//!
+//! - `garraia_agents::embeddings` tem o `EmbeddingProvider` que o runtime
+//!   chama de verdade. É um trait **diferente** e incompatível com o daqui.
+//! - `garraia_db::vector_store` guarda os vetores em **sqlite-vec**, em
+//!   tabelas virtuais `vec0` chamadas `vec_embeddings_{dims}` — uma por
+//!   dimensão, criadas sob demanda. A dimensão é derivada do vetor que o
+//!   provider devolve, não fixada em 768.
+//!
+//! A tabela `memory_embeddings` da migration 005 (pgvector + HNSW) existe e
+//! está correta, mas nenhum código de produção lê ou escreve nela ainda.
+//!
+//! Se você abriu este crate procurando como o GarraIA faz busca semântica,
+//! está no arquivo errado. Ver a Amendment de 2026-09-06 na [ADR 0002][adr-0002],
+//! que registra a divergência e as duas saídas em aberto (remover este crate
+//! ou alinhá-lo). Enquanto isso não se decide, **não** trate a `EMBEDDING_DIM`
+//! daqui como verdade sobre o sistema.
+//!
+//! ---
+//!
 //! This crate ships the public surface (traits + strong types) that the rest of
 //! the GarraIA workspace programs against for embedding-based retrieval. It
 //! intentionally contains **no** concrete database wiring — the
 //! [`VectorStore`] trait is a definition; a real `PgVectorStore` over `sqlx`
 //! lives in a follow-up slice.
 //!
-//! Design is fixed by [ADR 0002][adr-0002] (Accepted 2026-04-21). Briefly:
+//! Design **as scaffolded** follows [ADR 0002][adr-0002] (Accepted 2026-04-21) —
+//! see the divergence warning above before relying on any of it. Briefly:
 //!
 //! - `pgvector` is the primary vector store.
 //! - Embedding dimension is 768 (mxbai-embed-large-v1).

--- a/crates/garraia-learning/src/retriever.rs
+++ b/crates/garraia-learning/src/retriever.rs
@@ -1,11 +1,30 @@
 use garraia_common::{Error, Result};
 
-/// Finds relevant skills for a query using embedding-based similarity search.
+/// Busca semântica de skills — **não implementada** (#964).
 ///
-/// Requires `garraia-embeddings` (Fase 2.1, GAR-372). Returns empty list until then.
-/// GAR-646 will implement the full retriever.
+/// A doc anterior dizia "Returns empty list until then" e o corpo devolvia
+/// `Err`. Duas frases sobre a mesma função, discordando: quem lesse o
+/// comentário escreveria `retrieve(q)?.is_empty()` e levaria um erro em
+/// produção. O comportamento que ficou é o `Err`, e agora a doc diz isso.
+///
+/// **Devolver `Ok(vec![])` seria pior.** Uma lista vazia é indistinguível de
+/// "procurei e não achei nada", então o chamador concluiria que não existe
+/// skill relevante — e seguiria em frente com um recall que nunca rodou. O
+/// erro é a única resposta que não mente.
+///
+/// A dependência que a doc antiga citava (`garraia-embeddings`) é o crate
+/// órfão do #949, que não é o caminho em uso. Quando isto for implementado, o
+/// que precisa ser usado é o par que já funciona na memória do agente:
+/// `garraia_agents::embeddings::EmbeddingProvider` para gerar o vetor e
+/// `garraia_db::vector_store` (sqlite-vec) para o KNN — os mesmos que o
+/// `garra memory search` exercita.
+///
+/// Hoje não há nenhum chamador no workspace.
 pub fn retrieve(_query: &str) -> Result<Vec<crate::Skill>> {
     Err(Error::Other(
-        "Skill Retriever not yet implemented — requires garraia-embeddings (GAR-646)".into(),
+        "busca semantica de skills nao implementada (#964): quando for, use \
+         garraia_agents::embeddings + garraia_db::vector_store, o mesmo par da \
+         memoria do agente — nao o crate orfao garraia-embeddings"
+            .into(),
     ))
 }

--- a/docs/adr/0002-vector-store.md
+++ b/docs/adr/0002-vector-store.md
@@ -182,6 +182,73 @@ Reprodução empírica em produção real com dataset de usuários (quando Fase 
 
 ---
 
+## Amendment 2026-09-06 — o que foi construído não é o que este ADR descreve (#949)
+
+> **Status deste ADR permanece `Accepted`.** O que muda é o escopo: ele decide o
+> vector store do **workspace multi-tenant em Postgres**, e não o da **memória do
+> agente**, que foi construída em outra tecnologia sem que este documento fosse
+> atualizado. Quem lê o ADR de cima a baixo hoje acredita que o GarraIA faz busca
+> semântica em pgvector com 768 dimensões, e isso não é verdade em nenhuma
+> instalação real.
+
+### O que existe de fato, verificado no código
+
+| O que o ADR diz | O que está rodando | Onde |
+| --- | --- | --- |
+| pgvector, HNSW cosine | **sqlite-vec 0.1.9**, tabelas virtuais `vec0` | `crates/garraia-db/src/vector_store.rs` |
+| Uma coluna `embedding vector(768)` | **Uma tabela por dimensão**, `vec_embeddings_{dims}`, criada sob demanda | `ensure_vec_table` (`vector_store.rs:109`) |
+| Dimensão fixa em 768 | **Dimensão dinâmica**, derivada do vetor que o provider devolve | `insert_embedding(.., dimensions)` |
+| mxbai-embed-large-v1 | Default do código é `nomic-embed-text`; instalações reais usam outros (o relato do #949 é `qwen3-embedding:0.6b`, 1024d) | `crates/garraia-agents/src/embeddings.rs:89` |
+| Crate `garraia-embeddings` envolvendo `sqlx` | O `EmbeddingProvider` **em uso** mora em `garraia-agents`; o crate homônimo tem um segundo trait, incompatível, e `EMBEDDING_DIM = 768` | `garraia-agents/src/embeddings.rs` vs. `garraia-embeddings/src/types.rs` |
+
+A tabela `memory_embeddings` da migration 005 (pgvector + HNSW) **existe** e está
+correta — mas nenhum código de produção lê ou escreve nela. Os únicos
+consumidores são os casos da matriz de RLS em
+`crates/garraia-auth/tests/common/matrix.rs`. Ou seja: o caminho Postgres está
+provisionado e vazio; o caminho que guarda memória de verdade é o SQLite.
+
+### Por que divergiu
+
+Não foi descuido de implementação — foram **dois produtos diferentes** que este
+ADR tratou como um só.
+
+A memória do agente é **local-first e mono-usuário**: `garra chat` e o gateway
+rodam na máquina de quem usa, contra `~/.config/garraia/data/memory.db`, sem
+Postgres em lugar nenhum. Exigir um Postgres de pé para o agente lembrar do nome
+do usuário teria matado o caso de uso principal. O ADR só considerou o cenário do
+workspace multi-tenant (ADR 0003), onde Postgres já é obrigatório por outros
+motivos, e concluiu — corretamente, para *aquele* cenário — que adicionar um
+store dedicado seria desalinhamento.
+
+O erro está no ADR ter escrito "vector store" sem qualificar qual, e em ninguém
+ter voltado aqui quando o `sqlite-vec` entrou.
+
+### O que continua valendo
+
+Tudo que o ADR decide **para o workspace Postgres**: pgvector como store, filtro
+multi-tenant dentro do mesmo sistema que aplica RLS, hybrid query em CTE única, e
+os triggers de supersessão. Quando a memória do workspace for implementada de
+verdade, é este documento que manda.
+
+### O que fica em aberto (decisão do dono, não desta amendment)
+
+O crate `garraia-embeddings` é órfão — verificado: nenhum `Cargo.toml` o declara
+como dependência e nenhum `.rs` do workspace o referencia. Ao mesmo tempo, o
+`CLAUDE.md` o registra como scaffold **deliberado** da Fase 2.1 (plan 0145,
+promovido a crate ativo em 2026-05-18). As duas coisas são verdade.
+
+Apagá-lo é decisão de arquitetura, não limpeza, então não entra aqui. As saídas
+são: (a) remover o crate e o `EMBEDDING_DIM` errado, deixando o caminho Postgres
+para quando a memória do workspace existir; ou (b) mantê-lo e corrigir
+`EMBEDDING_DIM` para dimensão dinâmica, alinhando os dois traits. Qualquer uma
+das duas pede ADR próprio (regra absoluta 8).
+
+Enquanto não se decidir, vale registrar em `garraia-embeddings` que ele **não** é
+o caminho em uso — quem abrir aquele crate hoje acredita que está lendo o sistema
+de embeddings do GarraIA.
+
+---
+
 ## Supersession path
 
 Este ADR **pode** ser superseded por um novo ADR (próximo número monotônico disponível em `docs/adr/`, convenção `NNNN-slug.md`) se qualquer trigger acima bater. A supersessão vai documentar benchmark comparativo e plano de migração.


### PR DESCRIPTION
## Descrição

A ADR 0002 decide **"pgvector, 768 dimensões fixas, mxbai-embed-large-v1"**. Nada disso roda.

A memória do agente foi construída em **sqlite-vec**, com uma tabela virtual `vec_embeddings_{dims}` por dimensão, criada sob demanda a partir do vetor que o provider devolve — e ninguém voltou ao ADR quando isso aconteceu. Quem lia o documento de cima a baixo acreditava num sistema que não existe em instalação nenhuma.

## O que existe de fato, verificado antes de escrever

| ADR diz | Roda de fato | Onde |
| --- | --- | --- |
| pgvector, HNSW cosine | **sqlite-vec 0.1.9**, tabelas virtuais `vec0` | `garraia-db/src/vector_store.rs` |
| Uma coluna `vector(768)` | **Uma tabela por dimensão**, criada sob demanda | `ensure_vec_table` (`vector_store.rs:109`) |
| Dimensão fixa 768 | **Derivada em runtime** do vetor recebido | `insert_embedding(.., dimensions)` |
| mxbai-embed-large-v1 | Default do código é `nomic-embed-text` | `garraia-agents/src/embeddings.rs:89` |
| Crate `garraia-embeddings` envolvendo `sqlx` | O `EmbeddingProvider` **em uso** mora em `garraia-agents`; o crate homônimo tem um segundo trait, incompatível | os dois arquivos |

E o achado que fecha o quadro: a tabela `memory_embeddings` (pgvector + HNSW, migration 005) **existe e está correta**, mas os únicos consumidores são os casos da matriz de RLS em `garraia-auth/tests/common/matrix.rs`. O caminho Postgres está provisionado e vazio; o que guarda memória de verdade é o SQLite.

## Por que o status continua `Accepted`

Não foi descuido de implementação — foram **dois produtos** que o ADR tratou como um só.

A memória do agente é **local-first e mono-usuário**: `garra chat` e o gateway rodam na máquina de quem usa, contra `~/.config/garraia/data/memory.db`. Exigir um Postgres de pé para o agente lembrar do nome do usuário teria matado o caso de uso principal.

O ADR só considerou o cenário do workspace multi-tenant (ADR 0003), onde Postgres já é obrigatório por outros motivos — e ali as conclusões dele valem **inteiras**: pgvector como store, filtro multi-tenant dentro do mesmo sistema que aplica RLS, hybrid query em CTE única, os triggers de supersessão. Quando a memória do workspace for implementada, é este documento que manda.

O erro está em ter escrito "vector store" sem qualificar qual. A Amendment corrige o escopo, não a decisão.

## O aviso vai onde ele engana

O crate órfão ganha o bloco no topo do próprio `lib.rs` — quem abre `garraia-embeddings` hoje procurando como o GarraIA faz busca semântica está no arquivo errado, e agora o arquivo diz isso, apontando para o par que de fato funciona.

## #964 — o mesmo problema em escala menor

A doc do `retriever.rs` dizia *"Returns empty list until then"* e o corpo devolvia `Err`. Duas frases sobre a mesma função, discordando: quem lesse o comentário escreveria `retrieve(q)?.is_empty()` e levaria erro em produção.

Ficou o **`Err`**. `Ok(vec[])` seria pior: lista vazia é indistinguível de "procurei e não achei nada", então o chamador concluiria que não existe skill relevante e seguiria em frente com um recall que nunca rodou. O erro é a única resposta que não mente.

A doc também citava a dependência errada (`garraia-embeddings`, o crate órfão) e agora aponta `garraia_agents::embeddings` + `garraia_db::vector_store` — o mesmo par que o `garra memory search` exercita. Não há chamador no workspace hoje.

## A #949 fica aberta, e é de propósito

Ela pede para **remover** o crate ou **migrar** o runtime para ele. Não fiz nenhum dos dois: fiz a terceira coisa que a própria issue lista ("atualizar o ADR 0002 para refletir sqlite-vec + dimensão dinâmica") mais o aviso no crate.

O crate é órfão — verificado: nenhum `Cargo.toml` o declara como dependência e nenhum `.rs` do workspace o referencia. **E ao mesmo tempo** o `CLAUDE.md` o registra como scaffold deliberado da Fase 2.1 (plan 0145, promovido a crate ativo em 2026-05-18). As duas coisas são verdade.

Apagar um crate que o projeto criou de propósito para uma fase futura é decisão de arquitetura, não limpeza — a regra absoluta 8 manda passar por ADR próprio. As duas saídas estão escritas na Amendment; a escolha é do dono. Fechar a issue aqui seria dizer que ela foi tomada.

## Tipo de mudança

- [x] `docs`: Documentação
- [x] `fix`: Correção de doc que contradizia o código (#964)

## Classe de Risco

- [x] **Classe A (Baixo Risco)**: sem mudança de comportamento. Um bloco de doc num crate que ninguém usa, a mensagem de erro de uma função sem chamador, e um ADR. Auditoria de segurança não se aplica — nada aqui toca dados, auth, storage, isolamento ou CI.

## Checklist de Segurança e Qualidade

- [x] `cargo +1.95 fmt --all -- --check` limpo
- [x] `cargo +1.95 clippy -p garraia-learning -p garraia-embeddings --all-targets -- -D warnings` sem erros
- [x] `cargo +1.95 test -p garraia-learning -p garraia-embeddings` — 170 testes passando
- [x] `cargo +1.95 doc -p garraia-embeddings --no-deps` sem warning novo (o único que resta é pré-existente, `HybridQuery::build`)
- [x] `python3 scripts/changelog/assemble.py --check` OK
- [x] Nenhum `unwrap()`, nenhum segredo, nenhuma migração

## Mudanças na API pública e Schema

Nenhuma. A assinatura de `retriever::retrieve` não muda — só o texto do erro e a doc.

## Plano de Rollback

Reverter o merge. Volta a doc antiga, que estava errada.

## O que fica para o próximo PR

**#963** (reescrever `docs/src/memory.md`, hoje um produto fictício: seis subcomandos que nunca existiram, chaves de config inexistentes e o caminho errado do banco). Ficou de fora porque precisa descrever o filtro de ruído do #992 junto — que só mergeou agora — e escrever contra código não mergeado é como se erra esse tipo de doc.

Closes #964

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF

---
_Generated by [Claude Code](https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF)_