### PR TITLE
feat(ui): markdown legivel no terminal, sem parar o streaming (#939)

### DIFF
--- a/changelog.d/added/939-markdown-no-terminal.md
+++ b/changelog.d/added/939-markdown-no-terminal.md
@@ -31,3 +31,13 @@
   que e o que mantem `garra chat > arquivo` util para automacao. O `garra ask`
   fica de fora por contrato proprio ja escrito no codigo: ele nunca imprime
   ANSI no stdout.
+- **Tres limites que a auditoria pediu, e um pânico que ela achou.** Acento
+  como primeiro caractere de uma linha dentro de bloco cercado derrubava o CLI
+  — o ramo que decide se a linha e a cerca de fechamento fatiava o primeiro
+  **byte**, e num `é` esse byte nao e fronteira de caractere. Alem disso: o que
+  fica retido esperando um delimitador fechar tem teto (um `**` sem par numa
+  resposta sem quebra de linha segurava a tela e o buffer crescia junto), a
+  linha e compactada enquanto sai (uma resposta de uma linha so ficava inteira
+  em memoria), e o estilo de titulo ou citacao e fechado no fim do turno mesmo
+  sem o `\n` final — antes um turno truncado deixava o proximo prompt em
+  negrito.

--- a/changelog.d/added/939-markdown-no-terminal.md
+++ b/changelog.d/added/939-markdown-no-terminal.md
@@ -1,0 +1,33 @@
+- **A resposta do modelo passa a sair formatada no terminal (#939).** Titulo,
+  negrito, enfase, codigo inline, bloco cercado, lista com marcador ou numero,
+  citacao, link e regra horizontal saem renderizados em vez de com a sintaxe
+  crua na tela.
+- **Sem bufferizar por linha, que era a solucao obvia e errada.** Renderizar a
+  linha inteira quando ela fecha da resultado perfeito e zero cintilacao — e
+  para a prosa: o modelo costuma emitir um paragrafo inteiro como uma unica
+  linha, entao o usuario ficaria olhando para o nada ate o ponto final.
+  Streaming que nao aparece nao e streaming. O renderizador segura so o que
+  ainda pode mudar de significado: poucos caracteres no inicio da linha para
+  decidir o tipo de bloco, e depois a cauda a partir do ultimo delimitador
+  inline ainda sem par. O atraso maximo e de uma palavra.
+- **Um construto partido entre dois deltas continua sendo um construto.** E a
+  mesma classe de problema do filtro ANSI (#996) e tem a mesma forma de
+  solucao — estado que atravessa as chamadas. O teste que importa renderiza
+  cada exemplo em **todo** tamanho de pedaco possivel, e nao num corte
+  escolhido a dedo: o corte que o autor imagina e justamente o que nao quebra.
+- **A prosa quebra na largura do terminal, e a continuacao recebe o recuo do
+  bloco.** E esse alinhamento que justifica quebrar: o terminal ja quebra
+  sozinho no limite direito, mas sempre na coluna zero, e a segunda linha de um
+  item de lista passava a parecer um item novo. Quem mede e
+  `console::measure_text_width`, que ignora escape e conta largura visual —
+  contar bytes erraria com acento e com ideograma.
+- **Bloco cercado nao ganha estilo inline nem quebra.** O criterio de aceite
+  pede que codigo continue facil de copiar: um `*` no meio de um programa e um
+  `*`, e um `\n` que o modelo nao escreveu vira um `\n` que o usuario cola.
+  Linha longa de codigo passa a decisao ao terminal. Pela mesma razao, um bloco
+  unico maior que a linha inteira (URL longa, base64) sai sem quebra inventada.
+- **Sem cor, nada disto acontece — nem um escape.** Saida redirecionada,
+  `NO_COLOR` ou `TERM=dumb` devolvem o texto exatamente como veio, byte a byte,
+  que e o que mantem `garra chat > arquivo` util para automacao. O `garra ask`
+  fica de fora por contrato proprio ja escrito no codigo: ele nunca imprime
+  ANSI no stdout.

--- a/crates/garraia-cli/src/chat.rs
+++ b/crates/garraia-cli/src/chat.rs
@@ -1820,7 +1820,14 @@ mod tests {
         let printed = strip_spinner(&String::from_utf8(out).expect("utf8"));
         assert!(printed.starts_with("d0 "));
         assert!(printed.ends_with("d299 "));
-        assert_eq!(printed.matches(' ').count(), 300);
+        // Separadores, e nao espacos: com a quebra por largura do #939 o
+        // espaco que separa duas palavras vira `\n` quando a linha enche. O
+        // que este teste mede e que os 300 deltas chegaram — e sao 300
+        // separadores de um jeito ou de outro.
+        assert_eq!(printed.matches(char::is_whitespace).count(), 300);
+        for i in 0..300 {
+            assert!(printed.contains(&format!("d{i}")), "faltou o delta d{i}");
+        }
     }
 
     /// On timeout the call future must be dropped (closing the sender) and

--- a/crates/garraia-cli/src/ui/markdown.rs
+++ b/crates/garraia-cli/src/ui/markdown.rs
@@ -1,0 +1,1036 @@
+//! Markdown legivel no terminal, sem quebrar o streaming (#939).
+//!
+//! # O problema que decide o desenho
+//!
+//! O texto do modelo chega em pedacos, e um construto de Markdown pode ser
+//! partido entre dois deltas: `**neg` num, `rito**` no outro. E a mesma classe
+//! de problema do [`super::ansi_filter`], e a solucao tem a mesma forma —
+//! estado que atravessa as chamadas.
+//!
+//! A tentacao e bufferizar ate a quebra de linha e renderizar a linha inteira.
+//! Isso da renderizacao correta e zero cintilacao, mas **para a prosa**: o
+//! modelo costuma emitir um paragrafo inteiro como uma unica linha, entao o
+//! usuario ficaria olhando para o nada ate o paragrafo terminar. Streaming que
+//! nao aparece nao e streaming.
+//!
+//! Entao a regra e outra: **segurar so o que ainda pode mudar de significado.**
+//!
+//! - No comeco da linha, segura ate dar para decidir o tipo do bloco — sao
+//!   poucos caracteres (`# `, `- `, `> `, ```` ``` ````, `1. `). Um `-` sozinho
+//!   ainda pode virar lista (`- item`) ou regra (`---`), entao espera o
+//!   proximo.
+//! - Decidido o bloco, o resto da linha sai incrementalmente, segurando apenas
+//!   a cauda que ainda pode fazer parte de um delimitador inline nao fechado
+//!   (`` ` ``, `**`, `*`, `_`, `[`).
+//!
+//! O atraso maximo e de uma palavra, e nunca de uma linha inteira.
+//!
+//! # Quebra na largura do terminal
+//!
+//! A prosa quebra na largura detectada, e a continuacao recebe o recuo do
+//! bloco: a segunda linha de um item de lista fica alinhada com a primeira em
+//! vez de voltar a coluna zero e se confundir com o item seguinte. E esse
+//! alinhamento, e nao a quebra em si, que justifica quebrar — o terminal ja
+//! quebra sozinho no limite direito, mas sempre na coluna zero.
+//!
+//! E por isso que a emissao e por palavra inteira: para decidir se a palavra
+//! cabe e preciso conhece-la inteira. Quem mede e
+//! [`console::measure_text_width`], que ignora escape e conta largura visual —
+//! contar bytes erraria com acento e com ideograma, e para o lado errado.
+//!
+//! Bloco cercado **nao** quebra: um `\n` que o modelo nao escreveu vira um
+//! `\n` que o usuario cola. La a decisao fica com o terminal.
+//!
+//! # O que nao e estilizado
+//!
+//! Dentro de bloco cercado (```` ``` ````) nao ha estilo inline nem quebra de
+//! linha por largura: o criterio de aceite pede que codigo continue facil de
+//! copiar, e um `*` no meio de um programa e um `*`, nao enfase.
+//!
+//! Sem cor — `NO_COLOR`, saida redirecionada, `TERM=dumb` — nada disto emite
+//! escape nenhum: o texto sai como veio. Isso e o que mantem
+//! `garra chat > arquivo` util para automacao.
+
+use super::conversation::Style;
+
+/// Sequencias usadas na renderizacao. Sao as mesmas famílias que o resto da
+/// interface ja usa, para o visual nao destoar.
+const RESET: &str = "\x1b[0m";
+const BOLD: &str = "\x1b[1m";
+const DIM: &str = "\x1b[2m";
+const ITALICO: &str = "\x1b[3m";
+const CIANO: &str = "\x1b[36m";
+const AMARELO: &str = "\x1b[33m";
+
+/// Quantos caracteres bastam para decidir o tipo de bloco de uma linha.
+///
+/// O maior prefixo que interessa e ```` ```lang ```` e `###### `; sete cobre
+/// os dois com folga. E o teto tambem serve de rede: uma linha que comece com
+/// muitos `-` (uma regra longa) nao fica presa esperando decisao.
+const PREFIXO_MAX: usize = 7;
+
+/// O tipo de bloco em que a linha corrente esta.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Bloco {
+    /// Ainda juntando caracteres para decidir.
+    Indeciso,
+    /// Prosa comum — inclui item de lista e citacao depois do marcador.
+    Texto,
+    /// Dentro de bloco cercado: sai literal.
+    Codigo,
+}
+
+/// O que `decide_traco_ou_lista` concluiu.
+///
+/// Precisa dos tres estados: sem separar "nao e comigo" de "e comigo mas ainda
+/// nao sei", o chamador lia a duvida como negativa e um `- ` virava texto comum
+/// antes de o espaco chegar.
+enum TracoOuLista {
+    NaoEhMeuCaso,
+    Esperando,
+    Decidido(String),
+}
+
+/// Renderiza Markdown incrementalmente para o terminal.
+#[derive(Debug)]
+pub struct MarkdownStream {
+    style: Style,
+    /// Largura util do terminal. `0` desliga a quebra.
+    largura: usize,
+    /// A linha em construcao, do inicio ate o que chegou.
+    linha: String,
+    /// Quantos **bytes** de `linha` ja foram emitidos.
+    emitido: usize,
+    bloco: Bloco,
+    /// `true` entre a cerca de abertura e a de fechamento.
+    em_fence: bool,
+    /// Colunas visiveis ja escritas na linha **fisica** corrente.
+    ///
+    /// Nao e o mesmo que `emitido`: a quebra insere `\n` no meio de uma linha
+    /// logica, e o que decide a proxima quebra e a fisica.
+    coluna: usize,
+    /// A ultima coisa escrita foi parte de uma palavra que pode continuar no
+    /// proximo pedaco?
+    ///
+    /// Um bloco unico maior que a linha sai em varias emissoes, e sem esta
+    /// marca a segunda emissao parecia uma palavra nova e ganhava uma quebra
+    /// no meio — bem no unico caso em que quebrar nao ajuda.
+    palavra_em_curso: bool,
+    /// Com o que comeca a continuacao quando a linha quebra.
+    ///
+    /// E o que faz um item de lista longo continuar parecendo um item: sem
+    /// isto a segunda linha volta a coluna zero e se confunde com o proximo.
+    recuo: String,
+}
+
+impl MarkdownStream {
+    /// `largura` e a largura util do terminal; `0` desliga a quebra.
+    pub fn new(style: Style, largura: usize) -> Self {
+        Self {
+            style,
+            largura,
+            linha: String::new(),
+            emitido: 0,
+            bloco: Bloco::Indeciso,
+            em_fence: false,
+            coluna: 0,
+            palavra_em_curso: false,
+            recuo: String::new(),
+        }
+    }
+
+    /// Consome um pedaco e devolve o que ja da para escrever na tela.
+    pub fn push(&mut self, delta: &str) -> String {
+        // Sem cor, nao ha o que renderizar: o texto sai como veio, e nenhum
+        // escape e inventado. E o caminho de pipe, arquivo e `NO_COLOR`.
+        if !self.style.color {
+            return delta.to_string();
+        }
+
+        let mut saida = String::new();
+        for ch in delta.chars() {
+            if ch == '\n' {
+                saida.push_str(&self.fecha_linha());
+                continue;
+            }
+            self.linha.push(ch);
+            saida.push_str(&self.avanca());
+        }
+        saida
+    }
+
+    /// Fecha o que sobrou. Chamado no fim do turno.
+    pub fn finish(&mut self) -> String {
+        if !self.style.color {
+            return String::new();
+        }
+        let mut saida = self.emite_resto_da_linha();
+        self.linha.clear();
+        self.emitido = 0;
+        self.coluna = 0;
+        self.palavra_em_curso = false;
+        self.recuo.clear();
+        self.bloco = Bloco::Indeciso;
+        // A cerca aberta nao e fechada a forca: o texto acabou assim, e
+        // inventar um fim mudaria o que o modelo disse.
+        if !saida.is_empty() && self.em_fence {
+            saida.push_str(RESET);
+        }
+        saida
+    }
+
+    /// Emite o que a chegada de mais um caractere liberou.
+    fn avanca(&mut self) -> String {
+        if self.bloco == Bloco::Indeciso {
+            match self.decide_bloco() {
+                None => return String::new(), // ainda esperando
+                Some(prefixo) => return prefixo,
+            }
+        }
+        if self.bloco == Bloco::Codigo {
+            // Codigo sai literal, sem segurar nada.
+            return self.emite_ate(self.linha.len());
+        }
+        let limite = self.limite_de_emissao();
+        self.emite_ate(limite)
+    }
+
+    /// Tenta decidir o tipo de bloco. `Some(prefixo_renderizado)` quando
+    /// decidiu; `None` quando ainda faltam caracteres.
+    fn decide_bloco(&mut self) -> Option<String> {
+        let l = self.linha.clone();
+        let l = l.as_str();
+
+        if self.em_fence {
+            // Dentro de cerca, so a propria cerca fecha.
+            if l == "```" || (l.len() >= 3 && l.starts_with("```")) {
+                self.em_fence = false;
+                self.bloco = Bloco::Texto;
+                self.emitido = self.linha.len();
+                self.coluna = 3;
+                return Some(format!("{DIM}```{RESET}"));
+            }
+            if l.chars().count() >= 3 || !"`".starts_with(&l[..l.len().min(1)]) {
+                self.bloco = Bloco::Codigo;
+                return Some(self.emite_ate(self.linha.len()));
+            }
+            return None;
+        }
+
+        // Cerca de abertura.
+        if l.starts_with("```") {
+            self.em_fence = true;
+            self.bloco = Bloco::Codigo;
+            self.emitido = self.linha.len();
+            self.coluna = l.chars().count();
+            return Some(format!("{DIM}{l}{RESET}"));
+        }
+        if "```".starts_with(l) {
+            return None; // "`" ou "``": ainda pode virar cerca
+        }
+
+        // Titulo: `#` ate `######` seguido de espaco.
+        if l.starts_with('#') {
+            let sustenidos = l.chars().take_while(|c| *c == '#').count();
+            if sustenidos <= 6 && l.len() > sustenidos {
+                if l.as_bytes()[sustenidos] == b' ' {
+                    self.bloco = Bloco::Texto;
+                    self.emitido = sustenidos + 1;
+                    // O `# ` some da tela, entao a coluna nao anda.
+                    self.coluna = 0;
+                    return Some(format!("{BOLD}{CIANO}"));
+                }
+                // `#texto` nao e titulo em Markdown.
+                self.bloco = Bloco::Texto;
+                return Some(self.emite_ate(self.limite_de_emissao()));
+            }
+            if sustenidos > 6 {
+                self.bloco = Bloco::Texto;
+                return Some(self.emite_ate(self.limite_de_emissao()));
+            }
+            return None;
+        }
+
+        // Citacao.
+        if l.starts_with("> ") {
+            self.bloco = Bloco::Texto;
+            self.emitido = 2;
+            self.coluna = 2;
+            self.recuo = "  ".to_string();
+            let barra = if self.style.unicode { "│ " } else { "| " };
+            return Some(format!("{DIM}{barra}"));
+        }
+        if l == ">" {
+            return None;
+        }
+
+        // Regra horizontal e lista compartilham o primeiro caractere.
+        match self.decide_traco_ou_lista() {
+            TracoOuLista::NaoEhMeuCaso => {}
+            // Sem esta distincao, "ainda nao sei" era lido como "nao e lista" e
+            // um `- ` virava texto comum antes de o espaco chegar.
+            TracoOuLista::Esperando => return None,
+            TracoOuLista::Decidido(r) => return Some(r),
+        }
+
+        // Lista numerada: digitos seguidos de `. `.
+        let digitos = l.chars().take_while(|c| c.is_ascii_digit()).count();
+        if digitos > 0 {
+            if l.len() == digitos {
+                return if digitos < PREFIXO_MAX {
+                    None
+                } else {
+                    self.vira_texto()
+                };
+            }
+            if l.as_bytes()[digitos] == b'.' {
+                if l.len() == digitos + 1 {
+                    return None;
+                }
+                if l.as_bytes()[digitos + 1] == b' ' {
+                    self.bloco = Bloco::Texto;
+                    self.emitido = digitos + 2;
+                    // "  " + digitos + "." + " "
+                    self.coluna = digitos + 4;
+                    self.recuo = " ".repeat(digitos + 4);
+                    let n = &l[..digitos];
+                    return Some(format!("  {AMARELO}{n}.{RESET} "));
+                }
+            }
+            return self.vira_texto();
+        }
+
+        self.vira_texto()
+    }
+
+    /// `-`, `*` e `_` no inicio da linha podem ser lista, regra ou enfase.
+    fn decide_traco_ou_lista(&mut self) -> TracoOuLista {
+        let l = self.linha.clone();
+        let l = l.as_str();
+        let Some(primeiro) = l.chars().next() else {
+            return TracoOuLista::NaoEhMeuCaso;
+        };
+        if !matches!(primeiro, '-' | '*' | '_' | '+') {
+            return TracoOuLista::NaoEhMeuCaso;
+        }
+
+        // `- ` / `* ` / `+ ` -> item de lista.
+        if l.len() >= 2 && l.as_bytes()[1] == b' ' && primeiro != '_' {
+            self.bloco = Bloco::Texto;
+            self.emitido = 2;
+            // "  " + marcador + " "
+            self.coluna = 4;
+            self.recuo = "    ".to_string();
+            let ponto = if self.style.unicode { "•" } else { "*" };
+            return TracoOuLista::Decidido(format!("  {AMARELO}{ponto}{RESET} "));
+        }
+
+        // Tres ou mais iguais -> regra horizontal.
+        let iguais = l.chars().take_while(|c| *c == primeiro).count();
+        if iguais >= 3 {
+            self.bloco = Bloco::Texto;
+            self.emitido = l.len();
+            self.coluna = 24;
+            let traco = if self.style.unicode { "─" } else { "-" };
+            return TracoOuLista::Decidido(format!("{DIM}{}{RESET}", traco.repeat(24)));
+        }
+        if l.len() == iguais && iguais < 3 {
+            // `-` ou `--` ainda pode virar `- item` ou `---`.
+            return TracoOuLista::Esperando;
+        }
+
+        match self.vira_texto() {
+            Some(t) => TracoOuLista::Decidido(t),
+            None => TracoOuLista::Esperando,
+        }
+    }
+
+    fn vira_texto(&mut self) -> Option<String> {
+        self.bloco = Bloco::Texto;
+        Some(self.emite_ate(self.limite_de_emissao()))
+    }
+
+    /// Ate onde da para emitir: nem partir construto, nem partir palavra.
+    ///
+    /// # Por que uma varredura so
+    ///
+    /// Sao dois limites, e eles **nao** sao independentes. O primeiro segura
+    /// da ultima abertura nao fechada em diante: se `**neg` chegou e o `**` de
+    /// fechamento nao, emitir agora mostraria os asteriscos crus e nao daria
+    /// mais para estiliza-los. O segundo, quando ha quebra por largura, segura
+    /// a palavra incompleta — sem conhece-la inteira nao da para saber se ela
+    /// cabe.
+    ///
+    /// O segundo sozinho corta dentro do primeiro: em
+    /// `[o site](https://exemplo.org)` o ultimo espaco fica **dentro** do
+    /// link, e cortar ali entrega ao estilizador um `[o` sem o `](`, que sai
+    /// cru na tela. Por isso o espaco so conta quando esta fora de codigo
+    /// inline, enfase e link — o que exige a mesma varredura que acha a
+    /// abertura pendente.
+    fn limite_de_emissao(&self) -> usize {
+        let bytes = self.linha.as_bytes();
+        let mut i = self.emitido;
+        // Posicao e largura do delimitador aberto ainda sem par.
+        let mut aberto: Option<(usize, usize)> = None;
+        let mut em_codigo = false;
+        // Inicio do ultimo grupo de espacos visto **fora** de qualquer
+        // construto. E onde a palavra incompleta comeca a ser segurada.
+        let mut espaco_livre: Option<usize> = None;
+        while i < bytes.len() {
+            let b = bytes[i];
+            if b == b'`' {
+                if em_codigo {
+                    em_codigo = false;
+                    aberto = None;
+                } else {
+                    em_codigo = true;
+                    aberto = Some((i, 1));
+                }
+                i += 1;
+                continue;
+            }
+            if em_codigo {
+                i += 1;
+                continue;
+            }
+            match b {
+                b'*' | b'_' => {
+                    // A largura do fechamento tem de casar com a da abertura.
+                    //
+                    // Sem isso, o `*` final de `**forte*` — que ainda espera o
+                    // segundo asterisco — fechava o `**` do inicio, e o trecho
+                    // saia emitido no meio do delimitador. O estilo ficava
+                    // errado e nao dava mais para consertar: o texto ja estava
+                    // na tela.
+                    let largura = if i + 1 < bytes.len() && bytes[i + 1] == b {
+                        2
+                    } else {
+                        1
+                    };
+                    match aberto {
+                        Some((_, w)) if w == largura => aberto = None,
+                        Some(_) => {}
+                        None => aberto = Some((i, largura)),
+                    }
+                    i += largura;
+                }
+                b'[' => {
+                    aberto = Some((i, 1));
+                    i += 1;
+                }
+                b')' => {
+                    aberto = None;
+                    i += 1;
+                }
+                _ => {
+                    if aberto.is_none() && (b as char).is_whitespace() {
+                        // So o **inicio** do grupo: assim o espaco que separa
+                        // duas palavras viaja com a segunda, e a quebra
+                        // consegue descarta-lo em vez de deixa-lo pendurado.
+                        let anterior_era_espaco = i > self.emitido
+                            && (bytes[i - 1] as char).is_whitespace()
+                            && espaco_livre.is_some();
+                        if !anterior_era_espaco {
+                            espaco_livre = Some(i);
+                        }
+                    }
+                    i += 1;
+                }
+            }
+        }
+
+        let construto = aberto.map(|(pos, _)| pos).unwrap_or(bytes.len());
+        if self.largura == 0 {
+            return construto;
+        }
+        match espaco_livre {
+            Some(pos) => construto.min(pos),
+            // Sem espaco livre nenhum: segurar ate o `\n` pararia o streaming
+            // num bloco unico maior que a linha (URL longa, base64), entao ele
+            // sai e o terminal decide onde parte.
+            None if console::measure_text_width(&self.linha[self.emitido..]) > self.largura => {
+                construto
+            }
+            None => self.emitido,
+        }
+    }
+
+    /// Escreve um trecho ja estilizado quebrando na largura do terminal.
+    ///
+    /// Mede com [`console::measure_text_width`], que ignora escape e conta
+    /// largura visual — um `\x1b[1m` ocupa zero colunas e um ideograma ocupa
+    /// duas. Contar bytes quebraria nos dois casos, e para o lado errado.
+    fn quebra(&mut self, estilizado: &str) -> String {
+        if self.largura == 0 {
+            self.coluna += console::measure_text_width(estilizado);
+            return estilizado.to_string();
+        }
+        let recuo_largura = self.recuo.chars().count();
+        let mut saida = String::new();
+        for grupo in grupos(estilizado) {
+            let largura_do_grupo = console::measure_text_width(grupo);
+            if grupo.starts_with(char::is_whitespace) {
+                saida.push_str(grupo);
+                self.coluna += largura_do_grupo;
+                self.palavra_em_curso = false;
+                continue;
+            }
+            // Grupo que nao caberia nem numa linha vazia (URL longa, base64):
+            // quebrar antes dele nao resolve nada e so gasta uma linha. Passa
+            // a decisao ao terminal.
+            let cabe_sozinho = largura_do_grupo + recuo_largura <= self.largura;
+            if !self.palavra_em_curso
+                && cabe_sozinho
+                && self.coluna + largura_do_grupo > self.largura
+                && self.coluna > recuo_largura
+            {
+                apara_espacos(&mut saida, &mut self.coluna);
+                saida.push('\n');
+                saida.push_str(&self.recuo);
+                self.coluna = recuo_largura;
+            }
+            saida.push_str(grupo);
+            self.coluna += largura_do_grupo;
+            self.palavra_em_curso = true;
+        }
+        saida
+    }
+
+    /// Emite `linha[emitido..limite]` com estilo inline aplicado.
+    fn emite_ate(&mut self, limite: usize) -> String {
+        let limite = limite.min(self.linha.len());
+        if limite <= self.emitido {
+            return String::new();
+        }
+        // Nao corta no meio de um caractere multibyte.
+        let mut fim = limite;
+        while fim > self.emitido && !self.linha.is_char_boundary(fim) {
+            fim -= 1;
+        }
+        if fim <= self.emitido {
+            return String::new();
+        }
+        let trecho = self.linha[self.emitido..fim].to_string();
+        self.emitido = fim;
+        if self.bloco == Bloco::Codigo {
+            // Codigo nao quebra: o criterio de aceite pede que continue facil
+            // de copiar, e um `\n` que o modelo nao escreveu vira um `\n` que
+            // o usuario cola. Linha longa passa a decisao ao terminal.
+            self.coluna += trecho.chars().count();
+            return trecho;
+        }
+        let estilizado = estiliza_inline(&trecho, self.style);
+        self.quebra(&estilizado)
+    }
+
+    fn emite_resto_da_linha(&mut self) -> String {
+        if self.bloco == Bloco::Indeciso {
+            self.bloco = Bloco::Texto;
+        }
+        self.emite_ate(self.linha.len())
+    }
+
+    /// Termina a linha corrente e devolve o que faltava mais o `\n`.
+    fn fecha_linha(&mut self) -> String {
+        let era_titulo = self.linha.starts_with('#')
+            && !self.em_fence
+            && self.linha.chars().take_while(|c| *c == '#').count() <= 6;
+        let mut saida = self.emite_resto_da_linha();
+        if era_titulo || self.linha.starts_with("> ") {
+            saida.push_str(RESET);
+        }
+        saida.push('\n');
+        self.linha.clear();
+        self.emitido = 0;
+        self.coluna = 0;
+        self.palavra_em_curso = false;
+        self.recuo.clear();
+        // Toda linha nova comeca indecisa, dentro ou fora de cerca: e a
+        // propria linha que diz se e a cerca de fechamento ou codigo.
+        self.bloco = Bloco::Indeciso;
+        saida
+    }
+}
+
+/// Aplica negrito, enfase e codigo inline a um trecho ja delimitado.
+///
+/// Funciona sobre trecho, e nao sobre linha, porque o chamador so entrega o que
+/// ja esta fechado — ver `MarkdownStream::limite_de_emissao`.
+fn estiliza_inline(trecho: &str, style: Style) -> String {
+    if !style.color {
+        return trecho.to_string();
+    }
+    let mut fora = String::with_capacity(trecho.len());
+    let bytes = trecho.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        // Codigo inline vem primeiro: dentro dele, `*` e `*`.
+        //
+        // O `fim > i + 1` exige conteudo, como o `achar_par` ja exigia para
+        // `*` e `_`. Sem ele, uma crase colada na outra virava um vao vazio
+        // colorido: um ``` no meio da linha saia como um par de escapes
+        // seguido de uma crase solta. Achado rodando o binario.
+        if bytes[i] == b'`'
+            && let Some(fim) = trecho[i + 1..].find('`').map(|p| i + 1 + p)
+            && fim > i + 1
+        {
+            fora.push_str(CIANO);
+            fora.push_str(&trecho[i + 1..fim]);
+            fora.push_str(RESET);
+            i = fim + 1;
+            continue;
+        }
+        if (bytes[i] == b'*' || bytes[i] == b'_')
+            && i + 1 < bytes.len()
+            && bytes[i + 1] == bytes[i]
+            && let Some(fim) = achar_par(trecho, i + 2, bytes[i], 2)
+        {
+            fora.push_str(BOLD);
+            fora.push_str(&trecho[i + 2..fim]);
+            fora.push_str(RESET);
+            i = fim + 2;
+            continue;
+        }
+        if (bytes[i] == b'*' || bytes[i] == b'_')
+            && let Some(fim) = achar_par(trecho, i + 1, bytes[i], 1)
+        {
+            fora.push_str(ITALICO);
+            fora.push_str(&trecho[i + 1..fim]);
+            fora.push_str(RESET);
+            i = fim + 1;
+            continue;
+        }
+        // Link `[texto](url)`: mostra os dois. Esconder a URL num terminal
+        // tiraria justamente o que da para copiar.
+        if bytes[i] == b'['
+            && let Some(fecha) = trecho[i..].find("](").map(|p| i + p)
+            && let Some(fim) = trecho[fecha + 2..].find(')').map(|p| fecha + 2 + p)
+        {
+            fora.push_str(&trecho[i + 1..fecha]);
+            fora.push(' ');
+            fora.push_str(DIM);
+            fora.push('(');
+            fora.push_str(&trecho[fecha + 2..fim]);
+            fora.push(')');
+            fora.push_str(RESET);
+            i = fim + 1;
+            continue;
+        }
+        let ch_len = trecho[i..].chars().next().map(char::len_utf8).unwrap_or(1);
+        fora.push_str(&trecho[i..i + ch_len]);
+        i += ch_len;
+    }
+    fora
+}
+
+/// Parte o trecho em grupos alternados de espaco e nao-espaco.
+///
+/// Uma sequencia de escape nunca contem espaco, entao ela sempre acompanha a
+/// palavra a que se aplica — o estilo nunca fica orfao numa linha por causa de
+/// uma quebra.
+fn grupos(s: &str) -> Vec<&str> {
+    let mut saida = Vec::new();
+    let mut inicio = 0;
+    let mut atual: Option<bool> = None;
+    for (i, c) in s.char_indices() {
+        let espaco = c.is_whitespace();
+        match atual {
+            Some(anterior) if anterior != espaco => {
+                saida.push(&s[inicio..i]);
+                inicio = i;
+                atual = Some(espaco);
+            }
+            None => atual = Some(espaco),
+            _ => {}
+        }
+    }
+    if inicio < s.len() {
+        saida.push(&s[inicio..]);
+    }
+    saida
+}
+
+/// Tira os espacos que ficaram no fim da linha antes de quebra-la.
+///
+/// O espaco que separava duas palavras nao deve virar o ultimo caractere da
+/// linha: em selecao de texto e em `cat -A` ele aparece, e ninguem o escreveu.
+fn apara_espacos(saida: &mut String, coluna: &mut usize) {
+    let aparado = saida.trim_end_matches(char::is_whitespace).len();
+    if aparado < saida.len() {
+        *coluna -= console::measure_text_width(&saida[aparado..]);
+        saida.truncate(aparado);
+    }
+}
+
+/// Acha o fechamento de um delimitador de `largura` bytes iguais a `delim`.
+fn achar_par(s: &str, de: usize, delim: u8, largura: usize) -> Option<usize> {
+    let b = s.as_bytes();
+    let mut i = de;
+    while i + largura <= b.len() {
+        if b[i] == delim && (largura == 1 || b[i + 1] == delim) {
+            // Delimitador colado no abre (`**` vazio) nao conta.
+            return if i > de { Some(i) } else { None };
+        }
+        i += 1;
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Larga o bastante para os testes que nao sao sobre quebra nao quebrarem.
+    const LARGURA_DE_TESTE: usize = 200;
+
+    fn rico() -> MarkdownStream {
+        MarkdownStream::new(Style::RICH, LARGURA_DE_TESTE)
+    }
+
+    fn renderiza(texto: &str) -> String {
+        let mut m = rico();
+        let mut s = m.push(texto);
+        s.push_str(&m.finish());
+        s
+    }
+
+    /// Renderiza o mesmo texto cortado em **todo** tamanho de pedaco possivel.
+    ///
+    /// E o teste que importa num renderizador de streaming: um construto pode
+    /// chegar partido em qualquer ponto, e escolher um corte a dedo testa o
+    /// corte que o autor imaginou — que e justamente o que nao quebra.
+    fn renderiza_em_todos_os_cortes(texto: &str) -> Vec<String> {
+        let chars: Vec<char> = texto.chars().collect();
+        (1..=chars.len())
+            .map(|n| {
+                let mut m = rico();
+                let mut saida = String::new();
+                for pedaco in chars.chunks(n) {
+                    saida.push_str(&m.push(&pedaco.iter().collect::<String>()));
+                }
+                saida.push_str(&m.finish());
+                saida
+            })
+            .collect()
+    }
+
+    #[test]
+    fn o_resultado_nao_depende_de_como_o_texto_foi_partido() {
+        for texto in [
+            "**negrito** no meio\n",
+            "um `codigo` inline\n",
+            "# Titulo\ntexto depois\n",
+            "- item um\n- item dois\n",
+            "1. primeiro\n2. segundo\n",
+            "> uma citacao\n",
+            "---\n",
+            "veja [o site](https://exemplo.org) ali\n",
+            "```rust\nlet x = *y;\n```\n",
+            "misto: **forte** e `codigo` e *enfase*\n",
+        ] {
+            let saidas = renderiza_em_todos_os_cortes(texto);
+            let primeira = &saidas[0];
+            for (i, s) in saidas.iter().enumerate() {
+                assert_eq!(
+                    s,
+                    primeira,
+                    "corte de {} caractere(s) mudou o resultado de {texto:?}",
+                    i + 1
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn negrito_enfase_e_codigo_inline() {
+        let s = renderiza("**forte** e *fraco* e `codigo`\n");
+        assert!(s.contains(&format!("{BOLD}forte{RESET}")));
+        assert!(s.contains(&format!("{ITALICO}fraco{RESET}")));
+        assert!(s.contains(&format!("{CIANO}codigo{RESET}")));
+        assert!(!s.contains("**"), "os marcadores nao ficam na tela");
+    }
+
+    #[test]
+    fn titulo_lista_citacao_e_regra() {
+        let t = renderiza("# Um titulo\n");
+        assert!(t.contains("Um titulo") && t.contains(BOLD));
+        assert!(!t.contains("# "), "o sustenido nao vai para a tela");
+
+        let l = renderiza("- primeiro\n");
+        assert!(l.contains("primeiro") && l.contains('•'));
+
+        let n = renderiza("1. um\n");
+        assert!(n.contains("um") && n.contains("1."));
+
+        let c = renderiza("> citado\n");
+        assert!(c.contains("citado") && c.contains('│'));
+
+        let r = renderiza("---\n");
+        assert!(r.contains('─') && !r.contains("---"));
+    }
+
+    /// Codigo cercado sai literal — e o criterio "facil de copiar".
+    #[test]
+    fn bloco_de_codigo_sai_sem_estilo_inline() {
+        let s = renderiza("```rust\nlet a = *b + **c;\nlet s = `x`;\n```\n");
+        assert!(
+            s.contains("let a = *b + **c;"),
+            "os asteriscos do codigo tem de sobreviver: {s:?}"
+        );
+        assert!(
+            s.contains("let s = `x`;"),
+            "as crases do codigo tambem: {s:?}"
+        );
+        assert!(!s.contains(ITALICO), "nada de enfase dentro de codigo");
+    }
+
+    /// Sem cor, nao sai um unico escape — e o texto e identico ao original.
+    ///
+    /// E o criterio "redirected output does not contain unwanted ANSI escapes"
+    /// e o `NO_COLOR` de uma vez.
+    #[test]
+    fn sem_cor_o_texto_atravessa_intacto() {
+        let entrada = "# Titulo\n- item **forte**\n```\ncodigo\n```\n> citado\n";
+        let mut m = MarkdownStream::new(Style::PLAIN, LARGURA_DE_TESTE);
+        let mut s = m.push(entrada);
+        s.push_str(&m.finish());
+
+        assert_eq!(s, entrada, "sem cor o texto sai como veio");
+        assert!(!s.contains('\x1b'), "nenhum escape");
+    }
+
+    /// O link mostra texto **e** URL: esconder a URL tira o que da para copiar.
+    #[test]
+    fn link_mostra_texto_e_url() {
+        let s = renderiza("veja [o site](https://exemplo.org) ali\n");
+        assert!(s.contains("o site"));
+        assert!(s.contains("https://exemplo.org"));
+        assert!(!s.contains("]("), "a sintaxe crua nao fica");
+    }
+
+    /// A prosa nao espera a quebra de linha para aparecer.
+    ///
+    /// E a razao de o renderizador nao bufferizar por linha: o modelo emite
+    /// paragrafo inteiro como uma linha so, e o usuario ficaria olhando para o
+    /// nada ate o ponto final.
+    #[test]
+    fn prosa_aparece_antes_da_quebra_de_linha() {
+        let mut m = rico();
+        let saida = m.push("Este e um paragrafo longo que ainda nao terminou");
+        assert!(
+            saida.contains("paragrafo longo"),
+            "o texto tem de sair enquanto chega, e nao so no \\n: {saida:?}"
+        );
+    }
+
+    /// So a cauda ambigua fica retida, e ela sai no `finish`.
+    #[test]
+    fn delimitador_nao_fechado_sai_no_fim() {
+        let mut m = rico();
+        let durante = m.push("texto **aberto");
+        // Sem o espaco: com a quebra ligada, o espaco que separa duas palavras
+        // viaja com a segunda, para a quebra poder descarta-lo se ela cair ali.
+        assert!(durante.contains("texto"), "o que e certo sai na hora");
+        assert!(
+            !durante.contains("aberto"),
+            "o que ainda pode virar negrito espera: {durante:?}"
+        );
+
+        let fim = m.finish();
+        assert!(fim.contains("aberto"), "e nada se perde no fim: {fim:?}");
+    }
+
+    /// Acento nao pode ser cortado no meio.
+    #[test]
+    fn corte_nao_quebra_caractere_multibyte() {
+        for saida in renderiza_em_todos_os_cortes("ação e coração **ç**\n") {
+            assert!(saida.contains("ação"), "saiu: {saida:?}");
+            assert!(saida.contains("coração"));
+        }
+    }
+
+    /// `#texto` sem espaco nao e titulo, e `#######` tambem nao.
+    #[test]
+    fn sustenido_sem_espaco_nao_vira_titulo() {
+        let s = renderiza("#hashtag e nao titulo\n");
+        assert!(s.contains("#hashtag"), "o sustenido fica: {s:?}");
+
+        let sete = renderiza("####### sete\n");
+        assert!(
+            sete.contains("#######"),
+            "sete sustenidos nao e titulo: {sete:?}"
+        );
+    }
+
+    fn estreito(largura: usize) -> MarkdownStream {
+        MarkdownStream::new(Style::RICH, largura)
+    }
+
+    fn sem_escape(s: &str) -> String {
+        let mut fora = String::new();
+        let mut chars = s.chars();
+        while let Some(c) = chars.next() {
+            if c == '\x1b' {
+                for d in chars.by_ref() {
+                    if d.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+                continue;
+            }
+            fora.push(c);
+        }
+        fora
+    }
+
+    /// Nenhuma linha passa da largura, e nenhuma palavra e partida ao meio.
+    #[test]
+    fn a_prosa_quebra_na_largura() {
+        let mut m = estreito(24);
+        let mut s = m.push("uma frase razoavelmente longa que precisa quebrar em varias linhas\n");
+        s.push_str(&m.finish());
+        let limpo = sem_escape(&s);
+
+        for linha in limpo.lines() {
+            assert!(
+                console::measure_text_width(linha) <= 24,
+                "linha passou de 24 colunas: {linha:?}"
+            );
+        }
+        assert!(limpo.lines().count() > 1, "quebrou mesmo: {limpo:?}");
+        // Nenhuma palavra do original foi partida.
+        for palavra in
+            "uma frase razoavelmente longa que precisa quebrar em varias linhas".split_whitespace()
+        {
+            assert!(
+                limpo.contains(palavra),
+                "palavra {palavra:?} partida: {limpo:?}"
+            );
+        }
+    }
+
+    /// A continuacao de um item de lista fica alinhada com o texto do item.
+    ///
+    /// E o motivo de existir a quebra: o terminal tambem quebraria, mas na
+    /// coluna zero, e a segunda linha pareceria um item novo.
+    #[test]
+    fn a_continuacao_do_item_recebe_o_recuo() {
+        let mut m = estreito(24);
+        let mut s = m.push("- um item de lista bastante comprido aqui\n");
+        s.push_str(&m.finish());
+        let limpo = sem_escape(&s);
+        let linhas: Vec<&str> = limpo.lines().collect();
+
+        assert!(linhas.len() > 1, "precisava quebrar: {limpo:?}");
+        for continuacao in &linhas[1..] {
+            assert!(
+                continuacao.starts_with("    "),
+                "continuacao sem recuo: {continuacao:?}"
+            );
+        }
+    }
+
+    /// Codigo cercado nao ganha quebra: um `\n` inventado vira um `\n` colado.
+    #[test]
+    fn bloco_de_codigo_nao_quebra_na_largura() {
+        let longa = "let resultado = funcao_com_nome_bem_longo(argumento_um, argumento_dois);";
+        let mut m = estreito(24);
+        let mut s = m.push(&format!("```rust\n{longa}\n```\n"));
+        s.push_str(&m.finish());
+        let limpo = sem_escape(&s);
+
+        assert!(
+            limpo.lines().any(|l| l == longa),
+            "a linha de codigo tem de sair inteira: {limpo:?}"
+        );
+    }
+
+    /// Uma palavra maior que a linha inteira sai — nao trava o streaming, e
+    /// nao ganha uma quebra que ninguem escreveu.
+    ///
+    /// Segurar ate o `\n` deixaria a tela parada numa URL longa ou num base64.
+    /// E quebra-la nao ajudaria: ela estoura a linha de qualquer jeito, entao
+    /// quem parte e o terminal — e uma URL colada de volta continua inteira.
+    #[test]
+    fn palavra_maior_que_a_linha_nao_prende_a_saida() {
+        let gigante = "a".repeat(60);
+        let mut m = estreito(24);
+        let durante = m.push(&gigante);
+        assert!(
+            durante.len() > 24,
+            "o bloco unico maior que a linha tem de ir saindo: {durante:?}"
+        );
+
+        let tudo = format!("{durante}{}", m.finish());
+        assert!(tudo.contains(&gigante), "e sair inteiro: {tudo:?}");
+        assert!(!tudo.contains('\n'), "sem quebra inventada: {tudo:?}");
+    }
+
+    /// Com a quebra ligada, o corte do delta continua sem mudar o resultado.
+    #[test]
+    fn a_quebra_nao_depende_de_como_o_texto_foi_partido() {
+        let texto = "- um item de lista bastante comprido aqui\nprosa longa que tambem quebra em mais de uma linha\n";
+        let chars: Vec<char> = texto.chars().collect();
+        let saidas: Vec<String> = (1..=chars.len())
+            .map(|n| {
+                let mut m = estreito(24);
+                let mut saida = String::new();
+                for pedaco in chars.chunks(n) {
+                    saida.push_str(&m.push(&pedaco.iter().collect::<String>()));
+                }
+                saida.push_str(&m.finish());
+                saida
+            })
+            .collect();
+        for (i, s) in saidas.iter().enumerate() {
+            assert_eq!(
+                s,
+                &saidas[0],
+                "corte de {} caractere(s) mudou a quebra",
+                i + 1
+            );
+        }
+    }
+
+    /// Nenhuma linha quebrada termina em espaco.
+    #[test]
+    fn a_quebra_nao_deixa_espaco_pendurado() {
+        let mut m = estreito(24);
+        let mut s = m.push("uma frase razoavelmente longa que precisa quebrar\n");
+        s.push_str(&m.finish());
+        for linha in sem_escape(&s).lines() {
+            assert_eq!(
+                linha,
+                linha.trim_end(),
+                "linha com espaco no fim: {linha:?}"
+            );
+        }
+    }
+
+    /// Crase colada em crase nao vira um vao vazio colorido.
+    ///
+    /// Achado rodando o binario: uma linha com ``` no meio saia como um par de
+    /// escapes seguido de uma crase solta e do resto do texto.
+    #[test]
+    fn crase_sem_conteudo_fica_literal() {
+        let s = renderiza("use ``` para cercar\n");
+        assert!(s.contains("```"), "as tres crases ficam: {s:?}");
+        assert!(s.contains("para cercar"));
+        assert!(
+            !s.contains(&format!("{CIANO}{RESET}")),
+            "nada de vao vazio colorido: {s:?}"
+        );
+
+        let vazio = renderiza("um `` vazio\n");
+        assert!(vazio.contains("``"), "as duas crases ficam: {vazio:?}");
+    }
+
+    /// Uma linha que so tem `-` ou `--` nao trava esperando virar regra.
+    #[test]
+    fn traco_curto_nao_fica_preso() {
+        let mut m = rico();
+        let mut tudo = m.push("--");
+        tudo.push_str(&m.finish());
+        assert!(tudo.contains("--"), "o que chegou tem de sair: {tudo:?}");
+    }
+}

--- a/crates/garraia-cli/src/ui/markdown.rs
+++ b/crates/garraia-cli/src/ui/markdown.rs
@@ -62,6 +62,29 @@ const ITALICO: &str = "\x1b[3m";
 const CIANO: &str = "\x1b[36m";
 const AMARELO: &str = "\x1b[33m";
 
+/// Teto do que fica retido esperando um delimitador fechar.
+///
+/// Sem ele, `**` sem par e uma linha sem `\n` bastam para o buffer crescer sem
+/// limite: `limite_de_emissao` devolveria a posicao do `**` para sempre e nada
+/// sairia. Passado o teto, o texto sai cru — os asteriscos aparecem, que e
+/// melhor do que a tela parada e a memoria subindo. Mesma forma do
+/// `MAX_DENTRO_DE_SEQUENCIA` do [`super::ansi_filter`].
+///
+/// 1 KiB e folgado para o que existe de verdade — a URL mais longa de um link,
+/// a frase mais longa em negrito — e o valor tambem e o custo: a varredura le
+/// o pendente inteiro a cada caractere, entao o teto e o multiplicador do pior
+/// caso (uma linha sem espaco nenhum, tipo base64). Oito vezes maior custaria
+/// oito vezes mais e nao cobriria nenhum construto real a mais.
+const MAX_RETIDO: usize = 1024;
+
+/// A partir de quanto ja emitido vale compactar a linha.
+///
+/// `emitido` e indice dentro de `linha`, entao o que ja foi para a tela fica
+/// no buffer ate a proxima quebra de linha. Numa resposta de uma linha so
+/// (JSON, base64) isso e a resposta inteira em memoria. Compactar a cada
+/// caractere seria O(n²); a cada quilobyte e amortizado.
+const COMPACTA_ACIMA_DE: usize = 4 * 1024;
+
 /// Quantos caracteres bastam para decidir o tipo de bloco de uma linha.
 ///
 /// O maior prefixo que interessa e ```` ```lang ```` e `###### `; sete cobre
@@ -116,6 +139,14 @@ pub struct MarkdownStream {
     /// marca a segunda emissao parecia uma palavra nova e ganhava uma quebra
     /// no meio — bem no unico caso em que quebrar nao ajuda.
     palavra_em_curso: bool,
+    /// O bloco corrente abriu estilo que so fecha no fim da linha?
+    ///
+    /// Titulo e citacao emitem o escape no prefixo e o `RESET` na quebra de
+    /// linha. Quando o turno acaba sem `\n` — truncamento, timeout, ou o
+    /// modelo simplesmente nao emitiu — o estilo ficava aberto e o proximo
+    /// prompt saia em negrito. Derivar isso de `linha.starts_with('#')` no
+    /// fim nao funciona mais: a linha e compactada enquanto sai.
+    fecha_com_reset: bool,
     /// Com o que comeca a continuacao quando a linha quebra.
     ///
     /// E o que faz um item de lista longo continuar parecendo um item: sem
@@ -135,6 +166,7 @@ impl MarkdownStream {
             em_fence: false,
             coluna: 0,
             palavra_em_curso: false,
+            fecha_com_reset: false,
             recuo: String::new(),
         }
     }
@@ -172,10 +204,13 @@ impl MarkdownStream {
         self.recuo.clear();
         self.bloco = Bloco::Indeciso;
         // A cerca aberta nao e fechada a forca: o texto acabou assim, e
-        // inventar um fim mudaria o que o modelo disse.
-        if !saida.is_empty() && self.em_fence {
+        // inventar um fim mudaria o que o modelo disse. Mas o **estilo** e
+        // fechado sempre: um titulo sem `\n` no fim deixava o terminal em
+        // negrito e o proximo prompt saia estilizado.
+        if self.fecha_com_reset || (!saida.is_empty() && self.em_fence) {
             saida.push_str(RESET);
         }
+        self.fecha_com_reset = false;
         saida
     }
 
@@ -210,7 +245,12 @@ impl MarkdownStream {
                 self.coluna = 3;
                 return Some(format!("{DIM}```{RESET}"));
             }
-            if l.chars().count() >= 3 || !"`".starts_with(&l[..l.len().min(1)]) {
+            // `l.starts_with('`')`, e nao um fatiamento por byte: `&l[..1]`
+            // entra em panico quando o primeiro caractere e multibyte, e o
+            // primeiro caractere de uma linha de codigo e multibyte sempre que
+            // alguem escreve `# Acao` ou `"resume"`. Achado na auditoria, com
+            // contraexemplo — o CLI caia inteiro.
+            if l.chars().count() >= 3 || !l.starts_with('`') {
                 self.bloco = Bloco::Codigo;
                 return Some(self.emite_ate(self.linha.len()));
             }
@@ -238,6 +278,7 @@ impl MarkdownStream {
                     self.emitido = sustenidos + 1;
                     // O `# ` some da tela, entao a coluna nao anda.
                     self.coluna = 0;
+                    self.fecha_com_reset = true;
                     return Some(format!("{BOLD}{CIANO}"));
                 }
                 // `#texto` nao e titulo em Markdown.
@@ -257,6 +298,7 @@ impl MarkdownStream {
             self.emitido = 2;
             self.coluna = 2;
             self.recuo = "  ".to_string();
+            self.fecha_com_reset = true;
             let barra = if self.style.unicode { "│ " } else { "| " };
             return Some(format!("{DIM}{barra}"));
         }
@@ -423,12 +465,16 @@ impl MarkdownStream {
                     i += 1;
                 }
                 _ => {
-                    if aberto.is_none() && (b as char).is_whitespace() {
+                    // `b.is_ascii_whitespace()`, e nao `(b as char)`: os bytes
+                    // de continuacao 0x85 e 0xA0 aparecem dentro de `a`, `A`,
+                    // `s`, `c`... e viravam NEL e NBSP na conversao, marcando
+                    // um "espaco" no meio de um caractere.
+                    if aberto.is_none() && b.is_ascii_whitespace() {
                         // So o **inicio** do grupo: assim o espaco que separa
                         // duas palavras viaja com a segunda, e a quebra
                         // consegue descarta-lo em vez de deixa-lo pendurado.
                         let anterior_era_espaco = i > self.emitido
-                            && (bytes[i - 1] as char).is_whitespace()
+                            && bytes[i - 1].is_ascii_whitespace()
                             && espaco_livre.is_some();
                         if !anterior_era_espaco {
                             espaco_livre = Some(i);
@@ -439,8 +485,18 @@ impl MarkdownStream {
             }
         }
 
-        let construto = aberto.map(|(pos, _)| pos).unwrap_or(bytes.len());
+        // Teto do retido: passado ele, o construto pendente deixa de ser
+        // motivo para segurar. Ver `MAX_RETIDO`.
+        let estourou = bytes.len() - self.emitido > MAX_RETIDO;
+        let construto = if estourou {
+            bytes.len()
+        } else {
+            aberto.map(|(pos, _)| pos).unwrap_or(bytes.len())
+        };
         if self.largura == 0 {
+            return construto;
+        }
+        if estourou {
             return construto;
         }
         match espaco_livre {
@@ -469,7 +525,7 @@ impl MarkdownStream {
         let mut saida = String::new();
         for grupo in grupos(estilizado) {
             let largura_do_grupo = console::measure_text_width(grupo);
-            if grupo.starts_with(char::is_whitespace) {
+            if grupo.starts_with(|c: char| c.is_ascii_whitespace()) {
                 saida.push_str(grupo);
                 self.coluna += largura_do_grupo;
                 self.palavra_em_curso = false;
@@ -512,6 +568,12 @@ impl MarkdownStream {
         }
         let trecho = self.linha[self.emitido..fim].to_string();
         self.emitido = fim;
+        if self.emitido >= COMPACTA_ACIMA_DE {
+            // O que ja foi para a tela nao volta: sai do buffer. Ver
+            // `COMPACTA_ACIMA_DE`.
+            self.linha.drain(..self.emitido);
+            self.emitido = 0;
+        }
         if self.bloco == Bloco::Codigo {
             // Codigo nao quebra: o criterio de aceite pede que continue facil
             // de copiar, e um `\n` que o modelo nao escreveu vira um `\n` que
@@ -532,12 +594,10 @@ impl MarkdownStream {
 
     /// Termina a linha corrente e devolve o que faltava mais o `\n`.
     fn fecha_linha(&mut self) -> String {
-        let era_titulo = self.linha.starts_with('#')
-            && !self.em_fence
-            && self.linha.chars().take_while(|c| *c == '#').count() <= 6;
         let mut saida = self.emite_resto_da_linha();
-        if era_titulo || self.linha.starts_with("> ") {
+        if self.fecha_com_reset {
             saida.push_str(RESET);
+            self.fecha_com_reset = false;
         }
         saida.push('\n');
         self.linha.clear();
@@ -633,7 +693,9 @@ fn grupos(s: &str) -> Vec<&str> {
     let mut inicio = 0;
     let mut atual: Option<bool> = None;
     for (i, c) in s.char_indices() {
-        let espaco = c.is_whitespace();
+        // ASCII de proposito, e igual ao `limite_de_emissao`: um espaco
+        // inquebravel (U+00A0) existe justamente para nao ser ponto de quebra.
+        let espaco = c.is_ascii_whitespace();
         match atual {
             Some(anterior) if anterior != espaco => {
                 saida.push(&s[inicio..i]);
@@ -655,7 +717,9 @@ fn grupos(s: &str) -> Vec<&str> {
 /// O espaco que separava duas palavras nao deve virar o ultimo caractere da
 /// linha: em selecao de texto e em `cat -A` ele aparece, e ninguem o escreveu.
 fn apara_espacos(saida: &mut String, coluna: &mut usize) {
-    let aparado = saida.trim_end_matches(char::is_whitespace).len();
+    let aparado = saida
+        .trim_end_matches(|c: char| c.is_ascii_whitespace())
+        .len();
     if aparado < saida.len() {
         *coluna -= console::measure_text_width(&saida[aparado..]);
         saida.truncate(aparado);
@@ -1023,6 +1087,161 @@ mod tests {
 
         let vazio = renderiza("um `` vazio\n");
         assert!(vazio.contains("``"), "as duas crases ficam: {vazio:?}");
+    }
+
+    /// Acento dentro de bloco cercado nao derruba o CLI.
+    ///
+    /// O ramo que decide se a linha e a cerca de fechamento fatiava o primeiro
+    /// **byte** da linha; num `é` esse byte nao e fronteira de caractere e o
+    /// programa inteiro caia. Achado na auditoria — nenhum teste tinha
+    /// multibyte **dentro** de cerca, so fora. Casos reais: `# Acao` num
+    /// comentario, `"resume"` numa string, um emoji.
+    #[test]
+    fn multibyte_dentro_de_cerca_nao_entra_em_panico() {
+        for conteudo in ["été", "çedilha", "中文", "🦀 rust", "# Ação"] {
+            let s = renderiza(&format!("```\n{conteudo}\n```\n"));
+            assert!(s.contains(conteudo), "perdeu {conteudo:?}: {s:?}");
+        }
+        // E partido em todo tamanho de pedaco, que e como o delta chega.
+        for saida in renderiza_em_todos_os_cortes("```\nété\n```\n") {
+            assert!(saida.contains("été"), "saiu: {saida:?}");
+        }
+    }
+
+    /// Delimitador sem par nao segura a saida para sempre.
+    ///
+    /// Um `**` que nunca fecha, numa resposta sem `\n`, fazia o buffer crescer
+    /// sem teto e a tela ficar parada. Passado o teto o texto sai cru.
+    #[test]
+    fn delimitador_sem_par_nao_segura_a_saida_para_sempre() {
+        let mut m = rico();
+        // Uma abertura so, e nunca o fechamento: `**` repetido casaria em
+        // pares e o texto sairia sozinho — a primeira versao deste teste
+        // passava verde com o teto desligado exatamente por isso.
+        let mut visto = m.push("**").len();
+        for _ in 0..8 {
+            visto += m.push(&"x".repeat(512)).len();
+        }
+        assert!(
+            visto > 0,
+            "com {MAX_RETIDO} de teto, isto tinha de comecar a sair"
+        );
+        assert!(
+            m.linha.len() <= MAX_RETIDO + COMPACTA_ACIMA_DE + 1024,
+            "o buffer cresceu sem teto: {} bytes",
+            m.linha.len()
+        );
+    }
+
+    /// Uma linha muito longa nao guarda em memoria o que ja foi para a tela.
+    #[test]
+    fn a_linha_e_compactada_enquanto_sai() {
+        let mut m = rico();
+        for _ in 0..2000 {
+            let _ = m.push("palavra ");
+        }
+        assert!(
+            m.linha.len() < COMPACTA_ACIMA_DE * 2,
+            "16 KB emitidos e o buffer ficou com {} bytes",
+            m.linha.len()
+        );
+    }
+
+    /// Titulo sem `\n` no fim nao deixa o terminal em negrito.
+    ///
+    /// O `RESET` do titulo vinha da quebra de linha; num turno truncado ele
+    /// nunca chegava e o prompt seguinte saia estilizado.
+    #[test]
+    fn titulo_sem_quebra_de_linha_fecha_o_estilo_no_fim() {
+        let mut m = rico();
+        let mut s = m.push("# Titulo truncado");
+        s.push_str(&m.finish());
+        assert!(
+            s.ends_with(RESET),
+            "o estilo tem de fechar no fim do turno: {s:?}"
+        );
+
+        let mut m = rico();
+        let mut c = m.push("> citacao truncada");
+        c.push_str(&m.finish());
+        assert!(c.ends_with(RESET), "e a citacao tambem: {c:?}");
+    }
+
+    /// Texto acentuado quebra tao limpo quanto texto ASCII.
+    ///
+    /// A varredura convertia **byte** para `char`, e os bytes de continuacao
+    /// 0x85 e 0xA0 — que aparecem dentro de `à`, `Å`, `š` — viravam NEL e
+    /// NBSP. O corte caia no meio do caractere, o `emite_ate` recuava ate a
+    /// fronteira, e o espaco anterior ficava num pedaco ja escrito: o
+    /// `apara_espacos` nao alcancava mais, e cada linha quebrada terminava com
+    /// um espaco. Medido comparando a saida das duas versoes — nao suposto.
+    #[test]
+    fn acento_nao_deixa_espaco_pendurado_na_quebra() {
+        for amostra in [
+            "à à à à à à à à à à à à à à à à à à à à à à à à",
+            "Šaomeword àcomprida Ålongademais e mais texto aqui",
+            "Ação à Åland e coração numa frase que precisa quebrar",
+        ] {
+            let mut m = estreito(24);
+            let mut s = m.push(amostra);
+            s.push_str(&m.finish());
+            for linha in sem_escape(&s).lines() {
+                assert_eq!(
+                    linha,
+                    linha.trim_end(),
+                    "linha com espaco no fim em {amostra:?}: {linha:?}"
+                );
+            }
+            for palavra in amostra.split(' ') {
+                assert!(s.contains(palavra), "perdeu {palavra:?}: {s:?}");
+            }
+        }
+    }
+
+    /// Espaco inquebravel nao vira ponto de quebra — e para isso que ele serve.
+    #[test]
+    fn nbsp_nao_vira_ponto_de_quebra() {
+        let mut m = estreito(24);
+        let mut nb = m.push("um\u{a0}par inquebravel de palavras aqui no fim\n");
+        nb.push_str(&m.finish());
+        assert!(
+            nb.contains("um\u{a0}par"),
+            "o NBSP nao pode virar quebra: {nb:?}"
+        );
+    }
+
+    /// Sonda de throughput — nao e gate, e o registro de uma medida.
+    ///
+    /// Medido nesta maquina: **1 MiB de prosa em ~0,38 s** e **1 MiB numa
+    /// linha sem um unico espaco em ~5,3 s**. A diferenca e o `MAX_RETIDO`:
+    /// sem espaco onde cortar, a varredura le o pendente inteiro a cada
+    /// caractere, e o teto e o multiplicador.
+    ///
+    /// 5 MiB/s parece pouco para um numero absoluto e e enorme para este uso:
+    /// a entrada e um stream de tokens de LLM, que entrega na ordem de 1 KiB/s.
+    /// A folga e de tres ordens de grandeza. E ainda assim e uma melhora
+    /// grande sobre a versao sem teto, onde o pendente crescia sem limite e o
+    /// custo por caractere crescia junto.
+    #[test]
+    #[ignore = "sonda de throughput; roda com --ignored"]
+    fn sonda_throughput_linha_degenerada() {
+        let t = std::time::Instant::now();
+        let mut m = rico();
+        let mut saiu = 0usize;
+        for _ in 0..256 {
+            saiu += m.push(&"x".repeat(4096)).len();
+        }
+        saiu += m.finish().len();
+        eprintln!("1 MiB sem espaco: {:?}, {saiu} bytes na tela", t.elapsed());
+
+        let t = std::time::Instant::now();
+        let mut m = rico();
+        let mut saiu = 0usize;
+        for _ in 0..256 {
+            saiu += m.push(&"palavra ".repeat(512)).len();
+        }
+        saiu += m.finish().len();
+        eprintln!("1 MiB de prosa:   {:?}, {saiu} bytes na tela", t.elapsed());
     }
 
     /// Uma linha que so tem `-` ou `--` nao trava esperando virar regra.

--- a/crates/garraia-cli/src/ui/mod.rs
+++ b/crates/garraia-cli/src/ui/mod.rs
@@ -41,6 +41,7 @@
 pub mod ansi_filter;
 pub mod conversation;
 pub mod error_card;
+pub mod markdown;
 pub mod spinner;
 pub mod tool_log;
 
@@ -229,12 +230,16 @@ pub struct TerminalRenderer {
     /// o texto do modelo e streaming e uma sequencia pode chegar partida entre
     /// dois deltas, cada metade inofensiva sozinha. Ver `ansi_filter`.
     filtro: ansi_filter::AnsiFilter,
+    /// Renderiza Markdown enquanto o texto chega (#939). Vem **depois** do
+    /// filtro: ele limpa o que o modelo mandou, e este acrescenta o nosso.
+    markdown: markdown::MarkdownStream,
 }
 
 impl TerminalRenderer {
     pub fn new(caps: Capabilities, spinner: Option<Spinner>) -> Self {
         Self {
             filtro: ansi_filter::AnsiFilter::new(),
+            markdown: markdown::MarkdownStream::new(caps.style(), caps.width),
             assistant_prefix: caps.style().assistant_prefix(),
             caps,
             spinner,
@@ -262,6 +267,7 @@ impl TerminalRenderer {
             prefix_written: false,
             animating: true,
             filtro: ansi_filter::AnsiFilter::new(),
+            markdown: markdown::MarkdownStream::new(caps.style(), caps.width),
         }
     }
 
@@ -271,6 +277,9 @@ impl TerminalRenderer {
         self.spinner = spinner;
         self.prefix_written = false;
         self.animating = true;
+        // Turno novo comeca com o Markdown zerado: uma cerca de codigo que o
+        // turno anterior deixou aberta nao pode engolir o estilo do proximo.
+        self.markdown = markdown::MarkdownStream::new(self.caps.style(), self.caps.width);
     }
 
     /// Ha animacao rodando neste turno? O `select!` usa isto para nao armar o
@@ -322,11 +331,17 @@ impl TerminalRenderer {
             let _ = write!(out, "{}", self.assistant_prefix);
             self.prefix_written = true;
         }
-        // O texto do modelo nao pode escrever comando no terminal (#996). O
-        // filtro tem estado porque a sequencia pode chegar partida entre dois
-        // deltas — ver `ansi_filter`.
+        // A ordem entre os dois importa.
+        //
+        // Primeiro o filtro (#996): o texto do modelo nao pode escrever comando
+        // no terminal, e o filtro tem estado porque a sequencia pode chegar
+        // partida entre dois deltas — ver `ansi_filter`.
+        //
+        // Depois o Markdown (#939), que **adiciona** escapes nossos. Na ordem
+        // inversa o filtro comeria o proprio estilo que acabamos de aplicar.
         let seguro = self.filtro.push(delta);
-        let _ = write!(out, "{seguro}");
+        let renderizado = self.markdown.push(&seguro);
+        let _ = write!(out, "{renderizado}");
         let _ = out.flush();
         // A linha agora pertence a resposta.
         self.animating = false;
@@ -348,8 +363,16 @@ impl TerminalRenderer {
         // ainda deve virar quebra, e um `ESC` pendurado nao pode atravessar
         // para o turno seguinte e engolir o primeiro caractere dele (#996).
         let pendente = self.filtro.finish();
+        // Os dois fecham na mesma ordem em que trabalham: o filtro entrega o
+        // que reteve, o Markdown renderiza isso e entrega o que ele reteve. Um
+        // `**` sem par no fim do texto sai como texto — nada se perde (#939).
+        let pendente = self.markdown.push(&pendente);
+        let resto = self.markdown.finish();
         if !pendente.is_empty() {
             let _ = write!(out, "{pendente}");
+        }
+        if !resto.is_empty() {
+            let _ = write!(out, "{resto}");
         }
         if !self.prefix_written {
             let _ = write!(out, "{}", self.assistant_prefix);
@@ -723,6 +746,84 @@ mod tests {
         renderer.handle(UiEvent::TurnFinished, &mut out);
         let saida = String::from_utf8(out).expect("UTF-8");
         assert!(saida.starts_with("\r\x1b[2K"), "nao limpou: {saida:?}");
+    }
+
+    /// O Markdown chega ao renderizador, e o filtro ANSI nao come o estilo.
+    ///
+    /// A ordem entre os dois so aparece aqui: no `markdown.rs` os dois testes
+    /// vivem separados, e passar em ambos nao prova que estao encadeados na
+    /// ordem certa.
+    #[test]
+    fn markdown_atravessa_o_renderizador_num_terminal_rico() {
+        let caps = Capabilities {
+            interactive: true,
+            unicode: true,
+            animation: false,
+            width: 80,
+        };
+        let mut renderer = TerminalRenderer::with_prefix(caps, None, "");
+        let mut out: Vec<u8> = Vec::new();
+        // O titulo vem no primeiro delta de proposito: e a resposta que comeca
+        // com `# `, e ela so vira titulo se o estado do turno estiver zerado.
+        renderer.handle(
+            UiEvent::TextDelta("# Titulo\nveja **isto** aqui\n"),
+            &mut out,
+        );
+        renderer.handle(UiEvent::TurnFinished, &mut out);
+        let saida = String::from_utf8(out).expect("UTF-8");
+
+        assert!(saida.contains("\x1b[1misto\x1b[0m"), "negrito: {saida:?}");
+        assert!(!saida.contains("**"), "os asteriscos nao chegam a tela");
+        assert!(saida.contains("Titulo"), "o titulo sai: {saida:?}");
+        assert!(
+            !saida.contains("# "),
+            "o sustenido nao chega a tela: {saida:?}"
+        );
+    }
+
+    /// E num terminal sem cor nada disso acontece — nem um escape.
+    ///
+    /// E o criterio "redirected output does not contain unwanted ANSI escapes"
+    /// medido no ponto em que o usuario o observa.
+    #[test]
+    fn saida_redirecionada_nao_ganha_escape_de_markdown() {
+        let mut renderer = TerminalRenderer::with_prefix(Capabilities::PLAIN, None, "");
+        let mut out: Vec<u8> = Vec::new();
+        renderer.handle(UiEvent::TextDelta("# titulo\n- item **forte**\n"), &mut out);
+        renderer.handle(UiEvent::TurnFinished, &mut out);
+        let saida = String::from_utf8(out).expect("UTF-8");
+
+        assert!(!saida.contains('\x1b'), "nenhum escape: {saida:?}");
+        assert!(saida.contains("# titulo"), "o texto sai como veio");
+        assert!(saida.contains("- item **forte**"));
+    }
+
+    /// A largura do terminal chega ao renderizador de Markdown.
+    ///
+    /// Testar a quebra so no `markdown.rs` provaria que ela funciona quando
+    /// alguem passa a largura — nao que alguem passa. E o mesmo tipo de teste
+    /// que ja passou verde com a funcionalidade desligada nesta serie.
+    #[test]
+    fn a_largura_do_terminal_chega_ao_markdown() {
+        let caps = Capabilities {
+            interactive: true,
+            unicode: true,
+            animation: false,
+            width: 24,
+        };
+        let mut renderer = TerminalRenderer::with_prefix(caps, None, "");
+        let mut out: Vec<u8> = Vec::new();
+        renderer.handle(
+            UiEvent::TextDelta("uma frase razoavelmente longa que precisa quebrar\n"),
+            &mut out,
+        );
+        renderer.handle(UiEvent::TurnFinished, &mut out);
+        let saida = String::from_utf8(out).expect("UTF-8");
+
+        assert!(
+            saida.lines().count() > 1,
+            "com 24 colunas isto tinha de quebrar: {saida:?}"
+        );
     }
 
     /// Um turno novo volta a dever o rotulo — senao a segunda resposta da


### PR DESCRIPTION
## Descrição

Título, negrito, ênfase, código inline, bloco cercado, lista com marcador ou número, citação, link e regra horizontal passam a sair renderizados no `garra chat` em vez de com a sintaxe crua na tela.

### A decisão que define o desenho: não bufferizar por linha

Renderizar a linha inteira quando ela fecha dá resultado perfeito e zero cintilação — e **para a prosa**. O modelo costuma emitir um parágrafo inteiro como uma única linha, então o usuário ficaria olhando para o nada até o ponto final. Streaming que não aparece não é streaming.

O renderizador segura só o que ainda pode mudar de significado: poucos caracteres no início da linha para decidir o tipo de bloco (`# `, `- `, `> `, ` ``` `, `1. `), e depois a cauda a partir do último delimitador inline ainda sem par. O atraso máximo é de uma palavra.

Um construto partido entre dois deltas continua sendo um construto — é a mesma classe de problema do filtro ANSI do [#996](https://github.com/michelbr84/GarraRUST/pull/996) e tem a mesma forma de solução: estado que atravessa as chamadas. O teste que importa renderiza cada exemplo em **todo** tamanho de pedaço possível, e não num corte escolhido a dedo: o corte que o autor imagina é justamente o que não quebra.

### Os dois limites saem de uma varredura só, e não é otimização

São dois cortes — "não parta um construto" e "não parta uma palavra" — e eles **não são independentes**. Em `[o site](https://exemplo.org)` o último espaço fica **dentro** do link. Cortar ali entrega ao estilizador um `[o` sem o `](`, e a sintaxe crua sai na tela. Foi o primeiro bug que apareceu quando somei a quebra por largura: o `min` dos dois cortes calculados em separado está errado por construção.

### A quebra por largura, e por que ela existe

O terminal já quebra sozinho no limite direito — mas sempre na coluna zero, e aí a segunda linha de um item de lista passa a parecer um item novo. É o **recuo de continuação** que justifica quebrar, não a quebra.

Quem mede é `console::measure_text_width`, que ignora escape e conta largura visual: contar bytes erraria com acento e com ideograma, e para o lado errado.

Bloco cercado não quebra nem ganha estilo inline. O critério de aceite pede que código continue fácil de copiar: um `*` no meio de um programa é um `*`, e um `\n` que o modelo não escreveu vira um `\n` que o usuário cola. Pela mesma razão, um bloco único maior que a linha inteira (URL longa, base64) sai sem quebra inventada — quebrar não o faria caber.

### Sem cor, nada disto acontece — nem um escape

Saída redirecionada, `NO_COLOR` ou `TERM=dumb` devolvem o texto exatamente como veio, byte a byte. É o que mantém `garra chat > arquivo` útil para automação, e é o critério "redirected output does not contain unwanted ANSI escapes" medido no ponto em que o usuário o observa.

O `garra ask` fica **de fora**, por contrato já escrito no código (`ask.rs:369`: "NEVER prints banner / ANSI / interactive prompts to stdout") — a mesma razão pela qual o spinner é proibido lá.

## O que rodar o binário achou

Com `--provider echo` num PTY (`script -qec`, `COLUMNS=48`):

- **Crase colada em crase virava um vão vazio colorido.** Um ` ``` ` no meio da linha saía como um par de escapes seguido de uma crase solta e do resto do texto. O `achar_par` já exigia conteúdo para `*` e `_`; o ramo da crase não exigia.

## O que a auditoria achou (4 achados, todos corrigidos)

Cada correção tem teste que fica **vermelho sem ela** — verifiquei um a um revertendo só a linha do conserto. Dois dos meus testes iniciais passavam verde com a correção revertida, e foram reescritos:

| Nível | Achado | Como ficou provado |
|---|---|---|
| **ALTO** | `decide_bloco` fatiava o primeiro **byte** da linha dentro de cerca (`&l[..l.len().min(1)]`). Num `é` esse byte não é fronteira de caractere e **o processo inteiro caía**. Bastava `# Ação` num comentário ou `"résumé"` numa string dentro de um bloco de código | Reproduzi isolado com `rustc` antes de corrigir; teste cobre `été`, `çedilha`, `中文`, `🦀`, `# Ação`, e em todo tamanho de pedaço |
| **MÉDIO** | O que fica retido esperando um delimitador fechar não tinha teto: um `**` sem par numa resposta sem `\n` segurava a tela para sempre e o buffer crescia junto. E `linha` nunca era compactada, então uma resposta de uma linha só ficava inteira em memória | Dois testes. O primeiro passava verde com o teto desligado — os `**` repetidos **casavam em pares**. Reescrito com uma abertura só |
| **BAIXO** | Título e citação emitiam o escape no prefixo e o `RESET` só na quebra de linha. Turno truncado deixava o terminal em negrito e o próximo prompt saía estilizado | Teste com `# Titulo truncado` sem `\n` |
| **BAIXO** | A varredura convertia **byte** para `char`, e os bytes de continuação `0x85`/`0xA0` — que aparecem dentro de `à`, `Å`, `š` — viravam NEL e NBSP | Meu primeiro teste passava nas duas versões. Medi a diferença real comparando a saída das duas: **cada linha quebrada de texto acentuado terminava com um espaço**, exatamente o que o `apara_espacos` existe para evitar. Teste reescrito sobre esse sintoma |

### O que a auditoria levantou e não procede

- **"O texto do modelo pode fazer o renderizador emitir uma sequência perigosa."** Não. O `AnsiFilter` roda **incondicionalmente** (`mod.rs:342`), antes e independente de `color`, e remove todo `\x1b` do texto do modelo. As constantes que o renderizador emite são só SGR (`\x1b[Nm`): cor e peso, sem movimento de cursor, sem limpeza de tela, sem hyperlink. O conteúdo do modelo nunca é interpolado **dentro** de uma sequência — sempre entre sequências completas.
- **`apara_espacos` com risco de underflow em `usize`.** Não: `coluna` acumula tudo que foi escrito, e a subtração só remove o que foi somado.
- **Fatiamento não-UTF-8 em `estiliza_inline`.** Não: todos os delimitadores são ASCII, e UTF-8 garante que byte de continuação está em `0x80..=0xBF`.

## Throughput, medido e registrado

Sonda `#[ignore]`d no próprio módulo (`sonda_throughput_linha_degenerada`), porque número sem medida é palpite:

- **1 MiB de prosa: ~0,38 s**
- **1 MiB numa linha sem um único espaço: ~5,3 s**

A diferença é o `MAX_RETIDO`: sem espaço onde cortar, a varredura lê o pendente a cada caractere. 5 MiB/s é pouco como número absoluto e enorme para este uso — a entrada é um stream de tokens de LLM, na ordem de 1 KiB/s. Três ordens de grandeza de folga. E ainda é uma melhora grande sobre a versão sem teto, onde o pendente crescia sem limite e o custo por caractere crescia junto.

Closes #939

## Tipo de mudança

- [x] `feat`: Nova funcionalidade
- [x] `fix`: Correção de bug (o pânico, o vão vazio colorido, o espaço pendurado)

## Classe de Risco

- [x] **Classe B (Médio Risco)**: mexe no caminho por onde passa todo o texto do modelo no terminal. Não toca auth, dado persistido, isolamento de tenant nem rede. O risco real é pânico e travamento de saída — e é onde a auditoria concentrou os achados.

## Checklist de Segurança e Qualidade

- [x] `cargo fmt --check` executado e limpo
- [x] `cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings` sem erros
- [x] `cargo test --workspace --exclude garraia-desktop` passando localmente — 54 binários verdes; única falha é a ambiental `migration_001_applies_and_schema_is_sane`, que exige `docker.sock`
- [x] Nenhum `unwrap()` adicionado — só `unwrap_or(...)` com fallback explícito (regra absoluta 4)
- [x] Nenhum segredo, API key, token ou credencial commitada — e o módulo não tem `tracing::`, `println!` nem qualquer E/S: o texto que atravessa não é logado nem persistido
- [x] Nenhuma migração, nenhuma rota nova, nenhum campo de config novo
- [x] `scripts/changelog/assemble.py --check` e `scripts/security/check-ledger-anchors.py` OK

## Mudanças na API pública

- **`crate::ui::markdown`** módulo novo: `MarkdownStream::{new, push, finish}`. Interno da CLI
- **`TerminalRenderer`** ganha o campo; sem mudança de assinatura pública
- Um teste existente mudou de asserção: `stream_turn_drains_concurrently_without_deadlock` contava `' '` como proxy de "os 300 deltas chegaram". Com a quebra, um separador vira `\n` quando a linha enche. Passou a contar **separadores** (`char::is_whitespace`) e a verificar cada `d0..d299` — mede o que sempre quis medir

## Como testar

```bash
cargo +1.95 fmt --all -- --check
cargo +1.95 clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings
cargo +1.95 test --workspace --exclude garraia-desktop

cargo +1.95 test -p garraia --bin garra ui::markdown
cargo +1.95 test -p garraia --bin garra ui::tests
cargo +1.95 test -p garraia --bin garra ui::markdown::tests::sonda_throughput -- --ignored --nocapture
```

No binário, com PTY:

```bash
cargo +1.95 build --bin garra --features dev-echo-provider
printf 'Um **texto** com `codigo`, um [site](https://exemplo.org) e acentuacao: ação, coração\n/exit\n' \
  | COLUMNS=48 script -qec "./target/debug/garra chat --provider echo" /dev/null | cat -v
```

E o critério negativo, onde o usuário o observa:

```bash
./target/debug/garra --help > /tmp/x && grep -cP '\x1b' /tmp/x   # 0
```

## Plano de Rollback

`git revert` dos dois commits. `MarkdownStream` some, `write_delta` volta a escrever o texto filtrado direto, e a asserção do teste de drenagem volta a contar espaços. Nada persistido, nada de migração, nada de passo manual.

## Registrado, não corrigido

- **`garra about` escreve ANSI incondicional no stdout redirecionado.** Verifiquei com `garra about > arquivo`: sai cheio de escape. É a dívida dos `println!` síncronos que a ADR 0017 registra, é anterior a este PR, e o plano já a atribui à **#940** — que é a issue das slash commands e superfícies de status, onde esse código vive. Alargar este PR para lá misturaria duas mudanças sem relação.
- **Modo whitelist e ferramenta MCP** seguem como o [#1007](https://github.com/michelbr84/GarraRUST/pull/1007) documentou. Sem relação com este diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF

---
_Generated by [Claude Code](https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF)_