### PR TITLE
feat(cli): /tool mostra a saída inteira de uma chamada (#938, parte 1 de 2)

### DIFF
--- a/changelog.d/added/938-tool-mostra-a-saida-inteira.md
+++ b/changelog.d/added/938-tool-mostra-a-saida-inteira.md
@@ -1,0 +1,31 @@
+- **`/tool` mostra a saida inteira de uma chamada de ferramenta (#938).** O
+  #937 reduziu cada chamada a uma linha, o que deixou a conversa legivel — mas
+  resumo bom e resumo que esconde coisa, e esconder sem dar como reaver e so
+  perder: quando o `cargo test` diz "Failed" e o resumo mostra a primeira
+  linha, a causa costuma estar na linha 300. Agora cada linha de ferramenta
+  termina com um numero (`#7`) e `/tool 7` mostra a saida completa; `/tool`
+  sozinho lista o que esta guardado. O numero e curto de proposito porque
+  aparece em toda linha, e ele existe porque sem ele o `/tool <n>` do `/help`
+  seria instrucao sem como ser seguida.
+- **Indices nao sao reusados.** Numerar por posicao faria `/tool 3` significar
+  coisas diferentes conforme outras chamadas acontecessem — o usuario le "3" na
+  tela, roda mais um comando e recebe outra saida sem nada indicando a troca.
+  Sao monotonicos, e pedir uma entrada ja descartada diz que ela expirou em vez
+  de mostrar a errada. "Expirou" e "nunca existiu" sao mensagens diferentes: a
+  primeira e acionavel (rode de novo), a segunda quer dizer que o numero esta
+  errado.
+- **Dois limites, nao um.** O registro guarda as 20 ultimas chamadas E no
+  maximo 512 KiB. So o teto de entradas nao seguraria memoria (vinte saidas de
+  64 KiB sao 1,2 MiB grudados no processo); so o teto de bytes tornaria o
+  `/tool` imprevisivel, porque uma saida gorda expulsaria dez pequenas e o
+  indice recem-visto sumiria. Cada saida e capada em 64 KiB **na origem**, no
+  `garraia-agents`, preservando comeco e fim com marcador do que sumiu — so o
+  fim perderia o que estava sendo compilado, so o comeco perderia a causa da
+  falha.
+- **A saida completa passa pelas mesmas garantias do resumo**: redacao de
+  segredo e remocao de controle de terminal (#995), na origem. Era criterio de
+  aceite explicito da issue e daria para errar, porque o resumo ja era seguro e
+  dava para achar que a saida crua tambem era. A diferenca e so de forma —
+  quebra de linha e tabulacao sobrevivem, porque sao a estrutura do texto que o
+  usuario pediu para ler; o `\r` continua saindo, porque sozinho ele devolve o
+  cursor ao inicio da linha e e a primitiva de sobrescrever texto ja impresso.

--- a/changelog.d/added/938-tool-mostra-a-saida-inteira.md
+++ b/changelog.d/added/938-tool-mostra-a-saida-inteira.md
@@ -27,5 +27,9 @@
   aceite explicito da issue e daria para errar, porque o resumo ja era seguro e
   dava para achar que a saida crua tambem era. A diferenca e so de forma —
   quebra de linha e tabulacao sobrevivem, porque sao a estrutura do texto que o
-  usuario pediu para ler; o `\r` continua saindo, porque sozinho ele devolve o
-  cursor ao inicio da linha e e a primitiva de sobrescrever texto ja impresso.
+  usuario pediu para ler; o `\r` nao sobrevive, porque sozinho ele devolve o
+  cursor ao inicio da linha e e a primitiva de sobrescrever texto ja impresso —
+  mas na saida completa ele vira **quebra de linha** em vez de sumir, senao uma
+  barra de progresso (`10%\r20%\r100%`) viraria `10%20%100%`, um amontoado que
+  o leitor nao distingue de uma saida que era assim mesmo. Idem backspace,
+  tabulacao vertical e form feed, que viram marcador visivel.

--- a/crates/garraia-agents/src/runtime.rs
+++ b/crates/garraia-agents/src/runtime.rs
@@ -25,7 +25,9 @@ use crate::providers::{
     StreamEvent, ToolDefinition,
 };
 use crate::tools::{Tool, ToolContext, ToolOutput};
-use crate::turn_events::{TurnSink, summarize_tool_input, summarize_tool_output};
+use crate::turn_events::{
+    TurnSink, capture_tool_output, summarize_tool_input, summarize_tool_output,
+};
 
 /// Where a registered tool came from. Issue #924: without this the runtime
 /// cannot tell a native tool from an MCP one, so it cannot replace just the
@@ -1694,6 +1696,7 @@ impl AgentRuntime {
                                 iniciado_em.elapsed(),
                                 ok,
                                 summarize_tool_output(&output.content, ok),
+                                capture_tool_output(&output.content),
                             )
                             .await;
                         }
@@ -1833,6 +1836,7 @@ impl AgentRuntime {
                                     iniciado_em.elapsed(),
                                     ok,
                                     summarize_tool_output(&output.content, ok),
+                                    capture_tool_output(&output.content),
                                 )
                                 .await;
                             }

--- a/crates/garraia-agents/src/turn_events.rs
+++ b/crates/garraia-agents/src/turn_events.rs
@@ -279,11 +279,25 @@ fn sanear_controles(texto: &str, preservar_quebras: bool) -> String {
             '\n' | '\t' if preservar_quebras => out.push(c),
             '\t' | '\n' => out.push(' '),
 
-            // O `\r` sai **sempre**, inclusive na saida completa. Sozinho ele
-            // devolve o cursor ao inicio da linha, que e exatamente a primitiva
-            // de sobrescrever texto ja impresso que o #995 fechou. Num `\r\n`
-            // legitimo tira-lo deixa o `\n`, que e o que se quer.
-            '\r' if preservar_quebras => {}
+            // O `\r` nunca sobrevive: sozinho ele devolve o cursor ao inicio da
+            // linha, que e a primitiva de sobrescrever texto ja impresso que o
+            // #995 fechou.
+            //
+            // Mas na saida completa ele vira **quebra de linha**, e nao sumico.
+            // A auditoria do #938 deu o caso que decide isso: uma barra de
+            // progresso emite `10%\r20%\r100%`, e apaga-lo produzia
+            // `10%20%100%` — um amontoado que o leitor nao distingue de uma
+            // saida que era assim mesmo. Como quebra, cada estado vira sua
+            // linha, que e o que o programa quis desenhar.
+            //
+            // O `\r\n` legitimo continua virando um `\n` so: o `\r` e engolido
+            // porque o `\n` seguinte ja faz o trabalho.
+            '\r' if preservar_quebras => {
+                if chars.peek() == Some(&'\n') {
+                    continue;
+                }
+                out.push('\n');
+            }
             '\r' => out.push(' '),
 
             '\u{1b}' => match chars.peek() {
@@ -509,13 +523,21 @@ mod tests {
 
     /// O `\r` sai mesmo na saida completa: sozinho ele devolve o cursor ao
     /// inicio da linha, que e a primitiva de sobrescrever texto ja impresso.
+    /// O `\r` sai, mas vira quebra em vez de sumir.
+    ///
+    /// A auditoria do #938 apontou o caso que decide: apagando, uma barra de
+    /// progresso vira `10%20%100%`, um amontoado indistinguivel de uma saida
+    /// que era assim mesmo. Como quebra, cada estado vira sua linha.
     #[test]
-    fn saida_completa_ainda_tira_o_retorno_de_carro() {
-        let capturado = capture_tool_output("progresso 10%\rprogresso 100%");
+    fn retorno_de_carro_vira_quebra_e_nao_sumico() {
+        let capturado = capture_tool_output("10%\r20%\r100%");
         assert!(!capturado.contains('\r'), "CR sobreviveu: {capturado:?}");
-        assert_eq!(capturado, "progresso 10%progresso 100%");
-        // E o `\r\n` legitimo vira `\n`, sem perder a quebra.
+        assert_eq!(capturado, "10%\n20%\n100%");
+
+        // O `\r\n` legitimo vira UM `\n`, nao dois — senao toda saida de
+        // Windows viria com o dobro das linhas.
         assert_eq!(capture_tool_output("um\r\ndois"), "um\ndois");
+        assert_eq!(capture_tool_output("a\r\nb\r\nc"), "a\nb\nc");
     }
 
     /// O corte preserva comeco E fim: so o fim perderia o que estava sendo

--- a/crates/garraia-agents/src/turn_events.rs
+++ b/crates/garraia-agents/src/turn_events.rs
@@ -38,6 +38,21 @@ use tokio::sync::mpsc;
 /// Quanto de um resumo de ferramenta cabe numa linha de terminal.
 const SUMMARY_MAX_CHARS: usize = 72;
 
+/// Teto por saida capturada para inspecao posterior (#938).
+///
+/// Nao e limite de exibicao — e limite de **memoria**: e o que impede um
+/// `find /` de morar no processo do chat. Generoso o bastante para um
+/// `cargo test` inteiro (que e o caso de uso citado na issue) e pequeno o
+/// bastante para que vinte deles nao pesem.
+const CAPTURE_MAX_BYTES: usize = 64 * 1024;
+
+/// Do teto, quanto fica do **comeco**. O resto fica do fim.
+///
+/// O fim leva a maior parte de proposito: em falha de compilacao ou de teste,
+/// o que importa esta no fim. Mas o comeco nao pode ir a zero — e la que mora
+/// o comando que gerou a saida e as primeiras linhas de erro de um build.
+const CAPTURE_HEAD_BYTES: usize = 16 * 1024;
+
 /// Um acontecimento do turno, na linguagem de quem **observa** o agente.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TurnEvent {
@@ -62,6 +77,14 @@ pub enum TurnEvent {
         /// Uma linha sobre o resultado, ja redigida e truncada. Em falha, o
         /// trecho mais relevante do erro.
         summary: String,
+        /// A saida inteira, ja redigida, saneada e capada por
+        /// [`capture_tool_output`] — o que o `/tool` do CLI mostra (#938).
+        ///
+        /// Vive no evento, e nao num canal a parte, para nao repetir o erro
+        /// que o docblock deste modulo descreve: dois canais nao garantem
+        /// ordem entre si, e a saida tem de chegar junto com o resultado a
+        /// que ela pertence.
+        output: String,
     },
 }
 
@@ -108,6 +131,7 @@ impl TurnSink {
         duration: Duration,
         success: bool,
         summary: String,
+        output: String,
     ) {
         if let Self::Events(tx) = self {
             let _ = tx
@@ -116,6 +140,7 @@ impl TurnSink {
                     duration,
                     success,
                     summary,
+                    output,
                 })
                 .await;
         }
@@ -206,7 +231,7 @@ fn campo(input: &serde_json::Value, chave: &str) -> Option<String> {
 /// poderia deixar meia sequencia passar pela mesma razao.
 fn sanear(texto: &str) -> String {
     let redigido = garraia_security::redact_secrets(texto.trim());
-    let sem_controle = sanear_controles(&redigido);
+    let sem_controle = sanear_controles(&redigido, false);
     truncar(&sem_controle, SUMMARY_MAX_CHARS)
 }
 
@@ -241,16 +266,25 @@ fn sanear(texto: &str) -> String {
 /// A consequencia de o reconhecimento errar e **cosmetica, nao de seguranca**:
 /// uma sequencia exotica que o parser nao entenda perde o `ESC` do mesmo jeito
 /// e sobra como texto literal feio. E o modo de falhar que se quer.
-fn sanear_controles(texto: &str) -> String {
+fn sanear_controles(texto: &str, preservar_quebras: bool) -> String {
     let mut out = String::with_capacity(texto.len());
     let mut chars = texto.chars().peekable();
 
     while let Some(c) = chars.next() {
         match c {
-            // Separadores viram espaco em vez de sumir: num resumo de uma
-            // linha eles separam palavras, e apaga-los grudaria tokens que o
+            // Na saida completa a quebra e a tabulacao sao a estrutura do
+            // texto e ficam. No resumo de uma linha viram espaco, em vez de
+            // sumir: elas separam palavras, e apaga-las grudaria tokens que o
             // usuario precisa ler separados.
-            '\t' | '\n' | '\r' => out.push(' '),
+            '\n' | '\t' if preservar_quebras => out.push(c),
+            '\t' | '\n' => out.push(' '),
+
+            // O `\r` sai **sempre**, inclusive na saida completa. Sozinho ele
+            // devolve o cursor ao inicio da linha, que e exatamente a primitiva
+            // de sobrescrever texto ja impresso que o #995 fechou. Num `\r\n`
+            // legitimo tira-lo deixa o `\n`, que e o que se quer.
+            '\r' if preservar_quebras => {}
+            '\r' => out.push(' '),
 
             '\u{1b}' => match chars.peek() {
                 // CSI: `ESC [` ... byte final na faixa 0x40-0x7e. Cobre cor,
@@ -295,6 +329,68 @@ fn sanear_controles(texto: &str) -> String {
     }
 
     out
+}
+
+/// A saida da ferramenta inteira, pronta para ser guardada e relida (#938).
+///
+/// Passa pelas **mesmas** garantias do resumo — redige segredo, tira controle
+/// de terminal — porque a inspecao mostra mais texto, nao texto menos seguro.
+/// Era um criterio de aceite explicito da #938 ("secret redaction applies to
+/// both summaries and full output") e teria sido facil de errar: o resumo ja
+/// era seguro, e daria para achar que a saida crua tambem era.
+///
+/// A diferenca para o resumo e a forma, nao a protecao: aqui a quebra de linha
+/// e a tabulacao sobrevivem, porque sao a estrutura do texto que o usuario
+/// pediu para ler. O `\r` continua saindo — ver [`sanear_controles`].
+///
+/// # Por que capar aqui, e nao no CLI
+///
+/// O cap acontece **antes** de virar evento, na origem, pelo mesmo motivo que
+/// a redacao acontece aqui: quem guarda nao precisa lembrar do limite. Se o
+/// cap morasse no CLI, a saida inteira de um `find /` ja teria atravessado o
+/// canal e existido em memoria antes de alguem a cortar.
+///
+/// O corte preserva **comeco e fim**, com um marcador dizendo quanto sumiu.
+/// Cortar so o fim perderia a causa de uma falha de teste; cortar so o comeco
+/// perderia o que estava sendo compilado.
+pub fn capture_tool_output(content: &str) -> String {
+    let redigido = garraia_security::redact_secrets(content);
+    let limpo = sanear_controles(&redigido, true);
+
+    if limpo.len() <= CAPTURE_MAX_BYTES {
+        return limpo;
+    }
+
+    // Fatiar `String` por byte quebra UTF-8 no meio de um caractere. Os dois
+    // limites andam para tras ate uma fronteira de caractere — no pior caso
+    // tres bytes, o que nao muda nada de util e evita um panic.
+    let fim_do_comeco = fronteira_para_tras(&limpo, CAPTURE_HEAD_BYTES);
+    let tamanho_do_fim = CAPTURE_MAX_BYTES - CAPTURE_HEAD_BYTES;
+    let inicio_do_fim = fronteira_para_frente(&limpo, limpo.len() - tamanho_do_fim);
+
+    let omitidos = inicio_do_fim - fim_do_comeco;
+    format!(
+        "{}\n\n[... {omitidos} bytes omitidos — a saida passou de {} KiB ...]\n\n{}",
+        &limpo[..fim_do_comeco],
+        CAPTURE_MAX_BYTES / 1024,
+        &limpo[inicio_do_fim..],
+    )
+}
+
+/// Recua ate uma fronteira de caractere, para poder fatiar sem panic.
+fn fronteira_para_tras(texto: &str, mut i: usize) -> usize {
+    while i > 0 && !texto.is_char_boundary(i) {
+        i -= 1;
+    }
+    i
+}
+
+/// Avanca ate uma fronteira de caractere.
+fn fronteira_para_frente(texto: &str, mut i: usize) -> usize {
+    while i < texto.len() && !texto.is_char_boundary(i) {
+        i += 1;
+    }
+    i
 }
 
 /// Corta por **caractere**, nunca por byte — comando e caminho carregam
@@ -384,6 +480,128 @@ mod tests {
             !saida.contains("sk-ant-api03-aaaaaaaaaaaaaaaaaaaa"),
             "segredo sobreviveu: {saida:?}"
         );
+    }
+
+    /// A saida completa passa pelas MESMAS garantias do resumo. Era criterio
+    /// de aceite explicito da #938 e daria para errar: o resumo ja era seguro,
+    /// e dava para achar que a saida crua tambem era.
+    #[test]
+    fn saida_completa_redige_segredo_e_saneia_controle() {
+        let bruto = "linha 1\nsk-ant-api03-aaaaaaaaaaaaaaaaaaaa\n\u{1b}[2Jlinha 3";
+        let capturado = capture_tool_output(bruto);
+        assert!(
+            !capturado.contains('\u{1b}'),
+            "ESC sobreviveu: {capturado:?}"
+        );
+        assert!(
+            !capturado.contains("sk-ant-api03-aaaaaaaaaaaaaaaaaaaa"),
+            "segredo sobreviveu: {capturado:?}"
+        );
+    }
+
+    /// Diferente do resumo, a saida completa preserva a estrutura do texto —
+    /// e para le-la que o usuario pediu.
+    #[test]
+    fn saida_completa_preserva_quebra_de_linha() {
+        let capturado = capture_tool_output("um\ndois\ntres");
+        assert_eq!(capturado, "um\ndois\ntres");
+    }
+
+    /// O `\r` sai mesmo na saida completa: sozinho ele devolve o cursor ao
+    /// inicio da linha, que e a primitiva de sobrescrever texto ja impresso.
+    #[test]
+    fn saida_completa_ainda_tira_o_retorno_de_carro() {
+        let capturado = capture_tool_output("progresso 10%\rprogresso 100%");
+        assert!(!capturado.contains('\r'), "CR sobreviveu: {capturado:?}");
+        assert_eq!(capturado, "progresso 10%progresso 100%");
+        // E o `\r\n` legitimo vira `\n`, sem perder a quebra.
+        assert_eq!(capture_tool_output("um\r\ndois"), "um\ndois");
+    }
+
+    /// O corte preserva comeco E fim: so o fim perderia o que estava sendo
+    /// compilado, so o comeco perderia a causa da falha.
+    #[test]
+    fn saida_gigante_e_cortada_no_meio_preservando_as_pontas() {
+        let gigante = format!(
+            "COMECO\n{}\nFIM-DO-ERRO",
+            "linha de ruido\n".repeat(CAPTURE_MAX_BYTES / 10)
+        );
+        let capturado = capture_tool_output(&gigante);
+
+        assert!(capturado.starts_with("COMECO"), "perdeu o comeco");
+        assert!(capturado.ends_with("FIM-DO-ERRO"), "perdeu o fim");
+        assert!(capturado.contains("bytes omitidos"), "nao marcou o corte");
+        // Cabe no teto, com folga para o marcador.
+        assert!(
+            capturado.len() < CAPTURE_MAX_BYTES + 200,
+            "passou do teto: {}",
+            capturado.len()
+        );
+    }
+
+    /// Cortar `String` por byte no meio de um caractere multibyte causaria
+    /// panic. O corte anda ate a fronteira.
+    #[test]
+    fn corte_nao_quebra_caractere_multibyte() {
+        // Enche com um caractere de 2 bytes para que o limite caia no meio.
+        let gigante = "ç".repeat(CAPTURE_MAX_BYTES);
+        let capturado = capture_tool_output(&gigante);
+        assert!(capturado.contains("bytes omitidos"));
+        // Se tivesse quebrado, o `String` nem existiria — chegar aqui ja prova.
+        assert!(capturado.starts_with('ç'));
+    }
+
+    /// O backspace apaga o caractere anterior no terminal — e outra forma de
+    /// reescrever o que ja foi impresso, como o `\r`. Junto com tabulacao
+    /// vertical e form feed, que tambem movem o cursor.
+    #[test]
+    fn saida_completa_neutraliza_backspace_e_movimento_vertical() {
+        for (bruto, o_que_e) in [
+            (
+                "senha: xxx\u{8}\u{8}\u{8}ok",
+                "backspace apaga o que foi escrito",
+            ),
+            ("um\u{b}dois", "tabulacao vertical"),
+            ("um\u{c}dois", "form feed"),
+        ] {
+            let capturado = capture_tool_output(bruto);
+            assert!(
+                !capturado
+                    .chars()
+                    .any(|c| c.is_control() && c != '\n' && c != '\t'),
+                "controle sobreviveu ({o_que_e}): {capturado:?}"
+            );
+        }
+    }
+
+    /// As bordas exatas do corte. Um byte a menos que o teto passa inteiro;
+    /// um a mais entra no caminho do corte — e e la que mora a aritmetica que
+    /// poderia dar underflow.
+    #[test]
+    fn as_bordas_do_corte_nao_estouram() {
+        for n in [
+            CAPTURE_MAX_BYTES - 1,
+            CAPTURE_MAX_BYTES,
+            CAPTURE_MAX_BYTES + 1,
+            CAPTURE_MAX_BYTES + CAPTURE_HEAD_BYTES,
+        ] {
+            let capturado = capture_tool_output(&"a".repeat(n));
+            if n <= CAPTURE_MAX_BYTES {
+                assert_eq!(capturado.len(), n, "cabia no teto e foi cortado (n={n})");
+            } else {
+                assert!(
+                    capturado.contains("bytes omitidos"),
+                    "passou do teto e nao foi cortado (n={n})"
+                );
+            }
+        }
+    }
+
+    /// Saida que cabe no teto atravessa inteira, sem marcador.
+    #[test]
+    fn saida_pequena_nao_ganha_marcador() {
+        let capturado = capture_tool_output("tudo certo");
+        assert_eq!(capturado, "tudo certo");
     }
 
     #[test]
@@ -494,8 +712,14 @@ mod tests {
 
         sink.tool_started("bash", "cargo test".into()).await;
         sink.text("oi".into()).await;
-        sink.tool_finished("bash", Duration::from_secs(1), true, "ok".into())
-            .await;
+        sink.tool_finished(
+            "bash",
+            Duration::from_secs(1),
+            true,
+            "ok".into(),
+            "saida completa".into(),
+        )
+        .await;
         drop(sink);
 
         let mut recebidos = Vec::new();
@@ -518,6 +742,7 @@ mod tests {
             Duration::from_millis(1500),
             true,
             "148 passed".into(),
+            "test result: ok. 148 passed".into(),
         )
         .await;
         sink.text("depois".into()).await;
@@ -539,7 +764,8 @@ mod tests {
                     name: "bash".into(),
                     duration: Duration::from_millis(1500),
                     success: true,
-                    summary: "148 passed".into()
+                    summary: "148 passed".into(),
+                    output: "test result: ok. 148 passed".into()
                 },
                 TurnEvent::TextDelta("depois".into()),
             ]

--- a/crates/garraia-cli/src/chat.rs
+++ b/crates/garraia-cli/src/chat.rs
@@ -16,6 +16,7 @@ use garraia_agents::{
 use garraia_config::AppConfig;
 use tokio::sync::mpsc;
 
+use crate::ui::tool_log::{Busca, ToolLog};
 use crate::ui::{TerminalRenderer, UiEvent};
 use garraia_agents::TurnEvent;
 
@@ -784,6 +785,7 @@ async fn stream_turn<F, T, E>(
     timeout: std::time::Duration,
     out: &mut (impl io::Write + ?Sized),
     renderer: &mut TerminalRenderer,
+    tool_log: &mut ToolLog,
     cancel: &tokio::sync::Notify,
 ) -> TurnOutcome<T, E>
 where
@@ -828,7 +830,7 @@ where
                 renderer.handle(UiEvent::ActivityTick, out);
             }
             maybe = rx.recv(), if rx_open => match maybe {
-                Some(evento) => render_turn_event(&evento, renderer, out),
+                Some(evento) => render_turn_event(&evento, renderer, tool_log, out),
                 None => rx_open = false,
             },
         }
@@ -839,7 +841,7 @@ where
     drop(call);
     if rx_open {
         while let Some(evento) = rx.recv().await {
-            render_turn_event(&evento, renderer, out);
+            render_turn_event(&evento, renderer, tool_log, out);
         }
     }
 
@@ -860,6 +862,7 @@ where
 fn render_turn_event(
     evento: &TurnEvent,
     renderer: &mut TerminalRenderer,
+    tool_log: &mut ToolLog,
     out: &mut (impl io::Write + ?Sized),
 ) {
     let ui = match evento {
@@ -870,12 +873,21 @@ fn render_turn_event(
             duration,
             success,
             summary,
-        } => UiEvent::ToolFinished {
-            name,
-            duration: *duration,
-            success: *success,
-            summary,
-        },
+            output,
+        } => {
+            // Guardar acontece **aqui**, e nao no renderer, porque o renderer
+            // desenha e nao lembra (ADR 0017). O indice volta para a linha
+            // desenhada: sem ele o usuario veria "/tool" no `/help` e nao teria
+            // como saber qual numero pedir.
+            let indice = tool_log.registrar(name, summary, *success, *duration, output.clone());
+            UiEvent::ToolFinished {
+                name,
+                duration: *duration,
+                success: *success,
+                summary,
+                indice: Some(indice),
+            }
+        }
     };
     renderer.handle(ui, out);
 }
@@ -994,6 +1006,9 @@ pub async fn run_chat(
 
     let session_id = format!("cli-{}", uuid::Uuid::new_v4());
     let mut history: Vec<ChatMessage> = Vec::new();
+    // A saida completa das ferramentas do turno, para o `/tool` (#938).
+    // Limitada em entradas e em bytes — ver `ui::tool_log`.
+    let mut tool_log = ToolLog::new();
     // Semente do indicador de atividade: roda a mensagem de abertura a
     // cada turno, para dois envios seguidos não começarem com a mesma frase.
     let mut turn_index: usize = 0;
@@ -1076,6 +1091,8 @@ pub async fn run_chat(
                 println!("  /clear             Limpar historico");
                 println!("  /history           Mostrar historico");
                 println!("  /context           Diretorio e projeto detectados");
+                println!("  /tool              Listar saidas de ferramenta guardadas");
+                println!("  /tool <n>          Ver a saida inteira de uma chamada");
                 println!("  /exit              Sair");
                 continue;
             }
@@ -1091,6 +1108,64 @@ pub async fn run_chat(
                     println!("{DIM}Projeto:   nenhum marcador detectado{RESET}");
                 } else {
                     println!("{DIM}Projeto:   {dir_context}{RESET}");
+                }
+                continue;
+            }
+            // A saida completa das ferramentas (#938). O resumo de uma linha
+            // do #937 deixou a conversa legivel; sem isto ele so teria
+            // escondido a causa da falha.
+            "/tool" | "/tools" | "/saida" => {
+                if tool_log.vazio() {
+                    println!("{DIM}Nenhuma ferramenta foi chamada ainda nesta sessao.{RESET}");
+                } else {
+                    println!("{DIM}Saidas guardadas (use /tool <n> para ver inteira):{RESET}");
+                    for e in tool_log.listar() {
+                        let marca = if e.sucesso { " " } else { "!" };
+                        let detalhe: String = e.detalhe.chars().take(52).collect();
+                        println!("  {marca}#{:<3} {:<12} {}", e.indice, e.ferramenta, detalhe);
+                    }
+                }
+                continue;
+            }
+            _ if input.starts_with("/tool ") || input.starts_with("/saida ") => {
+                let arg = input
+                    .split_once(' ')
+                    .map(|(_, resto)| resto.trim())
+                    .unwrap_or("");
+                match arg.trim_start_matches('#').parse::<usize>() {
+                    Ok(n) => match tool_log.buscar(n) {
+                        Busca::Achou(e) => {
+                            let estado = if e.sucesso { "ok" } else { "falhou" };
+                            println!(
+                                "{DIM}#{} {} · {} · {}{RESET}",
+                                e.indice,
+                                e.ferramenta,
+                                estado,
+                                crate::ui::format_duration(e.duracao)
+                            );
+                            if !e.detalhe.is_empty() {
+                                println!("{DIM}{}{RESET}", e.detalhe);
+                            }
+                            println!();
+                            // A saida ja veio redigida e saneada do
+                            // `garraia-agents`; aqui e so imprimir.
+                            println!("{}", e.saida);
+                        }
+                        // Expirada e inexistente sao mensagens diferentes de
+                        // proposito: "saiu do registro" e acionavel (rode de
+                        // novo), "nunca existiu" quer dizer que o numero esta
+                        // errado.
+                        Busca::Expirada => println!(
+                            "{DIM}A saida #{n} ja saiu do registro — so as mais \
+                             recentes ficam guardadas. Rode o comando de novo \
+                             para ve-la.{RESET}"
+                        ),
+                        Busca::Inexistente => println!(
+                            "{DIM}Nao ha saida #{n}. Use /tool para ver as \
+                             disponiveis.{RESET}"
+                        ),
+                    },
+                    Err(_) => println!("{DIM}Uso: /tool <numero>. Ex.: /tool 3{RESET}"),
                 }
                 continue;
             }
@@ -1219,6 +1294,7 @@ pub async fn run_chat(
             std::time::Duration::from_secs(timeout_secs),
             &mut stdout,
             &mut renderer,
+            &mut tool_log,
             &cancel,
         )
         .await;
@@ -1715,6 +1791,7 @@ mod tests {
                 std::time::Duration::from_secs(30),
                 &mut out,
                 &mut test_renderer(test_spinner()),
+                &mut ToolLog::new(),
                 &tokio::sync::Notify::new(),
             ),
         )
@@ -1751,6 +1828,7 @@ mod tests {
                 std::time::Duration::from_millis(50),
                 &mut out,
                 &mut test_renderer(None),
+                &mut ToolLog::new(),
                 &tokio::sync::Notify::new(),
             ),
         )
@@ -1805,6 +1883,7 @@ mod tests {
                 duration: std::time::Duration::from_millis(6300),
                 success: true,
                 summary: "148 passed".into(),
+                output: String::new(),
             })
             .await
             .map_err(|_| "receiver dropped")?;
@@ -1823,6 +1902,7 @@ mod tests {
                 std::time::Duration::from_secs(5),
                 &mut out,
                 &mut TerminalRenderer::with_prefix(crate::ui::Capabilities::PLAIN, None, ""),
+                &mut ToolLog::new(),
                 &tokio::sync::Notify::new(),
             ),
         )
@@ -1830,9 +1910,13 @@ mod tests {
         .expect("stream_turn nao pode travar");
 
         assert_eq!(outcome, TurnOutcome::Done(Ok("pronto".to_string())));
+        // O `| #0` no fim da linha e o ponteiro do #938: a saida inteira
+        // ficou guardada e este e o numero que o usuario digita no `/tool`.
+        // Afirma-lo aqui, no caminho real do `stream_turn`, e o que prova que
+        // o indice atravessa a ponte `TurnEvent` -> `ToolLog` -> `UiEvent`.
         assert_eq!(
             String::from_utf8(out).expect("utf8"),
-            "vou rodar os testes. * Bash cargo test\n  |- 148 passed | 6.3s\npassou tudo."
+            "vou rodar os testes. * Bash cargo test\n  |- 148 passed | 6.3s | #0\npassou tudo."
         );
     }
 
@@ -1913,6 +1997,7 @@ mod tests {
             std::time::Duration::from_secs(5),
             &mut out,
             &mut TerminalRenderer::with_prefix(test_caps(), test_spinner(), "garra > "),
+            &mut ToolLog::new(),
             &tokio::sync::Notify::new(),
         )
         .await;
@@ -1954,6 +2039,7 @@ mod tests {
             std::time::Duration::from_secs(5),
             &mut out,
             &mut TerminalRenderer::with_prefix(test_caps(), test_spinner(), "garra > "),
+            &mut ToolLog::new(),
             &tokio::sync::Notify::new(),
         )
         .await;
@@ -1994,6 +2080,7 @@ mod tests {
             std::time::Duration::from_secs(5),
             &mut out,
             &mut TerminalRenderer::with_prefix(test_caps(), test_spinner(), "garra > "),
+            &mut ToolLog::new(),
             &tokio::sync::Notify::new(),
         )
         .await;
@@ -2027,6 +2114,7 @@ mod tests {
                 std::time::Duration::from_millis(700),
                 &mut out,
                 &mut TerminalRenderer::with_prefix(test_caps(), test_spinner(), "garra > "),
+                &mut ToolLog::new(),
                 &tokio::sync::Notify::new(),
             ),
         )
@@ -2069,6 +2157,7 @@ mod tests {
                 std::time::Duration::from_secs(30),
                 &mut out,
                 &mut TerminalRenderer::with_prefix(test_caps(), test_spinner(), "garra > "),
+                &mut ToolLog::new(),
                 &cancel,
             ),
         )
@@ -2104,6 +2193,7 @@ mod tests {
             &mut out,
             // exatamente o que `Capabilities::detect` devolve num pipe: sem animacao
             &mut TerminalRenderer::with_prefix(crate::ui::Capabilities::PLAIN, None, "garra > "),
+            &mut ToolLog::new(),
             &tokio::sync::Notify::new(),
         )
         .await;
@@ -2142,6 +2232,7 @@ mod tests {
             std::time::Duration::from_secs(5),
             &mut out,
             &mut TerminalRenderer::with_prefix(test_caps(), test_spinner(), "garra > "),
+            &mut ToolLog::new(),
             &tokio::sync::Notify::new(),
         )
         .await;
@@ -2167,6 +2258,7 @@ mod tests {
             std::time::Duration::from_secs(5),
             &mut out,
             &mut test_renderer(None),
+            &mut ToolLog::new(),
             &tokio::sync::Notify::new(),
         )
         .await;

--- a/crates/garraia-cli/src/ui/mod.rs
+++ b/crates/garraia-cli/src/ui/mod.rs
@@ -40,6 +40,7 @@
 
 pub mod conversation;
 pub mod spinner;
+pub mod tool_log;
 
 use std::io;
 
@@ -81,6 +82,11 @@ pub enum UiEvent<'a> {
         success: bool,
         /// Uma linha sobre o resultado, ja redigida e truncada.
         summary: &'a str,
+        /// O numero que o usuario digita no `/tool N` para ver a saida
+        /// inteira (#938). `None` quando nada guardou a saida — sem registro
+        /// nao ha o que oferecer, e imprimir um numero morto seria pior do
+        /// que nao imprimir nenhum.
+        indice: Option<usize>,
     },
 }
 
@@ -263,7 +269,8 @@ impl TerminalRenderer {
                 duration,
                 success,
                 summary,
-            } => self.write_tool_finished(name, duration, success, summary, out),
+                indice,
+            } => self.write_tool_finished(name, duration, success, summary, indice, out),
         }
     }
 
@@ -358,6 +365,7 @@ impl TerminalRenderer {
         duration: std::time::Duration,
         success: bool,
         summary: &str,
+        indice: Option<usize>,
         out: &mut (impl io::Write + ?Sized),
     ) {
         if let Some(s) = self.spinner.as_mut() {
@@ -393,6 +401,15 @@ impl TerminalRenderer {
                 format!("{} {} {ramo}{corpo}", glifos.fail, tool_label(name)),
                 conversation::YELLOW,
             )
+        };
+
+        // O ponteiro para a saida inteira (#938). Curto de proposito: ele
+        // aparece em **toda** linha de ferramenta, entao qualquer coisa mais
+        // longa que `#7` viraria ruido repetido a cada chamada. O `/help`
+        // explica o que fazer com o numero; aqui basta ele existir.
+        let corpo = match indice {
+            Some(i) => format!("{corpo}{separador}#{i}"),
+            None => corpo,
         };
 
         if self.caps.interactive {
@@ -456,7 +473,7 @@ fn tool_label(name: &str) -> String {
 
 /// Duracao em uma casa decimal para segundos, inteiro para milissegundos:
 /// `6.3s`, `840ms`. Acima de um minuto, `1m03s`.
-fn format_duration(d: std::time::Duration) -> String {
+pub(crate) fn format_duration(d: std::time::Duration) -> String {
     let ms = d.as_millis();
     if ms < 1000 {
         return format!("{ms}ms");
@@ -513,6 +530,7 @@ mod tests {
                     duration: std::time::Duration::from_millis(6300),
                     success: true,
                     summary: "148 passed",
+                    indice: None,
                 },
                 UiEvent::Warning("cuidado"),
                 UiEvent::Error("quebrou"),
@@ -671,6 +689,7 @@ mod tests {
                     duration: std::time::Duration::from_millis(6300),
                     success: true,
                     summary: "148 passed",
+                    indice: None,
                 },
             ],
         );
@@ -697,6 +716,7 @@ mod tests {
                     duration: std::time::Duration::from_millis(40),
                     success: true,
                     summary: "",
+                    indice: None,
                 },
             ],
         );
@@ -717,6 +737,7 @@ mod tests {
                 duration: std::time::Duration::from_millis(4200),
                 success: false,
                 summary: "error: exit 101",
+                indice: None,
             }],
         );
         assert_eq!(saida, "x Bash   |- error: exit 101 | 4.2s\n");
@@ -731,6 +752,7 @@ mod tests {
                 duration: std::time::Duration::from_secs(2),
                 success: false,
                 summary: "",
+                indice: None,
             }],
         );
         assert!(saida.contains("falhou"), "{saida:?}");
@@ -805,6 +827,7 @@ mod tests {
                 duration: std::time::Duration::from_secs(1),
                 success: true,
                 summary: "ok",
+                indice: None,
             },
             &mut out,
         );
@@ -831,12 +854,48 @@ mod tests {
                     duration: std::time::Duration::from_secs(1),
                     success: true,
                     summary: "ok",
+                    indice: None,
                 },
                 UiEvent::TextDelta("depois"),
                 UiEvent::TurnFinished,
             ],
         );
         assert_eq!(saida.matches("Garra").count(), 1, "{saida:?}");
+    }
+
+    /// O numero tem de aparecer na linha: sem ele o `/tool <n>` do `/help`
+    /// seria uma instrucao sem como ser seguida (#938).
+    #[test]
+    fn a_linha_da_ferramenta_mostra_o_numero_para_inspecionar() {
+        let saida = render(
+            Capabilities::PLAIN,
+            &[UiEvent::ToolFinished {
+                name: "bash",
+                duration: std::time::Duration::from_millis(6300),
+                success: true,
+                summary: "148 passed",
+                indice: Some(7),
+            }],
+        );
+        assert!(saida.contains("#7"), "sem o numero: {saida:?}");
+        assert!(saida.contains("148 passed"), "perdeu o resumo: {saida:?}");
+    }
+
+    /// Sem registro nao ha numero — imprimir um numero morto seria pior do
+    /// que nao imprimir nenhum.
+    #[test]
+    fn sem_indice_a_linha_nao_inventa_numero() {
+        let saida = render(
+            Capabilities::PLAIN,
+            &[UiEvent::ToolFinished {
+                name: "bash",
+                duration: std::time::Duration::from_millis(100),
+                success: true,
+                summary: "ok",
+                indice: None,
+            }],
+        );
+        assert!(!saida.contains('#'), "inventou numero: {saida:?}");
     }
 
     #[test]

--- a/crates/garraia-cli/src/ui/tool_log.rs
+++ b/crates/garraia-cli/src/ui/tool_log.rs
@@ -1,0 +1,258 @@
+//! Onde a saida completa das ferramentas do turno fica ate alguem pedir (#938).
+//!
+//! O #937 reduziu cada chamada de ferramenta a uma linha, que era o que a
+//! conversa precisava. Mas resumo bom e resumo que esconde coisa, e esconder
+//! sem dar como reaver e so perder: quando o `cargo test` diz "Failed" e o
+//! resumo mostra a primeira linha, a causa costuma estar na linha 300.
+//!
+//! Este modulo e o "onde" dessa segunda metade. Ele **nao** decide o que e
+//! seguro mostrar: a saida ja chega redigida, saneada e capada do
+//! `garraia-agents` ([`garraia_agents::turn_events::capture_tool_output`]),
+//! pela mesma razao de sempre — quem guarda nao pode precisar lembrar da
+//! garantia.
+//!
+//! # Os dois limites, e por que sao dois
+//!
+//! Um teto de **entradas** sozinho nao segura memoria: vinte saidas de 64 KiB
+//! sao 1,2 MiB grudados no processo do chat de quem so queria conversar. Um
+//! teto de **bytes** sozinho tornaria o `/tool` imprevisivel — uma saida
+//! gorda expulsaria dez pequenas e o indice que o usuario acabou de ver some.
+//! Com os dois, o comportamento e dizivel: guarda as ultimas [`MAX_ENTRADAS`],
+//! e menos se elas passarem de [`MAX_BYTES`].
+//!
+//! # Indice que nao se reaproveita
+//!
+//! Esta e a decisao que mais custa se for errada. Numerar as entradas por
+//! posicao (`0..n`) faria `/tool 3` significar coisas diferentes conforme
+//! outras chamadas acontecessem — o usuario le "3" na tela, roda mais um
+//! comando, pede `/tool 3` e recebe outra saida, sem nada indicando a troca.
+//!
+//! Entao o indice e **monotonico** e nunca reusado. Pedir uma entrada ja
+//! descartada devolve [`Busca::Expirada`], que o chamador transforma numa
+//! mensagem dizendo isso — mostrar a entrada errada em silencio seria pior do
+//! que nao mostrar nada.
+
+/// Quantas chamadas de ferramenta ficam disponiveis para inspecao.
+///
+/// Vinte cobre a conversa recente com folga; a memoria de quem trabalhou o dia
+/// todo na mesma sessao nao cresce por isso.
+const MAX_ENTRADAS: usize = 20;
+
+/// Teto de memoria do registro inteiro.
+///
+/// Meio mega e o bastante para varias saidas grandes e pequeno o bastante para
+/// nao aparecer no consumo do processo.
+const MAX_BYTES: usize = 512 * 1024;
+
+/// Uma chamada de ferramenta guardada.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Entrada {
+    /// O numero que o usuario digita no `/tool N`. Monotonico, nunca reusado.
+    pub indice: usize,
+    pub ferramenta: String,
+    /// O que a chamada fazia — o `command` do bash, o `path` do read.
+    pub detalhe: String,
+    pub sucesso: bool,
+    pub duracao: std::time::Duration,
+    /// A saida inteira, ja segura, como veio do `garraia-agents`.
+    pub saida: String,
+}
+
+impl Entrada {
+    /// O que esta entrada custa de memoria. Aproximado de proposito: as
+    /// `String` dominam, e contar o resto seria precisao sem uso.
+    fn bytes(&self) -> usize {
+        self.saida.len() + self.ferramenta.len() + self.detalhe.len()
+    }
+}
+
+/// O resultado de procurar uma entrada — tres casos, nao dois.
+///
+/// "Nao achei" e ambiguo demais para uma coisa que envelhece: o usuario
+/// precisa saber se digitou um numero que nunca existiu ou se a entrada saiu
+/// do registro.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Busca<'a> {
+    Achou(&'a Entrada),
+    /// O indice ja existiu e foi descartado para caber no limite.
+    Expirada,
+    /// O indice nunca existiu.
+    Inexistente,
+}
+
+/// Registro limitado das saidas de ferramenta da sessao.
+#[derive(Debug, Default)]
+pub struct ToolLog {
+    entradas: std::collections::VecDeque<Entrada>,
+    /// Proximo indice a distribuir. So cresce.
+    proximo: usize,
+    bytes: usize,
+}
+
+impl ToolLog {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Guarda uma saida e devolve o indice que o usuario vai digitar.
+    pub fn registrar(
+        &mut self,
+        ferramenta: &str,
+        detalhe: &str,
+        sucesso: bool,
+        duracao: std::time::Duration,
+        saida: String,
+    ) -> usize {
+        let indice = self.proximo;
+        self.proximo += 1;
+
+        let entrada = Entrada {
+            indice,
+            ferramenta: ferramenta.to_string(),
+            detalhe: detalhe.to_string(),
+            sucesso,
+            duracao,
+            saida,
+        };
+        self.bytes += entrada.bytes();
+        self.entradas.push_back(entrada);
+
+        // Descarta do mais velho ate caber nos dois limites. O `while` cobre o
+        // caso de uma entrada sozinha estourar o teto de bytes — ela fica, por
+        // ser a unica, e a proxima e que a expulsa. Guardar a mais recente
+        // mesmo grande e o que o usuario espera depois de rodar um comando.
+        while self.entradas.len() > MAX_ENTRADAS
+            || (self.bytes > MAX_BYTES && self.entradas.len() > 1)
+        {
+            if let Some(velha) = self.entradas.pop_front() {
+                self.bytes -= velha.bytes();
+            }
+        }
+
+        indice
+    }
+
+    /// As entradas guardadas, da mais antiga para a mais nova.
+    pub fn listar(&self) -> impl Iterator<Item = &Entrada> {
+        self.entradas.iter()
+    }
+
+    pub fn vazio(&self) -> bool {
+        self.entradas.is_empty()
+    }
+
+    /// Procura por indice, distinguindo expirada de inexistente.
+    pub fn buscar(&self, indice: usize) -> Busca<'_> {
+        if let Some(e) = self.entradas.iter().find(|e| e.indice == indice) {
+            return Busca::Achou(e);
+        }
+        if indice < self.proximo {
+            Busca::Expirada
+        } else {
+            Busca::Inexistente
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn log_com(n: usize) -> ToolLog {
+        let mut log = ToolLog::new();
+        for i in 0..n {
+            log.registrar(
+                "bash",
+                &format!("cmd {i}"),
+                true,
+                Duration::ZERO,
+                "ok".into(),
+            );
+        }
+        log
+    }
+
+    #[test]
+    fn guarda_e_devolve_pelo_indice() {
+        let mut log = ToolLog::new();
+        let i = log.registrar(
+            "bash",
+            "cargo test",
+            true,
+            Duration::from_millis(6300),
+            "148 passed".into(),
+        );
+        match log.buscar(i) {
+            Busca::Achou(e) => {
+                assert_eq!(e.ferramenta, "bash");
+                assert_eq!(e.saida, "148 passed");
+            }
+            outro => panic!("esperava achar: {outro:?}"),
+        }
+    }
+
+    /// O indice e do usuario: ele le na tela e digita depois. Reaproveitar
+    /// numero faria `/tool 3` mudar de significado sem aviso.
+    #[test]
+    fn indice_nunca_e_reusado() {
+        let mut log = log_com(MAX_ENTRADAS + 5);
+        let novo = log.registrar("bash", "mais um", true, Duration::ZERO, "ok".into());
+        assert_eq!(novo, MAX_ENTRADAS + 5);
+        // E os antigos nao voltaram a existir com outro dono.
+        assert_eq!(log.listar().filter(|e| e.indice == 0).count(), 0);
+    }
+
+    /// Entrada descartada tem de dizer que expirou — mostrar outra em silencio
+    /// seria pior do que nao mostrar nada.
+    #[test]
+    fn expirada_e_diferente_de_inexistente() {
+        let log = log_com(MAX_ENTRADAS + 3);
+        assert_eq!(log.buscar(0), Busca::Expirada, "0 saiu do registro");
+        assert_eq!(log.buscar(9_999), Busca::Inexistente, "9999 nunca existiu");
+    }
+
+    #[test]
+    fn respeita_o_teto_de_entradas() {
+        let log = log_com(MAX_ENTRADAS * 2);
+        assert_eq!(log.listar().count(), MAX_ENTRADAS);
+    }
+
+    /// O teto de bytes existe porque o de entradas nao segura memoria sozinho.
+    #[test]
+    fn respeita_o_teto_de_bytes() {
+        let mut log = ToolLog::new();
+        let gorda = "x".repeat(200 * 1024);
+        for _ in 0..10 {
+            log.registrar("bash", "gera", true, Duration::ZERO, gorda.clone());
+        }
+        assert!(
+            log.bytes <= MAX_BYTES,
+            "estourou o teto de bytes: {}",
+            log.bytes
+        );
+        assert!(log.listar().count() < 10, "nada foi descartado");
+    }
+
+    /// Uma saida sozinha maior que o teto fica: e a que o usuario acabou de
+    /// gerar, e descarta-la deixaria o `/tool` vazio logo apos o comando.
+    #[test]
+    fn entrada_unica_gigante_sobrevive() {
+        let mut log = ToolLog::new();
+        let i = log.registrar(
+            "bash",
+            "gera",
+            true,
+            Duration::ZERO,
+            "x".repeat(MAX_BYTES * 2),
+        );
+        assert!(matches!(log.buscar(i), Busca::Achou(_)));
+    }
+
+    #[test]
+    fn comeca_vazio() {
+        let log = ToolLog::new();
+        assert!(log.vazio());
+        assert_eq!(log.buscar(0), Busca::Inexistente);
+    }
+}

--- a/crates/garraia-cli/src/ui/tool_log.rs
+++ b/crates/garraia-cli/src/ui/tool_log.rs
@@ -42,6 +42,20 @@ const MAX_ENTRADAS: usize = 20;
 ///
 /// Meio mega e o bastante para varias saidas grandes e pequeno o bastante para
 /// nao aparecer no consumo do processo.
+///
+/// # O acoplamento que este numero tem, e que nao aparece no tipo
+///
+/// Apontado pela auditoria do #938. Quem chama `registrar` em producao passa
+/// sempre o resultado de `garraia_agents::turn_events::capture_tool_output`,
+/// que ja capa cada saida em 64 KiB. E de la que vem a garantia de que uma
+/// entrada sozinha nunca estoura este teto — **nao** deste modulo.
+///
+/// Se alguem subir o cap de la acima deste valor, o guard `len > 1` do
+/// `registrar` passa a ser o unico impedindo que uma saida gigante entre e
+/// saia na mesma chamada, deixando o `/tool` vazio logo depois do comando.
+/// O guard existe justamente para esse dia; o teste
+/// `entrada_unica_gigante_sobrevive` o exercita chamando `registrar` direto,
+/// que e um caminho que a API normal nao produz hoje.
 const MAX_BYTES: usize = 512 * 1024;
 
 /// Uma chamada de ferramenta guardada.


### PR DESCRIPTION
## Descrição

O #937 reduziu cada chamada de ferramenta a uma linha, o que deixou a conversa legível. Mas resumo bom é resumo que esconde coisa, e **esconder sem dar como reaver é só perder**: quando o `cargo test` diz "Failed" e o resumo mostra a primeira linha, a causa costuma estar na linha 300.

```text
● Bash cargo test
  └─ 148 passed · 6.3s · #7

voce > /tool 7
```

`/tool` sozinho lista o que está guardado. O número é curto porque aparece em **toda** linha — qualquer coisa mais longa viraria ruído repetido a cada chamada — e ele existe porque sem ele o `/tool <n>` do `/help` seria instrução sem como ser seguida.

## Três decisões que custaram mais pensamento que código

### Índice monotônico, nunca reusado

Numerar por posição faria `/tool 3` significar coisas diferentes conforme outras chamadas acontecessem: o usuário lê "3" na tela, roda mais um comando, pede `/tool 3` e recebe outra saída **sem nada indicando a troca**.

Pedir uma entrada já descartada devolve `Expirada`, que vira mensagem dizendo isso — mostrar a entrada errada em silêncio seria pior do que não mostrar nada. E "expirou" e "nunca existiu" são mensagens diferentes de propósito: a primeira é acionável (rode de novo), a segunda quer dizer que o número está errado.

### Dois limites, não um

Um teto de entradas sozinho **não segura memória** — vinte saídas de 64 KiB são 1,2 MiB grudados no processo de quem só queria conversar. Um teto de bytes sozinho tornaria o `/tool` **imprevisível**, porque uma saída gorda expulsaria dez pequenas e o índice recém-visto sumiria. Com os dois o comportamento é dizível: as 20 últimas, e menos se passarem de 512 KiB.

### Cap na origem, com as duas pontas

Cada saída é capada em 64 KiB dentro do `garraia-agents`, **antes** de virar evento, pelo mesmo motivo que a redação mora lá: quem guarda não pode precisar lembrar do limite. Se o cap morasse no CLI, a saída inteira de um `find /` já teria atravessado o canal e existido em memória antes de alguém cortar.

O corte preserva começo **E** fim com marcador do que sumiu — só o fim perderia o que estava sendo compilado, só o começo perderia a causa da falha.

## A parte que daria para errar

A saída completa passa pelas **mesmas** garantias do resumo: redação de segredo e remoção de controle de terminal (#995). Era critério de aceite explícito da issue, e o resumo já ser seguro tornava fácil supor que a saída crua também era.

A diferença é só de forma — quebra de linha e tabulação sobrevivem, porque são a estrutura do texto que o usuário pediu para ler.

## Auditoria

`@security-auditor` rodou antes de abrir — **9/10, nenhum achado explorável**. Os dois itens foram tratados no segundo commit.

### BAIXO — o `\r` virava sumiço, e o exemplo me convenceu

O `\r` não podia sobreviver (sozinho ele devolve o cursor ao início da linha — a primitiva que o #995 fechou), mas apagá-lo tinha um custo que eu não tinha visto: uma barra de progresso emite `10%\r20%\r100%`, e isso virava `10%20%100%` — um amontoado que o leitor **não distingue** de uma saída que era assim mesmo.

Agora vira **quebra de linha**: cada estado ocupa a sua, que é o que o programa quis desenhar. O `\r\n` legítimo segue virando UM `\n`, não dois — senão toda saída de Windows viria com o dobro das linhas, e há teste afirmando isso em sequência.

### OBSERVAÇÃO — um acoplamento que não aparecia no tipo

O `ToolLog` conta com uma garantia que não mora nele: quem chama `registrar` em produção passa sempre o resultado do `capture_tool_output`, que já capa em 64 KiB, e é de lá que vem a certeza de que uma entrada sozinha não estoura os 512 KiB do registro.

Nada expressava isso. O docblock do `MAX_BYTES` agora nomeia a origem, diz o que acontece se alguém subir o cap do outro lado, e explica que o guard `len > 1` existe para esse dia — o que também responde por que um dos testes exercita um caminho que a API normal não produz hoje.

### O que a auditoria confirmou como correto

`\x08` (backspace), `\x0b` e `\x0c` já caem no catch-all de `is_control()` e viram marcador visível; o CSI de 8 bits (`\x9b`) é coberto pela faixa C1; preservar `\n` não abre vetor porque nenhum mecanismo de sobrescrita sobrou; a aritmética do corte não tem underflow nem sobreposição possível (o ramo só roda acima de 64 KiB, e as duas funções de fronteira só afastam os índices); o contador de bytes não dessincroniza porque os campos da entrada são imutáveis depois de criados; os 64 KiB só são construídos quando `wants_tool_events()`, então **canal de texto (Telegram, Discord, Slack) não paga nem vê a saída completa**; e há um único ponto de entrada no `ToolLog`, então não existe caminho que insira texto não saneado.

## Tipo de mudança

- [x] `feat`: Nova funcionalidade
- [x] `test`: Adição de testes

## Classe de Risco

- [x] **Classe C (Alto Risco)**: conteúdo de terceiro (README de repo clonado, página buscada, saída de comando) passa a sobreviver muito além das 72 chars do resumo, e a residir em memória. Auditoria rodou antes de abrir.

## Checklist de Segurança e Qualidade

- [x] `cargo +1.95 fmt --all -- --check` limpo
- [x] `cargo +1.95 clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings` sem erros
- [x] `cargo +1.95 test --workspace --exclude garraia-desktop` — 54 binários passando; única falha é a ambiental conhecida `migration_001_applies_and_schema_is_sane`, que exige `docker.sock`
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo commitado
- [x] Nenhuma migração
- [x] Redação de segredo vale na saída completa — com teste
- [x] Controle de terminal removido da saída completa — com teste nomeando `\x1b`, `\r`, `\x08`, `\x0b`, `\x0c`
- [x] Memória limitada por entradas **e** por bytes — com teste
- [ ] Verificação de políticas RLS — não se aplica

## Mudanças na API pública e Schema

- **`garraia-agents`:** `TurnEvent::ToolFinished` ganha `output: String`; `TurnSink::tool_finished` ganha o parâmetro correspondente; nova `capture_tool_output()`. Quebra quem constrói o evento à mão — só testes, todos atualizados.
- **`garraia-cli`:** novo `ui::tool_log`; `UiEvent::ToolFinished` ganha `indice: Option<usize>`.
- Sem schema, sem migração, sem chave de config nova.

## Como testar

```bash
cargo +1.95 test -p garraia-agents turn_events   # 28, dos quais 8 novos
cargo +1.95 test -p garraia tool_log             # 7, o registro limitado
cargo +1.95 test -p garraia                      # 350, inclui a ponte real
```

No binário:

```console
$ printf '/tool\n/help\n/tool 3\n/tool abc\n/exit\n' | garra chat
Nenhuma ferramenta foi chamada ainda nesta sessao.
...
  /tool              Listar saidas de ferramenta guardadas
  /tool <n>          Ver a saida inteira de uma chamada
Nao ha saida #3. Use /tool para ver as disponiveis.
Uso: /tool <numero>. Ex.: /tool 3
```

## Plano de Rollback

Reverter o merge. Nada persistido — o registro vive só na memória da sessão de chat.

## A issue #938 fica aberta

Ela pede duas coisas, e esta entrega a segunda: o mecanismo de inspeção. Falta a **sumarização por classe de comando** — `cargo test` virar "148 passed" em vez da primeira linha não-vazia, que hoje costuma ser "Compiling ...".

Fiz nesta ordem de propósito: é a inspeção que torna o resumo agressivo seguro. Resumir melhor sem ter como ver o inteiro é escolher outro palpite sobre o que o usuário queria; com o `/tool` no lugar, um resumo que erre custa uma tecla, não a informação.

Refs #938

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF

---
_Generated by [Claude Code](https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF)_