### PR TITLE
fix(cli): o texto do modelo também para de injetar comando no terminal (#996)

### DIFF
--- a/changelog.d/security/996-modelo-nao-injeta-ansi.md
+++ b/changelog.d/security/996-modelo-nao-injeta-ansi.md
@@ -1,0 +1,25 @@
+- **O texto do modelo tambem para de injetar comando no terminal (#996).** O
+  #995 fechou a superficie da ferramenta; esta e a irma. O `write_delta`
+  escrevia o delta do modelo direto no terminal, entao um modelo induzido a
+  emitir `\x1b[2J` limpava a tela de quem estava conversando, e `\x1b[?25l`
+  deixava o terminal sem cursor — a mesma invariante do CLAUDE.md violada por
+  outro caminho. Vale tambem para aviso, erro e dica, que carregam texto de
+  fora (corpo de erro de provedor, por exemplo).
+- **O filtro tem estado, e e isso que o distingue do #995.** Aquele recebe a
+  saida da ferramenta inteira e decide olhando o texto todo. Este nao: o texto
+  do modelo e streaming, e `\x1b` pode chegar num delta e `[2J` no seguinte —
+  cada metade inofensiva isolada, e um filtro sem estado deixaria as duas
+  passarem, com o terminal executando a concatenacao. Ha teste que varre
+  **todos** os cortes possiveis de uma carga hostil, nao so um escolhido a
+  dedo. O `finish` do turno limpa o pendente, senao um `ESC` no fim de uma
+  resposta engoliria o primeiro caractere da proxima.
+- **Cor do modelo fica bloqueada, e nao por conservadorismo.** A issue deixava
+  em aberto se o modelo devia poder emitir cor de proposito, como algumas CLIs
+  permitem. A resposta sai de um principio que o projeto ja tem escrito:
+  respeitar `NO_COLOR`, non-TTY e saida redirecionada. Cor vinda do modelo
+  passa por cima disso — ela nao sabe se o usuario pediu `NO_COLOR`, se a saida
+  vai para um pipe, ou se o terminal e legado. Quem decide cor e o
+  `TerminalRenderer`, olhando `Capabilities`; o modelo escreve texto.
+- **Teto para sequencia sem terminador.** Um `ESC ]` solto engoliria a resposta
+  inteira em silencio, porque OSC so termina em `BEL` ou `ESC \`. Com teto de
+  128 caracteres, o pior caso e perder um trecho curto.

--- a/crates/garraia-cli/src/ui/ansi_filter.rs
+++ b/crates/garraia-cli/src/ui/ansi_filter.rs
@@ -1,0 +1,283 @@
+//! Filtro de sequencia de terminal que **sobrevive entre deltas** (#996).
+//!
+//! O texto do modelo chega em pedacos. Ate aqui ele ia direto para o terminal
+//! (`write!(out, "{delta}")`), entao um modelo induzido a emitir `\x1b[2J`
+//! limpava a tela de quem estava conversando, e `\x1b[?25l` deixava o terminal
+//! sem cursor — a mesma invariante que o #995 restaurou pelo lado da
+//! ferramenta.
+//!
+//! # Por que nao deu para reusar o saneador do #995
+//!
+//! Aquele recebe a saida da ferramenta **inteira**, de uma vez, e pode decidir
+//! olhando o texto todo. Este nao: `\x1b` pode chegar num delta e `[2J` no
+//! seguinte. Cada metade e inofensiva isolada, e um filtro sem estado deixaria
+//! as duas passarem — o terminal, que so ve a concatenacao, executaria a
+//! sequencia. **O estado e a feature**, nao um detalhe de implementacao.
+//!
+//! # Cor do modelo: bloqueada, e nao e conservadorismo
+//!
+//! A pergunta em aberto na issue era se o modelo devia poder emitir cor de
+//! proposito, como algumas CLIs permitem. A resposta sai de um principio que o
+//! projeto ja tem escrito: **respeitar `NO_COLOR`, non-TTY e saida
+//! redirecionada**. Cor vinda do modelo passa por cima disso — ela nao sabe se
+//! o usuario pediu `NO_COLOR`, se a saida esta indo para um pipe, ou se o
+//! terminal e legado. Quem decide cor aqui e o `TerminalRenderer`, olhando
+//! `Capabilities`; o modelo escreve texto.
+//!
+//! O renderer continua colorindo o que ele mesmo emite: o filtro trata do
+//! **conteudo**, e a cor e aplicada em volta dele.
+//!
+//! # Estado puro, sem relogio e sem E/S
+//!
+//! Como o `SpinnerState` do #936, e pelo mesmo motivo: da para afirmar cada
+//! transicao contra uma `String`, inclusive as que dependem de onde o delta
+//! foi cortado — que e justamente o que se quer testar aqui.
+
+/// Onde o filtro esta no meio de uma sequencia.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+enum Estado {
+    #[default]
+    Texto,
+    /// Viu `ESC`, esperando saber que tipo de sequencia e.
+    ViuEsc,
+    /// Dentro de `ESC [` — cor, movimento de cursor, limpeza de tela, `?25l`.
+    EmCsi,
+    /// Dentro de `ESC ]` — titulo de janela, hyperlink.
+    EmOsc,
+    /// Dentro de OSC e viu `ESC`, que pode ser o comeco do terminador `ESC \`.
+    EmOscViuEsc,
+    /// Viu `\r`. Precisa do proximo caractere para saber se e `\r\n` (uma
+    /// quebra so) ou um `\r` solto (que vira quebra).
+    ViuCr,
+}
+
+/// Teto de caracteres consumidos dentro de uma sequencia sem terminador.
+///
+/// O CSI termina no primeiro byte da faixa `0x40..=0x7e`, que inclui todas as
+/// letras — entao ele se resolve sozinho em poucos caracteres. O **OSC** nao:
+/// ele so termina em `BEL` ou `ESC \`, e um `ESC ]` solto engoliria a resposta
+/// inteira em silencio. Com o teto, o pior caso e perder um trecho curto.
+const MAX_DENTRO_DE_SEQUENCIA: usize = 128;
+
+/// Filtro com estado, um por sessao de renderizacao.
+#[derive(Debug, Default)]
+pub struct AnsiFilter {
+    estado: Estado,
+    consumidos: usize,
+}
+
+impl AnsiFilter {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Passa um pedaco do texto e devolve o que pode ir para o terminal.
+    ///
+    /// O estado fica: um `ESC` no fim deste delta continua valendo no proximo.
+    pub fn push(&mut self, delta: &str) -> String {
+        let mut out = String::with_capacity(delta.len());
+
+        for c in delta.chars() {
+            match self.estado {
+                Estado::Texto => self.no_texto(c, &mut out),
+
+                Estado::ViuCr => {
+                    self.estado = Estado::Texto;
+                    // `\r\n` e uma quebra so; `\r` solto vira quebra e o
+                    // caractere atual segue normalmente.
+                    out.push('\n');
+                    if c != '\n' {
+                        self.no_texto(c, &mut out);
+                    }
+                }
+
+                Estado::ViuEsc => {
+                    self.consumidos = 0;
+                    match c {
+                        '[' => self.estado = Estado::EmCsi,
+                        ']' => self.estado = Estado::EmOsc,
+                        // Sequencia de dois caracteres (`ESC c` reseta o
+                        // terminal). Some inteira.
+                        _ => self.estado = Estado::Texto,
+                    }
+                }
+
+                Estado::EmCsi => {
+                    self.consumidos += 1;
+                    if ('\u{40}'..='\u{7e}').contains(&c)
+                        || self.consumidos > MAX_DENTRO_DE_SEQUENCIA
+                    {
+                        self.estado = Estado::Texto;
+                    }
+                }
+
+                Estado::EmOsc => {
+                    self.consumidos += 1;
+                    if c == '\u{7}' || self.consumidos > MAX_DENTRO_DE_SEQUENCIA {
+                        self.estado = Estado::Texto;
+                    } else if c == '\u{1b}' {
+                        self.estado = Estado::EmOscViuEsc;
+                    }
+                }
+
+                Estado::EmOscViuEsc => {
+                    self.consumidos += 1;
+                    // `ESC \` fecha o OSC. Qualquer outra coisa volta para
+                    // dentro dele — menos o teto, que sempre solta.
+                    self.estado = if c == '\\' || self.consumidos > MAX_DENTRO_DE_SEQUENCIA {
+                        Estado::Texto
+                    } else {
+                        Estado::EmOsc
+                    };
+                }
+            }
+        }
+
+        out
+    }
+
+    fn no_texto(&mut self, c: char, out: &mut String) {
+        match c {
+            '\u{1b}' => {
+                self.estado = Estado::ViuEsc;
+                self.consumidos = 0;
+            }
+            '\r' => self.estado = Estado::ViuCr,
+            '\n' | '\t' => out.push(c),
+            // Backspace, tabulacao vertical, form feed, NUL, DEL e o bloco C1
+            // (onde mora o CSI de 8 bits). Marcador visivel em vez de sumico:
+            // apagar em silencio faria a tentativa parecer texto normal.
+            c if c.is_control() || ('\u{80}'..='\u{9f}').contains(&c) => out.push('\u{fffd}'),
+            c => out.push(c),
+        }
+    }
+
+    /// Fecha o fluxo: devolve o que ficou pendente e volta ao estado limpo.
+    ///
+    /// So o `\r` no fim do ultimo delta produz saida aqui — uma sequencia
+    /// inacabada nao vira nada, de proposito. Chamar isso no fim do turno e o
+    /// que impede que um `ESC` pendurado no fim de uma resposta engula o
+    /// primeiro caractere da proxima.
+    pub fn finish(&mut self) -> String {
+        let pendente = if self.estado == Estado::ViuCr {
+            "\n".to_string()
+        } else {
+            String::new()
+        };
+        self.estado = Estado::Texto;
+        self.consumidos = 0;
+        pendente
+    }
+
+    /// Saneia um texto que chega inteiro, sem carregar estado.
+    ///
+    /// Para aviso, erro e dica — que nao sao streaming, mas tambem carregam
+    /// texto que veio de fora (mensagem de erro de provedor, por exemplo).
+    pub fn sanitize_once(texto: &str) -> String {
+        let mut f = Self::new();
+        let mut s = f.push(texto);
+        s.push_str(&f.finish());
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Passa o texto em pedacos de `n` caracteres, como o streaming faria.
+    fn em_pedacos(texto: &str, n: usize) -> String {
+        let chars: Vec<char> = texto.chars().collect();
+        let mut f = AnsiFilter::new();
+        let mut out = String::new();
+        for bloco in chars.chunks(n) {
+            let pedaco: String = bloco.iter().collect();
+            out.push_str(&f.push(&pedaco));
+        }
+        out.push_str(&f.finish());
+        out
+    }
+
+    /// O teste que da razao de existir ao modulo: a sequencia chega partida, e
+    /// cada metade e inofensiva sozinha.
+    #[test]
+    fn sequencia_partida_entre_deltas_nao_passa() {
+        let mut f = AnsiFilter::new();
+        let a = f.push("tudo bem\u{1b}");
+        let b = f.push("[2Jaqui");
+        let junto = format!("{a}{b}");
+        assert!(!junto.contains('\u{1b}'), "ESC sobreviveu: {junto:?}");
+        assert_eq!(junto, "tudo bemaqui");
+    }
+
+    /// E vale para qualquer corte, nao so o que eu escolhi para o teste acima.
+    #[test]
+    fn nenhum_corte_deixa_a_sequencia_passar() {
+        let hostil = "antes\u{1b}[2J\u{1b}[?25l\u{1b}]0;INVADIDO\u{7}depois";
+        for n in 1..=hostil.chars().count() {
+            let saida = em_pedacos(hostil, n);
+            assert!(
+                !saida.contains('\u{1b}'),
+                "ESC passou com pedaco de {n}: {saida:?}"
+            );
+            assert_eq!(saida, "antesdepois", "corte de {n} mudou o texto");
+        }
+    }
+
+    /// Cor do modelo tambem sai: quem decide cor e o renderer, olhando
+    /// `NO_COLOR` e o resto das capacidades do terminal.
+    #[test]
+    fn cor_do_modelo_nao_passa() {
+        assert_eq!(
+            AnsiFilter::sanitize_once("\u{1b}[32mverde\u{1b}[0m"),
+            "verde"
+        );
+    }
+
+    /// Um `ESC ]` sem terminador engoliria a resposta inteira sem o teto.
+    #[test]
+    fn osc_sem_terminador_nao_engole_o_resto() {
+        let entrada = format!("\u{1b}]0;{}FIM", "x".repeat(MAX_DENTRO_DE_SEQUENCIA * 2));
+        let saida = AnsiFilter::sanitize_once(&entrada);
+        assert!(saida.ends_with("FIM"), "engoliu o resto: {saida:?}");
+    }
+
+    /// Texto normal atravessa intacto, acento incluso.
+    #[test]
+    fn texto_normal_atravessa_intacto() {
+        assert_eq!(
+            em_pedacos("compilação concluída\ncom açúcar\te tab", 3),
+            "compilação concluída\ncom açúcar\te tab"
+        );
+    }
+
+    #[test]
+    fn backspace_e_movimento_vertical_viram_marcador() {
+        assert_eq!(AnsiFilter::sanitize_once("a\u{8}b"), "a\u{fffd}b");
+        assert_eq!(AnsiFilter::sanitize_once("a\u{b}b"), "a\u{fffd}b");
+        assert_eq!(AnsiFilter::sanitize_once("a\u{c}b"), "a\u{fffd}b");
+    }
+
+    #[test]
+    fn retorno_de_carro_vira_quebra_sem_duplicar() {
+        assert_eq!(AnsiFilter::sanitize_once("um\r\ndois"), "um\ndois");
+        assert_eq!(AnsiFilter::sanitize_once("um\rdois"), "um\ndois");
+        // E o `\r` no fim do fluxo nao se perde.
+        assert_eq!(AnsiFilter::sanitize_once("um\r"), "um\n");
+        // Inclusive quando o corte cai exatamente entre o `\r` e o `\n`.
+        let mut f = AnsiFilter::new();
+        let a = f.push("um\r");
+        let b = f.push("\ndois");
+        assert_eq!(format!("{a}{b}"), "um\ndois");
+    }
+
+    /// `finish` limpa o estado: um `ESC` pendurado no fim de um turno nao pode
+    /// engolir o primeiro caractere do turno seguinte.
+    #[test]
+    fn finish_limpa_o_estado_pendente() {
+        let mut f = AnsiFilter::new();
+        f.push("texto\u{1b}");
+        f.finish();
+        assert_eq!(f.push("Ainda aqui"), "Ainda aqui");
+    }
+}

--- a/crates/garraia-cli/src/ui/mod.rs
+++ b/crates/garraia-cli/src/ui/mod.rs
@@ -38,6 +38,7 @@
 //!   faz os dois explicitamente — a duplicacao e intencional e visivel, porque
 //!   unificar foi o que fez o console virar despejo de INFO (#933).
 
+pub mod ansi_filter;
 pub mod conversation;
 pub mod spinner;
 pub mod tool_log;
@@ -205,11 +206,18 @@ pub struct TerminalRenderer {
     /// seja reimpresso. Era o "retomar o spinner depois da tool" que ficou de
     /// fora do #936 por nao haver evento para ouvir.
     animating: bool,
+    /// Filtro de sequencia de terminal para o texto que vem de fora (#996).
+    ///
+    /// Vive no renderer, e nao numa funcao solta, porque **precisa de estado**:
+    /// o texto do modelo e streaming e uma sequencia pode chegar partida entre
+    /// dois deltas, cada metade inofensiva sozinha. Ver `ansi_filter`.
+    filtro: ansi_filter::AnsiFilter,
 }
 
 impl TerminalRenderer {
     pub fn new(caps: Capabilities, spinner: Option<Spinner>) -> Self {
         Self {
+            filtro: ansi_filter::AnsiFilter::new(),
             assistant_prefix: caps.style().assistant_prefix(),
             caps,
             spinner,
@@ -236,6 +244,7 @@ impl TerminalRenderer {
             assistant_prefix: prefix.into(),
             prefix_written: false,
             animating: true,
+            filtro: ansi_filter::AnsiFilter::new(),
         }
     }
 
@@ -293,7 +302,11 @@ impl TerminalRenderer {
             let _ = write!(out, "{}", self.assistant_prefix);
             self.prefix_written = true;
         }
-        let _ = write!(out, "{delta}");
+        // O texto do modelo nao pode escrever comando no terminal (#996). O
+        // filtro tem estado porque a sequencia pode chegar partida entre dois
+        // deltas — ver `ansi_filter`.
+        let seguro = self.filtro.push(delta);
+        let _ = write!(out, "{seguro}");
         let _ = out.flush();
         // A linha agora pertence a resposta.
         self.animating = false;
@@ -310,6 +323,13 @@ impl TerminalRenderer {
     fn finish(&mut self, out: &mut (impl io::Write + ?Sized)) {
         if let Some(s) = self.spinner.as_mut() {
             s.clear(out);
+        }
+        // Fecha o filtro **antes** do rotulo: um `\r` no fim do ultimo delta
+        // ainda deve virar quebra, e um `ESC` pendurado nao pode atravessar
+        // para o turno seguinte e engolir o primeiro caractere dele (#996).
+        let pendente = self.filtro.finish();
+        if !pendente.is_empty() {
+            let _ = write!(out, "{pendente}");
         }
         if !self.prefix_written {
             let _ = write!(out, "{}", self.assistant_prefix);
@@ -441,6 +461,10 @@ impl TerminalRenderer {
             s.clear(out);
         }
         let separador = if blank_line_before { "\n" } else { "" };
+        // Aviso e erro tambem carregam texto de fora — a mensagem de erro de
+        // um provedor, por exemplo, e corpo de resposta HTTP. Nao e streaming,
+        // entao vai sem estado (#996).
+        let text = ansi_filter::AnsiFilter::sanitize_once(text);
         if self.caps.interactive {
             let _ = writeln!(out, "{separador}{color}{text}{}", conversation::RESET);
         } else {
@@ -896,6 +920,53 @@ mod tests {
             }],
         );
         assert!(!saida.contains('#'), "inventou numero: {saida:?}");
+    }
+
+    /// O modelo nao escreve comando no terminal, e a sequencia partida entre
+    /// deltas e o caso que so o renderer com estado cobre (#996).
+    #[test]
+    fn o_texto_do_modelo_nao_injeta_sequencia_partida() {
+        let saida = render(
+            Capabilities::PLAIN,
+            &[
+                UiEvent::TextDelta("tudo bem\u{1b}"),
+                UiEvent::TextDelta("[2Jainda aqui"),
+                UiEvent::TurnFinished,
+            ],
+        );
+        assert!(!saida.contains('\u{1b}'), "ESC sobreviveu: {saida:?}");
+        assert!(
+            saida.contains("tudo bemainda aqui"),
+            "perdeu texto: {saida:?}"
+        );
+    }
+
+    /// Aviso e erro tambem carregam texto de fora — corpo de erro de provedor,
+    /// por exemplo.
+    #[test]
+    fn aviso_e_erro_tambem_sao_saneados() {
+        let saida = render(
+            Capabilities::PLAIN,
+            &[
+                UiEvent::Warning("cuidado\u{1b}[2J"),
+                UiEvent::Error("falhou\u{1b}[?25l"),
+                UiEvent::Hint("dica\u{1b}]0;x\u{7}"),
+            ],
+        );
+        assert!(!saida.contains('\u{1b}'), "ESC sobreviveu: {saida:?}");
+    }
+
+    /// Um `ESC` pendurado no fim de um turno nao pode engolir o primeiro
+    /// caractere do turno seguinte.
+    #[test]
+    fn esc_pendurado_nao_atravessa_o_fim_do_turno() {
+        let mut r = TerminalRenderer::new(Capabilities::PLAIN, None);
+        let mut out: Vec<u8> = Vec::new();
+        r.handle(UiEvent::TextDelta("fim do turno\u{1b}"), &mut out);
+        r.handle(UiEvent::TurnFinished, &mut out);
+        out.clear();
+        r.handle(UiEvent::TextDelta("Novo turno"), &mut out);
+        assert_eq!(String::from_utf8(out).expect("utf8"), "Novo turno");
     }
 
     #[test]

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -251,12 +251,20 @@ segurança.
 | **S** Spoofing | Conteúdo de terceiro reposiciona o cursor e sobrescreve linhas, forjando saída que parece do Garra — o usuário autoriza uma ação com base em tela falsificada. | Todo controle C0/C1/DEL removido antes de chegar ao renderer (#995). | — |
 | **T** Tampering | `\x1b[2J` limpa a tela; OSC troca o título da janela; `\x1b[?25l` deixa o terminal sem cursor após a sessão. | Idem. | — |
 
-**Superfície irmã ainda aberta:** o texto do **modelo** (`write_delta`) segue
-indo cru ao terminal — issue #996. Não foi corrigido junto porque exige
-saneador **com estado**: o texto é streaming, e uma sequência pode chegar
-partida entre dois deltas, cada metade inofensiva isolada. Gravidade menor
-(exige induzir o modelo a emitir a sequência, tipicamente via injeção de
-prompt) mas mesma classe.
+**A superfície irmã foi fechada em seguida (#996):** o texto do **modelo**
+(`write_delta`) também ia cru ao terminal, e o mesmo vale para aviso, erro e
+dica, que carregam corpo de erro de provedor. A correção é separada porque
+precisa de **estado**: o texto é streaming, e uma sequência pode chegar partida
+entre dois deltas, cada metade inofensiva isolada — um filtro sem estado
+deixaria as duas passarem, e o terminal vê a concatenação. O `AnsiFilter`
+(`crates/garraia-cli/src/ui/ansi_filter.rs`) guarda a posição dentro da
+sequência entre chamadas, e há teste varrendo **todos** os cortes possíveis de
+uma carga hostil.
+
+Cor do modelo fica bloqueada de propósito. A alternativa — permitir SGR e
+bloquear o resto — passaria por cima do `NO_COLOR`: cor vinda do modelo não
+sabe se o usuário a desligou, se a saída vai para um pipe, ou se o terminal é
+legado. Quem decide cor é o `TerminalRenderer`, olhando `Capabilities`.
 
 ---
 


### PR DESCRIPTION
## Descrição

O #995 fechou a superfície da ferramenta; esta é a irmã, que encontrei ao corrigir aquela. O `write_delta` escrevia o delta do modelo direto no terminal:

```rust
// crates/garraia-cli/src/ui/mod.rs — antes
let _ = write!(out, "{delta}");
```

Então um modelo induzido a emitir `\x1b[2J` limpava a tela de quem estava conversando, e `\x1b[?25l` deixava o terminal sem cursor — a mesma invariante do `CLAUDE.md` violada por outro caminho.

Vale também para aviso, erro e dica: a mensagem de erro de um provedor é corpo de resposta HTTP, então é texto de fora como qualquer outro.

## O filtro tem estado, e é isso que o distingue do #995

Aquele recebe a saída da ferramenta **inteira** e decide olhando o texto todo. Este não pode: o texto do modelo é streaming, e `\x1b` pode chegar num delta e `[2J` no seguinte. Cada metade é inofensiva isolada, e um filtro sem estado deixaria as duas passarem — **o terminal, que só vê a concatenação, executaria a sequência**.

O estado é a feature, não um detalhe de implementação. Por isso o `AnsiFilter` vive no `TerminalRenderer` e não numa função solta.

O teste que cobre isso varre **todos** os cortes possíveis de uma carga hostil, e não um escolhido a dedo:

```rust
for n in 1..=hostil.chars().count() {
    let saida = em_pedacos(hostil, n);
    assert!(!saida.contains('\u{1b}'), "ESC passou com pedaço de {n}");
    assert_eq!(saida, "antesdepois", "corte de {n} mudou o texto");
}
```

Um teste com um corte só passaria mesmo se o estado estivesse errado para os outros.

O `finish` do turno limpa o pendente, senão um `ESC` no fim de uma resposta engoliria o primeiro caractere da próxima — também com teste.

## Cor do modelo fica bloqueada, e não por conservadorismo

A issue deixava em aberto se o modelo devia poder emitir cor de propósito, como algumas CLIs permitem, e eu tinha marcado isso como decisão de produto pendente.

A resposta sai de um princípio que o projeto **já tem escrito**, no próprio épico #944: *respeitar `NO_COLOR`, non-TTY e saída redirecionada*. Cor vinda do modelo passa por cima disso — ela não sabe se o usuário pediu `NO_COLOR`, se a saída vai para um pipe, ou se o terminal é legado.

Quem decide cor aqui é o `TerminalRenderer`, olhando `Capabilities`; o modelo escreve texto. O renderer segue colorindo o que ele mesmo emite: o filtro trata do **conteúdo**, e a cor é aplicada em volta dele.

## Teto para sequência sem terminador

O CSI se resolve sozinho em poucos caracteres, porque termina no primeiro byte da faixa `0x40..=0x7e` — que inclui todas as letras. O **OSC não**: só termina em `BEL` ou `ESC \`, então um `ESC ]` solto engoliria a resposta inteira em silêncio. Com teto de 128 caracteres, o pior caso é perder um trecho curto.

## Tipo de mudança

- [x] `fix`: Correção de bug
- [x] `docs`: Documentação (modelo de ameaça §5.75)
- [x] `test`: Adição de testes

## Classe de Risco

- [x] **Classe C (Alto Risco)**: conteúdo influenciável por terceiro (via injeção de prompt) alcançando o terminal do usuário, com forja de saída como consequência — é lendo essa tela que o usuário decide o que autorizar.

## Checklist de Segurança e Qualidade

- [x] `cargo +1.95 fmt --all -- --check` limpo
- [x] `cargo +1.95 clippy -p garraia --all-targets -- -D warnings` sem erros
- [x] `cargo +1.95 test -p garraia` — 361 + 11 + 1 passando
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo commitado
- [x] Nenhuma migração
- [x] Texto legítimo com acento atravessa intacto, inclusive partido entre deltas — com teste
- [x] `NO_COLOR` continua sendo decisão do renderer, não do modelo
- [ ] Verificação de políticas RLS — não se aplica

## Mudanças na API pública e Schema

- **`garraia-cli`:** novo `ui::ansi_filter` (`AnsiFilter`, `sanitize_once`). `TerminalRenderer` ganha campo privado. Nenhuma assinatura pública alterada.
- Sem schema, sem migração, sem config.

## Como testar

```bash
cargo +1.95 test -p garraia ansi_filter   # 8, o filtro isolado
cargo +1.95 test -p garraia ui::          # 75, inclui os 3 no renderer real
```

Os do filtro cobrem: sequência partida entre deltas, **todos** os cortes possíveis, cor do modelo, OSC sem terminador, texto com acento partido, backspace/VT/FF, `\r` e `\r\n` (inclusive com o corte caindo exatamente entre os dois), e o `finish` limpando o pendente.

Os do renderer provam que a proteção vale no caminho real, não só no filtro isolado.

## Plano de Rollback

Reverter o merge. Nada persistido, nada de config, nada de schema — volta ao comportamento anterior, que é o vulnerável.

Closes #996

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF

---
_Generated by [Claude Code](https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF)_