### PR TITLE
feat(memory): o tamanho da memória aparece no /metrics (#957, fecha a issue)

### DIFF
--- a/changelog.d/added/957-gauges-de-tamanho-da-memoria.md
+++ b/changelog.d/added/957-gauges-de-tamanho-da-memoria.md
@@ -1,0 +1,38 @@
+- **O tamanho da memoria aparece no `/metrics` (#957, fecha a issue).** O #994
+  entregou quatro metricas de **instrumentacao** — elas contam o que aconteceu
+  quando aconteceu. Faltavam as de **estado**: quantas entradas existem agora e
+  quantas estao no indice vetorial. Estado nao tem evento, entao alguem precisa
+  ir olhar. Entram `garraia_memory_entries{has_embedding}` e
+  `garraia_memory_vector_index_size`.
+- **Os dois devem ser lidos juntos, e a distancia entre eles e o sinal.** Uma
+  entrada com vetor na coluna mas fora do indice nao aparece na busca
+  semantica. Isso era invisivel ate alguem rodar `garra memory stats` — que so
+  mostra quando perguntam. Como gauge, vira tendencia, que e o que faz alguem
+  pensar em perguntar. A consulta esta no `docs/telemetry.md`.
+- **Worker proprio, e nao um braco do de retencao.** Era o caminho obvio, ja
+  que existe um laco periodico tocando a memoria, e e errado por dois motivos
+  independentes: o `memory_retention_worker` so sobe quando
+  `memory.retention.enabled` e true, que nasce false porque apaga dado — os
+  gauges ficariam mortos em quase toda instalacao; e a cadencia dele e de 24h,
+  que nao mostra tendencia, mostra dois pontos por semana. Verificado no
+  binario: com a retencao desligada (o padrao), o log diz que aquele worker nao
+  subiu e os gauges estao servindo assim mesmo.
+- **Leitura barata, e nao o relatorio de integridade.** O `integrity_report()`
+  que alimenta o `garra memory stats` faz um `SELECT id FROM memory_entries`
+  inteiro mais varredura de orfaos — trabalho justificado sob demanda,
+  desperdicio a cada poucos minutos. O `gauge_snapshot()` novo sao tres
+  `count(*)`, com as **mesmas** consultas, e ha teste cobrando que os dois
+  concordem: dois numeros que deviam ser iguais e nao sao e o pior caso para
+  quem esta diagnosticando.
+- Falha de leitura nao derruba o laco: o proximo tick tenta de novo. Um gauge
+  que para de atualizar em silencio e pior que um que some, porque o Prometheus
+  continua servindo o ultimo valor e o painel mostra numero velho como atual.
+- Achados da auditoria tratados antes do merge: a leitura solta o mutex do banco
+  principal **antes** de consultar o vetorial (segurar os dois nao trava hoje,
+  porque nenhum caminho adquire na ordem inversa, mas bloqueava recall e
+  remember durante o tick e deixava a armadilha armada para o proximo caminho
+  com locking invertido); contagem inconsistente (`com vetor > total`, que so
+  acontece com corrupcao) passa a gritar em vez de publicar zero mudo; e entra
+  `garraia_memory_gauge_errors_total`, porque um gauge que congela em silencio e
+  pior que um que some — o Prometheus continua servindo o ultimo valor como se
+  fosse atual.

--- a/crates/garraia-common/src/metrics.rs
+++ b/crates/garraia-common/src/metrics.rs
@@ -45,7 +45,7 @@
 //! `garraia_active_sessions`. Duas familias de prefixo no mesmo `/metrics`
 //! quebrariam todo dashboard que agrupa por `garraia_.*`.
 
-use metrics::{counter, histogram};
+use metrics::{counter, gauge, histogram};
 
 /// Latencia de uma chamada ao provider de embeddings, em segundos.
 pub const MEMORY_EMBED_LATENCY_SECONDS: &str = "garraia_memory_embed_latency_seconds";
@@ -59,6 +59,31 @@ pub const MEMORY_RECALL_LATENCY_SECONDS: &str = "garraia_memory_recall_latency_s
 
 /// Turnos que entraram na memoria, por desfecho.
 pub const MEMORY_INGESTED_TOTAL: &str = "garraia_memory_ingested_total";
+
+/// Quantas entradas a memoria tem, separadas por ter vetor ou nao.
+///
+/// **Gauge**, e nao counter, porque o numero sobe e desce: a retencao apaga, o
+/// `compact` apaga, o `reindex` move entradas de um lado para o outro.
+pub const MEMORY_ENTRIES: &str = "garraia_memory_entries";
+
+/// Leituras do tamanho da memoria que falharam.
+///
+/// Existe por causa do pior modo de falha de um gauge: quando a leitura para de
+/// funcionar, o valor **nao some** — o Prometheus continua servindo o ultimo
+/// como se fosse atual, e quem olha o painel nao distingue "banco inacessivel"
+/// de "a base tem mesmo esse tamanho". Um contador ao lado torna a falha
+/// alertavel, e e a unica forma de o silencio virar sinal. Apontado pela
+/// auditoria do #957.
+pub const MEMORY_GAUGE_ERRORS_TOTAL: &str = "garraia_memory_gauge_errors_total";
+
+/// Linhas no indice vetorial (`vec_id_map`).
+///
+/// Lado a lado com o `MEMORY_ENTRIES{has_embedding="true"}`, os dois deviam
+/// ser iguais. **A distancia entre eles e o sinal**: entrada com vetor na
+/// coluna mas fora do indice nao aparece na busca semantica, e era invisivel
+/// ate o `garra memory stats` (#960) — que so mostra quando alguem pergunta.
+/// Aqui vira tendencia, que e o que faz alguem perguntar.
+pub const MEMORY_VECTOR_INDEX_SIZE: &str = "garraia_memory_vector_index_size";
 
 /// Qual das duas chamadas do provider foi medida.
 ///
@@ -145,6 +170,22 @@ pub fn inc_ingested(outcome: IngestOutcome) {
     counter!(MEMORY_INGESTED_TOTAL, "outcome" => outcome.as_label()).increment(1);
 }
 
+/// Publica o tamanho da memoria (#957).
+///
+/// Os tres numeros saem **da mesma leitura**, de proposito: publicados em
+/// momentos diferentes, um painel que compare "com vetor" contra "no indice"
+/// veria diferenca que e so defasagem entre as coletas, e nao o defeito real
+/// que essa comparacao existe para achar.
+pub fn inc_memory_gauge_error() {
+    counter!(MEMORY_GAUGE_ERRORS_TOTAL).increment(1);
+}
+
+pub fn set_memory_size(com_vetor: usize, sem_vetor: usize, linhas_no_indice: usize) {
+    gauge!(MEMORY_ENTRIES, "has_embedding" => "true").set(com_vetor as f64);
+    gauge!(MEMORY_ENTRIES, "has_embedding" => "false").set(sem_vetor as f64);
+    gauge!(MEMORY_VECTOR_INDEX_SIZE).set(linhas_no_indice as f64);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -181,6 +222,18 @@ mod tests {
         let _: fn(IngestOutcome) = inc_ingested;
     }
 
+    /// Os tres numeros do tamanho saem da mesma leitura.
+    ///
+    /// Publicados em momentos diferentes, um painel que compare "com vetor"
+    /// contra "no indice" veria defasagem entre coletas e leria como defeito —
+    /// justamente a comparacao que essas duas metricas existem para permitir.
+    /// Este teste nao consegue afirmar simultaneidade; ele ancora a assinatura,
+    /// que e o que a garante: **uma** funcao recebe os tres.
+    #[test]
+    fn o_tamanho_e_publicado_de_uma_leitura_so() {
+        let _: fn(usize, usize, usize) = set_memory_size;
+    }
+
     /// Prefixo `garraia_`, alinhado com `garraia_requests_total` e as outras
     /// tres que ja existem. A issue #957 propoe `garra_`; seguir a issue ao pe
     /// da letra quebraria todo dashboard que agrupa por `garraia_.*`.
@@ -191,6 +244,9 @@ mod tests {
             MEMORY_EMBED_FAILURES_TOTAL,
             MEMORY_RECALL_LATENCY_SECONDS,
             MEMORY_INGESTED_TOTAL,
+            MEMORY_ENTRIES,
+            MEMORY_VECTOR_INDEX_SIZE,
+            MEMORY_GAUGE_ERRORS_TOTAL,
         ] {
             assert!(
                 nome.starts_with("garraia_memory_"),
@@ -208,6 +264,13 @@ mod tests {
         assert!(MEMORY_INGESTED_TOTAL.ends_with("_total"));
         assert!(MEMORY_EMBED_LATENCY_SECONDS.ends_with("_seconds"));
         assert!(MEMORY_RECALL_LATENCY_SECONDS.ends_with("_seconds"));
+
+        // Gauge nao leva sufixo: `_total` mentiria (o numero desce) e
+        // `_seconds` nao e unidade de contagem. A convencao do Prometheus e
+        // justamente essa ausencia.
+        assert!(!MEMORY_ENTRIES.ends_with("_total"));
+        assert!(!MEMORY_VECTOR_INDEX_SIZE.ends_with("_total"));
+        assert!(MEMORY_GAUGE_ERRORS_TOTAL.ends_with("_total"));
     }
 
     /// Sem recorder instalado — o caso da CLI — emitir nao pode entrar em
@@ -219,5 +282,7 @@ mod tests {
         inc_embed_failure("ollama", EmbedOp::Query);
         record_recall_latency(0.01);
         inc_ingested(IngestOutcome::Noise);
+        set_memory_size(10, 2, 10);
+        inc_memory_gauge_error();
     }
 }

--- a/crates/garraia-db/src/memory_store.rs
+++ b/crates/garraia-db/src/memory_store.rs
@@ -158,6 +158,28 @@ pub struct EmbeddingBreakdownRow {
     pub entries: usize,
 }
 
+/// Contagens baratas para os gauges do `/metrics` (#957).
+///
+/// Deliberadamente **nao** e o [`IntegrityReport`]. Aquele existe para o
+/// `garra memory stats`, roda sob demanda e faz um `SELECT id FROM
+/// memory_entries` inteiro mais a varredura de orfaos — trabalho justificado
+/// quando alguem pede um diagnostico, e desperdicio a cada poucos minutos num
+/// worker de gauge.
+///
+/// Aqui sao tres `count(*)`. As consultas sao **as mesmas** que o
+/// `integrity_report` usa, de proposito: se divergirem, o numero do painel e o
+/// do `garra memory stats` passam a discordar, e nao ha nada pior para quem
+/// esta diagnosticando do que dois numeros que deviam ser iguais e nao sao.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct MemoryGauges {
+    pub entries_with_embedding: usize,
+    pub entries_without_embedding: usize,
+    /// Linhas no `vec_id_map` — a ligacao entre entrada e vetor. Zero quando
+    /// nao ha vector store, o que e diferente de "indice vazio" e por isso
+    /// merece o `knn_enabled` ao lado quando alguem for interpretar.
+    pub vector_index_rows: usize,
+}
+
 #[async_trait]
 pub trait MemoryProvider: Send + Sync {
     async fn remember(&self, entry: NewMemoryEntry) -> Result<String>;
@@ -170,6 +192,9 @@ pub trait MemoryProvider: Send + Sync {
     ) -> Result<Vec<MemoryEntry>>;
     async fn compact(&self, before: DateTime<Utc>) -> Result<CompactionReport>;
     async fn delete_session_memory(&self, session_id: &str) -> Result<usize>;
+
+    /// Contagens para os gauges (#957). Ver [`MemoryGauges`].
+    async fn gauge_snapshot(&self) -> Result<MemoryGauges>;
 }
 
 /// A condicao de compactacao (#959), escrita **inteira** nas duas sentencas.
@@ -1240,6 +1265,62 @@ impl MemoryProvider for MemoryStore {
     async fn delete_session_memory(&self, session_id: &str) -> Result<usize> {
         self.delete_session_memory(session_id).await
     }
+
+    async fn gauge_snapshot(&self) -> Result<MemoryGauges> {
+        // O bloco existe para **soltar o guard do banco principal** antes de
+        // tocar o vector store, que tem mutex proprio (apontado pela auditoria
+        // do #957).
+        //
+        // Segurar os dois nao trava hoje — nenhum caminho adquire na ordem
+        // inversa, e o `compact` solta o principal antes do `cleanup_vectors`.
+        // Mas segurar o principal durante a consulta vetorial bloqueia todo
+        // `recall` e `remember` concorrente pelo tempo dela, e deixa armada a
+        // ordem que o proximo caminho com locking invertido transformaria em
+        // deadlock. Um gauge de 5 em 5 minutos nao vale esse risco.
+        let (total, with_embedding) = {
+            let conn = self.connection()?;
+
+            // As duas consultas sao **identicas** as do `integrity_report`,
+            // palavra por palavra. Se alguem mudar uma, tem de mudar a outra:
+            // o teste `gauge_e_stats_contam_a_mesma_coisa` cobra.
+            let total: i64 = conn
+                .query_row("SELECT count(*) FROM memory_entries", [], |row| row.get(0))
+                .map_err(|e| Error::Database(format!("failed to count entries: {e}")))?;
+            let with_embedding: i64 = conn
+                .query_row(
+                    "SELECT count(*) FROM memory_entries WHERE embedding IS NOT NULL",
+                    [],
+                    |row| row.get(0),
+                )
+                .map_err(|e| Error::Database(format!("failed to count embedded entries: {e}")))?;
+            (total, with_embedding)
+        };
+
+        let vector_index_rows = match &self.vector_store {
+            Some(vs) => vs.index_inventory()?.map_rows,
+            None => 0,
+        };
+
+        // `with_embedding > total` e impossivel: as duas contagens saem da
+        // mesma guarda, entao nada escreveu entre elas. Se acontecer, e
+        // corrupcao no banco — e um `.max(0)` mudo publicaria zero como se
+        // fosse resposta. Dizer alto e o unico jeito de alguem descobrir.
+        if with_embedding > total {
+            tracing::warn!(
+                total,
+                with_embedding,
+                "contagem de memoria inconsistente: entradas com vetor excedem o total. \
+                 Isso indica corrupcao no banco — rode `garra memory stats` para o \
+                 relatorio de integridade."
+            );
+        }
+
+        Ok(MemoryGauges {
+            entries_with_embedding: with_embedding as usize,
+            entries_without_embedding: (total - with_embedding).max(0) as usize,
+            vector_index_rows,
+        })
+    }
 }
 
 fn row_to_entry(row: &rusqlite::Row<'_>) -> rusqlite::Result<MemoryEntry> {
@@ -1446,6 +1527,73 @@ mod tests {
             embedding_model: Some("unit-test".to_string()),
             metadata: serde_json::json!({}),
         }
+    }
+
+    /// O gauge e o `garra memory stats` tem de contar a mesma coisa.
+    ///
+    /// Sao dois caminhos de codigo com as mesmas consultas, escritas duas
+    /// vezes — e duas copias divergem. Este teste e o que cobra: se alguem
+    /// mudar o predicado num lugar so, o numero do painel passa a discordar do
+    /// numero do diagnostico, e nao ha nada pior para quem esta investigando
+    /// do que dois numeros que deviam ser iguais.
+    #[tokio::test]
+    async fn gauge_e_stats_contam_a_mesma_coisa() {
+        use super::MemoryProvider;
+
+        let store = MemoryStore::in_memory().expect("store");
+        // Duas com vetor, uma sem.
+        store
+            .remember(entry(
+                "s1",
+                None,
+                "com vetor um",
+                MemoryRole::User,
+                Some(vec![0.1; 8]),
+            ))
+            .await
+            .expect("remember");
+        store
+            .remember(entry(
+                "s1",
+                None,
+                "com vetor dois",
+                MemoryRole::User,
+                Some(vec![0.2; 8]),
+            ))
+            .await
+            .expect("remember");
+        store
+            .remember(entry("s1", None, "sem vetor", MemoryRole::User, None))
+            .await
+            .expect("remember");
+
+        let gauge = store.gauge_snapshot().await.expect("gauge");
+        let report = store.integrity_report().expect("report");
+
+        assert_eq!(
+            gauge.entries_with_embedding, report.entries_with_embedding,
+            "gauge e stats discordam em entries_with_embedding"
+        );
+        assert_eq!(
+            gauge.entries_without_embedding, report.entries_without_embedding,
+            "gauge e stats discordam em entries_without_embedding"
+        );
+        assert_eq!(gauge.entries_with_embedding, 2);
+        assert_eq!(gauge.entries_without_embedding, 1);
+    }
+
+    /// Sem vector store o indice reporta zero, e nao falha. Zero aqui quer
+    /// dizer "nao ha indice", que e diferente de "indice vazio" — quem le o
+    /// painel precisa do `knn_enabled` ao lado para distinguir.
+    #[tokio::test]
+    async fn gauge_sem_vector_store_reporta_zero_sem_falhar() {
+        use super::MemoryProvider;
+
+        let store = MemoryStore::in_memory().expect("store");
+        let gauge = store.gauge_snapshot().await.expect("gauge");
+        assert_eq!(gauge.vector_index_rows, 0);
+        assert_eq!(gauge.entries_with_embedding, 0);
+        assert_eq!(gauge.entries_without_embedding, 0);
     }
 
     /// O `remember_sync` grava a linha e insere no indice em best-effort:

--- a/crates/garraia-gateway/src/lib.rs
+++ b/crates/garraia-gateway/src/lib.rs
@@ -20,6 +20,7 @@ pub mod logs_handler;
 pub mod mcp;
 pub mod mcp_commands;
 pub mod mcp_marketplace;
+pub mod memory_gauge_worker;
 pub mod memory_handler;
 pub mod memory_retention_worker;
 pub mod metrics_auth;

--- a/crates/garraia-gateway/src/memory_gauge_worker.rs
+++ b/crates/garraia-gateway/src/memory_gauge_worker.rs
@@ -1,0 +1,123 @@
+//! Publica o tamanho da memoria no `/metrics`, periodicamente (#957).
+//!
+//! O #994 entregou quatro metricas de **instrumentacao**: elas contam o que
+//! aconteceu quando aconteceu — uma chamada de embedding, um recall, um turno
+//! ingerido. Faltavam as de **estado**: quantas entradas existem agora, e
+//! quantas estao no indice. Estado nao tem evento, entao alguem precisa ir
+//! olhar de tempos em tempos.
+//!
+//! # Por que um worker proprio, e nao um braco do de retencao
+//!
+//! Era o caminho obvio — ja existe um laco periodico tocando a memoria — e e
+//! errado por dois motivos independentes.
+//!
+//! O primeiro **desliga a metrica para quase todo mundo**: o
+//! `memory_retention_worker` so sobe quando `memory.retention.enabled` e
+//! `true`, e ela nasce `false` de proposito, porque apaga dado. Os gauges
+//! ficariam mortos em toda instalacao que nao ligou a retencao, que e a
+//! maioria — e um painel que nao mostra nada e indistinguivel de um sistema
+//! que nao tem nada.
+//!
+//! O segundo e cadencia: retencao roda a cada 24h por padrao. Um gauge com
+//! 24h de resolucao nao mostra tendencia; mostra dois pontos por semana.
+//!
+//! # Este worker nao apaga nada
+//!
+//! E a diferenca que justifica ele nascer **ligado**. A retencao nasce
+//! desligada porque apagar memoria de quem so atualizou a versao seria um
+//! estrago. Aqui o pior caso e tres `count(*)` a cada poucos minutos.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use garraia_db::MemoryProvider;
+use tracing::{debug, warn};
+
+/// De quanto em quanto tempo reler o tamanho.
+///
+/// Cinco minutos e o meio termo: um `scrape_interval` tipico do Prometheus e
+/// de 15s a 1min, entao valores mais lentos que isso viram degraus visiveis no
+/// grafico; mais rapido que isso paga `count(*)` sem ninguem olhar.
+const INTERVALO_PADRAO: Duration = Duration::from_secs(300);
+
+/// Sobe o laco que republica o tamanho da memoria.
+///
+/// Devolve o `JoinHandle` para quem chama decidir o ciclo de vida — o
+/// `server.rs` faz `mem::forget`, como nos outros workers.
+pub fn spawn_memory_gauge_worker(memory: Arc<dyn MemoryProvider>) -> tokio::task::JoinHandle<()> {
+    spawn_com_intervalo(memory, INTERVALO_PADRAO)
+}
+
+fn spawn_com_intervalo(
+    memory: Arc<dyn MemoryProvider>,
+    intervalo: Duration,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(intervalo);
+        // O primeiro tick do `interval` dispara imediatamente, o que e o que
+        // se quer: o painel tem numero desde o boot, e nao so depois do
+        // primeiro periodo.
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            ticker.tick().await;
+            publicar_uma_vez(memory.as_ref()).await;
+        }
+    })
+}
+
+/// Uma leitura e a publicacao dela. Separado do laco para ser testavel sem
+/// relogio.
+pub async fn publicar_uma_vez(memory: &dyn MemoryProvider) {
+    match memory.gauge_snapshot().await {
+        Ok(g) => {
+            garraia_common::metrics::set_memory_size(
+                g.entries_with_embedding,
+                g.entries_without_embedding,
+                g.vector_index_rows,
+            );
+            debug!(
+                com_vetor = g.entries_with_embedding,
+                sem_vetor = g.entries_without_embedding,
+                no_indice = g.vector_index_rows,
+                "memory gauges atualizados"
+            );
+        }
+        // Falhar a leitura **nao** derruba o laco: o proximo tick tenta de
+        // novo. Um erro transitorio de SQLite nao pode custar a metrica para
+        // sempre — e um gauge que para de atualizar em silencio e pior que um
+        // que some, porque o Prometheus continua servindo o ultimo valor e o
+        // painel mostra um numero velho como se fosse atual.
+        Err(e) => {
+            // O contador ao lado e o que torna a falha **alertavel**. Sem ele,
+            // uma falha persistente congelaria os gauges sem sinal nenhum: o
+            // Prometheus continua servindo o ultimo valor como atual, e o
+            // painel mostra numero velho como se fosse novo.
+            garraia_common::metrics::inc_memory_gauge_error();
+            warn!("falha ao ler o tamanho da memoria para os gauges: {e}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use garraia_db::MemoryStore;
+
+    /// A publicacao le do store e nao entra em panico sem recorder instalado
+    /// — que e o caso de todo teste e da CLI.
+    #[tokio::test]
+    async fn publicar_uma_vez_nao_entra_em_panico_sem_recorder() {
+        let store = MemoryStore::in_memory().expect("store");
+        publicar_uma_vez(&store).await;
+    }
+
+    /// Erro de leitura nao pode derrubar o laco. Aqui a leitura funciona; o
+    /// que este teste ancora e que `publicar_uma_vez` **retorna** em vez de
+    /// propagar — se alguem trocar por `?`, o laco passa a morrer no primeiro
+    /// erro transitorio e o gauge congela sem aviso.
+    #[tokio::test]
+    async fn publicar_uma_vez_nao_propaga_erro() {
+        let store = MemoryStore::in_memory().expect("store");
+        let _: () = publicar_uma_vez(&store).await;
+    }
+}

--- a/crates/garraia-gateway/src/server.rs
+++ b/crates/garraia-gateway/src/server.rs
@@ -521,6 +521,16 @@ impl GatewayServer {
             debug!("uploads_expiration_worker skipped (no AppPool wired)");
         }
 
+        // Tamanho da memoria no `/metrics` (#957). Sobe **sempre** que ha
+        // memoria, e nao junto da retencao: aquele worker so existe quando
+        // `memory.retention.enabled` e true, que e off por padrao, e os gauges
+        // ficariam mortos para quase todo mundo. Ver o docblock do modulo.
+        if let Some(memory) = state.agents.memory_provider() {
+            let handle = crate::memory_gauge_worker::spawn_memory_gauge_worker(memory);
+            std::mem::forget(handle);
+            debug!("memory_gauge_worker spawned");
+        }
+
         // Retencao da memoria do agente (#956): o `compact()` existia e nunca
         // rodava em producao — a memoria crescia sem teto e o recall degradava
         // com ela. A varredura nasce DESLIGADA de proposito; quando esta

--- a/docs/src/memory.md
+++ b/docs/src/memory.md
@@ -148,6 +148,9 @@ memória (#957):
 | `garraia_memory_embed_failures_total{provider,operation}` | **A que mais importa** — ver abaixo |
 | `garraia_memory_recall_latency_seconds` | O recall inteiro, embedding + busca |
 | `garraia_memory_ingested_total{outcome}` | Turnos por desfecho: `embedded`, `noise`, `no_provider`, `failed` |
+| `garraia_memory_entries{has_embedding}` | Quantas entradas existem, com e sem vetor |
+| `garraia_memory_vector_index_size` | Linhas no índice vetorial |
+| `garraia_memory_gauge_errors_total` | Leituras dos dois gauges acima que falharam |
 
 A de falha é a que merece alerta. Falha de embedding era **silenciosa**: a
 entrada ia para o banco sem vetor e ficava invisível para a busca semântica
@@ -158,6 +161,17 @@ descobrir que o provedor caiu **antes** de o recall degradar.
 `no_provider` e `failed` são desfechos separados porque são a diferença entre
 "ninguém configurou" e "configurou e está quebrado", que é a primeira pergunta
 de quem opera.
+
+**Os dois últimos merecem ser lidos juntos.** `garraia_memory_entries{has_embedding="true"}`
+e `garraia_memory_vector_index_size` deveriam ser iguais — a distância entre
+eles é o sinal. Uma entrada com vetor na coluna mas fora do índice não aparece
+na busca semântica, e isso era invisível até alguém rodar `garra memory stats`.
+Como gauge, vira tendência — que é o que faz alguém pensar em rodar.
+
+Eles são publicados por um worker próprio, que sobe **sempre** que há memória.
+Não são um braço do worker de retenção: aquele só existe quando
+`memory.retention.enabled` é `true`, que é o padrão desligado, e os gauges
+ficariam mortos para quase toda instalação.
 
 Detalhes e consultas PromQL em [telemetry.md](../telemetry.md).
 
@@ -184,7 +198,3 @@ DELETE /api/memory                 # limpa
   de fatos; não há inserção manual pela CLI.
 - **O retriever do `garraia-learning` é um stub.** A busca semântica de
   *skills* (distinta da memória de conversa) espera a Fase 2.1 — ver ADR 0002.
-- **Os gauges de tamanho do índice** (`garraia_memory_entries`,
-  `garraia_memory_vector_index_size`) estão na #957 e ainda não foram
-  entregues: precisam de um worker próprio, porque pendurá-los no worker de
-  retenção os deixaria mortos para quem não liga a retenção — que é o padrão.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -206,6 +206,9 @@ Four more, emitted by the agent runtime whenever the memory system is in use:
 | `garraia_memory_embed_failures_total{provider, operation}` | counter | Embedding calls that failed |
 | `garraia_memory_recall_latency_seconds` | histogram | Whole recall — query embedding **plus** the search |
 | `garraia_memory_ingested_total{outcome}` | counter | Turns ingested, by outcome: `embedded`, `noise`, `no_provider`, `failed` |
+| `garraia_memory_entries{has_embedding}` | gauge | Entries in memory, with and without a vector |
+| `garraia_memory_vector_index_size` | gauge | Rows in the vector index (`vec_id_map`) |
+| `garraia_memory_gauge_errors_total` | counter | Failed reads of the two gauges above |
 
 **The one to alert on** is `garraia_memory_embed_failures_total`. Issue #948
 described embedding failure as *silent*: the entry was stored without a vector
@@ -219,6 +222,24 @@ broken", which is the first question an operator asks. `noise` exists because of
 the ingestion filter (#952): without it, the count of entries without a vector
 would climb and nobody could tell defect from policy.
 
+**The two gauges are meant to be read together, and the gap between them is
+the signal**: an entry with a vector in its column but missing from the index
+does not show up in semantic search. That was invisible until someone ran
+`garra memory stats` — which only reports when asked. As a gauge it becomes a
+trend, which is what prompts the asking.
+
+The error counter exists because of the worst failure mode a gauge has: when
+the read stops working, the value does **not** disappear — Prometheus keeps
+serving the last one as if it were current, and nobody can tell "database
+unreachable" from "the base really is that size". Alert on
+`rate(garraia_memory_gauge_errors_total[15m]) > 0` to make that silence
+audible.
+
+They come from a dedicated worker (`memory_gauge_worker`) that starts whenever
+memory exists and resamples every 5 minutes. It is **not** a branch of the
+retention worker: that one only runs with `memory.retention.enabled=true`,
+which is off by default, so the gauges would be dead on almost every install.
+
 Useful queries:
 
 ```promql
@@ -227,6 +248,9 @@ rate(garraia_memory_embed_failures_total[5m])
 
 # p95 do recall (o que o usuario espera)
 histogram_quantile(0.95, rate(garraia_memory_recall_latency_seconds_bucket[5m]))
+
+# Entradas com vetor que nao estao no indice — deveria ser sempre 0
+garraia_memory_entries{has_embedding="true"} - garraia_memory_vector_index_size
 
 # Fracao dos turnos que o filtro de ruido descartou
 rate(garraia_memory_ingested_total{outcome="noise"}[1h])


### PR DESCRIPTION
## Descrição

Fecha o #957. O #994 entregou quatro métricas de **instrumentação** — elas contam o que aconteceu quando aconteceu. Faltavam as de **estado**: quantas entradas existem agora e quantas estão no índice. Estado não tem evento, então alguém precisa ir olhar.

```
garraia_memory_entries{has_embedding}   gauge
garraia_memory_vector_index_size        gauge
garraia_memory_gauge_errors_total       counter
```

## Os dois gauges devem ser lidos juntos, e a distância entre eles é o sinal

Uma entrada com vetor na coluna mas fora do índice **não aparece na busca semântica**. Isso era invisível até alguém rodar `garra memory stats` — que só mostra quando perguntam. Como gauge, vira tendência, que é o que faz alguém pensar em perguntar.

```promql
# Deveria ser sempre 0
garraia_memory_entries{has_embedding="true"} - garraia_memory_vector_index_size
```

## Worker próprio, e não um braço do de retenção

Era o caminho óbvio — já existe um laço periódico tocando a memória — e é errado por dois motivos independentes:

O `memory_retention_worker` só sobe quando `memory.retention.enabled` é `true`, e ela nasce `false` porque apaga dado. Os gauges ficariam mortos em quase toda instalação, e **um painel que não mostra nada é indistinguível de um sistema que não tem nada.**

E a cadência dele é de 24h. Um gauge com 24h de resolução não mostra tendência; mostra dois pontos por semana.

**Verificado no binário**, com a configuração padrão:

```console
$ grep retention gw.log
INFO garraia_gateway::server: retencao da memoria desligada (memory.retention.enabled=false)

$ curl -s localhost:9464/metrics | grep garraia_memory_entries
# TYPE garraia_memory_entries gauge
garraia_memory_entries{has_embedding="false"} 0
garraia_memory_entries{has_embedding="true"} 0
```

O worker de retenção não subiu, e os gauges estão servindo assim mesmo. Se eu os tivesse pendurado nele, estariam ausentes.

## Leitura barata, e não o relatório de integridade

O `integrity_report()` que alimenta o `garra memory stats` faz um `SELECT id FROM memory_entries` inteiro mais varredura de órfãos — trabalho justificado sob demanda, desperdício a cada poucos minutos.

O `gauge_snapshot()` são três `count(*)`, com as **mesmas** consultas, e há teste cobrando que os dois concordem. Dois números que deviam ser iguais e não são é o pior caso para quem está diagnosticando.

## Auditoria

`@security-auditor` rodou antes de abrir — **8/10**. Os três achados foram tratados.

### MÉDIO — a leitura segurava dois mutexes

`gauge_snapshot` mantinha o `MutexGuard` do banco principal enquanto chamava `vs.index_inventory()`, que pega outro mutex.

Não trava hoje: nenhum caminho adquire na ordem inversa, e o `compact` solta o principal antes do `cleanup_vectors`. Mas segurava o principal durante a consulta vetorial, **bloqueando todo `recall` e `remember` concorrente** pelo tempo dela — e deixava armada a ordem que o próximo caminho com locking invertido transformaria em deadlock. Um gauge de 5 em 5 minutos não vale esse risco.

Agora a leitura fecha o guard num bloco explícito antes de tocar o vetorial.

### BAIXO — contagem inconsistente publicava zero mudo

`com vetor > total` é impossível: as duas contagens saem da mesma guarda, então nada escreve entre elas. Se acontecer, é corrupção no banco — e o `.max(0)` silencioso publicaria zero como se fosse resposta. Agora grita, apontando para o `garra memory stats`.

### BAIXO — o gauge congelava em silêncio

É o pior modo de falha de um gauge: quando a leitura para de funcionar o valor **não some**. O Prometheus continua servindo o último como atual, e quem olha o painel não distingue "banco inacessível" de "a base tem mesmo esse tamanho".

Entrou `garraia_memory_gauge_errors_total`, que torna a falha alertável — a única forma de o silêncio virar sinal.

### O que a auditoria confirmou como correto

Nenhuma label de sessão, usuário ou tenant (só o booleano `has_embedding`); `/metrics` segue autenticado; sem `unwrap()` em produção; sem SQL concatenado no caminho novo; sem `SQLITE_BUSY` possível (o `Mutex` serializa, não há pool); e o laço não morre — `publicar_uma_vez` trata o erro e retorna, com teste ancorando que não propaga.

## Tipo de mudança

- [x] `feat`: Nova funcionalidade
- [x] `docs`: Documentação (telemetria + memória)
- [x] `test`: Adição de testes

## Classe de Risco

- [x] **Classe C (Alto Risco)**: métrica publicada é superfície de exposição, e o worker novo compartilha o `MemoryStore` com o caminho de recall. Auditoria rodou antes de abrir.

## Checklist de Segurança e Qualidade

- [x] `cargo +1.95 fmt --all -- --check` limpo
- [x] `cargo +1.95 clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings` sem erros
- [x] `cargo +1.95 test --workspace --exclude garraia-desktop` — 54 binários; única falha é a ambiental `migration_001_applies_and_schema_is_sane` (exige `docker.sock`)
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo commitado
- [x] Nenhuma migração
- [x] Nenhuma label carrega sessão, usuário ou tenant
- [x] O gauge e o `garra memory stats` contam a mesma coisa — com teste
- [ ] Verificação de políticas RLS — não se aplica

## Mudanças na API pública e Schema

- **`garraia-db`:** `MemoryGauges` novo; `MemoryProvider` ganha `gauge_snapshot()`. Quebra implementadores externos do trait — não há nenhum fora do workspace.
- **`garraia-common`:** três nomes de métrica novos + `set_memory_size` e `inc_memory_gauge_error`.
- **`garraia-gateway`:** módulo `memory_gauge_worker`.
- Sem schema, sem migração, sem chave de config nova.

## Como testar

```bash
cargo +1.95 test -p garraia-db gauge          # 2: consistência com stats, e sem vector store
cargo +1.95 test -p garraia-common metrics    # 6: nomes, sufixos, no-op sem recorder
cargo +1.95 test -p garraia-gateway memory_gauge
```

No binário, com `GARRAIA_METRICS_ENABLED=true`, o `/metrics` mostra os três.

## Plano de Rollback

Reverter o merge. Nada persistido, nada de config, nada de schema — perde-se a visibilidade.

Closes #957

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF

---
_Generated by [Claude Code](https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF)_