### PR TITLE
fix(gateway): /mode e /model no Telegram gravavam numa sessão morta

### DIFF
--- a/changelog.d/fixed/982-pre-session-id-do-telegram.md
+++ b/changelog.d/fixed/982-pre-session-id-do-telegram.md
@@ -1,0 +1,20 @@
+- **`/mode` e `/model` no Telegram gravavam numa sessao que a execucao nunca
+  lia.** O GAR-202 migrou a chave de sessao de `telegram-{chat_id}` —
+  adivinhavel — para um UUID do `ChatSessionManager`, mas a migracao pegou so o
+  caminho de execucao. A camada de comandos continuou montando a string antiga,
+  em tres lugares. O efeito era um recurso que parecia funcionar: `/mode code`
+  respondia "modo definido", gravava no banco, e a proxima mensagem rodava sem
+  ele; `/mode` sozinho lia da chave errada e mostrava "modo atual: ask" logo
+  depois. So nao aparecia quando o `chat_session_manager` era `None`, que e o
+  caminho de fallback.
+- **A correcao e ter um lugar so.** `AppState::telegram_session_id` passa a ser
+  a unica funcao que monta a chave, e os cinco pontos — tres de comando, dois de
+  execucao — chamam ela. Duplicar a resolucao foi o que permitiu a divergencia.
+- **Um teste varre o fonte** procurando `format!("telegram-{` fora do
+  `state.rs`. E o unico jeito de pegar a proxima copia antes de ela divergir:
+  um teste de comportamento so falharia depois de alguem reintroduzir o bug e
+  alguem mais notar.
+- O `user_id` continua sendo passado onde existe. Ele nao muda **qual** sessao
+  e encontrada (a busca e por `chat_id`), mas define o dono no `upsert` de
+  criacao — sem ele, um `/mode` antes da primeira mensagem criaria a sessao com
+  dono `"anonymous"`.

--- a/crates/garraia-gateway/src/bootstrap/telegram.rs
+++ b/crates/garraia-gateway/src/bootstrap/telegram.rs
@@ -88,14 +88,7 @@ pub fn build_telegram_voice_handler(state: &SharedState) -> Option<OnVoiceFn> {
                 }
 
                 // GAR-202: Resolve session via UUID-based key (replaces guessable telegram-{chat_id})
-                let session_id = if let Some(mgr) = &state.chat_session_manager {
-                    let hints = garraia_db::SessionHints::from_telegram(chat_id, None);
-                    mgr.resolve_session(&hints)
-                        .await
-                        .unwrap_or_else(|_| format!("telegram-{chat_id}"))
-                } else {
-                    format!("telegram-{chat_id}")
-                };
+                let session_id = state.telegram_session_id(chat_id, None).await;
                 state
                     .hydrate_session_history(&session_id, Some("telegram"), Some(&user_id))
                     .await;
@@ -290,16 +283,11 @@ pub fn build_telegram_channels(
                         }
                     }
 
-                    // GAR-202: UUID-based session ID (replaces guessable telegram-{chat_id})
-                    let session_id = if let Some(mgr) = &state.chat_session_manager {
-                        let uid_i64 = user_id.parse::<i64>().ok();
-                        let hints = garraia_db::SessionHints::from_telegram(chat_id, uid_i64);
-                        mgr.resolve_session(&hints)
-                            .await
-                            .unwrap_or_else(|_| format!("telegram-{chat_id}"))
-                    } else {
-                        format!("telegram-{chat_id}")
-                    };
+                    // GAR-202: chave UUID, resolvida no unico lugar que a
+                    // monta (`AppState::telegram_session_id`).
+                    let session_id = state
+                        .telegram_session_id(chat_id, user_id.parse::<i64>().ok())
+                        .await;
 
                     let text = garraia_security::InputValidator::sanitize(&text);
                     if garraia_security::InputValidator::check_prompt_injection(&text) {

--- a/crates/garraia-gateway/src/commands.rs
+++ b/crates/garraia-gateway/src/commands.rs
@@ -74,7 +74,16 @@ pub fn register_commands(registry: &mut CommandRegistry) {
                 .unwrap()
                 .downcast_ref::<AppState>()
                 .unwrap();
-            let session_id = format!("telegram-{}", ctx.chat_id); // Note: Discord uses strings, but chat_id is i64 here... we'll just use it for telegram for now
+            // GAR-202 + #982: a chave vem do MESMO resolvedor que a execucao
+            // usa. Montar `telegram-{chat_id}` aqui gravava numa linha que o
+            // runtime nunca lia — ver `AppState::telegram_session_id`.
+            let session_id = tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(async {
+                    state
+                        .telegram_session_id(ctx.chat_id, ctx.user_id.parse::<i64>().ok())
+                        .await
+                })
+            }); // Note: Discord uses strings, but chat_id is i64 here... we'll just use it for telegram for now
             if let Some(mut session) = state.sessions.get_mut(&session_id) {
                 session.history.clear();
             }
@@ -96,7 +105,16 @@ pub fn register_commands(registry: &mut CommandRegistry) {
                 .unwrap()
                 .downcast_ref::<AppState>()
                 .unwrap();
-            let session_id = format!("telegram-{}", ctx.chat_id);
+            // GAR-202 + #982: a chave vem do MESMO resolvedor que a execucao
+            // usa. Montar `telegram-{chat_id}` aqui gravava numa linha que o
+            // runtime nunca lia — ver `AppState::telegram_session_id`.
+            let session_id = tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(async {
+                    state
+                        .telegram_session_id(ctx.chat_id, ctx.user_id.parse::<i64>().ok())
+                        .await
+                })
+            });
             if ctx.args.is_empty() {
                 let current = state.channel_models.get(&session_id);
                 if let Some(m) = current {
@@ -328,7 +346,16 @@ pub fn register_commands(registry: &mut CommandRegistry) {
                 .unwrap()
                 .downcast_ref::<AppState>()
                 .unwrap();
-            let session_id = format!("telegram-{}", ctx.chat_id);
+            // GAR-202 + #982: a chave vem do MESMO resolvedor que a execucao
+            // usa. Montar `telegram-{chat_id}` aqui gravava numa linha que o
+            // runtime nunca lia — ver `AppState::telegram_session_id`.
+            let session_id = tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(async {
+                    state
+                        .telegram_session_id(ctx.chat_id, ctx.user_id.parse::<i64>().ok())
+                        .await
+                })
+            });
 
             if ctx.args.is_empty() {
                 // Show current mode

--- a/crates/garraia-gateway/src/state.rs
+++ b/crates/garraia-gateway/src/state.rs
@@ -794,6 +794,47 @@ impl AppState {
         });
     }
 
+    /// A chave de sessao do Telegram, resolvida do mesmo jeito em todo lugar.
+    ///
+    /// # Por que isto e uma funcao, e nao tres copias
+    ///
+    /// O GAR-202 migrou a execucao de `telegram-{chat_id}` — adivinhavel — para
+    /// uma chave UUID do `ChatSessionManager`. A migracao pegou o caminho de
+    /// execucao (`bootstrap/telegram.rs`) e **nao pegou a camada de comandos**,
+    /// que continuou montando a string antiga em tres lugares.
+    ///
+    /// O efeito era um recurso que parecia funcionar e nao funcionava: `/mode
+    /// code` gravava numa linha do banco que a execucao nunca lia, e `/mode`
+    /// sem argumento lia da chave errada — o usuario via "modo atual: ask"
+    /// logo depois de setar `code`. Idem `/model`. So nao aparecia quando o
+    /// `chat_session_manager` era `None`, que e o caminho de fallback.
+    ///
+    /// Duplicar a resolucao foi o que permitiu a divergencia, entao a correcao
+    /// e ter **um** lugar. Quem precisar da chave chama aqui.
+    ///
+    /// O fallback para `telegram-{chat_id}` fica: e o que a execucao faz quando
+    /// nao ha manager, e divergir dela seria recriar o mesmo bug ao contrario.
+    ///
+    /// # O `user_id` nao muda a chave, mas muda o dono
+    ///
+    /// `resolve_session` procura por `(source, external_id)` — o `chat_id`
+    /// sozinho ja acha a sessao. O `user_id` so e usado no `upsert` de
+    /// **criacao**, para registrar de quem ela e. Passar `None` numa primeira
+    /// interacao criaria a sessao com dono `"anonymous"`, entao quem tem o id
+    /// em maos passa; quem nao tem, passa `None` sem mudar qual sessao e
+    /// encontrada.
+    pub async fn telegram_session_id(&self, chat_id: i64, user_id: Option<i64>) -> String {
+        match &self.chat_session_manager {
+            Some(mgr) => {
+                let hints = garraia_db::SessionHints::from_telegram(chat_id, user_id);
+                mgr.resolve_session(&hints)
+                    .await
+                    .unwrap_or_else(|_| format!("telegram-{chat_id}"))
+            }
+            None => format!("telegram-{chat_id}"),
+        }
+    }
+
     /// GAR-202: Spawn a background task that cleans up expired session tokens every 5 min.
     pub fn spawn_token_cleanup(self: &Arc<Self>) {
         let Some(manager) = self.chat_session_manager.clone() else {
@@ -846,6 +887,57 @@ pub type SharedState = Arc<AppState>;
 
 #[cfg(test)]
 mod tests {
+
+    /// A chave de sessao do Telegram e montada **num lugar so**.
+    ///
+    /// Este teste existe porque a divergencia ja aconteceu: o GAR-202 migrou a
+    /// execucao para chave UUID e deixou a camada de comandos montando
+    /// `telegram-{chat_id}` a mao, em tres lugares. O resultado foi `/mode` e
+    /// `/model` gravando numa linha que o runtime nunca lia — recurso que
+    /// parece funcionar e nao funciona.
+    ///
+    /// Varre o fonte porque e o unico jeito de pegar a proxima copia antes de
+    /// ela divergir: um teste de comportamento so falharia depois de alguem
+    /// reintroduzir o bug e alguem mais notar.
+    #[test]
+    fn a_chave_do_telegram_e_montada_num_lugar_so() {
+        use std::path::Path;
+
+        let raiz = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut infratores = Vec::new();
+
+        fn varrer(dir: &Path, infratores: &mut Vec<String>) {
+            let Ok(entradas) = std::fs::read_dir(dir) else {
+                return;
+            };
+            for e in entradas.flatten() {
+                let caminho = e.path();
+                if caminho.is_dir() {
+                    varrer(&caminho, infratores);
+                } else if caminho.extension().is_some_and(|x| x == "rs") {
+                    let Ok(texto) = std::fs::read_to_string(&caminho) else {
+                        continue;
+                    };
+                    // `state.rs` e a fonte unica; o resto nao pode montar.
+                    if caminho.file_name().is_some_and(|f| f == "state.rs") {
+                        continue;
+                    }
+                    if texto.contains("format!(\"telegram-{") {
+                        infratores.push(caminho.display().to_string());
+                    }
+                }
+            }
+        }
+
+        varrer(&raiz, &mut infratores);
+        assert!(
+            infratores.is_empty(),
+            "a chave de sessao do Telegram foi montada fora do \
+             `AppState::telegram_session_id`, que e como o GAR-202 ficou pela \
+             metade: {infratores:?}"
+        );
+    }
+
     use super::*;
     use garraia_agents::AgentRuntime;
 


### PR DESCRIPTION
## Descrição

Pré-requisito do #982 que **nenhuma issue menciona** — e um bug por si só.

O GAR-202 migrou a chave de sessão do Telegram de `telegram-{chat_id}` para um UUID do `ChatSessionManager`. O próprio comentário no código diz:

```rust
// GAR-202: Resolve session via UUID-based key (replaces guessable telegram-{chat_id})
```

Mas a migração pegou o caminho de **execução** e deixou a camada de **comandos** montando a string antiga, à mão, em três lugares.

## O efeito é um recurso que parece funcionar

- `/mode code` responde "modo definido", grava no banco, e a próxima mensagem roda **sem ele** — a execução lê outra chave.
- `/mode` sem argumento lê da chave errada e responde "modo atual: ask" logo depois de o usuário setar `code`.
- `/model` tem o mesmo defeito, nos outros dois pontos.

**Só não aparece quando o `chat_session_manager` é `None`** — que é o caminho de fallback. Ou seja: funciona em desenvolvimento e falha em produção.

Isso também significa que implementar o #982 sem este fix entregaria um recurso que só funciona quando o gerenciador está desligado.

## A correção é ter um lugar só

`AppState::telegram_session_id` passa a ser a única função que monta a chave, e os cinco pontos chamam ela — três de comando, dois de execução.

Duplicar a resolução foi exatamente o que permitiu a divergência: o GAR-202 não tinha como saber que havia cópias.

## O teste varre o fonte, e isso é deliberado

```rust
// procura format!("telegram-{ fora do state.rs
assert!(infratores.is_empty(), "...é como o GAR-202 ficou pela metade: {infratores:?}");
```

É o único jeito de pegar a próxima cópia **antes** de ela divergir. Um teste de comportamento só falharia depois de alguém reintroduzir o bug *e* alguém mais notar que `/mode` não pega — que é precisamente o que aconteceu aqui, e levou meses.

## O `user_id` eu verifiquei antes de decidir

Os dois pontos de execução não eram idênticos: um passava o `user_id` nas hints, o outro não. Antes de unificar, fui ver o que ele faz.

`resolve_session` procura por `(source, external_id)` — o `chat_id` sozinho já acha a sessão. O `user_id` só entra no `upsert` de **criação**, definindo o dono. Então passar `None` acharia a mesma sessão, mas um `/mode` antes da primeira mensagem a criaria com dono `"anonymous"`.

Por isso a função recebe o dono, e cada chamador passa o que tem.

## Tipo de mudança

- [x] `fix`: Correção de bug
- [x] `test`: Adição de testes

## Classe de Risco

- [x] **Classe B (Médio Risco)**: muda qual sessão os comandos do Telegram leem e escrevem. É a correção de uma divergência, então o comportamento passa a ser o que já se esperava dele.

## Checklist de Segurança e Qualidade

- [x] `cargo +1.95 fmt --all -- --check` limpo
- [x] `cargo +1.95 clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings` sem erros
- [x] `cargo +1.95 test --workspace --exclude garraia-desktop` — 54 binários; única falha é a ambiental `migration_001_applies_and_schema_is_sane` (exige `docker.sock`)
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo commitado
- [x] Nenhuma migração
- [x] O fallback sem `chat_session_manager` é idêntico ao anterior
- [ ] Verificação de políticas RLS — não se aplica

## Mudanças na API pública e Schema

- **`garraia-gateway`:** `AppState::telegram_session_id(chat_id, user_id)` novo. Sem schema, sem migração, sem config.

## Como testar

```bash
cargo +1.95 test -p garraia-gateway telegram
```

O teste de varredura falha se alguém montar a chave fora do `state.rs`.

Manualmente, com o `chat_session_manager` ligado: `/mode code` seguido de uma mensagem deve aplicar o modo — hoje não aplica. E `/mode` sozinho logo depois deve responder `code`, não `ask`.

## Plano de Rollback

Reverter o merge. Volta à divergência.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF

---
_Generated by [Claude Code](https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF)_