### PR TITLE
fix(cli): saída de ferramenta não injeta mais comando no terminal (#995)

### DIFF
--- a/changelog.d/security/995-injecao-ansi-em-saida-de-ferramenta.md
+++ b/changelog.d/security/995-injecao-ansi-em-saida-de-ferramenta.md
@@ -1,0 +1,19 @@
+- **Saida de ferramenta nao injeta mais comando no terminal (#995).** O resumo
+  do #937 redigia segredo e trocava quebra de linha por espaco, mas deixava
+  passar `ESC` e os demais controles — e saida de ferramenta nao e conteudo
+  confiavel: e o que o agente leu de um arquivo, baixou de uma pagina ou o que
+  um comando escreveu. Um `README` de repositorio clonado conseguia limpar a
+  tela de quem roda o `garra chat` com `\x1b[2J`, trocar o titulo da janela com
+  OSC, ou reposicionar o cursor para sobrescrever linhas ja impressas, forjando
+  texto que parece ter vindo do proprio Garra. O caso mais pontudo era
+  `\x1b[?25l`: o projeto tem invariante explicita de que essa sequencia nao e
+  emitida em lugar nenhum, para que nenhum caminho de saida deixe o terminal
+  sem cursor — e saida de ferramenta a violava. Agora todo controle C0, C1 e
+  DEL sai, no `garraia-agents`, junto da redacao de segredo e antes do
+  truncamento (truncar antes deixaria meia sequencia passar, pela mesma razao
+  que ja valia para segredo). A seguranca vem da regra por caractere, nao do
+  reconhecimento de sequencia: sem `ESC`, `[2J` e texto inerte. O
+  reconhecimento de CSI e OSC que existe serve so para legibilidade, porque
+  saida colorida e comum e legitima e trocar so o `ESC` por marcador deixaria
+  ruido na tela do caso normal. Vale para o resumo do input tambem — o
+  `command` do bash tambem vem de fora.

--- a/crates/garraia-agents/src/turn_events.rs
+++ b/crates/garraia-agents/src/turn_events.rs
@@ -199,14 +199,102 @@ fn campo(input: &serde_json::Value, chave: &str) -> Option<String> {
         .map(str::to_string)
 }
 
-/// Redige segredo e trunca — nessa ordem, sempre.
+/// Redige segredo, tira controle de terminal e trunca — nessa ordem, sempre.
 ///
 /// Truncar antes de redigir poderia cortar uma chave ao meio e deixar o
-/// prefixo passar pelo regex sem casar.
+/// prefixo passar pelo regex sem casar. E truncar antes de tirar os controles
+/// poderia deixar meia sequencia passar pela mesma razao.
 fn sanear(texto: &str) -> String {
     let redigido = garraia_security::redact_secrets(texto.trim());
-    let uma_linha = redigido.replace(['\n', '\r'], " ");
-    truncar(&uma_linha, SUMMARY_MAX_CHARS)
+    let sem_controle = sanear_controles(&redigido);
+    truncar(&sem_controle, SUMMARY_MAX_CHARS)
+}
+
+/// Tira do texto tudo que o terminal interpretaria como comando (#995).
+///
+/// Saida de ferramenta **nao e conteudo confiavel**: e o que o agente leu de
+/// um arquivo, baixou de uma pagina ou o que um comando escreveu. Ate o #995
+/// esse texto ia direto para o terminal, e um `README` de repositorio clonado
+/// conseguia limpar a tela do usuario com `\x1b[2J`, trocar o titulo da janela
+/// com OSC, ou reposicionar o cursor para sobrescrever linhas ja impressas —
+/// forjando texto que parece ter vindo do proprio Garra.
+///
+/// O caso mais pontudo era `\x1b[?25l`: o projeto tem invariante explicita de
+/// que essa sequencia nao e emitida em lugar nenhum, para que nenhum caminho
+/// de saida deixe o terminal sem cursor. Saida de ferramenta a violava.
+///
+/// # A seguranca nao depende do reconhecimento de sequencia
+///
+/// Esta e a parte que importa entender antes de mexer aqui. **Tirar o `ESC` ja
+/// neutraliza**: sem ele, `[2J` e texto inerte, que o terminal imprime como
+/// tres caracteres em vez de executar. Todo controle C0, C1 e DEL sai, sem
+/// excecao — e essa regra por caractere, nao por padrao, e o que fecha o
+/// buraco. Reconhecer "sequencias ANSI" com regex e um jogo que se perde: ha
+/// CSI, OSC, DCS, formas de dois caracteres, com e sem terminador.
+///
+/// O reconhecimento que existe abaixo serve so para **legibilidade**. Saida
+/// colorida e comum e legitima — `cargo test` emite `\x1b[32mok\x1b[0m` —, e
+/// trocar so o `ESC` por um marcador deixaria `\u{fffd}[32mok\u{fffd}[0m` na
+/// tela, que e ruido para o caso normal. Entao quando a sequencia e
+/// reconhecivel ela sai inteira, e o resultado fica limpo.
+///
+/// A consequencia de o reconhecimento errar e **cosmetica, nao de seguranca**:
+/// uma sequencia exotica que o parser nao entenda perde o `ESC` do mesmo jeito
+/// e sobra como texto literal feio. E o modo de falhar que se quer.
+fn sanear_controles(texto: &str) -> String {
+    let mut out = String::with_capacity(texto.len());
+    let mut chars = texto.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        match c {
+            // Separadores viram espaco em vez de sumir: num resumo de uma
+            // linha eles separam palavras, e apaga-los grudaria tokens que o
+            // usuario precisa ler separados.
+            '\t' | '\n' | '\r' => out.push(' '),
+
+            '\u{1b}' => match chars.peek() {
+                // CSI: `ESC [` ... byte final na faixa 0x40-0x7e. Cobre cor,
+                // movimento de cursor, limpeza de tela, `?25l`.
+                Some('[') => {
+                    chars.next();
+                    for f in chars.by_ref() {
+                        if ('\u{40}'..='\u{7e}').contains(&f) {
+                            break;
+                        }
+                    }
+                }
+                // OSC: `ESC ]` ... BEL ou ST (`ESC \`). E onde mora a troca de
+                // titulo de janela e o hyperlink.
+                Some(']') => {
+                    chars.next();
+                    while let Some(f) = chars.next() {
+                        if f == '\u{7}' {
+                            break;
+                        }
+                        if f == '\u{1b}' && chars.peek() == Some(&'\\') {
+                            chars.next();
+                            break;
+                        }
+                    }
+                }
+                // Sequencia de dois caracteres (`ESC c` reseta o terminal) ou
+                // um `ESC` solto no fim do texto. Em ambos o `ESC` sai.
+                Some(_) => {
+                    chars.next();
+                }
+                None => {}
+            },
+
+            // Todo o resto que o terminal trataria como comando. Marcar em vez
+            // de apagar deixa visivel que algo foi removido — apagar em
+            // silencio faria a tentativa de injecao parecer texto normal.
+            c if c.is_control() || ('\u{80}'..='\u{9f}').contains(&c) => out.push('\u{fffd}'),
+
+            c => out.push(c),
+        }
+    }
+
+    out
 }
 
 /// Corta por **caractere**, nunca por byte — comando e caminho carregam
@@ -224,6 +312,79 @@ fn truncar(texto: &str, max: usize) -> String {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// Saida de ferramenta nao pode escrever comando no terminal (#995).
+    ///
+    /// Os tres casos sao os do mundo real: limpar a tela, esconder o cursor
+    /// (que viola invariante explicita do projeto) e trocar o titulo da
+    /// janela por OSC.
+    #[test]
+    fn saida_nao_injeta_sequencia_no_terminal() {
+        for (bruto, o_que_e) in [
+            ("\u{1b}[2Jlimpou", "limpa a tela"),
+            ("\u{1b}[?25lescondeu", "esconde o cursor"),
+            (
+                "\u{1b}]0;titulo novo\u{7}trocou",
+                "troca o titulo (OSC/BEL)",
+            ),
+            ("\u{1b}]0;titulo\u{1b}\\trocou", "troca o titulo (OSC/ST)"),
+            ("\u{1b}creset", "reseta o terminal"),
+        ] {
+            let saida = summarize_tool_output(bruto, true);
+            assert!(
+                !saida.contains('\u{1b}'),
+                "ESC sobreviveu ao resumo ({o_que_e}): {saida:?}"
+            );
+            assert!(
+                !saida.chars().any(|c| c.is_control()),
+                "controle sobreviveu ao resumo ({o_que_e}): {saida:?}"
+            );
+        }
+    }
+
+    /// O mesmo vale para o input — o `command` do bash tambem vem de fora.
+    #[test]
+    fn input_nao_injeta_sequencia_no_terminal() {
+        let input = json!({ "command": "echo \u{1b}[2J" });
+        let saida = summarize_tool_input("bash", &input);
+        assert!(!saida.contains('\u{1b}'), "ESC sobreviveu: {saida:?}");
+    }
+
+    /// Saida colorida e comum e legitima. O reconhecimento de sequencia existe
+    /// para que o caso normal fique limpo em vez de virar `\u{fffd}[32m`.
+    #[test]
+    fn saida_colorida_fica_legivel() {
+        let saida = summarize_tool_output("\u{1b}[32mtest result: ok\u{1b}[0m", true);
+        assert_eq!(saida, "test result: ok");
+    }
+
+    /// Um controle que nao faz parte de sequencia reconhecivel vira marcador
+    /// visivel, e nao sumico silencioso: a tentativa de injecao tem de
+    /// aparecer.
+    #[test]
+    fn controle_solto_vira_marcador_visivel() {
+        let saida = summarize_tool_output("antes\u{0}depois", true);
+        assert_eq!(saida, "antes\u{fffd}depois");
+    }
+
+    /// Sanear nao pode quebrar texto legitimo com acento.
+    #[test]
+    fn acento_atravessa_intacto() {
+        let saida = summarize_tool_output("compilação concluída com açúcar", true);
+        assert_eq!(saida, "compilação concluída com açúcar");
+    }
+
+    /// A ordem importa: redigir, sanear, truncar. Um segredo seguido de ESC
+    /// tem de sair redigido **e** sem o controle.
+    #[test]
+    fn segredo_e_controle_saem_os_dois() {
+        let saida = summarize_tool_output("sk-ant-api03-aaaaaaaaaaaaaaaaaaaa\u{1b}[2J", true);
+        assert!(!saida.contains('\u{1b}'), "ESC sobreviveu: {saida:?}");
+        assert!(
+            !saida.contains("sk-ant-api03-aaaaaaaaaaaaaaaaaaaa"),
+            "segredo sobreviveu: {saida:?}"
+        );
+    }
 
     #[test]
     fn resume_o_comando_do_bash() {

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -220,6 +220,46 @@ só tem `agent_id`, então o campo é descartado pelo serde. Não era superfíci
 viva; o guard existe para o dia em que a rota mudar, e
 `post_sessions_does_not_expose_working_dir_today` fixa esse estado.
 
+## 5.75. Saída de ferramenta escrita no terminal (#995)
+
+O `garra chat` imprime, a cada chamada de ferramenta, uma linha com o que ela
+fez e uma com o que devolveu (#937). Esse texto **não é confiável**: é o que o
+agente leu de um arquivo, baixou de uma página, ou o que um comando escreveu.
+Um `README` de repositório clonado é conteúdo de terceiro chegando ao terminal
+do usuário.
+
+Até o #995 ele chegava com os caracteres de controle intactos, o que dava a
+quem controlasse a saída: limpar a tela (`\x1b[2J`), esconder o cursor
+(`\x1b[?25l`, violando invariante explícita do projeto), trocar o título da
+janela (OSC), e reposicionar o cursor para sobrescrever linhas já impressas —
+**forjando texto que parece ter vindo do próprio Garra**, que é a consequência
+que importa: o usuário decide o que autorizar lendo essa tela.
+
+A sanitização mora no `garraia-agents`, junto da redação de segredo, mantendo
+a fronteira do ADR 0017 — o renderer recebe texto pronto e só decide como
+desenhar. Ordem obrigatória: **redige, saneia, trunca**; truncar antes deixaria
+meia sequência (ou meio segredo) passar.
+
+A garantia vem da regra **por caractere**, não do reconhecimento de sequência:
+todo controle C0, C1 e DEL sai, e sem `ESC` o `[2J` restante é texto inerte.
+O parser de CSI/OSC que existe é para legibilidade — saída colorida é comum e
+legítima —, e se ele errar numa sequência exótica a falha é cosmética, não de
+segurança.
+
+| STRIDE | Cenário concreto | Mitigação atual | Gap / Planejada |
+|---|---|---|---|
+| **S** Spoofing | Conteúdo de terceiro reposiciona o cursor e sobrescreve linhas, forjando saída que parece do Garra — o usuário autoriza uma ação com base em tela falsificada. | Todo controle C0/C1/DEL removido antes de chegar ao renderer (#995). | — |
+| **T** Tampering | `\x1b[2J` limpa a tela; OSC troca o título da janela; `\x1b[?25l` deixa o terminal sem cursor após a sessão. | Idem. | — |
+
+**Superfície irmã ainda aberta:** o texto do **modelo** (`write_delta`) segue
+indo cru ao terminal — issue #996. Não foi corrigido junto porque exige
+saneador **com estado**: o texto é streaming, e uma sequência pode chegar
+partida entre dois deltas, cada metade inofensiva isolada. Gravidade menor
+(exige induzir o modelo a emitir a sequência, tipicamente via injeção de
+prompt) mas mesma classe.
+
+---
+
 ## 5.8. `/metrics` — o que a observabilidade conta sobre a instalação (#957)
 
 O endpoint Prometheus é autenticado (`metrics_auth.rs`: loopback por padrão,


### PR DESCRIPTION
## Descrição

Encontrado ao começar o #938. O resumo de ferramenta do #937 redigia segredo e trocava quebra de linha por espaço, mas deixava passar `ESC` e os demais caracteres de controle — e **saída de ferramenta não é conteúdo confiável**: é o que o agente leu de um arquivo, baixou de uma página, ou o que um comando escreveu. Um `README` de repositório clonado é conteúdo de terceiro chegando ao terminal de quem roda o `garra chat`.

Confirmado contra a função real **antes** de mexer:

```rust
summarize_tool_output("\x1b[2J\x1b[?25lfoo", true)
// => "\u{1b}[2J\u{1b}[?25lfoo"
```

## Por que importa

O que isso dava a quem controlasse a saída: limpar a tela, trocar o título da janela por OSC, e reposicionar o cursor para **sobrescrever linhas já impressas**. Essa última é a consequência que importa — permite forjar texto que parece ter vindo do próprio Garra, e é lendo essa tela que o usuário decide o que autorizar.

O caso mais pontudo era `\x1b[?25l`: o projeto tem invariante explícita, escrita no `CLAUDE.md`, de que essa sequência **não é emitida em lugar nenhum**, para que nenhum caminho de saída deixe o terminal sem cursor. Saída de ferramenta a violava.

## A segurança vem da regra por caractere, não do reconhecimento de sequência

Esta é a parte que importa entender antes de mexer no saneador.

Todo controle C0, C1 e DEL sai — e **sem o `ESC`, o `[2J` que sobra é texto inerte**, que o terminal imprime em vez de executar. Reconhecer "sequências ANSI" por padrão seria o jogo errado: há CSI, OSC, DCS, formas de dois caracteres, com e sem terminador, e basta um buraco.

O parser de CSI/OSC que existe serve **só para legibilidade**. Saída colorida é comum e legítima — `cargo test` emite `\x1b[32mok\x1b[0m` — e trocar só o `ESC` por um marcador deixaria `�[32mok�[0m` na tela do caso normal. Quando a sequência é reconhecível ela sai inteira e o resultado fica limpo:

```rust
summarize_tool_output("\x1b[32mtest result: ok\x1b[0m", true)  // => "test result: ok"
```

Se o parser errar numa sequência exótica, o `ESC` sai do mesmo jeito e sobra texto literal feio. **A falha é cosmética, não de segurança** — é o modo de falhar que se quer.

Controle solto vira `�` em vez de sumir: apagar em silêncio faria uma tentativa de injeção parecer texto normal.

Ordem obrigatória: **redige, saneia, trunca**. Truncar antes deixaria meia sequência passar, pela mesma razão que já valia para segredo.

Vale para o input também — o `command` do bash também vem de fora. E a sanitização mora no `garraia-agents`, junto da redação, mantendo a fronteira do ADR 0017: o renderer recebe texto pronto e só decide como desenhar.

## Verificado no binário

Com a carga hostil completa — limpa tela, esconde cursor, título "INVADIDO":

```console
bruto  = "\u{1b}[2J\u{1b}[?25l\u{1b}]0;INVADIDO\u{7}tudo certo!"
resumo = "tudo certo!"
```

O terminal sobreviveu intacto.

## Superfície irmã ainda aberta — #996

O texto do **modelo** (`write_delta`) segue indo cru ao terminal. Não corrigi junto, e a razão não é escopo por escopo:

O texto do modelo é **streaming**, então uma sequência pode chegar partida entre dois deltas — `\x1b` num, `[2J` no outro —, cada metade inofensiva isolada e perigosa na concatenação que o terminal vê. Um saneador sem estado como este não pegaria. A correção precisa de parser **com estado** no renderer, e há uma decisão de produto antes (o modelo pode emitir cor de propósito?).

Gravidade menor — exige induzir o modelo a emitir a sequência, tipicamente via injeção de prompt, um passo a mais que não existe no caso da ferramenta. Registrado em #996 com a sutileza documentada, porque é exatamente o que alguém erraria ao tratar os dois como o mesmo bug.

## Tipo de mudança

- [x] `fix`: Correção de bug
- [x] `docs`: Documentação (modelo de ameaça §5.75)
- [x] `test`: Adição de testes

## Classe de Risco

- [x] **Classe C (Alto Risco)**: conteúdo de terceiro alcançando o terminal do usuário, com forja de saída como consequência. É correção de regressão do #937, live na main.

## Checklist de Segurança e Qualidade

- [x] `cargo +1.95 fmt --all -- --check` limpo
- [x] `cargo +1.95 clippy -p garraia-agents --all-targets -- -D warnings` sem erros
- [x] `cargo +1.95 test -p garraia-agents -p garraia` — 341 + 250 + 11 + 3 + 1 passando
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo commitado
- [x] Nenhuma migração
- [x] Texto legítimo com acento atravessa intacto — com teste
- [x] Redação de segredo continua valendo, e junto com a sanitização — com teste
- [ ] Verificação de políticas RLS — não se aplica

## Mudanças na API pública e Schema

Nenhuma. `sanear_controles` é privado; `summarize_tool_output` e `summarize_tool_input` mantêm assinatura. Sem schema, sem migração, sem config.

## Como testar

```bash
cargo +1.95 test -p garraia-agents turn_events
```

Seis testes novos: as cinco cargas hostis reais (`\x1b[2J`, `\x1b[?25l`, OSC com BEL, OSC com ST, `ESC c`), o input do bash, a saída colorida legítima que precisa continuar limpa, o controle solto que precisa ficar visível, o acento que não pode quebrar, e segredo + controle saindo os dois.

## Plano de Rollback

Reverter o merge. Nada persistido, nada de config, nada de schema — volta ao comportamento anterior, que é o vulnerável.

Closes #995

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF

---
_Generated by [Claude Code](https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF)_