### PR TITLE
docs(memory): a página passa a descrever o sistema que existe (#963)

### DIFF
--- a/changelog.d/changed/963-memory-md-descreve-o-que-existe.md
+++ b/changelog.d/changed/963-memory-md-descreve-o-que-existe.md
@@ -1,0 +1,24 @@
+- **O `docs/src/memory.md` passa a descrever o sistema que existe (#963).** A
+  pagina documentava um produto que nunca foi construido: `garra memory
+  add/clear/export/disable`, um `facts.json` com array de fatos datados, e as
+  chaves `memory.auto_extract`, `extraction_interval` e `max_facts`. Nenhum
+  desses comandos existe; nenhuma dessas chaves e lida. Quem seguisse a pagina
+  batia num `error: unrecognized subcommand` e concluia que o produto estava
+  quebrado — documentacao errada e pior que documentacao ausente, porque a
+  ausente manda a pessoa ler o `--help`.
+- Agora estao la os nove subcomandos reais (`stats`, `list`, `search`,
+  `reindex`, `backup`, `pin`, `ttl`, `delete`, `compact`), as chaves reais
+  (`memory.ingestion.*`, `memory.retention.*`, `embeddings.<nome>`), e as
+  quatro metricas do #957. Cada afirmacao foi conferida contra o codigo e
+  contra o binario — a tabela de comandos bate com o `garra memory --help`, e a
+  frase "diz se rodou semantica ou textual" foi verificada rodando a busca.
+- Registra tambem o que **nao** existe, que e metade do valor: nao ha `garra
+  memory add`; o retriever do `garraia-learning` segue stub ate a Fase 2.1; e
+  os dois gauges de tamanho do indice da #957 ainda nao foram entregues, com o
+  motivo (precisam de worker proprio, porque pendura-los no worker de retencao
+  os deixaria mortos para quem nao liga a retencao — que e o padrao).
+- Esclarece uma confusao que a pagina antiga criava: `fatos.json` existe, mas
+  e um **perfil estatico** escrito a mao e injetado no boot, e nao onde os
+  fatos extraidos ficam. Os fatos extraidos por LLM (confianca >= 0,80) moram
+  no mesmo `memory.db`, como entradas `[FACT]`, e nao passam pelo filtro de
+  ruido — um fato extraido e, por definicao, o que o extrator julgou ser sinal.

--- a/docs/src/memory.md
+++ b/docs/src/memory.md
@@ -1,168 +1,190 @@
-# Memory System
+# Memória semântica
 
-GarraIA has a comprehensive memory system that allows the agent to learn and remember information.
+O GarraIA guarda cada turno de conversa num banco local e o traz de volta
+quando é relevante. Este documento descreve **o que existe hoje**, com o nome
+real de cada comando, chave de configuração e arquivo.
 
-## Overview
+> **Nota histórica.** Até 2026-09 esta página descrevia um sistema que nunca
+> foi construído — `garra memory add/clear/export/disable`, um `facts.json`
+> com array de fatos datados, chaves `auto_extract` e `max_facts`. Nada disso
+> existiu. A reescrita (#963) foi feita conferindo cada afirmação contra o
+> código; onde algo é parcial ou tem limite conhecido, está dito.
 
+## O caminho de um turno
+
+```text
+turno (pergunta + resposta)
+        │
+        ├─ filtro de ruído ──── "oi", "ok", "obrigado" → grava SEM vetor
+        │                        (a entrada existe, só não é semanticamente
+        │                         buscável)
+        │
+        └─ com conteúdo ─────── embedding → grava COM vetor
+                                            │
+                                            ▼
+                                    memory.db (SQLite)
+                                    ├─ entries    (texto, tenant, modelo)
+                                    └─ vetores    (sqlite-vec)
 ```
-┌─────────────────────────────────────────────────────────────┐
-│                    MEMORY SYSTEM                               │
-├─────────────────────────────────────────────────────────────┤
-│                                                              │
-│  ┌─────────────────┐  ┌─────────────────┐                  │
-│  │   facts.json    │  │   memory.db     │                  │
-│  │  (extracted)    │  │   (SQLite)      │                  │
-│  └─────────────────┘  └─────────────────┘                  │
-│          │                    │                             │
-│          ▼                    ▼                             │
-│  ┌─────────────────────────────────────────┐               │
-│  │         Embeddings (Ollama/local)       │               │
-│  └─────────────────────────────────────────┘               │
-│                        │                                    │
-│                        ▼                                    │
-│         ┌─────────────────────────────┐                    │
-│         │      Agent Context          │                    │
-│         └─────────────────────────────┘                    │
-│                                                              │
-└─────────────────────────────────────────────────────────────┘
+
+Na volta, o `recall` embute a pergunta, busca por similaridade e devolve o que
+passa do limiar. Sem provedor de embeddings configurado, a busca cai para o
+caminho **textual** — e diz qual dos dois rodou, em vez de fingir semântica.
+
+## O que fica sem vetor, e por quê
+
+O filtro de ingestão (#952) é **ligado por padrão**, ao contrário da retenção.
+A diferença é o que está em jogo: a retenção **apaga** memória, então só roda
+quando o operador pede; o filtro não apaga nada.
+
+Uma entrada filtrada continua gravada, continua no histórico e continua
+achável pela busca textual. O que ela não ganha é vetor. Desligar a chave e
+rodar `garra memory reindex` devolve o vetor.
+
+O que o filtro **não** faz: limpar o que já está no índice. Um vetor de "oi"
+gravado antes desta versão continua lá — limpar o passado apaga dado, e isso é
+decisão do operador, via `garra memory compact`.
+
+## Fatos extraídos
+
+Além do turno inteiro, um extrator baseado em LLM lê a mensagem do usuário e
+tenta tirar dela fatos estruturados (tipo, chave, valor, confiança). Fatos com
+confiança **≥ 0,80** são gravados como entradas próprias, no formato:
+
+```text
+[FACT] type=preferencia key=idioma value=portugues confidence=0.95
 ```
 
-## Components
+Duas coisas que valem saber:
 
-### facts.json
+- **Eles moram no mesmo `memory.db`**, e não num arquivo separado. Aparecem no
+  `garra memory list` como qualquer outra entrada.
+- **Eles não passam pelo filtro de ruído.** Um fato extraído é, por definição,
+  algo que o extrator julgou ser sinal — então sempre recebe vetor.
 
-Automatically extracted facts from conversations:
+## `fatos.json` é outra coisa
+
+Existe um arquivo `~/.garraia/memoria/fatos.json`, e ele **não** é onde os
+fatos extraídos ficam. É um perfil estático que você escreve à mão e que o
+gateway injeta no prompt de sistema no boot:
 
 ```json
-[
-  {
-    "fact": "User prefers responses in Portuguese",
-    "context": "When asked about language preference",
-    "source": "telegram:123456",
-    "timestamp": "2026-02-27T10:00:00Z"
-  }
-]
+{
+  "nome": "Michel",
+  "sobre": "Desenvolvedor Rust, prefere respostas diretas e em português"
+}
 ```
 
-### memory.db
+É um objeto JSON com chaves livres — não um array. Se estiver malformado, o
+boot segue normalmente e registra um aviso, em vez de falhar.
 
-SQLite database with:
-- Conversation history
-- Session data
-- Vector search (sqlite-vec)
+## Configuração
 
-### Embeddings
+```toml
+[memory]
+enabled = true
+# Nome de uma entrada da seção [embeddings]. Sem isto, a memória grava
+# e busca textualmente, sem semântica.
+embedding_provider = "local"
+shared_continuity = false
 
-Semantic search using:
-- Ollama (local)
-- OpenAI
-- Cohere
+[memory.ingestion]
+filter_noise = true          # padrão
+min_chars = 12
+extra_noise_phrases = []     # frases suas, além da lista embutida
 
-## Configuration
+[memory.retention]
+enabled = false              # DESLIGADO por padrão: isto apaga memória
+max_age_days = 90            # faixa aceita 1..=3650
+interval_hours = 24          # faixa aceita 1..=720
 
-```yaml
-memory:
-  enabled: true
-  auto_extract: true        # Extract facts automatically
-  extraction_interval: 5     # Minutes between extractions
-  max_facts: 100           # Maximum facts to store
-
-embeddings:
-  provider: ollama
-  model: nomic-embed-text
-  base_url: "http://localhost:11434"
-  dimension: 768
+[embeddings.local]
+provider = "ollama"
+model = "nomic-embed-text"
+base_url = "http://localhost:11434"
+dimensions = 768
 ```
 
-## CLI Commands
+`garra config check` valida as faixas e reporta o que está fora.
 
-### List Facts
+**A retenção é desligada por padrão de propósito.** Ela apaga entradas mais
+velhas que `max_age_days`, e apagar dado do usuário sem ele ter pedido é o
+tipo de padrão que não se escolhe por conveniência.
 
-```bash
-garraia memory list
+## Comandos
+
+Todos abrem o **mesmo** `memory.db` que o gateway usa, e — quando precisam de
+um — o mesmo provedor de embeddings. O que o `reindex` escreve é exatamente o
+que o recall do agente lê de volta.
+
+| Comando | O que faz |
+|---|---|
+| `garra memory stats` | Contagens mais o relatório de integridade do índice |
+| `garra memory list` | As entradas mais recentes; `--no-embedding` mostra só as sem vetor |
+| `garra memory search <q>` | A **mesma** busca que o agente usa; diz se rodou semântica ou textual |
+| `garra memory reindex` | Re-embute as entradas gravadas sem vetor |
+| `garra memory backup` | Snapshot consistente, com retenção de cópias |
+| `garra memory pin <id>` | Marca uma entrada para a retenção nunca apagar |
+| `garra memory ttl <id>` | Define ou limpa a expiração de uma entrada |
+| `garra memory delete <id>` | Apaga uma entrada e o vetor dela |
+| `garra memory compact` | Apaga tudo mais velho que N dias, com os vetores |
+
+A maioria aceita `--json` para saída legível por máquina.
+
+### O backup usa `VACUUM INTO`, não `cp`
+
+O banco roda em modo WAL, então copiar o arquivo `.db` com `cp` pode produzir
+uma cópia sem as transações que ainda estão no WAL — um backup que parece bom
+e está incompleto. O `VACUUM INTO` do SQLite produz um snapshot consistente.
+
+## Observabilidade
+
+Com `GARRAIA_METRICS_ENABLED=true`, o `/metrics` expõe quatro métricas da
+memória (#957):
+
+| Métrica | Para quê |
+|---|---|
+| `garraia_memory_embed_latency_seconds{provider,operation}` | Quanto o provedor está demorando |
+| `garraia_memory_embed_failures_total{provider,operation}` | **A que mais importa** — ver abaixo |
+| `garraia_memory_recall_latency_seconds` | O recall inteiro, embedding + busca |
+| `garraia_memory_ingested_total{outcome}` | Turnos por desfecho: `embedded`, `noise`, `no_provider`, `failed` |
+
+A de falha é a que merece alerta. Falha de embedding era **silenciosa**: a
+entrada ia para o banco sem vetor e ficava invisível para a busca semântica
+para sempre. O #948 tirou isso do silêncio no log; a métrica tira do painel —
+log conta o caso, métrica conta a tendência, e é a tendência que faz alguém
+descobrir que o provedor caiu **antes** de o recall degradar.
+
+`no_provider` e `failed` são desfechos separados porque são a diferença entre
+"ninguém configurou" e "configurou e está quebrado", que é a primeira pergunta
+de quem opera.
+
+Detalhes e consultas PromQL em [telemetry.md](../telemetry.md).
+
+## Isolamento
+
+Cada entrada carrega um `tenant_id`, e o recall filtra por ele. Uma sessão
+nunca vê a memória de outro tenant.
+
+O recall também filtra pelo **modelo de embedding** que gerou o vetor: vetores
+de modelos diferentes não são comparáveis, e misturá-los produz similaridade
+sem sentido. Ao trocar de modelo, rode `garra memory reindex`.
+
+## API HTTP
+
+```http
+GET    /api/memory/recent          # entradas recentes
+GET    /api/memory/search?q=...    # busca
+DELETE /api/memory                 # limpa
 ```
 
-### Search Facts
+## O que ainda não existe
 
-```bash
-garraia memory search <query>
-```
-
-### Add Fact Manually
-
-```bash
-garraia memory add "User prefers short responses"
-```
-
-### Clear Memory
-
-```bash
-garraia memory clear
-```
-
-### Export Memory
-
-```bash
-garraia memory export
-```
-
-## How It Works
-
-### Fact Extraction
-
-1. After each conversation, LLM analyzes messages
-2. Important facts are identified
-3. Facts stored with context and source
-4. Facts included in future prompts
-
-### Semantic Search
-
-1. User query converted to embedding
-2. Similar facts found via vector search
-3. Relevant facts added to context
-4. Agent responds with context awareness
-
-## Data Location
-
-```
-~/.garraia/
-├── memoria/
-│   ├── fatos.json          # Extracted facts
-│   └── embeddings/         # Embedding cache
-├── data/
-│   ├── memory.db           # SQLite memory
-│   └── sessions.db         # Session data
-```
-
-## Memory API
-
-### Search
-
-```bash
-curl -X POST http://127.0.0.1:3888/api/memory/search \
-  -H "Content-Type: application/json" \
-  -d '{"query": "user preferences", "limit": 5}'
-```
-
-### Add
-
-```bash
-curl -X POST http://127.0.0.1:3888/api/memory \
-  -H "Content-Type: application/json" \
-  -d '{"fact": "User likes coffee", "context": "mentioned in chat"}'
-```
-
-## Disable Memory
-
-To disable memory:
-
-```yaml
-memory:
-  enabled: false
-```
-
-Or use CLI:
-
-```bash
-garraia memory disable
-```
+- **Não há `garra memory add`.** Entradas nascem de conversas ou da extração
+  de fatos; não há inserção manual pela CLI.
+- **O retriever do `garraia-learning` é um stub.** A busca semântica de
+  *skills* (distinta da memória de conversa) espera a Fase 2.1 — ver ADR 0002.
+- **Os gauges de tamanho do índice** (`garraia_memory_entries`,
+  `garraia_memory_vector_index_size`) estão na #957 e ainda não foram
+  entregues: precisam de um worker próprio, porque pendurá-los no worker de
+  retenção os deixaria mortos para quem não liga a retenção — que é o padrão.


### PR DESCRIPTION
## Descrição

O `docs/src/memory.md` documentava um produto que nunca foi construído:

| A página dizia | Realidade |
|---|---|
| `garra memory add` | não existe |
| `garra memory clear` | não existe |
| `garra memory export` | não existe |
| `garra memory disable` | não existe |
| `memory.auto_extract` | chave não é lida |
| `memory.extraction_interval` | chave não é lida |
| `memory.max_facts` | chave não é lida |
| `facts.json` com array de fatos datados | é um objeto de perfil, outra coisa |

**Isso é pior que não ter página.** Quem não tem documentação lê o `--help`. Quem tem documentação errada roda `garra memory add`, recebe `error: unrecognized subcommand` e conclui que o produto está quebrado.

## Cada afirmação foi conferida contra o código e contra o binário

Não bastava trocar ficção por outra ficção escrita com mais confiança. O que verifiquei rodando:

```console
$ garra memory --help
  stats    Counts plus the vector-index integrity report (#960)
  list     List the most recent entries, newest first
  search   Search the memory through the same recall the agent uses
  reindex  Re-embed the entries stored without a vector (#953)
  backup   Snapshot the memory database, consistently, with retention (#955)
  pin      Pin an entry so retention never deletes it (#959)
  ttl      Set or clear an entry's expiry (#959)
  delete   Delete one entry by id, along with its vector
  compact  Delete every entry older than N days, along with their vectors

$ garra memory search "teste"
Busca textual (sem provider de embeddings) — 0 resultado(s)
```

A tabela de comandos da página bate com o `--help`; a frase *"diz se rodou semântica ou textual"* é o que o binário de fato responde; `--no-embedding` e `--json` foram conferidos em cada subcomando; as faixas da retenção, contra as validações em `check.rs`.

## Metade do valor está no que a página diz **não** existir

- **Não há `garra memory add`** — entradas nascem de conversa ou da extração de fatos.
- **O retriever do `garraia-learning` segue stub** até a Fase 2.1 (ADR 0002).
- **Os dois gauges de tamanho do índice da #957 não foram entregues**, com o motivo escrito: precisam de worker próprio, porque pendurá-los no worker de retenção os deixaria mortos para quem não liga a retenção — que é o padrão.

Uma página que só lista o que funciona convida o leitor a supor o resto.

## A confusão que a página antiga criava sozinha

`fatos.json` **existe**, mas não é onde os fatos extraídos ficam. É um perfil estático que você escreve à mão e o gateway injeta no prompt de sistema no boot:

```json
{ "nome": "Michel", "sobre": "Desenvolvedor Rust, prefere respostas diretas" }
```

Os fatos extraídos por LLM (confiança ≥ 0,80) moram no mesmo `memory.db`, como entradas `[FACT]`, e **não passam pelo filtro de ruído** — um fato extraído é, por definição, o que o extrator julgou ser sinal.

## A nota histórica no topo

Deixei uma nota dizendo o que a página afirmava antes. Sem ela, quem leu a versão antiga e voltar não teria como saber que o `garra memory add` que tentou usar **nunca existiu** — concluiria que foi removido, e iria procurar o substituto.

## Tipo de mudança

- [x] `docs`: Documentação

## Classe de Risco

- [x] **Classe A (Baixo Risco)**: só documentação. Nenhuma linha de código muda.

## Checklist de Segurança e Qualidade

- [x] `python3 scripts/changelog/assemble.py --check` — 19 fragmentos válidos
- [x] Nenhum segredo, chave ou token no texto
- [x] Toda afirmação verificada contra código ou binário
- [ ] `cargo fmt/clippy/test` — não se aplica, nenhum código mudou
- [ ] Verificação de políticas RLS — não se aplica

## Mudanças na API pública e Schema

Nenhuma.

## Como testar

Leia `docs/src/memory.md` ao lado de `garra memory --help` — a tabela de comandos deve bater linha a linha.

## Plano de Rollback

Reverter o merge. Volta a página anterior, que é a ficcional.

Closes #963

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF

---
_Generated by [Claude Code](https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF)_