### PR TITLE
feat(ui): superficies de status, fim da cor incondicional, e garra logs (#940, #943)

### DIFF
--- a/changelog.d/added/940-superficies-de-status-no-chat.md
+++ b/changelog.d/added/940-superficies-de-status-no-chat.md
@@ -1,0 +1,32 @@
+- **`/status` e `/tools` novos, e `/context` legivel (#940).** O `/status` diz
+  provider, modelo, ferramentas, sessao e o que o ultimo turno de fato usou —
+  sempre o valor **vivo**: o `/model` troca o modelo no meio da sessao, entao
+  ler a config diria o que era verdade no boot. O `/tools` responde "quais
+  ferramentas o agente tem", que ate aqui nao dava para perguntar: `/tools` era
+  apelido de `/tool`, que mostra o que elas **produziram**.
+- **As superficies pararam de escrever cor incondicional.** `/help`,
+  `/context`, `/tool`, `/history`, `/models` e a despedida usavam
+  `println!("{DIM}...{RESET}")`, entao `garra chat | cat` carregava escape.
+  Medido no binario: **12 sequencias de escape numa sessao de seis comandos
+  redirecionada, agora zero.** E a divida que a ADR 0017 registra, paga onde
+  ela mais aparecia.
+- **Um painel e uma lista, com a mesma moldura.** Vale a regra do cartao de
+  erro: quem sabe **o que** mostrar e o `chat.rs`, quem sabe **como desenhar**
+  e a interface. Sendo funcao pura de `(titulo, linhas, estilo, largura)` para
+  `String`, "respeita `NO_COLOR`", "cabe no terminal estreito" e "alinha a
+  continuacao" viram assercao sobre um valor de retorno, sem terminal e sem
+  processo.
+- **O `/help` nao pode mais divergir do que existe** — e ele ja divergia: nao
+  citava `/models`, e prometia `/provider <nome>` como se trocasse de provider
+  (ele responde "reinicie"). Os comandos viraram uma tabela, e um teste confere
+  os dois sentidos contra o proprio fonte: comando anunciado que nao existe, e
+  comando que existe sem ser anunciado, param no CI.
+- **Sem contagem de arquivos no `/context`**, ao contrario do exemplo da issue.
+  A propria issue pede para nao varrer o diretorio so para desenhar status, e
+  num repositorio grande a varredura custa mais que todo o resto do comando. O
+  `/context` tambem deixou de despejar quinze nomes de arquivo no campo
+  "Projeto": aquela listagem existe para o prompt do sistema, onde e util ao
+  modelo, e nao para quem digitou o comando querendo uma linha.
+- **Valor sem espaco maior que a largura estoura, e nao e truncado.** Um
+  caminho e um nome de ramo nao tem onde quebrar, e cortar com reticencia
+  destruiria justamente o que se copia do painel — quem quebra e o terminal.

--- a/changelog.d/added/943-garra-logs.md
+++ b/changelog.d/added/943-garra-logs.md
@@ -22,3 +22,11 @@
   linhas quando carrega backtrace, e filtrar linha a linha partiria a entrada
   ao meio — sobraria a primeira linha do erro sem o rastro que a explica. Quem
   quer menos ruido tem o `RUST_LOG`, que decide na escrita.
+- **`-n 0` mostra nada, que e o idioma do `tail`** e o par natural do
+  `--follow` ("so o que vier daqui em diante"). Ele fazia o oposto: o buffer
+  circular nunca podava e o arquivo **inteiro** ia para a memoria e para a
+  tela. Num log de 1 GB, um OOM com uma flag. Achado rodando o binario e
+  confirmado na auditoria.
+- **Linha maior que 1 MiB e pulada.** `BufReader::lines()` nao tem limite: um
+  arquivo binario ou sem quebra de linha viraria uma alocacao do tamanho do
+  arquivo. Log de texto nao tem linha assim; o que tem e arquivo corrompido.

--- a/changelog.d/added/943-garra-logs.md
+++ b/changelog.d/added/943-garra-logs.md
@@ -1,0 +1,24 @@
+- **`garra logs` e `garra logs --follow` (#943).** Le o arquivo canonico
+  (`garraia.log`, no diretorio de config) direto do disco: **nao fala com o
+  gateway** e nao pede que ele esteja rodando — que e justamente quando o log
+  importa. `-n/--lines` escolhe quantas linhas do fim (100 por padrao) e
+  `--path` imprime so o caminho, para encadear com outro comando.
+- **A redacao continua sendo da escrita, e o comando nao a repete.** O
+  `RedactingMakeWriter` envolve o appender, entao o que esta no disco ja esta
+  redigido. Redigir de novo na leitura mascararia um vazamento em vez de
+  conserta-lo: quem abrisse o arquivo no `less` veria o segredo do mesmo jeito,
+  e nos acharíamos que estamos protegidos. Ha teste afirmando que o comando
+  devolve o byte que leu.
+- **`Ctrl+C` no `--follow` sai limpo, com codigo 130** — a convencao do shell,
+  a mesma que o `garra chat` ocioso ja seguia, e a mesma do `tail -f` e do
+  `journalctl -f`.
+- **Log ausente nao e erro.** E o estado normal de quem nunca rodou nada, e a
+  mensagem diz onde o arquivo estaria e o que o cria.
+- **`/logs` no chat diz onde o log esta, e nao o despeja na conversa.**
+  Misturar centenas de linhas de log com a conversa e o oposto do que a Fase 2
+  deste epico foi fazer, e seguir o arquivo em tempo real disputaria a mesma
+  tela com o streaming da resposta.
+- **Sem `--level`, com o motivo escrito.** Uma entrada de log ocupa varias
+  linhas quando carrega backtrace, e filtrar linha a linha partiria a entrada
+  ao meio — sobraria a primeira linha do erro sem o rastro que a explica. Quem
+  quer menos ruido tem o `RUST_LOG`, que decide na escrita.

--- a/changelog.d/fixed/940-turno-do-fallback-nao-era-anotado.md
+++ b/changelog.d/fixed/940-turno-do-fallback-nao-era-anotado.md
@@ -1,0 +1,17 @@
+- **O turno que caiu no fallback nao-streaming nao era anotado.** O `/stats`
+  (#984) e o `/status` novo respondiam "nenhum turno ainda" **depois de um
+  turno inteiro**, sempre que o provider nao fazia streaming — Ollama antigo,
+  llama.cpp sem SSE, ou qualquer provider num momento em que o streaming
+  falha. Dos tres `return Ok` do `stream_turn_with_sink`, so um anotava.
+  Achado rodando o binario: `Turnos 1` e `Ultimo turno: nenhum ainda` na mesma
+  tela.
+- **E o ramo do fallback agora anota melhor que o de streaming.** La ha uma
+  `LlmResponse` de verdade, entao o modelo vem **confirmado pelo provider** e a
+  contagem de tokens existe — o caminho de streaming so conhece o modelo
+  *pedido*. O turno que pede confirmacao de ferramenta tambem passou a contar:
+  um `/stats` em branco depois de uma pergunta diria que nada aconteceu.
+- **A descricao de ferramenta MCP passa por redacao de segredo.** Ela e texto
+  livre escrito pelo servidor, e o `/tools` a mostra. O painel ja tirava
+  escape, mas escape nao e o unico problema: uma descricao mal escrita pode
+  trazer uma URL com token, e ela iria para a tela em texto plano. E a mesma
+  redacao que a **saida** da ferramenta ja recebia.

--- a/crates/garraia-agents/src/runtime.rs
+++ b/crates/garraia-agents/src/runtime.rs
@@ -2008,7 +2008,27 @@ impl AgentRuntime {
                 }
                 Err(_) => {
                     // Streaming not supported — fall back to non-streaming with retry/fallback
-                    let response = self.complete_with_fallback(&provider, &request).await?;
+                    //
+                    // #984/#940: aqui ha uma `LlmResponse` de verdade, entao o
+                    // turno pode ser anotado **melhor** que no caminho de
+                    // streaming: o modelo vem confirmado pelo provider e a
+                    // contagem de tokens existe. Ate aqui este ramo nao
+                    // anotava nada, e o `/stats` respondia "nenhum turno
+                    // ainda" depois de um turno inteiro — em todo provider
+                    // que nao faz streaming. Achado rodando o binario com o
+                    // `EchoProvider`, que cai exatamente aqui.
+                    let (response, provider_usado) = self
+                        .complete_reportando_provider(&provider, &request)
+                        .await?;
+                    turno.fallback = provider_usado != provider.provider_id();
+                    turno.provider = provider_usado;
+                    turno.model = response.model.clone();
+                    turno.model_confirmado = true;
+                    if let Some(u) = &response.usage {
+                        turno.tokens_conhecidos = true;
+                        turno.input_tokens = turno.input_tokens.saturating_add(u.input_tokens);
+                        turno.output_tokens = turno.output_tokens.saturating_add(u.output_tokens);
+                    }
 
                     let tool_calls_count = response
                         .content
@@ -2041,6 +2061,10 @@ impl AgentRuntime {
                         {
                             warn!("failed to store turn in memory: {}", e);
                         }
+
+                        turno.tool_calls = budget.chamadas_na_tarefa();
+                        turno.latency_ms = inicio_do_turno.elapsed().as_millis() as u64;
+                        self.record_turn_stats(session_id, turno);
 
                         return Ok(full_response);
                     }
@@ -2545,6 +2569,88 @@ impl Default for AgentRuntime {
 
 #[cfg(test)]
 mod tests {
+    /// Provider que so sabe responder de uma vez — o `stream_complete` cai no
+    /// padrao do trait, que devolve erro.
+    ///
+    /// E o que existe de verdade: Ollama antigo, llama.cpp sem SSE, ou
+    /// qualquer provider num momento em que o streaming falha. O turno entao
+    /// segue pelo ramo de fallback nao-streaming, e era **exatamente** esse
+    /// ramo que nao anotava nada.
+    struct SoBatch;
+
+    #[async_trait::async_trait]
+    impl LlmProvider for SoBatch {
+        fn provider_id(&self) -> &str {
+            "so_batch"
+        }
+
+        async fn complete(&self, _request: &LlmRequest) -> Result<LlmResponse> {
+            Ok(LlmResponse {
+                content: vec![ContentBlock::Text {
+                    text: "pronto".to_string(),
+                }],
+                model: "modelo-que-respondeu".to_string(),
+                stop_reason: None,
+                usage: Some(crate::providers::Usage {
+                    input_tokens: 11,
+                    output_tokens: 7,
+                }),
+            })
+        }
+
+        async fn health_check(&self) -> Result<bool> {
+            Ok(true)
+        }
+    }
+
+    /// O turno que caiu no fallback nao-streaming tambem e anotado.
+    ///
+    /// O `/stats` (#984) e o `/status` (#940) respondiam "nenhum turno ainda"
+    /// depois de um turno inteiro sempre que o provider nao fazia streaming:
+    /// dos tres `return Ok` do `stream_turn_with_sink`, so um anotava. Achado
+    /// rodando o binario — `Turnos 1` e `Ultimo turno nenhum ainda` na mesma
+    /// tela.
+    #[tokio::test]
+    async fn turno_que_caiu_no_fallback_tambem_e_anotado() {
+        let runtime = AgentRuntime::new();
+        runtime.register_provider(std::sync::Arc::new(SoBatch));
+
+        let (tx, mut rx) = mpsc::channel::<crate::turn_events::TurnEvent>(64);
+        // O receptor precisa existir enquanto o turno roda: o canal e
+        // limitado e o `sink.text` bloquearia.
+        let dreno = tokio::spawn(async move { while rx.recv().await.is_some() {} });
+
+        let resposta = runtime
+            .process_message_streaming_with_events(
+                "sessao-de-teste",
+                "oi",
+                &[],
+                tx,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                &ExecContext::default(),
+            )
+            .await
+            .expect("o turno completa pelo fallback");
+        assert!(resposta.contains("pronto"), "veio: {resposta:?}");
+        dreno.await.expect("dreno");
+
+        let st = runtime
+            .last_turn_stats("sessao-de-teste")
+            .expect("o turno tem de ficar registrado");
+        assert_eq!(st.provider, "so_batch");
+        // O modelo vem da **resposta**, e nao do pedido: neste ramo ha uma
+        // `LlmResponse`, entao da para confirmar — e o `/stats` diz isso.
+        assert_eq!(st.model, "modelo-que-respondeu");
+        assert!(st.model_confirmado, "aqui o modelo e confirmado");
+        assert!(st.tokens_conhecidos, "e os tokens existem");
+        assert_eq!(st.input_tokens, 11);
+        assert_eq!(st.output_tokens, 7);
+    }
 
     /// O objetivo entra no prompt de sistema, e nao na mensagem (#983).
     #[test]

--- a/crates/garraia-cli/src/chat.rs
+++ b/crates/garraia-cli/src/chat.rs
@@ -1231,9 +1231,16 @@ pub async fn run_chat(
                 let linhas: Vec<panel::Linha<'_>> = ferramentas
                     .iter()
                     .map(|(nome, descricao)| {
-                        // A descricao vem da tool, e tool de servidor MCP vem
-                        // de fora: uma linha so, e o painel ainda saneia.
-                        panel::linha(nome.as_str(), descricao.lines().next().unwrap_or(""))
+                        // A descricao de uma tool MCP e texto livre escrito
+                        // pelo servidor. O painel tira escape, mas escape nao e
+                        // o unico problema: uma descricao mal escrita pode
+                        // trazer uma URL com token dentro, e ela iria para a
+                        // tela em texto plano. E a mesma redacao que o
+                        // `capture_tool_output` ja aplica na **saida** da
+                        // ferramenta — faltava na descricao. Achado na
+                        // auditoria.
+                        let curta = descricao.lines().next().unwrap_or("");
+                        panel::linha(nome.as_str(), garraia_security::redact_secrets(curta))
                     })
                     .collect();
                 renderer.handle(
@@ -1671,6 +1678,11 @@ mod tests {
         //
         // So os literais de comando: o corpo dos arms tem texto de ajuda com
         // barra dentro, e a busca e ancorada em `"/` seguido de letra.
+        //
+        // As duas terminacoes contam. `"/status"` e braco exato; `"/model "`
+        // (com espaco) e prefixo de `starts_with`. Vendo so a primeira, um
+        // `_ if input.starts_with("/novo ")` novo entraria sem aparecer no
+        // `/help` e sem o teste notar — achado na auditoria.
         let mut vistos = std::collections::BTreeSet::new();
         let bytes = corpo.as_bytes();
         for (i, _) in corpo.match_indices("\"/") {
@@ -1678,7 +1690,9 @@ mod tests {
             let fim = resto
                 .find(|c: char| !c.is_ascii_lowercase())
                 .unwrap_or(resto.len());
-            if fim == 0 || bytes.get(i + 2 + fim) != Some(&b'"') {
+            let fecha = bytes.get(i + 2 + fim);
+            let fecha_com_espaco = fecha == Some(&b' ') && bytes.get(i + 3 + fim) == Some(&b'"');
+            if fim == 0 || !(fecha == Some(&b'"') || fecha_com_espaco) {
                 continue;
             }
             vistos.insert(format!("/{}", &resto[..fim]));

--- a/crates/garraia-cli/src/chat.rs
+++ b/crates/garraia-cli/src/chat.rs
@@ -18,6 +18,7 @@ use garraia_config::AppConfig;
 use tokio::sync::mpsc;
 
 use crate::ui::error_card::ErrorCard;
+use crate::ui::panel;
 use crate::ui::tool_log::{Busca, ToolLog};
 use crate::ui::{TerminalRenderer, UiEvent};
 use garraia_agents::TurnEvent;
@@ -25,20 +26,60 @@ use garraia_agents::TurnEvent;
 use std::path::Path;
 
 /// ANSI color helpers
-const CYAN: &str = "\x1b[36m";
 const GREEN: &str = "\x1b[32m";
 const YELLOW: &str = "\x1b[33m";
+/// Os comandos do `garra chat`, e a fonte do `/help`.
+///
+/// Uma tabela, e nao dez `println!`: o `/help` de antes era uma lista escrita
+/// a mao ao lado do `match`, entao ele ja mentia — nao citava `/models` nem
+/// `/tools`, e prometia um `/provider <nome>` que so responde "reinicie".
+/// Ha um teste que confere a tabela contra o `match` do REPL, para a proxima
+/// divergencia aparecer no CI e nao no terminal de quem usa.
+const COMANDOS: &[(&str, &str)] = &[
+    ("/status", "Provider, modelo, ferramentas e o ultimo turno"),
+    ("/context", "Diretorio, ramo e projeto detectados"),
+    ("/tools", "Ferramentas que o agente tem"),
+    ("/tool", "Saidas de ferramenta guardadas nesta sessao"),
+    ("/tool <n>", "A saida inteira de uma chamada"),
+    ("/history", "Historico da conversa"),
+    ("/models", "Modelos que este provider lista"),
+    ("/model <nome>", "Trocar de modelo sem reiniciar"),
+    (
+        "/provider <nome>",
+        "Como trocar de provider (pede reinicio)",
+    ),
+    ("/clear", "Limpar o historico"),
+    ("/help", "Mostrar isto"),
+    ("/exit", "Sair"),
+];
+
 const DIM: &str = "\x1b[2m";
 const RESET: &str = "\x1b[0m";
 
-/// Scan the current directory for project markers and build a context summary.
-fn scan_directory_context(cwd: &str) -> String {
+/// So os marcadores de projeto, sem a listagem de arquivos (#940).
+///
+/// O `/context` mostra isto e o prompt do sistema mostra
+/// [`scan_directory_context`], que acrescenta os arquivos do topo. Sao
+/// publicos diferentes: o modelo se beneficia de saber que existe um
+/// `docker-compose.yml`; a pessoa que digitou `/context` queria uma linha, e
+/// recebia quinze nomes de arquivo embrulhados no painel.
+///
+/// Nao ha varredura nova aqui — sao `exists()` de caminho conhecido. A propria
+/// issue pede para nao varrer o diretorio so para desenhar status.
+fn project_summary(cwd: &str) -> String {
     let p = Path::new(cwd);
     // Mesma tabela que o cabecalho usa (#935) — duas copias divergiriam.
     let mut markers = crate::ui::project_markers(p);
     if p.join(".git").exists() {
         markers.push("Git repo");
     }
+    markers.join(", ")
+}
+
+/// Scan the current directory for project markers and build a context summary.
+fn scan_directory_context(cwd: &str) -> String {
+    let p = Path::new(cwd);
+    let markers = project_summary(cwd);
 
     // List top-level files (up to 15) for context
     let mut files: Vec<String> = Vec::new();
@@ -58,7 +99,7 @@ fn scan_directory_context(cwd: &str) -> String {
         return String::new();
     }
 
-    let mut result = markers.join(", ");
+    let mut result = markers;
     if !files.is_empty() {
         if !result.is_empty() {
             result.push_str(" | ");
@@ -1034,9 +1075,17 @@ pub async fn run_chat(
     //   - ocioso no prompt -> encerra a sessão, como sempre encerrou.
     let cancel = std::sync::Arc::new(tokio::sync::Notify::new());
     let turn_active = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    // Uma so fonte para a despedida, usada aqui e no `/exit`. Com cor quando
+    // ha terminal, e sem um escape sequer quando a saida esta redirecionada.
+    let despedida = if style.color {
+        format!("{DIM}Ate mais! 🦀{RESET}")
+    } else {
+        "Ate mais!".to_string()
+    };
     {
         let cancel = std::sync::Arc::clone(&cancel);
         let turn_active = std::sync::Arc::clone(&turn_active);
+        let despedida = despedida.clone();
         tokio::spawn(async move {
             loop {
                 if tokio::signal::ctrl_c().await.is_err() {
@@ -1047,7 +1096,10 @@ pub async fn run_chat(
                     cancel.notify_waiters();
                 } else {
                     // 130 = terminado por SIGINT, a convenção do shell.
-                    println!("\n{DIM}Ate mais! 🦀{RESET}");
+                    // A despedida sai pelo estilo detectado: dentro da task
+                    // nao ha `&mut renderer`, entao o texto e montado antes e
+                    // movido para ca ja pronto (#940).
+                    println!("\n{despedida}");
                     let _ = io::stdout().flush();
                     std::process::exit(130);
                 }
@@ -1065,7 +1117,7 @@ pub async fn run_chat(
         let mut input = String::new();
         if reader.read_line(&mut input)? == 0 {
             // EOF (Ctrl+D)
-            println!("\n{DIM}Ate mais! 🦀{RESET}");
+            println!("\n{despedida}");
             break;
         }
 
@@ -1077,56 +1129,181 @@ pub async fn run_chat(
         // Handle slash commands
         match input.as_str() {
             "/exit" | "/quit" | "/sair" => {
-                println!("{DIM}Ate mais! 🦀{RESET}");
+                println!("{despedida}");
                 break;
             }
             "/clear" | "/limpar" => {
                 history.clear();
-                println!("{DIM}Historico limpo.{RESET}");
+                renderer.handle(UiEvent::Hint("Historico limpo."), &mut io::stdout());
                 continue;
             }
             "/help" | "/ajuda" => {
-                println!("{DIM}Comandos disponiveis:{RESET}");
-                println!("  /model <nome>      Trocar modelo");
-                println!("  /provider <nome>   Trocar provider (ollama, anthropic, openai)");
-                println!("  /models            Listar modelos disponiveis");
-                println!("  /clear             Limpar historico");
-                println!("  /history           Mostrar historico");
-                println!("  /context           Diretorio e projeto detectados");
-                println!("  /tool              Listar saidas de ferramenta guardadas");
-                println!("  /tool <n>          Ver a saida inteira de uma chamada");
-                println!("  /exit              Sair");
+                // A lista sai pela mesma moldura das outras superficies, e nao
+                // por `println!` com cor incondicional: era o `/help` que
+                // aparecia com escape em `garra chat | cat` (#940).
+                let itens: Vec<String> = COMANDOS
+                    .iter()
+                    .map(|(nome, o_que_faz)| format!("  {nome:<18} {o_que_faz}"))
+                    .collect();
+                renderer.handle(
+                    UiEvent::List {
+                        titulo: "Comandos",
+                        itens: &itens,
+                    },
+                    &mut io::stdout(),
+                );
+                continue;
+            }
+            // As superficies de status que a #940 pede. O que elas mostram e
+            // sempre o valor **vivo** — `/model` troca o modelo no meio da
+            // sessao, entao ler a config diria o que era verdade no boot.
+            "/status" => {
+                let ferramentas = runtime.list_tool_info();
+                let mut linhas = vec![
+                    panel::linha("Provider", provider_name.clone()),
+                    panel::linha("Modelo", model_name.clone()),
+                    panel::linha("Ferramentas", ferramentas.len().to_string()),
+                    panel::linha("Sessao", session_id.clone()),
+                    panel::linha("Turnos", turn_index.to_string()),
+                ];
+                match runtime.last_turn_stats(&session_id) {
+                    // O `/stats` dos canais (#984) faz a mesma distincao, e
+                    // pela mesma razao: no streaming o provider nao informa
+                    // token nenhum, e zero-porque-nao-sei nao e
+                    // zero-porque-nao-usou.
+                    Some(st) => {
+                        let modelo = if st.model_confirmado {
+                            format!("{} (confirmado pelo provider)", st.model)
+                        } else {
+                            format!("{} (pedido; o provider nao confirmou)", st.model)
+                        };
+                        linhas.push(panel::linha("Ultimo modelo", modelo));
+                        linhas.push(panel::linha(
+                            "Ultimo turno",
+                            format!(
+                                "{} ferramenta(s), {}",
+                                st.tool_calls,
+                                crate::ui::format_duration(std::time::Duration::from_millis(
+                                    st.latency_ms
+                                ))
+                            ),
+                        ));
+                        linhas.push(panel::linha(
+                            "Tokens",
+                            if st.tokens_conhecidos {
+                                format!("{} entrada, {} saida", st.input_tokens, st.output_tokens)
+                            } else {
+                                "nao informados neste caminho".to_string()
+                            },
+                        ));
+                        if st.fallback {
+                            linhas.push(panel::linha("Fallback", "sim — o primario falhou"));
+                        }
+                    }
+                    None => linhas.push(panel::linha("Ultimo turno", "nenhum ainda")),
+                }
+                renderer.handle(
+                    UiEvent::Panel {
+                        titulo: "Status",
+                        linhas: &linhas,
+                    },
+                    &mut io::stdout(),
+                );
+                continue;
+            }
+            // Quais ferramentas o agente **tem** — diferente do `/tool`, que
+            // mostra o que elas **produziram**. Ate aqui `/tools` era apelido
+            // de `/tool`, e nao havia como perguntar a primeira coisa.
+            "/tools" | "/ferramentas" => {
+                let ferramentas = runtime.list_tool_info();
+                if ferramentas.is_empty() {
+                    renderer.handle(
+                        UiEvent::Hint("Nenhuma ferramenta registrada nesta sessao."),
+                        &mut io::stdout(),
+                    );
+                    continue;
+                }
+                // Painel, e nao lista: nome e descricao sao duas colunas, e
+                // so o painel alinha a continuacao. Como lista de strings ja
+                // montadas, a descricao longa do `file_write` quebrava na
+                // coluna zero e desmontava o alinhamento — visto rodando o
+                // binario.
+                let linhas: Vec<panel::Linha<'_>> = ferramentas
+                    .iter()
+                    .map(|(nome, descricao)| {
+                        // A descricao vem da tool, e tool de servidor MCP vem
+                        // de fora: uma linha so, e o painel ainda saneia.
+                        panel::linha(nome.as_str(), descricao.lines().next().unwrap_or(""))
+                    })
+                    .collect();
+                renderer.handle(
+                    UiEvent::Panel {
+                        titulo: "Ferramentas disponiveis",
+                        linhas: &linhas,
+                    },
+                    &mut io::stdout(),
+                );
                 continue;
             }
             // A inspecao detalhada de diretorio saiu do cabecalho de abertura
             // (#935) e mora aqui: quem quer ver, pede.
             "/context" | "/contexto" => {
-                println!("{DIM}Diretorio: {cwd}{RESET}");
-                match crate::ui::git_branch(std::path::Path::new(&cwd)) {
-                    Some(branch) => println!("{DIM}Ramo:      {branch}{RESET}"),
-                    None => println!("{DIM}Ramo:      (fora de um repositorio git){RESET}"),
-                }
-                if dir_context.is_empty() {
-                    println!("{DIM}Projeto:   nenhum marcador detectado{RESET}");
+                let ramo = crate::ui::git_branch(std::path::Path::new(&cwd))
+                    .unwrap_or_else(|| "(fora de um repositorio git)".to_string());
+                let marcadores = project_summary(&cwd);
+                let projeto = if marcadores.is_empty() {
+                    "nenhum marcador detectado".to_string()
                 } else {
-                    println!("{DIM}Projeto:   {dir_context}{RESET}");
-                }
+                    marcadores
+                };
+                // **Sem** contagem de arquivos, que o exemplo da issue mostra.
+                // A propria issue pede para nao varrer o diretorio so para
+                // desenhar status, e num repositorio grande a varredura custa
+                // mais que tudo o mais junto. O marcador de projeto ja responde
+                // "que projeto e este" sem ler a arvore.
+                let linhas = vec![
+                    panel::linha("Diretorio", cwd.clone()),
+                    panel::linha("Ramo", ramo),
+                    panel::linha("Projeto", projeto),
+                    panel::linha("Provider", provider_name.clone()),
+                    panel::linha("Modelo", model_name.clone()),
+                    panel::linha("Ferramentas", runtime.list_tool_info().len().to_string()),
+                ];
+                renderer.handle(
+                    UiEvent::Panel {
+                        titulo: "Contexto",
+                        linhas: &linhas,
+                    },
+                    &mut io::stdout(),
+                );
                 continue;
             }
             // A saida completa das ferramentas (#938). O resumo de uma linha
             // do #937 deixou a conversa legivel; sem isto ele so teria
             // escondido a causa da falha.
-            "/tool" | "/tools" | "/saida" => {
+            "/tool" | "/saida" => {
                 if tool_log.vazio() {
-                    println!("{DIM}Nenhuma ferramenta foi chamada ainda nesta sessao.{RESET}");
-                } else {
-                    println!("{DIM}Saidas guardadas (use /tool <n> para ver inteira):{RESET}");
-                    for e in tool_log.listar() {
+                    renderer.handle(
+                        UiEvent::Hint("Nenhuma ferramenta foi chamada ainda nesta sessao."),
+                        &mut io::stdout(),
+                    );
+                    continue;
+                }
+                let itens: Vec<String> = tool_log
+                    .listar()
+                    .map(|e| {
                         let marca = if e.sucesso { " " } else { "!" };
                         let detalhe: String = e.detalhe.chars().take(52).collect();
-                        println!("  {marca}#{:<3} {:<12} {}", e.indice, e.ferramenta, detalhe);
-                    }
-                }
+                        format!("  {marca}#{:<3} {:<12} {}", e.indice, e.ferramenta, detalhe)
+                    })
+                    .collect();
+                renderer.handle(
+                    UiEvent::List {
+                        titulo: "Saidas guardadas (use /tool <n> para ver inteira)",
+                        itens: &itens,
+                    },
+                    &mut io::stdout(),
+                );
                 continue;
             }
             _ if input.starts_with("/tool ") || input.starts_with("/saida ") => {
@@ -1138,16 +1315,20 @@ pub async fn run_chat(
                     Ok(n) => match tool_log.buscar(n) {
                         Busca::Achou(e) => {
                             let estado = if e.sucesso { "ok" } else { "falhou" };
-                            println!(
-                                "{DIM}#{} {} · {} · {}{RESET}",
-                                e.indice,
-                                e.ferramenta,
-                                estado,
-                                crate::ui::format_duration(e.duracao)
-                            );
+                            let mut cabecalho = vec![panel::linha(
+                                "Estado",
+                                format!("{estado} · {}", crate::ui::format_duration(e.duracao)),
+                            )];
                             if !e.detalhe.is_empty() {
-                                println!("{DIM}{}{RESET}", e.detalhe);
+                                cabecalho.push(panel::linha("Resumo", e.detalhe.clone()));
                             }
+                            renderer.handle(
+                                UiEvent::Panel {
+                                    titulo: &format!("#{} {}", e.indice, e.ferramenta),
+                                    linhas: &cabecalho,
+                                },
+                                &mut io::stdout(),
+                            );
                             println!();
                             // A saida ja veio redigida e saneada do
                             // `garraia-agents`; aqui e so imprimir.
@@ -1157,44 +1338,65 @@ pub async fn run_chat(
                         // proposito: "saiu do registro" e acionavel (rode de
                         // novo), "nunca existiu" quer dizer que o numero esta
                         // errado.
-                        Busca::Expirada => println!(
-                            "{DIM}A saida #{n} ja saiu do registro — so as mais \
-                             recentes ficam guardadas. Rode o comando de novo \
-                             para ve-la.{RESET}"
+                        Busca::Expirada => renderer.handle(
+                            UiEvent::Hint(&format!(
+                                "A saida #{n} ja saiu do registro — so as mais \
+                                 recentes ficam guardadas. Rode o comando de novo \
+                                 para ve-la."
+                            )),
+                            &mut io::stdout(),
                         ),
-                        Busca::Inexistente => println!(
-                            "{DIM}Nao ha saida #{n}. Use /tool para ver as \
-                             disponiveis.{RESET}"
+                        Busca::Inexistente => renderer.handle(
+                            UiEvent::Hint(&format!(
+                                "Nao ha saida #{n}. Use /tool para ver as disponiveis."
+                            )),
+                            &mut io::stdout(),
                         ),
                     },
-                    Err(_) => println!("{DIM}Uso: /tool <numero>. Ex.: /tool 3{RESET}"),
+                    Err(_) => renderer.handle(
+                        UiEvent::Hint("Uso: /tool <numero>. Ex.: /tool 3"),
+                        &mut io::stdout(),
+                    ),
                 }
                 continue;
             }
             "/history" | "/historico" => {
                 if history.is_empty() {
-                    println!("{DIM}Historico vazio.{RESET}");
-                } else {
-                    for msg in &history {
+                    renderer.handle(UiEvent::Hint("Historico vazio."), &mut io::stdout());
+                    continue;
+                }
+                let itens: Vec<String> = history
+                    .iter()
+                    .map(|msg| {
                         let role = match msg.role {
-                            ChatRole::User => format!("{GREEN}voce{RESET}"),
-                            ChatRole::Assistant => format!("{CYAN}garra{RESET}"),
-                            _ => "system".to_string(),
+                            ChatRole::User => "voce",
+                            ChatRole::Assistant => "garra",
+                            _ => "system",
                         };
                         let text = match &msg.content {
                             MessagePart::Text(t) => t.as_str(),
                             MessagePart::Parts(_) => "(multi-part)",
                         };
+                        // O texto do modelo entra aqui: o painel saneia, mas o
+                        // corte de 80 tambem e defesa — uma resposta inteira
+                        // por linha tornaria o historico ilegivel.
                         let preview: String = text.chars().take(80).collect();
-                        println!("  {role}: {preview}");
-                    }
-                }
+                        format!("  {role:<6} {preview}")
+                    })
+                    .collect();
+                renderer.handle(
+                    UiEvent::List {
+                        titulo: "Historico",
+                        itens: &itens,
+                    },
+                    &mut io::stdout(),
+                );
                 continue;
             }
             _ if input.starts_with("/model ") => {
                 let new_model = input[7..].trim();
                 if new_model.is_empty() {
-                    println!("{DIM}Uso: /model <nome>{RESET}");
+                    renderer.handle(UiEvent::Hint("Uso: /model <nome>"), &mut io::stdout());
                     continue;
                 }
                 // On Ollama, `/model qwen3.8` means `qwen3.8:latest` — spell
@@ -1224,9 +1426,15 @@ pub async fn run_chat(
                     );
                 }
                 model_name = resolved;
-                println!("{DIM}Modelo alterado para: {model_name}{RESET}");
-                println!(
-                    "{DIM}  (o provider continua {provider_name} — para trocar, reinicie com --provider ou --model){RESET}"
+                renderer.handle(
+                    UiEvent::Hint(&format!("Modelo alterado para: {model_name}")),
+                    &mut io::stdout(),
+                );
+                renderer.handle(
+                    UiEvent::Hint(&format!(
+                        "  (o provider continua {provider_name} — para trocar, reinicie com --provider ou --model)"
+                    )),
+                    &mut io::stdout(),
                 );
                 continue;
             }
@@ -1235,27 +1443,46 @@ pub async fn run_chat(
                 if let Some(p) = provider_ref {
                     match p.available_models().await {
                         Ok(models) => {
-                            println!("{DIM}Modelos disponiveis ({provider_name}):{RESET}");
-                            for m in models.iter().take(20) {
-                                let marker = if m == &model_name { " *" } else { "" };
-                                println!("  {m}{marker}");
-                            }
+                            let mut itens: Vec<String> = models
+                                .iter()
+                                .take(20)
+                                .map(|m| {
+                                    let marker = if m == &model_name { " *" } else { "" };
+                                    format!("  {m}{marker}")
+                                })
+                                .collect();
                             if models.len() > 20 {
-                                println!("  ... e mais {} modelos", models.len() - 20);
+                                itens.push(format!("  ... e mais {} modelos", models.len() - 20));
                             }
+                            renderer.handle(
+                                UiEvent::List {
+                                    titulo: &format!("Modelos disponiveis ({provider_name})"),
+                                    itens: &itens,
+                                },
+                                &mut io::stdout(),
+                            );
                         }
-                        Err(e) => println!("{DIM}Erro listando modelos: {e}{RESET}"),
+                        // A mensagem do provider e de fora: vai como aviso, que
+                        // ja saneia, e nao como `println!` cru.
+                        Err(e) => renderer.handle(
+                            UiEvent::Warning(&format!("Erro listando modelos: {e}")),
+                            &mut io::stdout(),
+                        ),
                     }
                 }
                 continue;
             }
             _ if input.starts_with("/provider ") => {
                 let new_provider = input[10..].trim();
-                println!(
-                    "{DIM}Para trocar provider, reinicie com: garraia chat --provider {new_provider}{RESET}"
+                renderer.handle(
+                    UiEvent::Hint(&format!(
+                        "Para trocar provider, reinicie com: garraia chat --provider {new_provider}"
+                    )),
+                    &mut io::stdout(),
                 );
-                println!(
-                    "{DIM}  Para um modelo local do Ollama basta: garraia --model <tag>{RESET}"
+                renderer.handle(
+                    UiEvent::Hint("  Para um modelo local do Ollama basta: garraia --model <tag>"),
+                    &mut io::stdout(),
                 );
                 continue;
             }
@@ -1385,6 +1612,91 @@ mod tests {
     use super::*;
     use garraia_config::{AgentConfig, AppConfig, LlmProviderConfig};
     use std::collections::HashMap;
+
+    /// Apelidos aceitos no `match` que **de proposito** nao aparecem no
+    /// `/help`: listar `/sair`, `/limpar` e `/historico` ao lado de `/exit`,
+    /// `/clear` e `/history` dobraria a tela sem ensinar nada.
+    const APELIDOS: &[&str] = &[
+        "/quit",
+        "/sair",
+        "/limpar",
+        "/ajuda",
+        "/contexto",
+        "/historico",
+        "/saida",
+        "/ferramentas",
+    ];
+
+    /// O `/help` nao pode divergir do `match` — e ele ja tinha divergido.
+    ///
+    /// A lista antiga era escrita a mao ao lado do `match` e omitia `/models`,
+    /// nao tinha `/status` nem `/tools`, e prometia `/provider <nome>` como se
+    /// trocasse de provider. O jeito de isso nao voltar e o CI conferir os dois
+    /// lados, e nao a disciplina de quem edita.
+    ///
+    /// Le o proprio fonte por `include_str!`: e o mesmo recurso que os
+    /// tripwires do `state.rs` usam, e o unico jeito de afirmar sobre o `match`
+    /// sem transforma-lo numa tabela em runtime.
+    #[test]
+    fn o_help_e_o_match_nao_divergem() {
+        const FONTE: &str = include_str!("chat.rs");
+
+        // A varredura tem de excluir a **propria** tabela e o modulo de teste,
+        // senao ela se satisfaz sozinha: um `/fantasma` inventado no `/help`
+        // aparece como literal na tabela e passaria por "existe no match".
+        // Foi o que aconteceu na primeira versao deste teste — verifiquei
+        // inserindo o comando falso, e ele passou verde.
+        let tabela = FONTE.find("const COMANDOS:").expect("a tabela existe");
+        let fim_tabela = FONTE[tabela..]
+            .find("\n];")
+            .map(|i| tabela + i)
+            .expect("a tabela fecha");
+        let inicio_testes = FONTE.find("#[cfg(test)]").unwrap_or(FONTE.len());
+        let corpo = format!("{}{}", &FONTE[..tabela], &FONTE[fim_tabela..inicio_testes]);
+        let corpo = corpo.as_str();
+
+        // Todo comando anunciado existe de verdade.
+        //
+        // Duas grafias porque ha duas formas de casar: comando sem argumento
+        // vira braco exato (`"/status"`), e comando com argumento vira prefixo
+        // (`starts_with("/model ")`) — com o espaco fazendo parte do literal.
+        for (nome, _) in COMANDOS {
+            let base = nome.split(' ').next().unwrap_or(nome);
+            let exato = corpo.contains(&format!("\"{base}\""));
+            let prefixo = corpo.contains(&format!("\"{base} \""));
+            assert!(exato || prefixo, "{base} esta no /help e nao no match");
+        }
+
+        // E todo comando do match esta anunciado ou e apelido declarado.
+        //
+        // So os literais de comando: o corpo dos arms tem texto de ajuda com
+        // barra dentro, e a busca e ancorada em `"/` seguido de letra.
+        let mut vistos = std::collections::BTreeSet::new();
+        let bytes = corpo.as_bytes();
+        for (i, _) in corpo.match_indices("\"/") {
+            let resto = &corpo[i + 2..];
+            let fim = resto
+                .find(|c: char| !c.is_ascii_lowercase())
+                .unwrap_or(resto.len());
+            if fim == 0 || bytes.get(i + 2 + fim) != Some(&b'"') {
+                continue;
+            }
+            vistos.insert(format!("/{}", &resto[..fim]));
+        }
+        for cmd in &vistos {
+            let anunciado = COMANDOS
+                .iter()
+                .any(|(nome, _)| nome.split(' ').next() == Some(cmd.as_str()));
+            assert!(
+                anunciado || APELIDOS.contains(&cmd.as_str()),
+                "{cmd} existe no match e nao aparece no /help nem em APELIDOS"
+            );
+        }
+        assert!(
+            vistos.contains("/status"),
+            "a varredura achou algo: {vistos:?}"
+        );
+    }
 
     fn make_llm_cfg(
         provider: &str,

--- a/crates/garraia-cli/src/chat.rs
+++ b/crates/garraia-cli/src/chat.rs
@@ -42,6 +42,7 @@ const COMANDOS: &[(&str, &str)] = &[
     ("/tool", "Saidas de ferramenta guardadas nesta sessao"),
     ("/tool <n>", "A saida inteira de uma chamada"),
     ("/history", "Historico da conversa"),
+    ("/logs", "Onde fica o log, e como segui-lo"),
     ("/models", "Modelos que este provider lista"),
     ("/model <nome>", "Trocar de modelo sem reiniciar"),
     (
@@ -1214,6 +1215,38 @@ pub async fn run_chat(
             // Quais ferramentas o agente **tem** — diferente do `/tool`, que
             // mostra o que elas **produziram**. Ate aqui `/tools` era apelido
             // de `/tool`, e nao havia como perguntar a primeira coisa.
+            // O `/logs` **nao** despeja o log na conversa: ele diz onde ele
+            // esta e qual comando o le. Misturar centenas de linhas de log com
+            // a conversa e o oposto do que a Fase 2 deste epico foi fazer, e
+            // seguir o arquivo em tempo real disputaria a mesma tela com o
+            // streaming da resposta. O criterio de aceite pede "expose the log
+            // location/workflow", e e isso.
+            "/logs" | "/log" => {
+                let caminho = crate::logs_cmd::caminho_do_log(&crate::garraia_dir());
+                let existe = caminho.exists();
+                let linhas = vec![
+                    panel::linha("Arquivo", caminho.display().to_string()),
+                    panel::linha(
+                        "Estado",
+                        if existe {
+                            "existe"
+                        } else {
+                            "ainda nao foi criado"
+                        },
+                    ),
+                    panel::linha("Ver o fim", "garra logs"),
+                    panel::linha("Acompanhar", "garra logs --follow"),
+                    panel::linha("Mais detalhe", "RUST_LOG=debug garra start"),
+                ];
+                renderer.handle(
+                    UiEvent::Panel {
+                        titulo: "Log",
+                        linhas: &linhas,
+                    },
+                    &mut io::stdout(),
+                );
+                continue;
+            }
             "/tools" | "/ferramentas" => {
                 let ferramentas = runtime.list_tool_info();
                 if ferramentas.is_empty() {
@@ -1632,6 +1665,7 @@ mod tests {
         "/historico",
         "/saida",
         "/ferramentas",
+        "/log",
     ];
 
     /// O `/help` nao pode divergir do `match` — e ele ja tinha divergido.

--- a/crates/garraia-cli/src/logs_cmd.rs
+++ b/crates/garraia-cli/src/logs_cmd.rs
@@ -1,0 +1,305 @@
+//! `garra logs` — ler o log sem depender do gateway (#943).
+//!
+//! # O que este comando e, e o que ele nao e
+//!
+//! E um leitor do arquivo canonico. **Nao** fala com o gateway, nao abre
+//! socket e nao pede que nada esteja rodando — o criterio de aceite pede isso
+//! com essas palavras, e e o que torna o comando util justamente quando o
+//! gateway morreu.
+//!
+//! # Redacao
+//!
+//! Nao ha redacao aqui, e isso e de proposito. Ela acontece na **escrita**: o
+//! `RedactingMakeWriter` embrulha o appender em `main.rs`, entao o que esta no
+//! disco ja esta redigido. Redigir de novo na leitura mascararia um vazamento
+//! em vez de conserta-lo — quem depura um incidente lendo `garraia.log` no
+//! `less` veria o segredo do mesmo jeito, e nos acharíamos que estamos
+//! protegidos. Ha um teste afirmando que o comando devolve o byte que leu.
+//!
+//! # Por que nao ha `--level`
+//!
+//! A issue cita `--level debug` como extensao possivel. Uma entrada de log
+//! ocupa **varias linhas** quando carrega backtrace ou payload multi-linha, e
+//! filtrar linha a linha partiria a entrada ao meio: sobraria a primeira linha
+//! do erro sem o rastro que explica. Quem quer menos ruido no arquivo tem o
+//! `RUST_LOG`, que decide na escrita e nao corta entrada pela metade.
+
+use std::io::{BufRead, BufReader, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+
+/// Quantas linhas do fim mostrar quando ninguem pede outra coisa.
+pub const LINHAS_PADRAO: usize = 100;
+
+/// De quanto em quanto tempo o `--follow` procura conteudo novo.
+///
+/// Poll, e nao `inotify`: o `--follow` precisa funcionar no Windows e num
+/// diretorio montado por rede, onde a notificacao do sistema nao chega. 250 ms
+/// e imperceptivel para quem le e e barato — um `read` num fd ja aberto.
+const INTERVALO_DO_FOLLOW: Duration = Duration::from_millis(250);
+
+/// O caminho canonico do log.
+///
+/// Vive aqui e nao no `main.rs` porque la ele e `#[cfg(unix)]` — o daemon so
+/// existe no Unix. O **arquivo** existe nos dois, escrito pelo appender de
+/// tracing, e a issue pede o comando cross-platform onde for pratico.
+pub fn caminho_do_log(dir: &Path) -> PathBuf {
+    dir.join("garraia.log")
+}
+
+/// O que fazer quando o arquivo nao esta la.
+///
+/// Nao e erro: e o estado normal de uma instalacao que nunca rodou nada. A
+/// issue pede "helpful message", e a mensagem util diz **onde** ele estaria e
+/// **o que** o cria.
+fn ausente(caminho: &Path, out: &mut impl Write) -> Result<()> {
+    writeln!(out, "Nenhum log ainda em {}", caminho.display())?;
+    writeln!(
+        out,
+        "O arquivo aparece quando algo roda: `garra start` e o caso comum."
+    )?;
+    writeln!(
+        out,
+        "Para mais detalhe no arquivo: RUST_LOG=debug garra start"
+    )?;
+    Ok(())
+}
+
+/// Imprime as ultimas `linhas` do log.
+///
+/// Le o arquivo inteiro para pegar o fim. E o suficiente e nao vale otimizar:
+/// o appender e `rolling::never`, o arquivo cresce ate a instalacao ser
+/// limpa, e ainda assim e um log de texto de uma maquina so — quando ele
+/// chegar a um tamanho em que isso doa, o problema a resolver e a rotacao, e
+/// nao a leitura.
+pub fn tail(caminho: &Path, linhas: usize, out: &mut impl Write) -> Result<()> {
+    if !caminho.exists() {
+        return ausente(caminho, out);
+    }
+    let arquivo = std::fs::File::open(caminho)
+        .with_context(|| format!("nao consegui abrir {}", caminho.display()))?;
+    let leitor = BufReader::new(arquivo);
+
+    // Buffer circular: guarda so as ultimas `linhas`.
+    let mut ultimas: std::collections::VecDeque<String> = std::collections::VecDeque::new();
+    for linha in leitor.lines() {
+        // Linha invalida em UTF-8 nao derruba o comando: um log truncado no
+        // meio de um caractere e exatamente o caso em que se quer ler o log.
+        let linha = match linha {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+        if ultimas.len() == linhas {
+            ultimas.pop_front();
+        }
+        ultimas.push_back(linha);
+    }
+
+    if ultimas.is_empty() {
+        writeln!(out, "O log em {} esta vazio.", caminho.display())?;
+        return Ok(());
+    }
+    for l in &ultimas {
+        writeln!(out, "{l}")?;
+    }
+    Ok(())
+}
+
+/// Segue o arquivo ate ser interrompido.
+///
+/// `parar` e consultado a cada volta: e por onde o `Ctrl+C` entra. Sem isso o
+/// laco so morreria com o processo, e o criterio de aceite pede saida limpa.
+pub fn follow(
+    caminho: &Path,
+    linhas: usize,
+    out: &mut impl Write,
+    parar: &dyn Fn() -> bool,
+) -> Result<()> {
+    tail(caminho, linhas, out)?;
+    let _ = out.flush();
+
+    // A posicao de onde continuar. Quando o arquivo ainda nao existe,
+    // comeca do zero — e o caso de `garra logs --follow` aberto antes do
+    // `garra start`, que e justamente quando ele e mais util.
+    let mut posicao = std::fs::metadata(caminho).map(|m| m.len()).unwrap_or(0);
+
+    while !parar() {
+        std::thread::sleep(INTERVALO_DO_FOLLOW);
+        let tamanho = match std::fs::metadata(caminho) {
+            Ok(m) => m.len(),
+            // Sumiu no meio do caminho (limpeza, reinstalacao): espera voltar
+            // em vez de morrer.
+            Err(_) => continue,
+        };
+        if tamanho < posicao {
+            // Truncado ou recriado: o appender e `rolling::never`, mas nada
+            // impede alguem de apagar o arquivo. Recomeça do inicio em vez de
+            // ficar lendo alem do fim para sempre.
+            posicao = 0;
+        }
+        if tamanho == posicao {
+            continue;
+        }
+        let mut arquivo = match std::fs::File::open(caminho) {
+            Ok(f) => f,
+            Err(_) => continue,
+        };
+        if arquivo.seek(SeekFrom::Start(posicao)).is_err() {
+            continue;
+        }
+        let leitor = BufReader::new(&mut arquivo);
+        for linha in leitor.lines().map_while(std::result::Result::ok) {
+            writeln!(out, "{linha}")?;
+        }
+        let _ = out.flush();
+        posicao = tamanho;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn escreve(dir: &Path, conteudo: &str) -> PathBuf {
+        let p = caminho_do_log(dir);
+        std::fs::write(&p, conteudo).expect("escrever");
+        p
+    }
+
+    #[test]
+    fn arquivo_ausente_da_mensagem_util_e_nao_erro() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let mut out: Vec<u8> = Vec::new();
+        tail(&caminho_do_log(dir.path()), 10, &mut out).expect("nao e erro");
+        let s = String::from_utf8(out).expect("utf8");
+
+        assert!(s.contains("Nenhum log ainda"), "saiu: {s:?}");
+        assert!(s.contains("garraia.log"), "diz onde estaria: {s:?}");
+        assert!(s.contains("garra start"), "diz o que o cria: {s:?}");
+    }
+
+    #[test]
+    fn arquivo_vazio_tambem_e_dito() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let p = escreve(dir.path(), "");
+        let mut out: Vec<u8> = Vec::new();
+        tail(&p, 10, &mut out).expect("ok");
+        assert!(String::from_utf8_lossy(&out).contains("esta vazio"));
+    }
+
+    #[test]
+    fn mostra_so_as_ultimas_linhas_e_na_ordem() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let corpo: String = (1..=50).map(|n| format!("linha {n}\n")).collect();
+        let p = escreve(dir.path(), &corpo);
+
+        let mut out: Vec<u8> = Vec::new();
+        tail(&p, 3, &mut out).expect("ok");
+        assert_eq!(
+            String::from_utf8(out).expect("utf8"),
+            "linha 48\nlinha 49\nlinha 50\n"
+        );
+    }
+
+    /// Pedir mais linhas do que existem devolve o arquivo inteiro.
+    #[test]
+    fn pedir_demais_devolve_o_que_ha() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let p = escreve(dir.path(), "a\nb\n");
+        let mut out: Vec<u8> = Vec::new();
+        tail(&p, 1000, &mut out).expect("ok");
+        assert_eq!(String::from_utf8(out).expect("utf8"), "a\nb\n");
+    }
+
+    /// O comando devolve o byte que leu — a redacao e da escrita.
+    ///
+    /// Se isto falhar porque alguem acrescentou redacao na leitura, o
+    /// problema nao e o teste: mascarar aqui esconderia um vazamento que
+    /// continua no disco, visivel para quem abrir o arquivo no `less`.
+    #[test]
+    fn o_conteudo_sai_como_esta_no_disco() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let linha = "2026-01-01T00:00:00Z INFO tudo bem por aqui\n";
+        let p = escreve(dir.path(), linha);
+        let mut out: Vec<u8> = Vec::new();
+        tail(&p, 10, &mut out).expect("ok");
+        assert_eq!(String::from_utf8(out).expect("utf8"), linha);
+    }
+
+    /// Byte invalido em UTF-8 nao derruba a leitura.
+    #[test]
+    fn log_com_byte_invalido_nao_derruba() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let p = caminho_do_log(dir.path());
+        std::fs::write(&p, b"boa\n\xff\xfe quebrado\nfim\n").expect("escrever");
+        let mut out: Vec<u8> = Vec::new();
+        tail(&p, 10, &mut out).expect("nao derruba");
+        let s = String::from_utf8(out).expect("utf8");
+        assert!(s.contains("boa") && s.contains("fim"), "saiu: {s:?}");
+    }
+
+    /// O follow para quando mandam parar — e o caminho do Ctrl+C.
+    #[test]
+    fn follow_para_quando_mandam_parar() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let p = escreve(dir.path(), "inicio\n");
+        let mut out: Vec<u8> = Vec::new();
+
+        // Para na primeira consulta: o `tail` inicial ja saiu, e o laco nem
+        // chega a dormir.
+        follow(&p, 10, &mut out, &|| true).expect("ok");
+        assert!(String::from_utf8_lossy(&out).contains("inicio"));
+    }
+
+    /// O que for acrescentado depois aparece.
+    #[test]
+    fn follow_mostra_o_que_chega_depois() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let p = escreve(dir.path(), "antes\n");
+
+        // Para na terceira consulta, dando duas voltas ao laco.
+        let voltas = std::sync::atomic::AtomicUsize::new(0);
+        let caminho = p.clone();
+        let parar = move || {
+            let n = voltas.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if n == 0 {
+                // Entre a primeira e a segunda volta, alguem escreve.
+                let mut f = std::fs::OpenOptions::new()
+                    .append(true)
+                    .open(&caminho)
+                    .expect("abrir");
+                f.write_all(b"depois\n").expect("escrever");
+            }
+            n >= 2
+        };
+
+        let mut out: Vec<u8> = Vec::new();
+        follow(&p, 10, &mut out, &parar).expect("ok");
+        let s = String::from_utf8(out).expect("utf8");
+        assert!(s.contains("antes"), "o tail inicial: {s:?}");
+        assert!(s.contains("depois"), "e o que chegou depois: {s:?}");
+    }
+
+    /// Arquivo apagado no meio do follow nao derruba o comando.
+    #[test]
+    fn follow_sobrevive_ao_arquivo_sumir() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let p = escreve(dir.path(), "antes\n");
+
+        let voltas = std::sync::atomic::AtomicUsize::new(0);
+        let caminho = p.clone();
+        let parar = move || {
+            let n = voltas.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if n == 0 {
+                let _ = std::fs::remove_file(&caminho);
+            }
+            n >= 2
+        };
+
+        let mut out: Vec<u8> = Vec::new();
+        follow(&p, 10, &mut out, &parar).expect("nao derruba");
+    }
+}

--- a/crates/garraia-cli/src/logs_cmd.rs
+++ b/crates/garraia-cli/src/logs_cmd.rs
@@ -9,12 +9,22 @@
 //!
 //! # Redacao
 //!
-//! Nao ha redacao aqui, e isso e de proposito. Ela acontece na **escrita**: o
-//! `RedactingMakeWriter` embrulha o appender em `main.rs`, entao o que esta no
-//! disco ja esta redigido. Redigir de novo na leitura mascararia um vazamento
-//! em vez de conserta-lo — quem depura um incidente lendo `garraia.log` no
-//! `less` veria o segredo do mesmo jeito, e nos acharíamos que estamos
-//! protegidos. Ha um teste afirmando que o comando devolve o byte que leu.
+//! Nao ha redacao aqui, e isso e de proposito: ela acontece na **escrita**.
+//! Redigir de novo na leitura mascararia um vazamento em vez de conserta-lo —
+//! quem depura um incidente lendo `garraia.log` no `less` veria o segredo do
+//! mesmo jeito, e nos acharíamos que estamos protegidos. Ha um teste afirmando
+//! que o comando devolve o byte que leu.
+//!
+//! **A premissa tem um limite, e vale escrever qual.** O
+//! `RedactingMakeWriter` cobre o que passa pelo `tracing`, nos dois caminhos
+//! (foreground e daemon). No daemon, porem, o `dup2` manda stdout e stderr
+//! para o mesmo arquivo **antes** de o subscriber existir, entao um
+//! `println!` de codigo de producao que rode no processo do gateway chega ao
+//! log cru — o proprio `main.rs` documenta isso onde o `dup2` acontece. Hoje
+//! nao ha nenhum: a auditoria do #943 varreu `garraia-gateway` e
+//! `garraia-agents` e os `println!` que existem estao todos dentro de
+//! `#[test]`. Se um dia houver, o conserto e **la**, na escrita. Ler menos
+//! aqui nao protegeria ninguem que abrisse o arquivo por fora.
 //!
 //! # Por que nao ha `--level`
 //!
@@ -39,6 +49,14 @@ pub const LINHAS_PADRAO: usize = 100;
 /// diretorio montado por rede, onde a notificacao do sistema nao chega. 250 ms
 /// e imperceptivel para quem le e e barato — um `read` num fd ja aberto.
 const INTERVALO_DO_FOLLOW: Duration = Duration::from_millis(250);
+
+/// Teto de uma linha lida do log.
+///
+/// `BufReader::lines()` aloca uma `String` por linha sem limite: um arquivo
+/// sem `\n` nenhum viraria uma alocacao do tamanho do arquivo. Uma linha de
+/// log de verdade nao chega perto de 1 MiB — o que chega e arquivo corrompido
+/// ou binario, e desses o util e pular, nao carregar.
+const MAX_BYTES_POR_LINHA: usize = 1024 * 1024;
 
 /// O caminho canonico do log.
 ///
@@ -78,6 +96,14 @@ pub fn tail(caminho: &Path, linhas: usize, out: &mut impl Write) -> Result<()> {
     if !caminho.exists() {
         return ausente(caminho, out);
     }
+    // `-n 0` e o idioma do `tail` para "so o que vier daqui em diante", e e o
+    // par natural do `--follow`. Sem esta guarda ele fazia o **oposto**: o
+    // `ultimas.len() == 0` era verdade so na primeira volta, entao o buffer
+    // circular nunca podava e o arquivo inteiro ia para a memoria e para a
+    // tela. Achado rodando o binario e confirmado na auditoria.
+    if linhas == 0 {
+        return Ok(());
+    }
     let arquivo = std::fs::File::open(caminho)
         .with_context(|| format!("nao consegui abrir {}", caminho.display()))?;
     let leitor = BufReader::new(arquivo);
@@ -85,13 +111,21 @@ pub fn tail(caminho: &Path, linhas: usize, out: &mut impl Write) -> Result<()> {
     // Buffer circular: guarda so as ultimas `linhas`.
     let mut ultimas: std::collections::VecDeque<String> = std::collections::VecDeque::new();
     for linha in leitor.lines() {
-        // Linha invalida em UTF-8 nao derruba o comando: um log truncado no
-        // meio de um caractere e exatamente o caso em que se quer ler o log.
         let linha = match linha {
+            // Linha maior que o teto e descartada em vez de carregada: um
+            // arquivo binario ou um JSON de centenas de MB numa linha so
+            // viraria uma `String` do tamanho do arquivo. Log de texto nao
+            // tem linha assim; o que tem e arquivo corrompido.
+            Ok(l) if l.len() > MAX_BYTES_POR_LINHA => continue,
             Ok(l) => l,
+            // Linha invalida em UTF-8 nao derruba o comando: um log truncado
+            // no meio de um caractere e exatamente o caso em que se quer ler
+            // o log.
             Err(_) => continue,
         };
-        if ultimas.len() == linhas {
+        // `>=` e nao `==`: e a semantica correta de um buffer circular, e nao
+        // depende de o contador passar exatamente pelo limite.
+        if ultimas.len() >= linhas {
             ultimas.pop_front();
         }
         ultimas.push_back(linha);
@@ -239,6 +273,77 @@ mod tests {
         tail(&p, 10, &mut out).expect("nao derruba");
         let s = String::from_utf8(out).expect("utf8");
         assert!(s.contains("boa") && s.contains("fim"), "saiu: {s:?}");
+    }
+
+    /// `-n 0` nao mostra nada — e o idioma do `tail`, e o par do `--follow`.
+    ///
+    /// Antes ele fazia o oposto: o `len() == 0` era verdade so na primeira
+    /// volta, entao o buffer nunca podava e o arquivo **inteiro** ia para a
+    /// memoria e para a tela. Num log de 1 GB isso e um OOM com uma flag.
+    #[test]
+    fn lines_zero_nao_mostra_nada() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let corpo: String = (1..=200).map(|n| format!("linha {n}\n")).collect();
+        let p = escreve(dir.path(), &corpo);
+
+        let mut out: Vec<u8> = Vec::new();
+        tail(&p, 0, &mut out).expect("ok");
+        assert!(
+            out.is_empty(),
+            "devia sair vazio: {:?}",
+            String::from_utf8_lossy(&out)
+        );
+    }
+
+    /// E `-n 0 --follow` mostra so o que chegar depois.
+    #[test]
+    fn lines_zero_com_follow_mostra_so_o_que_vem_depois() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let p = escreve(dir.path(), "historico antigo\n");
+
+        let voltas = std::sync::atomic::AtomicUsize::new(0);
+        let caminho = p.clone();
+        let parar = move || {
+            let n = voltas.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if n == 0 {
+                let mut f = std::fs::OpenOptions::new()
+                    .append(true)
+                    .open(&caminho)
+                    .expect("abrir");
+                f.write_all(b"chegou agora\n").expect("escrever");
+            }
+            n >= 2
+        };
+
+        let mut out: Vec<u8> = Vec::new();
+        follow(&p, 0, &mut out, &parar).expect("ok");
+        let s = String::from_utf8(out).expect("utf8");
+        assert!(!s.contains("historico antigo"), "sem historico: {s:?}");
+        assert!(s.contains("chegou agora"), "com o que chegou: {s:?}");
+    }
+
+    /// Linha maior que o teto e pulada, e o resto do arquivo continua saindo.
+    ///
+    /// Sem o teto, um arquivo sem `\n` viraria uma `String` do tamanho do
+    /// arquivo — o `BufReader::lines()` nao tem limite proprio.
+    #[test]
+    fn linha_gigante_e_pulada_sem_derrubar_o_resto() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let gigante = "x".repeat(MAX_BYTES_POR_LINHA + 10);
+        let p = escreve(dir.path(), &format!("antes\n{gigante}\ndepois\n"));
+
+        let mut out: Vec<u8> = Vec::new();
+        tail(&p, 100, &mut out).expect("ok");
+        let s = String::from_utf8(out).expect("utf8");
+        assert!(
+            s.contains("antes") && s.contains("depois"),
+            "saiu: {}",
+            s.len()
+        );
+        assert!(
+            !s.contains(&"x".repeat(1000)),
+            "a linha gigante nao vai para a tela"
+        );
     }
 
     /// O follow para quando mandam parar — e o caminho do Ctrl+C.

--- a/crates/garraia-cli/src/main.rs
+++ b/crates/garraia-cli/src/main.rs
@@ -7,6 +7,7 @@ mod cli_args;
 mod config_cmd;
 mod doctor;
 mod glob_cmd;
+mod logs_cmd;
 mod max_power;
 mod mcp_server;
 mod memory_cmd;
@@ -122,6 +123,24 @@ enum Commands {
 
     /// Show current status
     Status,
+
+    /// Show the GarraIA log (#943)
+    ///
+    /// Le o arquivo canonico direto: nao fala com o gateway e nao precisa que
+    /// ele esteja rodando — que e justamente quando o log importa.
+    Logs {
+        /// Follow new entries until interrupted (Ctrl+C)
+        #[arg(long, short = 'f')]
+        follow: bool,
+
+        /// How many lines from the end to show
+        #[arg(long, short = 'n', default_value_t = logs_cmd::LINHAS_PADRAO)]
+        lines: usize,
+
+        /// Print the log path and exit
+        #[arg(long)]
+        path: bool,
+    },
 
     /// Diagnose the installation (platform, dirs, config, providers, daemon)
     Doctor {
@@ -1334,6 +1353,58 @@ async fn async_main(
                 .with_telemetry_config(Some(telemetry_config));
             server.run().await?;
         }
+        Commands::Logs {
+            follow,
+            lines,
+            path,
+        } => {
+            // **Sem** `init_tracing` de proposito: subir o subscriber aqui
+            // abriria o proprio `garraia.log` para escrita so para le-lo, e
+            // um `garra logs --follow` ficaria se vendo no espelho.
+            let caminho = logs_cmd::caminho_do_log(&garraia_dir());
+            let mut out = std::io::stdout();
+            if path {
+                use std::io::Write as _;
+                writeln!(out, "{}", caminho.display())?;
+                return Ok(());
+            }
+            if follow {
+                // O Ctrl+C fecha o laco em vez de matar o processo: o
+                // criterio de aceite pede saida limpa. A flag e lida a cada
+                // volta pelo `parar`.
+                let parada = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+                let sinal = std::sync::Arc::clone(&parada);
+                tokio::spawn(async move {
+                    if tokio::signal::ctrl_c().await.is_ok() {
+                        sinal.store(true, std::sync::atomic::Ordering::SeqCst);
+                    }
+                });
+                let visto = std::sync::Arc::clone(&parada);
+                // Bloqueante num executor async: vai para uma thread propria,
+                // senao o laco de poll prenderia a thread do runtime e o
+                // proprio handler do Ctrl+C nao rodaria.
+                tokio::task::spawn_blocking(move || {
+                    let mut out = std::io::stdout();
+                    logs_cmd::follow(&caminho, lines, &mut out, &|| {
+                        visto.load(std::sync::atomic::Ordering::SeqCst)
+                    })
+                })
+                .await??;
+                // 130 = terminado por SIGINT, a convencao do shell — e a mesma
+                // escolha que o `garra chat` ocioso ja faz. `tail -f` e
+                // `journalctl -f` tambem saem assim: seguir um arquivo termina
+                // por interrupcao, e quem chama por script conta com isso.
+                if parada.load(std::sync::atomic::Ordering::SeqCst) {
+                    use std::io::Write as _;
+                    let _ = std::io::stdout().flush();
+                    std::process::exit(130);
+                }
+            } else {
+                logs_cmd::tail(&caminho, lines, &mut out)?;
+            }
+            return Ok(());
+        }
+
         Commands::Status => {
             init_tracing(&effective_level);
 

--- a/crates/garraia-cli/src/ui/conversation.rs
+++ b/crates/garraia-cli/src/ui/conversation.rs
@@ -9,9 +9,9 @@
 
 use std::path::Path;
 
-const CYAN: &str = "\x1b[36m";
+pub(crate) const CYAN: &str = "\x1b[36m";
 const GREEN: &str = "\x1b[32m";
-const BOLD: &str = "\x1b[1m";
+pub(crate) const BOLD: &str = "\x1b[1m";
 pub(crate) const DIM: &str = "\x1b[2m";
 /// Avisos e erros dirigidos ao usuario (o renderer os usa).
 pub(crate) const YELLOW: &str = "\x1b[33m";

--- a/crates/garraia-cli/src/ui/mod.rs
+++ b/crates/garraia-cli/src/ui/mod.rs
@@ -42,6 +42,7 @@ pub mod ansi_filter;
 pub mod conversation;
 pub mod error_card;
 pub mod markdown;
+pub mod panel;
 pub mod spinner;
 pub mod tool_log;
 
@@ -88,6 +89,24 @@ pub enum UiEvent<'a> {
         titulo: &'a str,
         detalhe: &'a str,
         acoes: &'a [String],
+    },
+
+    /// Uma superficie de status: titulo, regua e pares rotulo/valor (#940).
+    ///
+    /// Variante propria pelo mesmo motivo do [`UiEvent::ErrorCard`]: quem sabe
+    /// **o que** mostrar e o `chat.rs`, quem sabe **como desenhar** e daqui.
+    /// Era isto que faltava quando o `/context` escrevia
+    /// `println!("{DIM}Diretorio: …{RESET}")` — cor incondicional e largura
+    /// ignorada, a divida que a ADR 0017 registra.
+    Panel {
+        titulo: &'a str,
+        linhas: &'a [panel::Linha<'a>],
+    },
+
+    /// Uma lista sob a mesma moldura do painel (#940): `/help`, `/models`.
+    List {
+        titulo: &'a str,
+        itens: &'a [String],
     },
 
     /// Uma ferramenta comecou (#937). `detail` ja vem redigido e truncado do
@@ -301,6 +320,8 @@ impl TerminalRenderer {
                 detalhe,
                 acoes,
             } => self.write_error_card(titulo, detalhe, acoes, out),
+            UiEvent::Panel { titulo, linhas } => self.write_panel(titulo, linhas, out),
+            UiEvent::List { titulo, itens } => self.write_list(titulo, itens, out),
             UiEvent::ToolStarted { name, detail } => self.write_tool_started(name, detail, out),
             UiEvent::ToolFinished {
                 name,
@@ -550,6 +571,30 @@ impl TerminalRenderer {
                 let _ = writeln!(out, "    {dim}{a}{reset}");
             }
         }
+        let _ = out.flush();
+    }
+
+    /// Painel de status (#940). A linha em branco antes separa da conversa.
+    fn write_panel(
+        &mut self,
+        titulo: &str,
+        linhas: &[panel::Linha<'_>],
+        out: &mut (impl io::Write + ?Sized),
+    ) {
+        if let Some(s) = self.spinner.as_mut() {
+            s.clear(out);
+        }
+        let texto = panel::render(titulo, linhas, self.caps.style(), self.caps.width);
+        let _ = write!(out, "\n{texto}");
+        let _ = out.flush();
+    }
+
+    fn write_list(&mut self, titulo: &str, itens: &[String], out: &mut (impl io::Write + ?Sized)) {
+        if let Some(s) = self.spinner.as_mut() {
+            s.clear(out);
+        }
+        let texto = panel::render_list(titulo, itens, self.caps.style(), self.caps.width);
+        let _ = write!(out, "\n{texto}");
         let _ = out.flush();
     }
 
@@ -824,6 +869,77 @@ mod tests {
             saida.lines().count() > 1,
             "com 24 colunas isto tinha de quebrar: {saida:?}"
         );
+    }
+
+    /// O painel atravessa o renderizador e respeita as `Capabilities` (#940).
+    ///
+    /// O `panel.rs` prova que a funcao desenha certo; isto prova que a largura
+    /// e a cor **chegam** nela. Sao coisas diferentes, e ja passou nesta serie
+    /// de um teste verde com a funcionalidade desligada.
+    #[test]
+    fn o_painel_atravessa_o_renderizador_com_as_capabilities() {
+        let linhas = vec![panel::linha(
+            "Projeto",
+            "Rust Cargo Docker Compose Kubernetes Terraform",
+        )];
+
+        let estreito = Capabilities {
+            interactive: true,
+            unicode: true,
+            animation: false,
+            width: 30,
+        };
+        let mut r = TerminalRenderer::with_prefix(estreito, None, "");
+        let mut out: Vec<u8> = Vec::new();
+        r.handle(
+            UiEvent::Panel {
+                titulo: "Contexto",
+                linhas: &linhas,
+            },
+            &mut out,
+        );
+        let rico = String::from_utf8(out).expect("UTF-8");
+        assert!(rico.contains('\x1b'), "num terminal rico ha cor: {rico:?}");
+        assert!(
+            rico.lines()
+                .filter(|l| l.contains("Cargo") || l.contains("Terraform"))
+                .count()
+                >= 2,
+            "com 30 colunas o valor quebra: {rico:?}"
+        );
+
+        let mut r = TerminalRenderer::with_prefix(Capabilities::PLAIN, None, "");
+        let mut out: Vec<u8> = Vec::new();
+        r.handle(
+            UiEvent::Panel {
+                titulo: "Contexto",
+                linhas: &linhas,
+            },
+            &mut out,
+        );
+        let plano = String::from_utf8(out).expect("UTF-8");
+        assert!(
+            !plano.contains('\x1b'),
+            "redirecionado nao ganha escape: {plano:?}"
+        );
+    }
+
+    /// A lista tambem, e pelo mesmo motivo.
+    #[test]
+    fn a_lista_atravessa_o_renderizador() {
+        let itens = vec!["  /help   mostra isto".to_string()];
+        let mut r = TerminalRenderer::with_prefix(Capabilities::PLAIN, None, "");
+        let mut out: Vec<u8> = Vec::new();
+        r.handle(
+            UiEvent::List {
+                titulo: "Comandos",
+                itens: &itens,
+            },
+            &mut out,
+        );
+        let s = String::from_utf8(out).expect("UTF-8");
+        assert!(!s.contains('\x1b'), "sem escape: {s:?}");
+        assert!(s.contains("/help   mostra isto"));
     }
 
     /// Um turno novo volta a dever o rotulo — senao a segunda resposta da

--- a/crates/garraia-cli/src/ui/panel.rs
+++ b/crates/garraia-cli/src/ui/panel.rs
@@ -363,6 +363,34 @@ mod tests {
         }
     }
 
+    /// Largura hostil nao vira alocacao gigante.
+    ///
+    /// `terminal_width()` le a env var `COLUMNS` sem teto superior, entao
+    /// `COLUMNS=999999999` chega ate aqui. A regua acompanha o **conteudo** e
+    /// so entao e limitada pela largura — se fosse `traco.repeat(largura)`,
+    /// esta linha alocaria alguns gigabytes. E o mesmo cuidado que o
+    /// `Header::render` ja tomava; o painel novo tinha de nao reintroduzir o
+    /// problema.
+    #[test]
+    fn largura_absurda_nao_aloca_o_mundo() {
+        let s = render("Contexto", &amostra(), Style::PLAIN, usize::MAX);
+        assert!(s.len() < 4096, "saida grande demais: {} bytes", s.len());
+
+        let l = render_list("Comandos", &["/help".to_string()], Style::PLAIN, usize::MAX);
+        assert!(l.len() < 4096, "saida grande demais: {} bytes", l.len());
+    }
+
+    /// Largura 0 e 1 nao entram em panico.
+    #[test]
+    fn largura_degenerada_nao_entra_em_panico() {
+        for largura in [0usize, 1, 2] {
+            let s = render("Contexto", &amostra(), Style::PLAIN, largura);
+            assert!(s.contains("Diretorio"), "largura {largura}: {s:?}");
+            let l = render_list("Comandos", &["/help".to_string()], Style::PLAIN, largura);
+            assert!(l.contains("/help"), "largura {largura}: {l:?}");
+        }
+    }
+
     /// Valor sem espaco maior que a largura **estoura**, e nao e truncado.
     ///
     /// Um caminho e um nome de ramo nao tem onde quebrar, e cortar com `…`

--- a/crates/garraia-cli/src/ui/panel.rs
+++ b/crates/garraia-cli/src/ui/panel.rs
@@ -1,0 +1,383 @@
+//! Painel de rotulo e valor — a superficie das telas de status (#940).
+//!
+//! # Por que uma funcao pura, e nao um `println!` no `chat.rs`
+//!
+//! O `/context` de hoje escreve `println!("{DIM}Diretorio: {cwd}{RESET}")`:
+//! cor incondicional, largura ignorada, e um escape que aparece em
+//! `garra chat | cat`. E a divida que a ADR 0017 registra, e ela cresce a cada
+//! superficie nova — que e exatamente o que a #940 pede para acrescentar.
+//!
+//! Aqui vale a mesma regra do [`super::error_card`]: quem sabe **o que**
+//! mostrar e o chamador, quem sabe **como desenhar** e a interface. Um painel
+//! ja formatado do outro lado dessa fronteira ignoraria
+//! [`super::Capabilities`] — largura, cor, Unicode —, que sao justamente os
+//! tres criterios de aceite da issue.
+//!
+//! Sendo funcao pura de `(titulo, linhas, style, largura)` para `String`, cada
+//! um desses criterios vira uma assercao sobre um valor de retorno, sem
+//! terminal e sem processo.
+
+use super::conversation::{BOLD, CYAN, DIM, RESET, Style};
+
+/// Espaco entre a coluna do rotulo e a do valor.
+const ESPACO: usize = 2;
+
+/// Abaixo disto nao ha duas colunas: o valor vai para a linha de baixo.
+///
+/// Nao e um numero escolhido no olho — e o ponto em que a coluna do valor
+/// ficaria mais estreita que uma palavra comum, e o texto passaria a quebrar
+/// a cada duas silabas. Nesse caso empilhar le melhor do que alinhar.
+const MIN_COLUNA_DE_VALOR: usize = 16;
+
+/// Uma linha do painel.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Linha<'a> {
+    pub rotulo: &'a str,
+    pub valor: String,
+}
+
+/// Atalho para montar uma linha sem cerimonia no chamador.
+pub fn linha<'a>(rotulo: &'a str, valor: impl Into<String>) -> Linha<'a> {
+    Linha {
+        rotulo,
+        valor: valor.into(),
+    }
+}
+
+/// Desenha o painel inteiro, com `\n` no fim.
+///
+/// O valor **e saneado aqui**, e nao so na origem. Nome de modelo vem da API
+/// do provider, nome de ramo vem do disco, caminho vem do ambiente: os tres
+/// entram no painel e nenhum e nosso. Sanear no chamador funcionaria ate
+/// alguem escrever o proximo chamador — a mesma razao pela qual o
+/// `write_error_card` saneia de novo o que o `ErrorCard::from_error` ja
+/// saneou.
+pub fn render(titulo: &str, linhas: &[Linha<'_>], style: Style, largura: usize) -> String {
+    let (bold, cyan, dim, reset) = if style.color {
+        (BOLD, CYAN, DIM, RESET)
+    } else {
+        ("", "", "", "")
+    };
+    let traco = if style.unicode { "\u{2500}" } else { "-" };
+
+    let titulo = super::ansi_filter::AnsiFilter::sanitize_once(titulo);
+    let saneadas: Vec<(String, String)> = linhas
+        .iter()
+        .map(|l| {
+            (
+                super::ansi_filter::AnsiFilter::sanitize_once(l.rotulo),
+                super::ansi_filter::AnsiFilter::sanitize_once(&l.valor),
+            )
+        })
+        .collect();
+
+    let maior_rotulo = saneadas
+        .iter()
+        .map(|(r, _)| r.chars().count())
+        .max()
+        .unwrap_or(0);
+    let coluna = maior_rotulo + ESPACO;
+    // Duas colunas so quando sobra largura para a segunda ser util.
+    let empilha = largura.saturating_sub(coluna) < MIN_COLUNA_DE_VALOR;
+
+    let mut saida = String::new();
+    saida.push_str(&format!("{bold}{cyan}{titulo}{reset}\n"));
+    saida.push_str(&format!(
+        "{dim}{}{reset}\n",
+        traco.repeat(regua(&titulo, &saneadas, coluna, largura, empilha))
+    ));
+
+    for (rotulo, valor) in &saneadas {
+        if empilha {
+            saida.push_str(&format!("{dim}{rotulo}{reset}\n"));
+            for (i, pedaco) in quebra(valor, largura.saturating_sub(ESPACO).max(1))
+                .iter()
+                .enumerate()
+            {
+                let _ = i;
+                saida.push_str(&format!("{}{pedaco}\n", " ".repeat(ESPACO)));
+            }
+            continue;
+        }
+        let recuo = " ".repeat(coluna);
+        let pedacos = quebra(valor, largura.saturating_sub(coluna).max(1));
+        for (i, pedaco) in pedacos.iter().enumerate() {
+            if i == 0 {
+                let preenche = " ".repeat(coluna - rotulo.chars().count());
+                saida.push_str(&format!("{dim}{rotulo}{reset}{preenche}{pedaco}\n"));
+            } else {
+                // Continuacao alinhada com o valor, e nao com a margem: senao
+                // a segunda linha de um caminho longo parece um rotulo novo.
+                saida.push_str(&format!("{recuo}{pedaco}\n"));
+            }
+        }
+    }
+    saida
+}
+
+/// Desenha uma lista simples sob o mesmo cabecalho do painel.
+///
+/// `/help`, `/models` e o indice do `/tool` sao listas, nao pares. Passariam
+/// como painel de rotulo vazio, mas o alinhamento existe para relacionar duas
+/// colunas e aqui ha uma — o resultado seria uma margem sem motivo. O que
+/// precisa ser igual e a moldura, e e ela que esta compartilhada.
+pub fn render_list(titulo: &str, itens: &[String], style: Style, largura: usize) -> String {
+    let (bold, cyan, dim, reset) = if style.color {
+        (BOLD, CYAN, DIM, RESET)
+    } else {
+        ("", "", "", "")
+    };
+    let traco = if style.unicode { "\u{2500}" } else { "-" };
+
+    let titulo = super::ansi_filter::AnsiFilter::sanitize_once(titulo);
+    let itens: Vec<String> = itens
+        .iter()
+        .map(|i| super::ansi_filter::AnsiFilter::sanitize_once(i))
+        .collect();
+
+    let comprimento = itens
+        .iter()
+        .map(|i| i.chars().count())
+        .max()
+        .unwrap_or(0)
+        .max(titulo.chars().count())
+        .clamp(1, largura.max(1));
+
+    let mut saida = String::new();
+    saida.push_str(&format!("{bold}{cyan}{titulo}{reset}\n"));
+    saida.push_str(&format!("{dim}{}{reset}\n", traco.repeat(comprimento)));
+    for item in &itens {
+        for pedaco in quebra(item, largura.max(1)) {
+            saida.push_str(&pedaco);
+            saida.push('\n');
+        }
+    }
+    saida
+}
+
+/// Comprimento da regua: acompanha o conteudo, sem passar da largura.
+///
+/// Uma regua de largura fixa num painel de tres linhas curtas fica maior que
+/// o painel; uma que acompanha o conteudo emoldura o que existe.
+fn regua(
+    titulo: &str,
+    linhas: &[(String, String)],
+    coluna: usize,
+    largura: usize,
+    empilha: bool,
+) -> usize {
+    let maior = linhas
+        .iter()
+        .map(|(r, v)| {
+            if empilha {
+                r.chars().count().max(v.chars().count() + ESPACO)
+            } else {
+                coluna + v.chars().count()
+            }
+        })
+        .max()
+        .unwrap_or(0)
+        .max(titulo.chars().count());
+    maior.clamp(1, largura.max(1))
+}
+
+/// Quebra o valor em pedacos que cabem em `largura`, preferindo o espaco.
+///
+/// Devolve **sempre** ao menos um pedaco, inclusive para valor vazio: um
+/// rotulo sem linha nenhuma sumiria do painel, e "sem valor" e uma informacao.
+fn quebra(valor: &str, largura: usize) -> Vec<String> {
+    if valor.chars().count() <= largura {
+        return vec![valor.to_string()];
+    }
+    let mut pedacos = Vec::new();
+    let mut atual = String::new();
+    for palavra in valor.split(' ') {
+        let cabe =
+            atual.is_empty() || atual.chars().count() + 1 + palavra.chars().count() <= largura;
+        if !cabe {
+            pedacos.push(std::mem::take(&mut atual));
+        }
+        if !atual.is_empty() {
+            atual.push(' ');
+        }
+        // Palavra maior que a linha inteira (um caminho fundo, uma URL): entra
+        // e estoura. Parti-la ao meio quebraria justamente o que se quer
+        // copiar do painel.
+        atual.push_str(palavra);
+    }
+    if !atual.is_empty() {
+        pedacos.push(atual);
+    }
+    if pedacos.is_empty() {
+        pedacos.push(String::new());
+    }
+    pedacos
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn amostra() -> Vec<Linha<'static>> {
+        vec![
+            linha("Diretorio", "/home/user/GarraRUST"),
+            linha("Ramo", "main"),
+            linha("Provider", "ollama"),
+        ]
+    }
+
+    /// Sem cor, nao sai um unico escape — o criterio "non-TTY behavior remains
+    /// deterministic" medido no valor de retorno.
+    #[test]
+    fn sem_cor_nao_sai_escape() {
+        let s = render("Contexto", &amostra(), Style::PLAIN, 72);
+        assert!(!s.contains('\x1b'), "saiu: {s:?}");
+        assert!(s.contains("Diretorio  /home/user/GarraRUST"));
+        assert!(!s.contains('\u{2500}'), "sem Unicode a regua e ASCII");
+    }
+
+    #[test]
+    fn com_cor_o_titulo_ganha_destaque_e_o_rotulo_fica_discreto() {
+        let s = render("Contexto", &amostra(), Style::RICH, 72);
+        assert!(s.contains(&format!("{BOLD}{CYAN}Contexto{RESET}")));
+        assert!(s.contains(&format!("{DIM}Ramo{RESET}")));
+        assert!(s.contains('\u{2500}'));
+    }
+
+    /// Os valores comecam todos na mesma coluna.
+    #[test]
+    fn os_valores_ficam_alinhados() {
+        let s = render("Contexto", &amostra(), Style::PLAIN, 72);
+        let colunas: Vec<usize> = s
+            .lines()
+            .skip(2)
+            .filter(|l| !l.trim().is_empty())
+            .filter_map(|l| {
+                l.find("/home")
+                    .or_else(|| l.find("main"))
+                    .or_else(|| l.find("ollama"))
+            })
+            .collect();
+        assert_eq!(colunas.len(), 3, "tres valores: {s:?}");
+        assert!(
+            colunas.windows(2).all(|p| p[0] == p[1]),
+            "colunas diferentes {colunas:?} em {s:?}"
+        );
+    }
+
+    /// Nenhuma linha passa da largura, e a continuacao fica alinhada.
+    #[test]
+    fn valor_longo_quebra_e_a_continuacao_alinha() {
+        let linhas = vec![linha(
+            "Projeto",
+            "Rust Cargo Docker Compose Kubernetes Terraform Ansible Vagrant",
+        )];
+        let s = render("Contexto", &linhas, Style::PLAIN, 40);
+        let corpo: Vec<&str> = s.lines().skip(2).filter(|l| !l.is_empty()).collect();
+        assert!(corpo.len() > 1, "precisava quebrar: {s:?}");
+        for l in &corpo {
+            assert!(l.chars().count() <= 40, "linha longa demais: {l:?}");
+        }
+        let coluna = "Projeto".chars().count() + ESPACO;
+        for c in &corpo[1..] {
+            assert!(
+                c.starts_with(&" ".repeat(coluna)),
+                "continuacao sem alinhamento: {c:?}"
+            );
+        }
+    }
+
+    /// Num terminal muito estreito o painel empilha em vez de espremer.
+    #[test]
+    fn terminal_estreito_empilha_em_vez_de_espremer() {
+        let s = render("Contexto", &amostra(), Style::PLAIN, 20);
+        assert!(
+            s.contains("Diretorio\n  /home/user/GarraRUST"),
+            "devia empilhar: {s:?}"
+        );
+    }
+
+    /// Escape vindo de nome de ramo, de modelo ou de caminho nao atravessa.
+    ///
+    /// Nenhum dos tres e nosso: ramo vem do disco, modelo vem da API do
+    /// provider, caminho vem do ambiente.
+    #[test]
+    fn valor_hostil_nao_injeta_escape() {
+        let linhas = vec![
+            linha("Ramo", "main\x1b[2J\x1b[H"),
+            linha("Modelo", "gpt\x1b]0;titulo\x07-4"),
+        ];
+        let s = render("Status\x1b[31m", &linhas, Style::PLAIN, 72);
+        assert!(!s.contains('\x1b'), "escape atravessou: {s:?}");
+        assert!(s.contains("main"), "o texto util fica: {s:?}");
+    }
+
+    /// Valor vazio nao faz o rotulo sumir.
+    #[test]
+    fn valor_vazio_mantem_a_linha() {
+        let linhas = vec![linha("Ramo", "")];
+        let s = render("Contexto", &linhas, Style::PLAIN, 72);
+        assert!(s.contains("Ramo"), "o rotulo fica: {s:?}");
+    }
+
+    /// A lista usa a mesma moldura do painel, e sem cor nao sai escape.
+    #[test]
+    fn a_lista_compartilha_a_moldura_e_respeita_o_no_color() {
+        let itens = vec![
+            "/help    mostra isto".to_string(),
+            "/exit    sair".to_string(),
+        ];
+        let plano = render_list("Comandos", &itens, Style::PLAIN, 72);
+        assert!(!plano.contains('\x1b'), "saiu: {plano:?}");
+        assert!(plano.starts_with("Comandos\n"));
+        assert!(plano.lines().nth(1).is_some_and(|l| l.starts_with('-')));
+
+        let rico = render_list("Comandos", &itens, Style::RICH, 72);
+        assert!(rico.contains(&format!("{BOLD}{CYAN}Comandos{RESET}")));
+        assert!(rico.contains('\u{2500}'));
+    }
+
+    /// Item hostil na lista tambem nao injeta escape.
+    #[test]
+    fn item_de_lista_hostil_nao_injeta_escape() {
+        let itens = vec!["modelo\x1b[2J-x".to_string()];
+        let s = render_list("Modelos", &itens, Style::PLAIN, 72);
+        assert!(!s.contains('\x1b'), "escape atravessou: {s:?}");
+        assert!(s.contains("modelo"));
+    }
+
+    /// A regua acompanha o conteudo e nunca passa da largura.
+    #[test]
+    fn a_regua_acompanha_o_conteudo() {
+        let curto = render("Ct", &[linha("A", "b")], Style::PLAIN, 72);
+        let regua = curto.lines().nth(1).expect("regua");
+        assert!(regua.chars().count() < 20, "regua grande demais: {regua:?}");
+
+        for largura in [24usize, 30, 40, 72] {
+            let p = render("Contexto", &amostra(), Style::PLAIN, largura);
+            let regua = p.lines().nth(1).expect("regua");
+            assert!(
+                regua.chars().count() <= largura,
+                "regua passou da largura {largura}: {regua:?}"
+            );
+        }
+    }
+
+    /// Valor sem espaco maior que a largura **estoura**, e nao e truncado.
+    ///
+    /// Um caminho e um nome de ramo nao tem onde quebrar, e cortar com `…`
+    /// destruiria justamente o que se copia do painel. Quem quebra e o
+    /// terminal — a mesma decisao do renderizador de Markdown para URL longa.
+    /// Medido rodando o binario com `COLUMNS=30`: e o comportamento, e nao um
+    /// descuido.
+    #[test]
+    fn valor_sem_espaco_estoura_em_vez_de_ser_truncado() {
+        let linhas = vec![linha("Ramo", "claude/6-issues-strategy-5mufs3-e5")];
+        let s = render("Contexto", &linhas, Style::PLAIN, 30);
+        assert!(
+            s.contains("claude/6-issues-strategy-5mufs3-e5"),
+            "o valor tem de sair inteiro: {s:?}"
+        );
+        assert!(!s.contains('\u{2026}'), "nada de reticencia: {s:?}");
+    }
+}


### PR DESCRIPTION
## Descrição

Os dois juntos porque o `/logs` do #943 **renderiza pelo painel que o #940 introduz** — separados, o #943 teria de esperar o #940 ou duplicar a superfície. Com o #939 já em `main`, este PR fecha a Fase 3 e o épico #944.

---

# Parte 1 — `/status`, `/tools` e o fim da cor incondicional (#940)

### O que a issue chama de "interaction model consistente" tinha um número

`/help`, `/context`, `/tool`, `/history`, `/models` e a despedida escreviam `println!("{DIM}…{RESET}")` direto. Medido no binário, numa sessão de seis comandos redirecionada:

```
ESC em saída redirecionada: 12   →   0
```

É a dívida dos `println!` síncronos que a ADR 0017 registra, paga onde ela mais aparecia. O critério "Non-TTY behavior remains deterministic" deixou de ser uma intenção.

### Um painel e uma lista, com a mesma moldura

Vale a regra que o `error_card` já estabeleceu: **quem sabe o que mostrar é o `chat.rs`, quem sabe como desenhar é a interface.** Sendo função pura de `(titulo, linhas, estilo, largura) → String`, "respeita `NO_COLOR`", "cabe no terminal estreito" e "alinha a continuação" viram asserção sobre um valor de retorno, sem terminal e sem processo.

### `/status`: o estado vivo, não o do boot

`/model` troca o modelo no meio da sessão, então perguntar à config diria o que era verdade quando o processo subiu.

### `/tools` deixou de ser apelido de `/tool`

Não havia como perguntar "quais ferramentas o agente tem" — `/tools` mostrava o que elas **produziram**. Mudança de comportamento, registrada no changelog.

### O `/help` já mentia

Não citava `/models`, e prometia `/provider <nome>` como se trocasse de provider. Virou tabela, com um teste que confere **os dois sentidos** contra o próprio fonte.

A primeira versão desse teste **se satisfazia sozinha** — o comando falso aparecia como literal na própria tabela `COMANDOS`, no arquivo que o `include_str!` lê. Verifiquei inserindo um `/fantasma`: passou verde. A varredura passou a excluir a tabela e o módulo de teste.

### Sem contagem de arquivos no `/context`

O exemplo da issue mostra `Files 1,284`, e a mesma issue pede para **não varrer o diretório só para desenhar status**. O campo "Projeto" também parou de despejar quinze nomes de arquivo — aquela listagem existe para o **prompt do sistema**, onde é útil ao modelo.

---

# Parte 2 — `garra logs` (#943)

Lê o arquivo canônico direto do disco. **Não fala com o gateway** e não pede que ele esteja rodando — o critério de aceite pede isso com essas palavras, e é o que torna o comando útil justamente quando o gateway morreu.

`-n/--lines` escolhe quantas linhas do fim (100 por padrão), `--follow` acompanha, `--path` imprime só o caminho. O `Ctrl+C` no follow fecha o laço e sai com **130** — a convenção do shell, a mesma escolha que o `garra chat` ocioso já fazia, e a mesma do `tail -f` e do `journalctl -f`.

O caminho do log passou a viver no módulo novo porque em `main.rs` ele é `#[cfg(unix)]` — o daemon só existe lá, mas o **arquivo** existe nos dois sistemas. O poll de 250 ms também é escolha de portabilidade: `inotify` não chega no Windows nem em diretório montado por rede.

### Redação: por que **não** redigir na leitura

Ela acontece na escrita. Redigir de novo aqui mascararia um vazamento em vez de consertá-lo — quem abrisse `garraia.log` no `less` veria o segredo do mesmo jeito, e nós acharíamos que estamos protegidos. Há teste afirmando que o comando devolve o byte que leu.

**A premissa tem um limite, e eu a escrevi forte demais primeiro.** O `RedactingMakeWriter` cobre o que passa pelo `tracing`. No daemon, o `dup2` manda stdout e stderr para o arquivo **antes** de o subscriber existir — o `main.rs` já documenta isso onde o `dup2` acontece, e eu repeti a premissa sem o limite. A auditoria varreu `garraia-gateway` e `garraia-agents`: hoje não há nenhum `println!` de produção nesses crates (todos estão em `#[test]`). Se houver, o conserto é **na escrita**.

### Sem `--level`

A issue cita como extensão possível. Uma entrada de log ocupa **várias linhas** quando carrega backtrace, e filtrar linha a linha partiria a entrada ao meio — sobraria a primeira linha do erro sem o rastro que a explica. Quem quer menos ruído tem o `RUST_LOG`, que decide na escrita.

### `/logs` no chat diz onde o log está, e não o despeja na conversa

Misturar centenas de linhas de log com a conversa é o oposto do que a Fase 2 deste épico foi fazer.

---

## O que rodar o binário achou

Quatro coisas, e a terceira é a mais séria:

1. **`/tools` quebrava o alinhamento** — como lista de strings já montadas, a descrição longa do `file_write` quebrava na coluna zero. Virou painel.

2. **`garra logs -n 0` imprimia o arquivo inteiro** — o oposto do idioma do `tail`, e `-n 0 --follow` ("só o que vier daqui em diante") é a combinação mais útil do comando. O `ultimas.len() == 0` só era verdade na primeira volta, então o buffer circular nunca podava. Num log de 1 GB, um OOM com uma flag.

3. **`/status` mostrava `Turnos 1` e `Ultimo turno: nenhum ainda` na mesma tela.** Dos três `return Ok` do `stream_turn_with_sink`, **só um** chamava `record_turn_stats`. Faltava o ramo de fallback: quando `stream_complete` devolve erro (Ollama antigo, llama.cpp sem SSE, ou qualquer provider num momento ruim), o turno inteiro roda em batch e terminava sem registro.

   **O `/stats` do [#1011](https://github.com/michelbr84/GarraRUST/pull/1011) tem esse buraco desde que nasceu** — o `/status` só o tornou visível. E o ramo do fallback anota **melhor** que o de streaming: ali existe uma `LlmResponse`, então o modelo vem confirmado pelo provider e a contagem de tokens existe.

4. **Ctrl+C, follow e log ausente** verificados de ponta a ponta: `--follow` pega o que chega, `SIGINT` sai com 130, e HOME limpo dá mensagem útil em vez de erro.

## O que as duas auditorias acharam

| Nível | Achado | Como ficou provado |
|---|---|---|
| **MÉDIO** | Descrição de ferramenta MCP é texto livre do servidor e ia para a tela sem `redact_secrets` — uma URL com token sairia em texto plano | Mesma redação que a *saída* da ferramenta já recebia |
| **MÉDIO** | `garra logs -n 0` carregava o arquivo inteiro | Confirmou o que o binário mostrou; teste vai vermelho sem a guarda |
| **MÉDIO** | A premissa "tudo no disco está redigido" é falsa para o `dup2` do daemon | Doc corrigida; risco residual registrado, sem exploração atual |
| **BAIXO** | A direção 2 do tripwire do `/help` só via braço exato, não prefixo `starts_with` | Inseri `starts_with("/inedito ")`: com a varredura antiga **passava verde** |
| **BAIXO** | Linha única gigante alocava uma `String` do tamanho do arquivo | Teto de 1 MiB, com teste |

**Cada correção tem teste que fica vermelho sem ela** — verifiquei revertendo só a linha do conserto, uma a uma.

### O que as auditorias levantaram e não procede

- **Underflow em `coluna - rotulo.chars().count()`**: `coluna = maior_rotulo + ESPACO`, e `rotulo` entrou nesse máximo.
- **`traco.repeat(n)` com `COLUMNS` hostil**: a régua acompanha o **conteúdo** e só então é limitada pela largura. Teste com `usize::MAX` e com largura 0/1/2.
- **Path traversal no `garra logs`**: o nome do arquivo é fixo, e o comando roda com o privilégio de quem o chamou.
- **`await??`**: o primeiro trata `JoinError`, o segundo o `anyhow::Error`. Correto.

## Tipo de mudança

- [x] `feat`: Nova funcionalidade
- [x] `fix`: Correção de bug (turno do fallback sem registro, `-n 0`, alinhamento do `/tools`)
- [x] `sec`: Hardening (redação na descrição MCP, teto de linha)

## Classe de Risco

- [x] **Classe B (Médio Risco)**: superfícies novas imprimem estado que antes não era impresso, e o caminho toca `runtime.rs`. Não toca auth, dado persistido, isolamento de tenant nem rede.

## Checklist de Segurança e Qualidade

- [x] `cargo fmt --check` limpo
- [x] `cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings` sem erros
- [x] `cargo test --workspace --exclude garraia-desktop` — 54 binários verdes; única falha é a ambiental `migration_001_applies_and_schema_is_sane`, que exige `docker.sock`
- [x] Nenhum `unwrap()` adicionado em código de produção (regra absoluta 4)
- [x] Nenhum segredo commitado; redação **acrescentada** onde faltava
- [x] Nenhuma migração, nenhuma rota nova, nenhum campo de config novo
- [x] `scripts/changelog/assemble.py --check` e `scripts/security/check-ledger-anchors.py` OK

## Mudanças na API pública

- **`crate::ui::panel`** novo: `render`, `render_list`, `Linha`, `linha`
- **`crate::logs_cmd`** novo: `caminho_do_log`, `tail`, `follow`, `LINHAS_PADRAO`
- **`UiEvent::Panel`** e **`UiEvent::List`** novos
- **`Commands::Logs { follow, lines, path }`** novo subcomando
- **`conversation::{BOLD, CYAN}`** passam a `pub(crate)`
- Comportamento: **`/tools` não é mais apelido de `/tool`**

## Como testar

```bash
cargo +1.95 test --workspace --exclude garraia-desktop
cargo +1.95 test -p garraia --bin garra ui::panel
cargo +1.95 test -p garraia --bin garra logs_cmd
cargo +1.95 test -p garraia --bin garra chat::tests::o_help_e_o_match_nao_divergem
cargo +1.95 test -p garraia-agents --lib turno_que_caiu_no_fallback_tambem_e_anotado
```

No binário, que é onde os quatro bugs apareceram:

```bash
cargo +1.95 build --bin garra --features dev-echo-provider

printf '/help\n/status\n/context\n/tools\n/exit\n' \
  | ./target/debug/garra chat --provider echo 2>&1 | grep -cP '\x1b'   # 12 → 0

printf 'oi\n/status\n/exit\n' | ./target/debug/garra chat --provider echo  # turno anotado

./target/debug/garra logs -n 0 | wc -l        # 58 → 0
./target/debug/garra logs --follow            # Ctrl+C sai com 130
HOME=/tmp/vazio ./target/debug/garra logs     # mensagem util, nao erro
```

## Plano de Rollback

`git revert` dos cinco commits. `panel.rs` e `logs_cmd.rs` somem, os comandos voltam ao `println!`, `/tools` volta a ser apelido de `/tool`. O registro do turno no fallback some junto — este é o único que eu **não** reverteria sozinho, porque conserta o `/stats` que já está em `main`.

## Registrado, não corrigido

- **`chat.rs` cruzou 2500 linhas** (2293 → 2653): `files_over_2500` foi de 9 para 10 no ratchet. Ver [o comentário de correção](https://github.com/michelbr84/GarraRUST/pull/1014#issuecomment-5565268684) — extrair o bloco de slash commands não é mecânico (o `match` lê onze variáveis locais do laço), e dividir mal é pior que não dividir. Fica como dívida deste PR.
- **`garra about` escreve ANSI incondicional no stdout redirecionado.** Mesma dívida da ADR 0017, mas em `banner.rs`, que este PR não toca.
- **O prompt de pull do Ollama** (`chat.rs`) ainda usa cor incondicional. É stderr, anterior ao REPL, e só dispara quando falta baixar um modelo.
- **Lint de CI contra `println!` em crates alcançáveis pelo daemon** — a auditoria sugeriu, e é a defesa estrutural certa para o gap do `dup2`. Não entra aqui: detectar "fora de `#[cfg(test)]`" por grep é frágil, e merece desenho próprio.

Closes #940
Closes #943

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF

---
_Generated by [Claude Code](https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF)_