### PR TITLE
feat(memory): a memória aparece no /metrics (#957, parte 1 de 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2729,6 +2729,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3244,6 +3250,8 @@ dependencies = [
  "garraia-db",
  "garraia-security",
  "libc",
+ "metrics",
+ "metrics-util",
  "reqwest 0.12.28",
  "rmcp",
  "serde",
@@ -3321,6 +3329,7 @@ dependencies = [
  "chrono",
  "futures",
  "garraia-common",
+ "metrics",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -5382,11 +5391,15 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96f8722f8562635f92f8ed992f26df0532266eb03d5202607c20c0d7e9745e13"
 dependencies = [
+ "aho-corasick",
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.16.1",
+ "indexmap 2.14.0",
  "metrics",
+ "ordered-float",
  "quanta",
+ "radix_trie",
  "rand 0.9.4",
  "rand_xoshiro",
  "rapidhash",
@@ -5546,6 +5559,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "nix"
@@ -6152,6 +6174,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7c9e0d9b23589f26070720bac724174bfec1083e82f7854cdd0267518343c0"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "ordered-stream"
@@ -6978,6 +7009,16 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "rand"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,10 @@ clap = { version = "4", features = ["derive", "env"] }
 # Logging / Tracing
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+# Facade de metricas (#957). Mesma versao que o `garraia-telemetry` ja usa —
+# duas versoes do facade na arvore dariam dois recorders globais, e o que o
+# gateway instala nao veria o que o agents emite.
+metrics = "0.24"
 
 # Error handling
 thiserror = "2"

--- a/changelog.d/added/957-metricas-de-memoria.md
+++ b/changelog.d/added/957-metricas-de-memoria.md
@@ -1,0 +1,21 @@
+- **A memoria passa a aparecer no `/metrics` (#957).** Ate aqui o `/metrics`
+  tinha quatro metricas HTTP genericas e nada sobre o componente central do
+  produto: o operador nao tinha como monitorar a saude do recall semantico.
+  Entram quatro, com prefixo `garraia_` — nao `garra_` como a issue propoe,
+  porque duas familias de prefixo no mesmo endpoint quebrariam todo dashboard
+  que agrupa por `garraia_.*`: `garraia_memory_embed_latency_seconds`
+  {provider,operation}, `garraia_memory_embed_failures_total`{provider,operation},
+  `garraia_memory_recall_latency_seconds` e `garraia_memory_ingested_total`
+  {outcome}. A que mais importa e a de falha: o #948 tirou a falha de embedding
+  do silencio no log, e esta a tira do painel — log conta o caso, metrica conta
+  a tendencia, e e a tendencia que faz alguem descobrir que o provider caiu
+  antes de o recall degradar. `no_provider` e `failed` sao desfechos separados
+  de proposito (a diferenca entre "ninguem configurou" e "configurou e esta
+  quebrado"), e `noise` existe por causa do filtro do #952 — sem ele o total de
+  entradas sem vetor subiria sem que ninguem distinguisse defeito de politica.
+  Emitidas pelo facade `metrics` via `garraia-common`, e **nao** pelo
+  `garraia-telemetry`: quem emite e o `garraia-agents`, que a CLI linka, e
+  depender da telemetria arrastaria OpenTelemetry, OTLP, tonic e axum para
+  dentro do binario da CLI. Sem recorder instalado cada chamada e um no-op.
+  Toda label vem de conjunto fechado, com teste afirmando que id de sessao, id
+  de usuario e conteudo nunca chegam a uma label.

--- a/crates/garraia-agents/Cargo.toml
+++ b/crates/garraia-agents/Cargo.toml
@@ -38,6 +38,14 @@ mcp-http = ["mcp", "rmcp?/transport-streamable-http-client-reqwest"]
 dev-echo-provider = []
 
 [dev-dependencies]
+# #957: so para os testes de metrica. O `DebuggingRecorder` + `with_local_recorder`
+# instalam um recorder **thread-local**, o que permite afirmar que o runtime
+# emitiu de fato — sem tocar no recorder global, que so pode ser instalado uma
+# vez por processo e quebraria testes em paralelo.
+metrics-util = { version = "0.20", features = ["debugging"] }
+# O facade, para o teste poder instalar o recorder local. Em codigo de
+# producao este crate emite via `garraia_common::metrics`, nao direto.
+metrics = { workspace = true }
 tempfile = "3"
 axum = { workspace = true }
 tokio-stream = { workspace = true }

--- a/crates/garraia-agents/src/runtime.rs
+++ b/crates/garraia-agents/src/runtime.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, RwLock};
 
 use futures::future::join_all;
 use futures::{Stream, StreamExt};
-use garraia_common::{Error, Result};
+use garraia_common::{Error, Result, metrics};
 use garraia_db::{MemoryEntry, MemoryProvider, MemoryRole, NewMemoryEntry, RecallQuery};
 use tokio::sync::mpsc;
 use tokio::time::timeout;
@@ -514,6 +514,12 @@ impl AgentRuntime {
             return Ok(Vec::new());
         };
 
+        // #957: mede o recall **inteiro** — o embedding da consulta mais a
+        // busca —, porque e isso que o usuario espera. Medir so a busca
+        // esconderia o caso que mais dói: o provider de embeddings lento
+        // fazendo o recall demorar antes mesmo de o banco ser tocado.
+        let inicio = std::time::Instant::now();
+
         let query_embedding = self.embed_query(query_text).await;
         // O filtro por modelo só faz sentido acompanhando um embedding (#954):
         // sem vetor de consulta, o recall é textual e não deve ser estreitado.
@@ -522,7 +528,7 @@ impl AgentRuntime {
             .then(|| self.embedding_model())
             .flatten();
 
-        memory
+        let resultado = memory
             .recall(RecallQuery {
                 tenant_id: None,
                 query_text: Some(query_text.to_string()),
@@ -532,7 +538,14 @@ impl AgentRuntime {
                 continuity_key: continuity_key.map(|s| s.to_string()),
                 limit,
             })
-            .await
+            .await;
+
+        // Medido tambem quando falha: um recall que morre em 30s de timeout e
+        // exatamente a latencia que o operador precisa ver. Contar so o
+        // sucesso faria o painel melhorar quando o sistema piora.
+        metrics::record_recall_latency(inicio.elapsed().as_secs_f64());
+
+        resultado
     }
 
     /// Register a natively-built tool. Takes `&self` since #924 — the runtime
@@ -2044,6 +2057,7 @@ impl AgentRuntime {
     /// que se grava e sempre longo.
     async fn embed_turn_unless_noise(&self, text: &str, papel: &str) -> Option<Vec<f32>> {
         if self.noise_policy.is_noise(text) {
+            metrics::inc_ingested(metrics::IngestOutcome::Noise);
             debug!(
                 papel,
                 chars = text.chars().count(),
@@ -2053,18 +2067,53 @@ impl AgentRuntime {
             );
             return None;
         }
-        self.embed_document(text).await
+
+        // #957: o desfecho e contado **aqui**, e nao dentro do
+        // `embed_document`, porque so este nivel sabe distinguir os quatro
+        // casos. La embaixo, "sem provider" e "provider falhou" saem os dois
+        // como `None` — e sao a diferenca entre "ninguem configurou" e
+        // "configurou e esta quebrado", que e exatamente o que o operador
+        // precisa separar.
+        if self.embeddings.is_none() {
+            metrics::inc_ingested(metrics::IngestOutcome::NoProvider);
+            return None;
+        }
+
+        let vetor = self.embed_document(text).await;
+        metrics::inc_ingested(if vetor.is_some() {
+            metrics::IngestOutcome::Embedded
+        } else {
+            metrics::IngestOutcome::Failed
+        });
+        vetor
     }
 
     async fn embed_document(&self, text: &str) -> Option<Vec<f32>> {
         let provider = self.embeddings.as_ref()?;
+        // #957: a medicao cerca a chamada ao provider e nada mais. Incluir o
+        // que vem antes ou depois faria o histograma medir o GarraIA em vez de
+        // medir o provider, que e a pergunta que o operador tem.
+        let inicio = std::time::Instant::now();
         match provider.embed_documents(&[text.to_string()]).await {
-            Ok(mut vectors) => vectors.pop(),
+            Ok(mut vectors) => {
+                metrics::record_embed_latency(
+                    provider.provider_id(),
+                    metrics::EmbedOp::Document,
+                    inicio.elapsed().as_secs_f64(),
+                );
+                vectors.pop()
+            }
             Err(e) => {
                 // O `.ok()` que existia aqui era o primeiro elo da cadeia de
                 // perda silenciosa do #948: a entrada era gravada sem vetor,
                 // ficava invisivel para a busca semantica para sempre, e nada
                 // no log dizia que tinha acontecido.
+                //
+                // O #948 tirou o silencio do log; o #957 tira do painel. Log
+                // conta o caso, metrica conta a tendencia — e e a tendencia
+                // que faz alguem descobrir que o provider caiu antes de o
+                // recall degradar.
+                metrics::inc_embed_failure(provider.provider_id(), metrics::EmbedOp::Document);
                 warn!(
                     provider = provider.provider_id(),
                     model = provider.model(),
@@ -2079,9 +2128,18 @@ impl AgentRuntime {
 
     async fn embed_query(&self, text: &str) -> Option<Vec<f32>> {
         let provider = self.embeddings.as_ref()?;
+        let inicio = std::time::Instant::now();
         match provider.embed_query(text).await {
-            Ok(vector) => Some(vector),
+            Ok(vector) => {
+                metrics::record_embed_latency(
+                    provider.provider_id(),
+                    metrics::EmbedOp::Query,
+                    inicio.elapsed().as_secs_f64(),
+                );
+                Some(vector)
+            }
             Err(e) => {
+                metrics::inc_embed_failure(provider.provider_id(), metrics::EmbedOp::Query);
                 warn!(
                     provider = provider.provider_id(),
                     model = provider.model(),
@@ -2147,6 +2205,241 @@ impl Default for AgentRuntime {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ─── #957: as metricas da memoria ─────────────────────────────────────
+
+    /// Nome + labels de tudo que foi emitido enquanto `f` rodava.
+    ///
+    /// O recorder e **thread-local**, nao global, de proposito: o recorder
+    /// global do ecossistema `metrics` so pode ser instalado uma vez por
+    /// processo, e um teste que o instalasse quebraria todos os outros que
+    /// rodam em paralelo. `#[tokio::test]` usa o runtime `current_thread`,
+    /// entao o guard cobre o bloco inteiro sem risco de a task migrar de
+    /// thread no meio.
+    async fn metricas_emitidas<F, Fut>(f: F) -> Vec<String>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = ()>,
+    {
+        let recorder = metrics_util::debugging::DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let guard = ::metrics::set_default_local_recorder(&recorder);
+        f().await;
+        drop(guard);
+
+        let mut nomes: Vec<String> = snapshotter
+            .snapshot()
+            .into_vec()
+            .into_iter()
+            .map(|(chave, _, _, _)| {
+                let key = chave.key();
+                let mut labels: Vec<String> = key
+                    .labels()
+                    .map(|l| format!("{}={}", l.key(), l.value()))
+                    .collect();
+                labels.sort();
+                if labels.is_empty() {
+                    key.name().to_string()
+                } else {
+                    format!("{}{{{}}}", key.name(), labels.join(","))
+                }
+            })
+            .collect();
+        nomes.sort();
+        nomes
+    }
+
+    /// O caso que a issue #957 descreve: falha de embedding era silenciosa. O
+    /// #948 tirou o silencio do log; isto tira do painel.
+    #[tokio::test]
+    async fn falha_de_embedding_vira_contador() {
+        struct SempreFalha;
+
+        #[async_trait]
+        impl crate::embeddings::EmbeddingProvider for SempreFalha {
+            fn provider_id(&self) -> &str {
+                "provider-de-teste"
+            }
+            fn model(&self) -> &str {
+                "modelo"
+            }
+            async fn embed_documents(
+                &self,
+                _t: &[String],
+            ) -> garraia_common::Result<Vec<Vec<f32>>> {
+                Err(garraia_common::Error::Agent("fora do ar".into()))
+            }
+            async fn embed_query(&self, _t: &str) -> garraia_common::Result<Vec<f32>> {
+                Err(garraia_common::Error::Agent("fora do ar".into()))
+            }
+            async fn health_check(&self) -> garraia_common::Result<bool> {
+                Ok(false)
+            }
+        }
+
+        let store = Arc::new(garraia_db::MemoryStore::in_memory_with_vectors().expect("store"));
+        let mut rt = AgentRuntime::new();
+        rt.set_memory_provider(store);
+        rt.set_embedding_provider(Arc::new(SempreFalha));
+
+        let emitidas = metricas_emitidas(|| async {
+            rt.remember_turn("s1", None, None, "meu nome e Michel e moro na Florida", "")
+                .await
+                .expect("remember_turn");
+        })
+        .await;
+
+        assert!(
+            emitidas.iter().any(|m| m
+                == "garraia_memory_embed_failures_total{operation=document,provider=provider-de-teste}"),
+            "falha nao virou contador: {emitidas:?}"
+        );
+        assert!(
+            emitidas
+                .iter()
+                .any(|m| m == "garraia_memory_ingested_total{outcome=failed}"),
+            "desfecho `failed` nao foi contado: {emitidas:?}"
+        );
+    }
+
+    /// Os quatro desfechos precisam ser distinguiveis. `no_provider` e
+    /// `failed` sao a diferenca entre "ninguem configurou" e "configurou e
+    /// esta quebrado" — a pergunta que o operador faz primeiro.
+    #[tokio::test]
+    async fn sem_provider_e_desfecho_proprio_nao_falha() {
+        let store = Arc::new(garraia_db::MemoryStore::in_memory_with_vectors().expect("store"));
+        let mut rt = AgentRuntime::new();
+        rt.set_memory_provider(store);
+        // Sem `set_embedding_provider`.
+
+        let emitidas = metricas_emitidas(|| async {
+            rt.remember_turn("s1", None, None, "um fato de verdade para lembrar", "")
+                .await
+                .expect("remember_turn");
+        })
+        .await;
+
+        assert!(
+            emitidas
+                .iter()
+                .any(|m| m == "garraia_memory_ingested_total{outcome=no_provider}"),
+            "{emitidas:?}"
+        );
+        assert!(
+            !emitidas.iter().any(|m| m.contains("embed_failures")),
+            "sem provider nao e falha do provider: {emitidas:?}"
+        );
+    }
+
+    /// Ruido tem desfecho proprio (#952). Sem isso, o operador veria o total
+    /// de entradas sem vetor subir e nao teria como saber se e defeito ou
+    /// politica.
+    #[tokio::test]
+    async fn ruido_tem_desfecho_proprio_e_nao_chama_o_provider() {
+        let store = Arc::new(garraia_db::MemoryStore::in_memory_with_vectors().expect("store"));
+        let embeddings = Arc::new(ContandoEmbeddings(std::sync::atomic::AtomicUsize::new(0)));
+        let mut rt = AgentRuntime::new();
+        rt.set_memory_provider(store);
+        rt.set_embedding_provider(embeddings.clone());
+
+        let emitidas = metricas_emitidas(|| async {
+            rt.remember_turn("s1", None, None, "oi", "bom dia")
+                .await
+                .expect("remember_turn");
+        })
+        .await;
+
+        assert!(
+            emitidas
+                .iter()
+                .any(|m| m == "garraia_memory_ingested_total{outcome=noise}"),
+            "{emitidas:?}"
+        );
+        assert_eq!(chamadas(&embeddings), 0, "ruido nao pode ir ao provider");
+        assert!(
+            !emitidas.iter().any(|m| m.contains("embed_latency")),
+            "nao houve chamada, nao pode haver latencia: {emitidas:?}"
+        );
+    }
+
+    /// O caminho feliz: latencia medida por provider e por operacao, e o
+    /// desfecho contado como `embedded`.
+    #[tokio::test]
+    async fn sucesso_mede_latencia_por_provider_e_operacao() {
+        let store = Arc::new(garraia_db::MemoryStore::in_memory_with_vectors().expect("store"));
+        let mut rt = AgentRuntime::new();
+        rt.set_memory_provider(store);
+        rt.set_embedding_provider(Arc::new(ContandoEmbeddings(
+            std::sync::atomic::AtomicUsize::new(0),
+        )));
+
+        let emitidas = metricas_emitidas(|| async {
+            rt.remember_turn("s1", None, None, "um fato de verdade para lembrar", "")
+                .await
+                .expect("remember_turn");
+            rt.recall_context("quem sou eu", Some("s1"), None, 5)
+                .await
+                .expect("recall");
+        })
+        .await;
+
+        assert!(
+            emitidas.iter().any(|m| m
+                == "garraia_memory_embed_latency_seconds{operation=document,provider=contando}"),
+            "{emitidas:?}"
+        );
+        assert!(
+            emitidas
+                .iter()
+                .any(|m| m
+                    == "garraia_memory_embed_latency_seconds{operation=query,provider=contando}"),
+            "a consulta do recall nao foi medida: {emitidas:?}"
+        );
+        assert!(
+            emitidas
+                .iter()
+                .any(|m| m == "garraia_memory_recall_latency_seconds"),
+            "{emitidas:?}"
+        );
+        assert!(
+            emitidas
+                .iter()
+                .any(|m| m == "garraia_memory_ingested_total{outcome=embedded}"),
+            "{emitidas:?}"
+        );
+    }
+
+    /// Nenhuma label pode carregar id de sessao, de usuario ou conteudo — e a
+    /// explosao de cardinalidade que o docblock do `garraia-telemetry` descreve.
+    #[tokio::test]
+    async fn nenhuma_label_carrega_identificador_ou_conteudo() {
+        let store = Arc::new(garraia_db::MemoryStore::in_memory_with_vectors().expect("store"));
+        let mut rt = AgentRuntime::new();
+        rt.set_memory_provider(store);
+        rt.set_embedding_provider(Arc::new(ContandoEmbeddings(
+            std::sync::atomic::AtomicUsize::new(0),
+        )));
+
+        let emitidas = metricas_emitidas(|| async {
+            rt.remember_turn(
+                "sessao-secreta-42",
+                None,
+                Some("usuario-secreto"),
+                "minha senha do banco e 1234",
+                "",
+            )
+            .await
+            .expect("remember_turn");
+        })
+        .await;
+
+        for m in &emitidas {
+            for proibido in ["sessao-secreta", "usuario-secreto", "senha", "1234"] {
+                assert!(!m.contains(proibido), "label vazou {proibido:?}: {m}");
+            }
+        }
+        assert!(!emitidas.is_empty(), "o teste precisa ter emitido algo");
+    }
 
     // ─── #952: ruido nao merece vetor ─────────────────────────────────────
 

--- a/crates/garraia-agents/src/runtime.rs
+++ b/crates/garraia-agents/src/runtime.rs
@@ -2094,15 +2094,44 @@ impl AgentRuntime {
         // que vem antes ou depois faria o histograma medir o GarraIA em vez de
         // medir o provider, que e a pergunta que o operador tem.
         let inicio = std::time::Instant::now();
-        match provider.embed_documents(&[text.to_string()]).await {
-            Ok(mut vectors) => {
-                metrics::record_embed_latency(
-                    provider.provider_id(),
-                    metrics::EmbedOp::Document,
-                    inicio.elapsed().as_secs_f64(),
+        let resultado = provider.embed_documents(&[text.to_string()]).await;
+
+        // Mede sucesso **e** falha, pela mesma razao que o `recall_context`:
+        // uma chamada que morre em 30s de timeout e exatamente a latencia que
+        // o operador precisa ver. Registrar so o ramo `Ok` faria a p95
+        // melhorar durante uma rajada de timeout, que e quando o painel mais
+        // precisa piorar. (Apontado pela auditoria do #957: a primeira versao
+        // media so o sucesso aqui e os dois no recall, e a assimetria nao
+        // tinha defesa.)
+        //
+        // Sem label de desfecho: o contador de falha ao lado ja responde
+        // "quantas falharam", e separar o histograma em duas series faria a
+        // pergunta que importa — "quanto o provider esta demorando" — exigir
+        // somar as duas de volta.
+        metrics::record_embed_latency(
+            provider.provider_id(),
+            metrics::EmbedOp::Document,
+            inicio.elapsed().as_secs_f64(),
+        );
+
+        match resultado {
+            // Lote vazio conta como falha, e nao como `None` silencioso.
+            // Nenhum dos tres providers reais devolve lote vazio para uma
+            // entrada, mas tratar isso como sucesso-sem-vetor produziria um
+            // `ingested_total{outcome=failed}` sem par em
+            // `embed_failures_total`, e o operador veria dois numeros que nao
+            // fecham. Apontado pela auditoria do #957.
+            Ok(vectors) if vectors.is_empty() => {
+                metrics::inc_embed_failure(provider.provider_id(), metrics::EmbedOp::Document);
+                warn!(
+                    provider = provider.provider_id(),
+                    model = provider.model(),
+                    "memoria: o provider de embeddings devolveu lote vazio para um \
+                     texto; a entrada vai ser gravada sem vetor (#948)"
                 );
-                vectors.pop()
+                None
             }
+            Ok(mut vectors) => vectors.pop(),
             Err(e) => {
                 // O `.ok()` que existia aqui era o primeiro elo da cadeia de
                 // perda silenciosa do #948: a entrada era gravada sem vetor,
@@ -2129,15 +2158,17 @@ impl AgentRuntime {
     async fn embed_query(&self, text: &str) -> Option<Vec<f32>> {
         let provider = self.embeddings.as_ref()?;
         let inicio = std::time::Instant::now();
-        match provider.embed_query(text).await {
-            Ok(vector) => {
-                metrics::record_embed_latency(
-                    provider.provider_id(),
-                    metrics::EmbedOp::Query,
-                    inicio.elapsed().as_secs_f64(),
-                );
-                Some(vector)
-            }
+        let resultado = provider.embed_query(text).await;
+
+        // Sucesso e falha, como no `embed_document` e pelo mesmo motivo.
+        metrics::record_embed_latency(
+            provider.provider_id(),
+            metrics::EmbedOp::Query,
+            inicio.elapsed().as_secs_f64(),
+        );
+
+        match resultado {
+            Ok(vector) => Some(vector),
             Err(e) => {
                 metrics::inc_embed_failure(provider.provider_id(), metrics::EmbedOp::Query);
                 warn!(
@@ -2300,6 +2331,14 @@ mod tests {
                 .any(|m| m == "garraia_memory_ingested_total{outcome=failed}"),
             "desfecho `failed` nao foi contado: {emitidas:?}"
         );
+        // A latencia da tentativa que falhou tambem entra: e o timeout que o
+        // operador precisa ver. Antes da auditoria do #957 este ramo nao era
+        // medido, e a p95 melhorava durante uma rajada de falha.
+        assert!(
+            emitidas.iter().any(|m| m
+                == "garraia_memory_embed_latency_seconds{operation=document,provider=provider-de-teste}"),
+            "a tentativa que falhou nao foi medida: {emitidas:?}"
+        );
     }
 
     /// Os quatro desfechos precisam ser distinguiveis. `no_provider` e
@@ -2406,6 +2445,60 @@ mod tests {
                 .iter()
                 .any(|m| m == "garraia_memory_ingested_total{outcome=embedded}"),
             "{emitidas:?}"
+        );
+    }
+
+    /// Todo valor da label `provider` tem de vir do conjunto conhecido.
+    ///
+    /// A primeira versao deste teste afirmava **ausencia** — que nenhuma label
+    /// contivesse certas strings proibidas —, e a auditoria do #957 mostrou
+    /// que isso passa vazio: um provider futuro que devolvesse id dinamico sem
+    /// nenhuma daquelas strings teria cardinalidade ilimitada e o teste
+    /// continuaria verde. Afirmar **presenca** num conjunto fechado e o que
+    /// realmente cobra a invariante.
+    #[tokio::test]
+    async fn label_de_provider_vem_de_conjunto_fechado() {
+        // Os tres de producao mais os de teste deste arquivo. Um provider novo
+        // tem de entrar aqui de proposito, o que e o ponto: a lista e a
+        // revisao.
+        const CONHECIDOS: &[&str] = &["ollama", "openai", "cohere", "contando"];
+
+        let store = Arc::new(garraia_db::MemoryStore::in_memory_with_vectors().expect("store"));
+        let mut rt = AgentRuntime::new();
+        rt.set_memory_provider(store);
+        rt.set_embedding_provider(Arc::new(ContandoEmbeddings(
+            std::sync::atomic::AtomicUsize::new(0),
+        )));
+
+        let emitidas = metricas_emitidas(|| async {
+            rt.remember_turn("s1", None, None, "um fato de verdade para lembrar", "")
+                .await
+                .expect("remember_turn");
+            rt.recall_context("quem sou eu", Some("s1"), None, 5)
+                .await
+                .expect("recall");
+        })
+        .await;
+
+        let mut viu_provider = false;
+        for m in &emitidas {
+            let Some(inicio) = m.find("provider=") else {
+                continue;
+            };
+            viu_provider = true;
+            let resto = &m[inicio + "provider=".len()..];
+            let valor = resto
+                .split([',', '}'])
+                .next()
+                .expect("split sempre devolve ao menos um pedaco");
+            assert!(
+                CONHECIDOS.contains(&valor),
+                "label `provider` fora do conjunto fechado: {valor:?} em {m}"
+            );
+        }
+        assert!(
+            viu_provider,
+            "o teste precisa ter visto ao menos um provider"
         );
     }
 

--- a/crates/garraia-common/Cargo.toml
+++ b/crates/garraia-common/Cargo.toml
@@ -12,6 +12,17 @@ thiserror = { workspace = true }
 chrono = { workspace = true }
 uuid = { workspace = true }
 tracing = { workspace = true }
+# Facade de metricas (src/metrics.rs, #957). Deliberadamente o facade e NAO o
+# `garraia-telemetry`: quem emite as metricas da memoria e o `garraia-agents`,
+# que o `garraia-cli` linka — depender da telemetria arrastaria OpenTelemetry,
+# OTLP, tonic, axum e tower para dentro do binario da CLI, que nao usa nada
+# disso. O facade e o padrao do ecossistema: biblioteca emite, binario instala
+# o recorder. Sem recorder (o caso da CLI) cada macro e um no-op.
+#
+# Nao e opcional, ao contrario do `reqwest` acima: o facade sao dois ponteiros
+# atomicos e nenhuma dependencia de peso, entao um feature gate custaria mais
+# em complexidade do que economiza em arvore.
+metrics = { workspace = true }
 url = { workspace = true }
 async-trait = { workspace = true }
 toml = { workspace = true }

--- a/crates/garraia-common/src/lib.rs
+++ b/crates/garraia-common/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod error;
 pub mod handoff;
 pub mod message;
+pub mod metrics;
 pub mod safety_gate;
 #[cfg(feature = "ssrf")]
 pub mod ssrf;
@@ -11,6 +12,7 @@ pub use handoff::{
     HandoffAction, HandoffActionKind, HandoffError, HandoffState, RedactedString, redact,
 };
 pub use message::{Message, MessageContent, MessageDirection};
+pub use metrics::{EmbedOp, IngestOutcome};
 pub use safety_gate::{SafetyDenied, is_risky, safety_gate};
 #[cfg(feature = "ssrf")]
 pub use ssrf::{

--- a/crates/garraia-common/src/metrics.rs
+++ b/crates/garraia-common/src/metrics.rs
@@ -1,0 +1,223 @@
+//! Metricas da memoria semantica (#957).
+//!
+//! # Por que aqui, e nao em `garraia-telemetry`
+//!
+//! Quem **emite** estas metricas e o `garraia-agents` (e, num slice futuro, o
+//! `garraia-db`). Nenhum dos dois pode depender do `garraia-telemetry`: aquele
+//! crate arrasta OpenTelemetry, OTLP, tonic, axum e tower, e o `garraia-cli`
+//! linka o `garraia-agents` — a CLI passaria a carregar um stack de servidor
+//! para nao usar nada dele.
+//!
+//! A saida e o padrao do proprio ecossistema `metrics`: **biblioteca emite,
+//! binario instala o recorder**. As macros do facade resolvem para um ponteiro
+//! global; sem recorder instalado — que e o caso da CLI — cada chamada e um
+//! no-op barato. O gateway instala o recorder Prometheus no boot
+//! (`garraia_telemetry::init_metrics`) e so entao as medicoes viram numero.
+//!
+//! O `garraia-common` e o crate que gateway, agents, db, config e security ja
+//! compartilham. E o mesmo argumento que esta escrito no `Cargo.toml` deste
+//! crate para o guard de SSRF: melhor um lugar do que tres copias.
+//!
+//! # Cardinalidade
+//!
+//! Toda label aqui vem de conjunto **fechado**, e isso foi verificado, nao
+//! presumido: `provider_id()` devolve literal fixo nos tres providers reais —
+//! `"ollama"`, `"openai"`, `"cohere"` (`garraia-agents/src/embeddings.rs`) — e
+//! o `ResilientEmbeddingProvider` delega para o de dentro. `operation` e
+//! `outcome` sao enums que viram `&'static str`. Nao ha caminho por onde um id
+//! de sessao, de usuario ou um texto de conteudo chegue a uma label, o que
+//! seria a explosao de cardinalidade que o docblock de
+//! `garraia-telemetry::metrics` descreve.
+//!
+//! **`model()` fica de fora de proposito**, e essa e a decisao que mais
+//! importa aqui. Ao contrario do `provider_id()`, o nome do modelo vem da
+//! config do usuario: `memory.embedding_provider` aponta para uma entrada de
+//! `embeddings:` onde o `model` e string livre. Usa-lo como label daria ao
+//! operador — sem querer — uma serie nova por valor digitado, e um erro de
+//! digitacao repetido viraria lixo permanente no Prometheus. Quem precisa
+//! saber o modelo tem o log, que nao paga cardinalidade.
+//!
+//! # Nome
+//!
+//! Prefixo `garraia_`, nao `garra_`. A issue #957 propoe `garra_memory_*`, mas
+//! as metricas que ja existem sao `garraia_requests_total`,
+//! `garraia_http_latency_seconds`, `garraia_errors_total` e
+//! `garraia_active_sessions`. Duas familias de prefixo no mesmo `/metrics`
+//! quebrariam todo dashboard que agrupa por `garraia_.*`.
+
+use metrics::{counter, histogram};
+
+/// Latencia de uma chamada ao provider de embeddings, em segundos.
+pub const MEMORY_EMBED_LATENCY_SECONDS: &str = "garraia_memory_embed_latency_seconds";
+
+/// Falhas ao pedir embedding. Era o buraco do #948: a falha ficou visivel no
+/// log, mas log nao alerta nem vira tendencia.
+pub const MEMORY_EMBED_FAILURES_TOTAL: &str = "garraia_memory_embed_failures_total";
+
+/// Latencia do recall (busca na memoria), em segundos.
+pub const MEMORY_RECALL_LATENCY_SECONDS: &str = "garraia_memory_recall_latency_seconds";
+
+/// Turnos que entraram na memoria, por desfecho.
+pub const MEMORY_INGESTED_TOTAL: &str = "garraia_memory_ingested_total";
+
+/// Qual das duas chamadas do provider foi medida.
+///
+/// Elas tem perfis diferentes e nao podem ser somadas: `embed_documents`
+/// recebe lote e roda na ingestao; `embed_query` e uma so e esta no caminho
+/// critico da resposta ao usuario.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EmbedOp {
+    Document,
+    Query,
+}
+
+impl EmbedOp {
+    pub fn as_label(self) -> &'static str {
+        match self {
+            EmbedOp::Document => "document",
+            EmbedOp::Query => "query",
+        }
+    }
+}
+
+/// O que aconteceu com um turno na ingestao.
+///
+/// E a metrica que a issue #957 pede sem saber o nome: "quantas entradas tem
+/// embedding" vira uma pergunta respondivel no tempo, e nao so no instante,
+/// quando se conta o **desfecho de cada ingestao**. `Noise` so existe por
+/// causa do filtro do #952 — sem ele, o operador veria o total de entradas sem
+/// vetor subir e nao teria como saber se e defeito ou politica.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IngestOutcome {
+    /// Recebeu vetor e entrou no indice.
+    Embedded,
+    /// A politica de ruido (#952) recusou. Nao e falha.
+    Noise,
+    /// Nao ha provider de embeddings configurado.
+    NoProvider,
+    /// O provider foi chamado e falhou. A entrada foi gravada sem vetor.
+    Failed,
+}
+
+impl IngestOutcome {
+    pub fn as_label(self) -> &'static str {
+        match self {
+            IngestOutcome::Embedded => "embedded",
+            IngestOutcome::Noise => "noise",
+            IngestOutcome::NoProvider => "no_provider",
+            IngestOutcome::Failed => "failed",
+        }
+    }
+}
+
+/// Mede uma chamada bem-sucedida ao provider de embeddings.
+pub fn record_embed_latency(provider: &str, op: EmbedOp, seconds: f64) {
+    histogram!(
+        MEMORY_EMBED_LATENCY_SECONDS,
+        "provider" => provider.to_string(),
+        "operation" => op.as_label(),
+    )
+    .record(seconds);
+}
+
+/// Conta uma falha do provider de embeddings.
+pub fn inc_embed_failure(provider: &str, op: EmbedOp) {
+    counter!(
+        MEMORY_EMBED_FAILURES_TOTAL,
+        "provider" => provider.to_string(),
+        "operation" => op.as_label(),
+    )
+    .increment(1);
+}
+
+/// Mede um recall inteiro — semantico ou textual, com ou sem provider.
+///
+/// Sem label de caminho de proposito: o que o operador quer saber e quanto o
+/// usuario esperou, e essa e a mesma pergunta nos dois casos. Separar por
+/// caminho aqui esconderia a piora que interessa (o recall degradar por cair
+/// no textual) atras de duas series que, cada uma, parecem saudaveis.
+pub fn record_recall_latency(seconds: f64) {
+    histogram!(MEMORY_RECALL_LATENCY_SECONDS).record(seconds);
+}
+
+/// Conta um turno ingerido, por desfecho.
+pub fn inc_ingested(outcome: IngestOutcome) {
+    counter!(MEMORY_INGESTED_TOTAL, "outcome" => outcome.as_label()).increment(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// As labels sao `&'static str` vindas de enum, o que e a garantia
+    /// estrutural contra explosao de cardinalidade: nao ha como um id de
+    /// sessao virar label sem alguem mudar a assinatura.
+    #[test]
+    fn labels_de_enum_sao_conjunto_fechado() {
+        assert_eq!(EmbedOp::Document.as_label(), "document");
+        assert_eq!(EmbedOp::Query.as_label(), "query");
+        for (outcome, esperado) in [
+            (IngestOutcome::Embedded, "embedded"),
+            (IngestOutcome::Noise, "noise"),
+            (IngestOutcome::NoProvider, "no_provider"),
+            (IngestOutcome::Failed, "failed"),
+        ] {
+            assert_eq!(outcome.as_label(), esperado);
+        }
+    }
+
+    /// O `provider` e label; o `model` nao pode ser. `provider_id()` e literal
+    /// fixo nos tres providers reais, mas o nome do modelo vem da config do
+    /// usuario — vira serie nova por valor digitado. Este teste nao consegue
+    /// afirmar a ausencia sozinho; ele ancora a intencao, e a assinatura dos
+    /// helpers e o que a cobra: nenhum deles aceita o modelo.
+    #[test]
+    fn os_helpers_nao_aceitam_o_nome_do_modelo() {
+        // Se alguem acrescentar um parametro de modelo, este teste para de
+        // compilar — que e o sinal desejado.
+        let _: fn(&str, EmbedOp, f64) = record_embed_latency;
+        let _: fn(&str, EmbedOp) = inc_embed_failure;
+        let _: fn(f64) = record_recall_latency;
+        let _: fn(IngestOutcome) = inc_ingested;
+    }
+
+    /// Prefixo `garraia_`, alinhado com `garraia_requests_total` e as outras
+    /// tres que ja existem. A issue #957 propoe `garra_`; seguir a issue ao pe
+    /// da letra quebraria todo dashboard que agrupa por `garraia_.*`.
+    #[test]
+    fn todo_nome_usa_o_prefixo_do_projeto() {
+        for nome in [
+            MEMORY_EMBED_LATENCY_SECONDS,
+            MEMORY_EMBED_FAILURES_TOTAL,
+            MEMORY_RECALL_LATENCY_SECONDS,
+            MEMORY_INGESTED_TOTAL,
+        ] {
+            assert!(
+                nome.starts_with("garraia_memory_"),
+                "prefixo errado: {nome}"
+            );
+        }
+    }
+
+    /// Convencao do Prometheus: contador termina em `_total`, histograma de
+    /// tempo termina em `_seconds`. Nao e frescura — e o que faz
+    /// `rate()`/`histogram_quantile()` serem escritos sem adivinhacao.
+    #[test]
+    fn sufixos_seguem_a_convencao_do_prometheus() {
+        assert!(MEMORY_EMBED_FAILURES_TOTAL.ends_with("_total"));
+        assert!(MEMORY_INGESTED_TOTAL.ends_with("_total"));
+        assert!(MEMORY_EMBED_LATENCY_SECONDS.ends_with("_seconds"));
+        assert!(MEMORY_RECALL_LATENCY_SECONDS.ends_with("_seconds"));
+    }
+
+    /// Sem recorder instalado — o caso da CLI — emitir nao pode entrar em
+    /// panico nem custar nada visivel. E a premissa que permite instrumentar
+    /// `garraia-agents` sem arrastar o stack de telemetria para o binario.
+    #[test]
+    fn emitir_sem_recorder_e_no_op() {
+        record_embed_latency("ollama", EmbedOp::Document, 0.42);
+        inc_embed_failure("ollama", EmbedOp::Query);
+        record_recall_latency(0.01);
+        inc_ingested(IngestOutcome::Noise);
+    }
+}

--- a/crates/garraia-telemetry/Cargo.toml
+++ b/crates/garraia-telemetry/Cargo.toml
@@ -23,8 +23,11 @@ opentelemetry = { version = "0.32", features = ["trace"] }
 opentelemetry_sdk = { version = "0.32", features = ["rt-tokio", "trace"] }
 opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic", "trace"] }
 
-# Metrics
-metrics = "0.24"
+# Metrics — versao vem do workspace desde o #957, para garantir que este crate
+# e o `garraia-common` (que o `garraia-agents` usa para emitir) falem com o
+# MESMO recorder global. Duas versoes do facade na arvore dariam dois
+# recorders, e o `/metrics` do gateway nao veria as metricas da memoria.
+metrics = { workspace = true }
 metrics-exporter-prometheus = "0.18"
 
 # HTTP layers

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -220,6 +220,43 @@ só tem `agent_id`, então o campo é descartado pelo serde. Não era superfíci
 viva; o guard existe para o dia em que a rota mudar, e
 `post_sessions_does_not_expose_working_dir_today` fixa esse estado.
 
+## 5.8. `/metrics` — o que a observabilidade conta sobre a instalação (#957)
+
+O endpoint Prometheus é autenticado (`metrics_auth.rs`: loopback por padrão,
+token ou allowlist para expor remotamente, fail-closed no boot). O que segue
+não é uma falha desse controle — é o que um leitor **legítimo** do `/metrics`
+passa a saber, e que não estava escrito em lugar nenhum.
+
+As métricas de memória do #957 carregam a label `provider` com o id do
+provedor de embeddings em uso (`ollama`, `openai`, `cohere`), e o desfecho
+`no_provider` denuncia a **ausência** de configuração. Isso é topologia: quem
+lê o `/metrics` sabe qual provedor atacar, e sabe se a memória semântica está
+sequer ligada. Somando com `garraia_memory_ingested_total`, também se infere
+volume de uso.
+
+**Decisão: a label fica.** Mascarar o provider (como o `config check` faz com
+secrets, reportando `configured: true` em vez do valor) destruiria a utilidade
+da métrica — "qual provedor está falhando" é exatamente a pergunta que ela
+existe para responder, e com um provedor só ela viraria uma constante. O
+controle correto para topologia é o mesmo de sempre: **não exponha o
+`/metrics` para quem não deveria ver a topologia.** Por isso o endpoint é
+loopback por padrão e o listener dedicado se recusa a subir sem token ou
+allowlist.
+
+O que **não** está lá, e é o que importa: nenhum id de sessão, id de usuário,
+conteúdo de memória ou nome de modelo. O nome do modelo ficou de fora
+deliberadamente — vem da config do usuário, então além de cardinalidade
+ilimitada seria mais um detalhe de infraestrutura publicado. As labels são
+enums Rust que viram `&'static str`, o que faz disso uma garantia de
+compilação e não de convenção; há teste afirmando que todo valor de `provider`
+vem de conjunto fechado.
+
+| STRIDE | Cenário concreto | Mitigação atual | Gap / Planejada |
+|---|---|---|---|
+| **I** Information disclosure | Leitor do `/metrics` (scraper legítimo, ou credencial de scraper vazada) descobre qual provedor de embeddings está configurado, se há algum, e o volume de turnos ingeridos. | Endpoint loopback por padrão; listener remoto exige token ou allowlist, fail-closed no boot (plan 0024). Nenhuma label carrega PII, conteúdo ou nome de modelo. | Aceito: mascarar `provider` inutilizaria a métrica. Revisar se o `/metrics` algum dia for exposto a um scraper multi-tenant. |
+
+---
+
 ## 6. Mobile apps (`apps/garraia-mobile`)
 
 **Divergência JWT TTL (conhecida)**: o path mobile legacy (`crates/garraia-gateway/src/mobile_auth.rs`, wired via GAR-335) emite JWT com TTL de **30 dias** (`JWT_EXPIRY_SECS = 30 * 24 * 3600`), distinto do access token de 15 min do `garraia-auth` workspace (plans 0011/0012). Coexistência é temporária — consolidação depende de GAR-413 (migrate workspace) + migração dos clientes mobile para `/v1/auth/*`. Enquanto coexistem, a janela de hijack de session mobile é 48× maior que a do fluxo workspace. Risco documentado, mitigação parcial via `flutter_secure_storage` (Keystore/Keychain) + refresh token rotation planejada.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -196,6 +196,55 @@ garraia_telemetry::inc_errors(kind);
 garraia_telemetry::set_active_sessions(n);
 ```
 
+### 6.0 Memory metrics (#957)
+
+Four more, emitted by the agent runtime whenever the memory system is in use:
+
+| Metric | Type | Description |
+|---|---|---|
+| `garraia_memory_embed_latency_seconds{provider, operation}` | histogram | Time spent inside the embeddings provider. `operation` is `document` (ingestion, batched) or `query` (recall, on the critical path) |
+| `garraia_memory_embed_failures_total{provider, operation}` | counter | Embedding calls that failed |
+| `garraia_memory_recall_latency_seconds` | histogram | Whole recall — query embedding **plus** the search |
+| `garraia_memory_ingested_total{outcome}` | counter | Turns ingested, by outcome: `embedded`, `noise`, `no_provider`, `failed` |
+
+**The one to alert on** is `garraia_memory_embed_failures_total`. Issue #948
+described embedding failure as *silent*: the entry was stored without a vector
+and became invisible to semantic search forever. #948 made it loud in the log;
+this makes it visible as a trend — and it is the trend that lets someone notice
+the provider went down *before* recall degrades.
+
+**`no_provider` and `failed` are deliberately different outcomes.** They are the
+difference between "nobody configured embeddings" and "it is configured and
+broken", which is the first question an operator asks. `noise` exists because of
+the ingestion filter (#952): without it, the count of entries without a vector
+would climb and nobody could tell defect from policy.
+
+Useful queries:
+
+```promql
+# Falha de embedding por minuto, por provider
+rate(garraia_memory_embed_failures_total[5m])
+
+# p95 do recall (o que o usuario espera)
+histogram_quantile(0.95, rate(garraia_memory_recall_latency_seconds_bucket[5m]))
+
+# Fracao dos turnos que o filtro de ruido descartou
+rate(garraia_memory_ingested_total{outcome="noise"}[1h])
+  / ignoring(outcome) group_left sum without(outcome) (rate(garraia_memory_ingested_total[1h]))
+```
+
+Unlike the four baseline metrics, these are emitted through
+`garraia_common::metrics`, not `garraia_telemetry` — the crates that emit them
+(`garraia-agents`) are linked by the CLI, which must not pull in the
+OpenTelemetry/OTLP/axum stack. They use the `metrics` facade directly: library
+emits, binary installs the recorder. In the CLI, where no recorder is
+installed, every call is a cheap no-op.
+
+Every label comes from a **closed set** — `provider` is a provider id,
+`operation` and `outcome` are enums rendered as `&'static str`. There is no path
+by which a session id, a user id or memory content reaches a label; a test
+asserts exactly that.
+
 The `/metrics` endpoint binds to `127.0.0.1` only by default. To expose it to a remote Prometheus scraper, set `GARRAIA_METRICS_BIND` explicitly (e.g., `0.0.0.0:9464`) **and** configure either `GARRAIA_METRICS_TOKEN` or `GARRAIA_METRICS_ALLOW` per §6.1 below. Without one of those the dedicated listener refuses to spawn (fail-closed startup) and the embedded route returns `503` for every non-loopback caller.
 
 ## 6.1 Security (plan 0024 / GAR-412)


### PR DESCRIPTION
## Descrição

O `/metrics` tinha quatro métricas HTTP genéricas e **nada** sobre o componente central do produto. A issue é explícita sobre por que isso importa: o #948 mostrou que falha de embedding era **silenciosa**, e sem métrica o operador só descobre quando o recall já degradou.

```
garraia_memory_embed_latency_seconds{provider,operation}   histogram
garraia_memory_embed_failures_total{provider,operation}    counter
garraia_memory_recall_latency_seconds                      histogram
garraia_memory_ingested_total{outcome}                     counter
```

A que mais importa é a de falha. **O #948 tirou a falha do silêncio no log; esta tira do painel.** Log conta o caso, métrica conta a tendência — e é a tendência que faz alguém descobrir que o provider caiu antes de o recall degradar.

## Prefixo `garraia_`, não `garra_`

A issue propõe `garra_memory_*`. As quatro que já existem são `garraia_requests_total`, `garraia_http_latency_seconds`, `garraia_errors_total` e `garraia_active_sessions` — duas famílias de prefixo no mesmo endpoint quebrariam todo dashboard que agrupa por `garraia_.*`. Segui a convenção do projeto, não a letra da issue.

## Os quatro desfechos da ingestão, e por que são quatro

`no_provider` e `failed` são a diferença entre **"ninguém configurou"** e **"configurou e está quebrado"** — a primeira pergunta que um operador faz. `noise` existe por causa do filtro do #952: sem ele, o total de entradas sem vetor subiria e ninguém distinguiria defeito de política.

Por isso a contagem mora em `embed_turn_unless_noise` e não dentro do `embed_document`: lá embaixo, "sem provider" e "provider falhou" saem os dois como `None`.

## Facade `metrics`, não `garraia-telemetry` — e isso foi medido

Quem emite é o `garraia-agents`, que o `garraia-cli` **linka**. Depender da telemetria arrastaria OpenTelemetry, OTLP, tonic e axum para dentro do binário da CLI, que não usa nada disso. O facade é o padrão do próprio ecossistema: biblioteca emite, binário instala o recorder; sem recorder cada macro é um no-op.

Verificado, não presumido:

```console
$ cargo tree -p garraia-agents | grep -cE "opentelemetry|metrics-exporter-prometheus|tonic"
0
$ cargo tree -p metrics@0.24.6 --depth 1
metrics v0.24.6
└── rapidhash v4.4.1
```

Os nomes e helpers ficam em `garraia-common`, o único crate que gateway, agents, db, config e security já compartilham — o mesmo argumento que o `Cargo.toml` dele já registra para o guard de SSRF. A versão do facade passou a vir do workspace para que `garraia-common` e `garraia-telemetry` falem com o **mesmo** recorder global; duas versões dariam dois recorders, e o `/metrics` não veria nada do que o agents emite. A auditoria confirmou: uma única entrada de `metrics` no `Cargo.lock`.

## Cardinalidade

`provider_id()` devolve literal fixo nos três providers reais (`"ollama"`, `"openai"`, `"cohere"`) e o `ResilientEmbeddingProvider` delega. A auditoria foi além e verificou o `build_embedding_provider`: ele casa exatamente os três tipos conhecidos e devolve `None` para o resto — **cardinalidade máxima de 3 em produção**.

**O `model()` fica de fora de propósito**, e é a decisão que mais importa aqui. Ao contrário do provider, o nome do modelo vem da config do usuário, onde é string livre: como label daria uma série nova por valor digitado, e um erro de digitação repetido viraria lixo permanente no Prometheus. Quem precisa do modelo tem o log, que não paga cardinalidade. Há teste que **quebra a compilação** se alguém acrescentar o modelo à assinatura dos helpers.

## Auditoria

`@security-auditor` rodou antes de abrir — **7.5/10, nenhuma vulnerabilidade**. Os quatro achados foram tratados no segundo commit.

### MÉDIO — o histograma media só o sucesso, e a incoerência era minha

Eu tinha escrito, no `recall_context`, que um recall que morre em 30s de timeout *"é exatamente a latência que o operador precisa ver"* — e logo acima registrava a latência do embed **apenas no ramo `Ok`**. A assimetria não tinha defesa: numa rajada de timeout, a p95 do embed **melhorava**, que é o oposto do que o painel deve fazer quando o sistema piora.

Agora mede os dois ramos. Sem label de desfecho, de propósito: o contador de falha ao lado já responde "quantas falharam", e quebrar o histograma em duas séries faria a pergunta que importa — "quanto o provider está demorando" — exigir somar as duas de volta.

### MÉDIO — o teste de cardinalidade passava vazio

Ele afirmava **ausência**: que nenhuma label contivesse certas strings proibidas. Um provider futuro com id dinâmico que não contivesse nenhuma delas teria cardinalidade ilimitada e o teste continuaria verde.

Virou afirmação de **presença** num conjunto fechado — todo valor de `provider` tem de estar na lista, e um provider novo precisa entrar nela de propósito. A lista é a revisão.

### BAIXO — lote vazio era `None` silencioso

`Ok(vec[])` fazia o `pop()` devolver `None`, o que contava `ingested_total{outcome=failed}` **sem** par em `embed_failures_total` — dois números que não fecham no painel. Nenhum dos três providers reais devolve lote vazio para uma entrada, mas a inconsistência existia. Agora conta como falha, com log, na mesma linha do #948.

### BAIXO — o `/metrics` conta a topologia da instalação

A label `provider` diz qual provedor está em uso, `no_provider` denuncia a ausência de configuração, e o contador de ingestão deixa inferir volume de uso. O endpoint é autenticado e loopback por padrão, então não é falha de controle — é o que um leitor **legítimo** passa a saber, e não estava escrito em lugar nenhum.

Virou a seção 5.8 do `docs/security/threat-model.md`, com a decisão explícita: **a label fica.** Mascarar o provider destruiria a utilidade da métrica, porque "qual provedor está falhando" é exatamente a pergunta que ela existe para responder — e com um provedor só ela viraria uma constante. O controle para topologia continua sendo não expor o `/metrics` a quem não deveria vê-la.

### O que a auditoria confirmou como correto

Os quatro caminhos de `embed_turn_unless_noise` contam exatamente uma vez cada, por serem mutuamente exclusivos na estrutura do código; `#[tokio::test]` sem argumento é `current_thread`, então o recorder thread-local não corre risco de migração de task; e a garantia de PII é **de compilação, não de teste** — as labels são enums cujo único caminho é `as_label() -> &'static str`.

## Tipo de mudança

- [x] `feat`: Nova funcionalidade
- [x] `docs`: Documentação (telemetria + modelo de ameaça)
- [x] `test`: Adição de testes

## Classe de Risco

- [x] **Classe C (Alto Risco)**: métrica publicada é **superfície de exposição** — uma label errada vaza PII para todo mundo que lê o `/metrics`, e uma label não-limitada derruba o Prometheus. Não toca auth, RLS nem schema, mas o critério que importa é exposição de dado. Auditoria rodou antes de abrir.

## Checklist de Segurança e Qualidade

- [x] `cargo +1.95 fmt --all -- --check` limpo
- [x] `cargo +1.95 clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings` sem erros
- [x] `cargo +1.95 test --workspace --exclude garraia-desktop` passando — única falha é a ambiental conhecida `migration_001_applies_and_schema_is_sane`, que exige `docker.sock`
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo, API key, token ou credencial commitada
- [x] Nenhuma migração
- [x] Nenhuma label carrega id de sessão, id de usuário, conteúdo ou nome de modelo — com teste
- [x] Todo valor de `provider` vem de conjunto fechado — com teste de **presença**, não de ausência
- [x] Exposição nova registrada no modelo de ameaça (§5.8)
- [ ] Verificação de políticas RLS — não se aplica

## Mudanças na API pública e Schema

- **`garraia-common`:** módulo novo `metrics` (`EmbedOp`, `IngestOutcome`, quatro nomes, quatro helpers). Dependência nova: o facade `metrics`.
- **`garraia-agents`:** nenhuma mudança de assinatura pública — só instrumentação interna. Dev-dependency nova: `metrics-util` (recorder de teste).
- **`garraia-telemetry`:** `metrics` passa a vir do workspace. Sem mudança de API.
- Sem mudança de schema, sem migração, sem chave de config nova.

## Como testar

```bash
cargo +1.95 test -p garraia-common metrics       # 5: nomes, sufixos, conjunto fechado, no-op sem recorder
cargo +1.95 test -p garraia-agents runtime::     # 19, dos quais 6 novos com recorder de verdade
```

Os testes de runtime instalam um `DebuggingRecorder` **thread-local** — não o global, que só pode ser instalado uma vez por processo e quebraria os testes em paralelo — e afirmam nome e labels do que foi emitido de fato. Sem eles, os testes provariam só que as constantes estão escritas certo.

## Plano de Rollback

Reverter o merge. Nada persistido, nada de config, nada de schema. O que se perde é a visibilidade.

## A issue #957 fica aberta

Ela pede **cinco** métricas; entreguei quatro. As duas de gauge (`garraia_memory_entries{has_embedding}`, `garraia_memory_vector_index_size`) precisam de método novo no trait `MemoryProvider` mais um worker dedicado no gateway — metade do PR, e não é a metade que a issue diz que dói.

**E não dá para pendurá-las no `memory_retention_worker`**, que era o caminho óbvio: ele só sobe quando a retenção está ligada (`server.rs:530`), e ela é **desligada por padrão** de propósito, porque apaga memória. Os gauges ficariam mortos para quase todo mundo. Precisa de worker próprio, e a cadência é outra — retenção é diária, gauge quer minutos. Isso é o C-PR5c.

Refs #957

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF

---
_Generated by [Claude Code](https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF)_