### PR TITLE
fix(sec): identidade em /v1/chat/completions para de vir do chamador (#1012)

### DIFF
--- a/changelog.d/security/1012-identidade-openai-compat.md
+++ b/changelog.d/security/1012-identidade-openai-compat.md
@@ -1,0 +1,28 @@
+- **`/v1/chat/completions` para de derivar identidade do que o chamador
+  escreve (#1012).** A rota e auth-free por desenho, como todo o `/api/*` — mas
+  auth-free significa "nao exige credencial", e nao "aceita a identidade que o
+  chamador afirmar". Ela aceitava as duas coisas que vem do proprio chamador:
+  um `Authorization: Bearer` qualquer virava o `user_id` (o comentario no fonte
+  dizia *"this allows custom API keys to identify users"*, o que nunca foi
+  verdade — a rota nao verifica o token contra nada, entao equivalia a deixar
+  o chamador escolher o proprio nome), e na ausencia dele o header `X-User-Id`
+  era usado cru.
+- **Severidade: latente, nao ativa.** Rastreado ate o fim, o `user_id` nao abria
+  leitura de dado alheio — a carga de historico e chaveada por `session_id`. O
+  impacto era **atribuicao falsa**: a sessao e o registro no banco ficavam sob
+  uma identidade que ninguem provou. Vale fechar porque e a mesma forma do
+  buraco que a #1010 fechou de proposito *antes* de ligar execucao nele.
+- **Agora a identidade e a do dono da instalacao local, ou `None`.** `None` e a
+  resposta honesta para instalacao sem dono: preenche-la com o header seria
+  inventar um dono. O `garra-local` continua resolvendo o dono, com teste de
+  nao-regressao. Um bearer que nao seja `garra-local` e ignorado, com apenas o
+  fingerprint no log — nunca o token.
+- **`AppState::continuity_key` perdeu o parametro que nunca usava.** Ele
+  recebia `_user_id` e quatorze chamadores passavam identidade real (Telegram,
+  Slack, WhatsApp, Discord, iMessage) recebendo a mesma `bus:shared-global` de
+  volta; o `_` era a unica coisa separando o leitor da conclusao errada de que
+  a chave era escopada por pessoa. O parametro foi **removido** em vez de
+  passar a ser honrado: honra-lo mudaria o significado de
+  `memory.shared_continuity` para quem ja o ligou, e "shared" e o que a opcao
+  promete. O barramento e global por desenho, e agora a assinatura diz isso.
+- Postura da rota documentada em `docs/security/threat-model.md` §5.9.

--- a/changelog.d/security/1012-identidade-openai-compat.md
+++ b/changelog.d/security/1012-identidade-openai-compat.md
@@ -16,11 +16,15 @@
   resposta honesta para instalacao sem dono: preenche-la com o header seria
   inventar um dono. O `garra-local` continua resolvendo o dono, com teste de
   nao-regressao. Um bearer que nao seja `garra-local` e ignorado, com apenas o
-  fingerprint no log — nunca o token.
+  fingerprint no log — nunca o token. E o **valor do dono tambem nao vai para o
+  log**: a primeira versao desta correcao o logava em toda requisicao, o que
+  era pior que o codigo vulneravel (que so o logava quando um `garra-local`
+  era apresentado). No WhatsApp o dono e o proprio numero de telefone.
 - **`AppState::continuity_key` perdeu o parametro que nunca usava.** Ele
-  recebia `_user_id` e quatorze chamadores passavam identidade real (Telegram,
-  Slack, WhatsApp, Discord, iMessage) recebendo a mesma `bus:shared-global` de
-  volta; o `_` era a unica coisa separando o leitor da conclusao errada de que
+  recebia `_user_id`, e dos quatorze chamadores **sete** passavam um id por
+  pessoa literal (Telegram x2, Slack, WhatsApp, Discord, iMessage, e a
+  `task.user_id` do A2A) — todos recebendo a mesma `bus:shared-global` de
+  volta. O `_` era a unica coisa separando o leitor da conclusao errada de que
   a chave era escopada por pessoa. O parametro foi **removido** em vez de
   passar a ser honrado: honra-lo mudaria o significado de
   `memory.shared_continuity` para quem ja o ligou, e "shared" e o que a opcao

--- a/crates/garraia-gateway/src/a2a.rs
+++ b/crates/garraia-gateway/src/a2a.rs
@@ -99,7 +99,7 @@ pub async fn create_task(
         .hydrate_session_history(&session_id, Some("a2a"), None)
         .await;
     let history = state.session_history(&session_id);
-    let continuity_key = state.continuity_key(None);
+    let continuity_key = state.continuity_key();
 
     // Sem `ExecContext` de modo, e de proposito.
     //

--- a/crates/garraia-gateway/src/api.rs
+++ b/crates/garraia-gateway/src/api.rs
@@ -173,7 +173,7 @@ pub async fn send_message(
         .hydrate_session_history(&session_id, Some("api"), None)
         .await;
     let history = state.session_history(&session_id);
-    let continuity_key = state.continuity_key(None);
+    let continuity_key = state.continuity_key();
 
     // Resolve named agent config
     let config = state.current_config();

--- a/crates/garraia-gateway/src/bootstrap/discord.rs
+++ b/crates/garraia-gateway/src/bootstrap/discord.rs
@@ -118,7 +118,7 @@ pub fn build_discord_channels(
                         .hydrate_session_history(&session_id, Some("discord"), Some(&user_id))
                         .await;
                     let history: Vec<ChatMessage> = state.session_history(&session_id);
-                    let continuity_key = state.continuity_key(Some(&user_id));
+                    let continuity_key = state.continuity_key();
 
                     // O modo escolhido vale aqui tambem (#988). Antes este canal
                     // chamava o wrapper `_with_context`, que passa

--- a/crates/garraia-gateway/src/bootstrap/imessage.rs
+++ b/crates/garraia-gateway/src/bootstrap/imessage.rs
@@ -97,7 +97,7 @@ pub fn build_imessage_channels(
                         .await;
                     let history: Vec<garraia_agents::ChatMessage> =
                         state.session_history(&session_id);
-                    let continuity_key = state.continuity_key(Some(&sender_id));
+                    let continuity_key = state.continuity_key();
 
                     // O modo escolhido vale aqui tambem (#988). Antes este canal
                     // chamava o wrapper `_with_context`, que passa

--- a/crates/garraia-gateway/src/bootstrap/slack.rs
+++ b/crates/garraia-gateway/src/bootstrap/slack.rs
@@ -130,7 +130,7 @@ pub fn build_slack_channels(
                         .hydrate_session_history(&session_id, Some("slack"), Some(&user_id))
                         .await;
                     let history: Vec<ChatMessage> = state.session_history(&session_id);
-                    let continuity_key = state.continuity_key(Some(&user_id));
+                    let continuity_key = state.continuity_key();
 
                     // O modo escolhido vale aqui tambem (#988). Antes este canal
                     // chamava o wrapper `_with_context`, que passa

--- a/crates/garraia-gateway/src/bootstrap/telegram.rs
+++ b/crates/garraia-gateway/src/bootstrap/telegram.rs
@@ -93,7 +93,7 @@ pub fn build_telegram_voice_handler(state: &SharedState) -> Option<OnVoiceFn> {
                     .hydrate_session_history(&session_id, Some("telegram"), Some(&user_id))
                     .await;
                 let history: Vec<ChatMessage> = state.session_history(&session_id);
-                let continuity_key = state.continuity_key(Some(&user_id));
+                let continuity_key = state.continuity_key();
 
                 // Send typing indicator
                 let _ = bot
@@ -301,7 +301,7 @@ pub fn build_telegram_channels(
                         .hydrate_session_history(&session_id, Some("telegram"), Some(&user_id))
                         .await;
                     let history: Vec<ChatMessage> = state.session_history(&session_id);
-                    let continuity_key = state.continuity_key(Some(&user_id));
+                    let continuity_key = state.continuity_key();
 
                     let model_override = state
                         .channel_models

--- a/crates/garraia-gateway/src/bootstrap/whatsapp.rs
+++ b/crates/garraia-gateway/src/bootstrap/whatsapp.rs
@@ -136,7 +136,7 @@ pub fn build_whatsapp_channels(
                         .hydrate_session_history(&session_id, Some("whatsapp"), Some(&from_number))
                         .await;
                     let history: Vec<ChatMessage> = state.session_history(&session_id);
-                    let continuity_key = state.continuity_key(Some(&from_number));
+                    let continuity_key = state.continuity_key();
 
                     // O modo escolhido vale aqui tambem (#988). Antes este canal
                     // chamava o wrapper `_with_context`, que passa

--- a/crates/garraia-gateway/src/openai_api.rs
+++ b/crates/garraia-gateway/src/openai_api.rs
@@ -22,7 +22,7 @@ use garraia_agents::{ChatMessage, ChatRole, MessagePart};
 use serde::{Deserialize, Serialize};
 use std::time::Instant;
 use tokio::sync::mpsc;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
 use crate::state::SharedState;
@@ -952,9 +952,20 @@ fn resolve_user_id(headers: &HeaderMap, state: &SharedState) -> Option<String> {
         .ok()
         .and_then(|list| list.owner().map(str::to_string));
 
+    // O **valor** do dono nunca sai no log, e essa e a diferenca em relacao ao
+    // codigo anterior. Ele so logava o dono quando um `garra-local` era
+    // apresentado; esta funcao resolve o dono em **toda** requisicao, entao
+    // logar o valor aqui o repetiria a cada chamada. E o que vira dono nem
+    // sempre e um id opaco: no WhatsApp e o proprio numero de telefone
+    // (`bootstrap/whatsapp.rs:88`, `claim_owner(&from_number)`), no iMessage o
+    // numero ou o Apple ID (`bootstrap/imessage.rs:59`). Regra absoluta 6.
+    //
+    // O que quem depura precisa saber e se a requisicao foi atribuida a alguem
+    // ou a ninguem — um booleano. O valor esta no `allowlist.json`, que a
+    // mesma pessoa pode abrir.
     match &owner {
-        Some(o) => info!("resolved user_id={o} from local allowlist owner"),
-        None => info!("no owner claimed yet; request recorded without user_id"),
+        Some(_) => debug!("user_id resolvido pelo dono da allowlist local (valor omitido)"),
+        None => info!("nenhum dono reivindicado ainda; requisicao gravada sem user_id"),
     }
     owner
 }
@@ -1164,6 +1175,36 @@ mod tests {
             "o token do chamador nao pode virar o `user_id`"
         );
         assert_eq!(resolvido.as_deref(), Some("dono-real"));
+    }
+
+    /// O **valor** do dono nao pode aparecer no log.
+    ///
+    /// Achado ALTO da auditoria do #1012, e uma regressao que a *primeira*
+    /// versao desta correcao introduziu: o codigo antigo so logava o dono
+    /// quando um `garra-local` era apresentado; a correcao passou a resolver o
+    /// dono em toda requisicao e logava o valor junto — mais vezes, portanto,
+    /// que o codigo vulneravel que ela substituia.
+    ///
+    /// E o dono nem sempre e um id opaco: no WhatsApp e o proprio numero de
+    /// telefone (`bootstrap/whatsapp.rs:88` chama `claim_owner(&from_number)`),
+    /// no iMessage e o numero ou o Apple ID. Regra absoluta 6.
+    #[tracing_test::traced_test]
+    #[test]
+    fn o_valor_do_dono_nao_vai_para_o_log() {
+        const DONO: &str = "+15551234567";
+        let state = state_de_teste_com_dono(Some(DONO));
+
+        let resolvido = resolve_user_id(&headers(&[]), &state);
+
+        // O dono continua sendo resolvido — a correcao e sobre o log, nao
+        // sobre a resolucao.
+        assert_eq!(resolvido.as_deref(), Some(DONO));
+
+        assert!(
+            !logs_contain(DONO),
+            "o valor do dono vazou para o log — no WhatsApp isso e um numero \
+             de telefone, repetido a cada requisicao"
+        );
     }
 
     /// E o caminho que precisa continuar funcionando: `garra-local`.

--- a/crates/garraia-gateway/src/openai_api.rs
+++ b/crates/garraia-gateway/src/openai_api.rs
@@ -472,7 +472,7 @@ pub async fn chat_completions(
 
     // Get continuity key based on user_id
     let continuity_key = state
-        .continuity_key(user_id.as_deref())
+        .continuity_key()
         .unwrap_or_else(|| "default".to_string());
 
     let response = if is_streaming {
@@ -884,63 +884,79 @@ fn token_fingerprint(token: &str) -> String {
     hex::encode(&digest[..6])
 }
 
-/// Mapeia um bearer que não é `garra-local` para o `user_id`.
+/// Registra que um bearer chegou, **sem** deixá-lo virar identidade (#1012).
 ///
 /// Separado de [`resolve_user_id`] porque não depende de `SharedState` — é o
 /// que torna o path testável sem subir o gateway inteiro, e é onde vive o
 /// invariante "o token não sai no log" (ver `token_fingerprint`).
-fn resolve_token_user_id(token: &str) -> Option<String> {
+///
+/// Antes da #1012 esta função devolvia o próprio token como `user_id`, com o
+/// comentário *"For other tokens, use the token itself as user_id — this
+/// allows custom API keys to identify users"*. Ela nunca identificou ninguém:
+/// a rota não verifica o token contra nada, então "o token identifica o
+/// usuário" equivalia a "o chamador escolhe o próprio nome". Hoje ela só
+/// deixa rastro para quem estiver se perguntando por que a chave dele não faz
+/// nada.
+fn note_ignored_bearer(token: &str) {
     if token.is_empty() {
-        return None;
+        return;
     }
-    // NUNCA logar `token`: ele é a credencial, e neste path também é o
-    // user_id. Só o fingerprint sai no log.
+    // NUNCA logar `token`: ele é credencial de alguém, mesmo que este
+    // caminho não a verifique. Só o fingerprint sai no log.
     info!(
         token_fp = %token_fingerprint(token),
-        "Resolved user_id from API token"
+        "bearer presented to /v1/chat/completions was ignored: this route is \
+         auth-free by design and does not derive identity from the caller"
     );
-    Some(token.to_string())
 }
 
-/// Resolve user identity from Authorization header.
-/// Maps API key to user_id for authenticated access.
+/// Resolve a identidade a ser **gravada** para uma chamada de
+/// `/v1/chat/completions`.
+///
+/// Esta rota é auth-free por desenho, como todo o `/api/*`
+/// (`docs/security/threat-model.md` §5.7 e §5.9). Auth-free significa "não
+/// exige credencial" — **não** "aceita a identidade que o chamador afirmar".
+///
+/// Antes da #1012 ela aceitava as duas coisas que o chamador escreve: um
+/// bearer qualquer virava o `user_id`, e na ausência dele o header
+/// `X-User-Id` era usado cru. O impacto medido era atribuição falsa, e não
+/// leitura cruzada — a carga de histórico é chaveada por `session_id`, não
+/// por `user_id` —, mas é a mesma forma do buraco que a #1010 fechou de
+/// propósito **antes** de ligar execução nele. Um header que não decide nada
+/// não pode ser forjado.
+///
+/// A identidade é a do dono da instalação local, ou `None`. `None` é a
+/// resposta honesta para uma instalação que ainda não sabe de quem é;
+/// preenchê-la com o que veio no header seria inventar um dono.
 fn resolve_user_id(headers: &HeaderMap, state: &SharedState) -> Option<String> {
-    // Try Authorization header first
+    // O `garra-local` continua sendo a convenção do cliente local. Ele não
+    // muda a resposta — o dono é o dono com ou sem ele —, mas distinguir os
+    // dois casos no log é o que diz a quem depurar se o cliente está mandando
+    // o que acha que manda.
     if let Some(auth_header) = headers.get("authorization")
         && let Ok(auth_str) = auth_header.to_str()
+        && let Some(token) = auth_str.strip_prefix("Bearer ")
     {
-        // Handle "Bearer <token>" format
-        if let Some(token) = auth_str.strip_prefix("Bearer ") {
-            let token = token.trim();
-
-            // Check if it's a valid API key from the config
-            // The token "garra-local" maps to the local owner
-            if token == "garra-local" {
-                // Get the owner from allowlist
-                if let Ok(list) = state.allowlist.lock()
-                    && let Some(owner) = list.owner()
-                {
-                    info!("Resolved user_id={} from 'garra-local' token", owner);
-                    return Some(owner.to_string());
-                }
-            }
-
-            // For other tokens, use the token itself as user_id
-            // This allows custom API keys to identify users
-            if let Some(user_id) = resolve_token_user_id(token) {
-                return Some(user_id);
-            }
+        let token = token.trim();
+        if token != "garra-local" {
+            note_ignored_bearer(token);
         }
     }
 
-    // Try X-User-Id header
-    if let Some(user_id_header) = headers.get("x-user-id")
-        && let Ok(user_id) = user_id_header.to_str()
-    {
-        return Some(user_id.to_string());
-    }
+    // O `X-User-Id` é deliberadamente **não lido**. Ver o doc-comment acima:
+    // é o header que a #1012 nomeia, e a correção é que ele deixe de decidir.
 
-    None
+    let owner = state
+        .allowlist
+        .lock()
+        .ok()
+        .and_then(|list| list.owner().map(str::to_string));
+
+    match &owner {
+        Some(o) => info!("resolved user_id={o} from local allowlist owner"),
+        None => info!("no owner claimed yet; request recorded without user_id"),
+    }
+    owner
 }
 
 /// GET /v1/models - List available models
@@ -998,12 +1014,12 @@ mod tests {
     fn api_token_never_reaches_the_log() {
         const SECRET: &str = "garra-tok-9f3c1d7ab24e0058";
 
-        let resolved = resolve_token_user_id(SECRET);
+        // Desde a #1012 o token nao vira mais `user_id` — mas ele continua
+        // chegando pela rede e continua sendo credencial de alguem, entao o
+        // invariante do log e o mesmo e este guard segue valendo.
+        note_ignored_bearer(SECRET);
 
-        // O token continua sendo o user_id — o comportamento não mudou.
-        assert_eq!(resolved.as_deref(), Some(SECRET));
-
-        // …mas ele não pode aparecer no log.
+        // Ele não pode aparecer no log.
         assert!(
             !logs_contain(SECRET),
             "bearer token vazou para o tracing — `resolve_token_user_id` deve \
@@ -1039,6 +1055,129 @@ mod tests {
         );
     }
 
+    // ── #1012: identidade em `/v1/chat/completions` ──────────────────────
+    //
+    // A rota e auth-free por desenho, como todo o `/api/*`
+    // (docs/security/threat-model.md §5.7 e §5.9). Auth-free significa "nao
+    // exige credencial", e nao "aceita qualquer identidade que o chamador
+    // afirme": um header forjavel que **decide** o `user_id` gravado e pior
+    // que nenhum, porque parece identidade sem ser.
+
+    /// Um `AppState` cuja allowlist **nao toca o disco**.
+    ///
+    /// `AppState::new` carrega a allowlist de
+    /// `ConfigLoader::default_config_dir()/allowlist.json`, e `claim_owner`
+    /// chama `save()`. A primeira versao deste helper usava a allowlist que
+    /// vinha de la: o teste do dono gravou `dono-real` no arquivo real da
+    /// maquina, e o teste seguinte — o que exige uma instalacao *sem* dono —
+    /// leu esse dono de volta e falhou. Um teste que grava no estado real do
+    /// operador esta errado mesmo quando passa.
+    ///
+    /// `Allowlist::restricted` nasce com `path: None`, e `save()` sai cedo
+    /// quando nao ha path. Nada e escrito.
+    fn state_de_teste_com_dono(dono: Option<&str>) -> SharedState {
+        use crate::state::AppState;
+        use garraia_config::AppConfig;
+        use garraia_security::Allowlist;
+
+        let state = AppState::new(
+            AppConfig::default(),
+            std::sync::Arc::new(garraia_agents::AgentRuntime::new()),
+            garraia_channels::ChannelRegistry::new(),
+        );
+
+        let mut lista = Allowlist::restricted(Vec::new());
+        if let Some(d) = dono {
+            lista.claim_owner(d);
+        }
+        *state
+            .allowlist
+            .lock()
+            .expect("allowlist envenenada no teste") = lista;
+
+        std::sync::Arc::new(state)
+    }
+
+    fn headers(pares: &[(&str, &str)]) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        for (k, v) in pares {
+            h.insert(
+                axum::http::HeaderName::from_bytes(k.as_bytes()).expect("header invalido"),
+                v.parse().expect("valor de header invalido"),
+            );
+        }
+        h
+    }
+
+    /// O caso que a issue nomeia: `X-User-Id` cru, sem `Authorization`.
+    ///
+    /// Antes deste conserto o header virava o `user_id` sem nenhuma
+    /// verificacao, e ia parar em `session.user_id` e na coluna `user` do
+    /// upsert da sessao. O impacto era atribuicao falsa, nao leitura cruzada
+    /// — mas e o mesmo formato do buraco que o #1010 fechou de proposito
+    /// antes de ligar execucao nele.
+    #[test]
+    fn x_user_id_forjado_nao_vira_identidade() {
+        let state = state_de_teste_com_dono(Some("dono-real"));
+        let h = headers(&[("x-user-id", "vitima")]);
+
+        let resolvido = resolve_user_id(&h, &state);
+
+        assert_ne!(
+            resolvido.as_deref(),
+            Some("vitima"),
+            "o `X-User-Id` do chamador nao pode decidir a identidade gravada"
+        );
+        assert_eq!(
+            resolvido.as_deref(),
+            Some("dono-real"),
+            "sem credencial, a identidade e a do dono da instalacao local"
+        );
+    }
+
+    /// Sem dono definido, o header forjado tambem nao pode preencher o vazio.
+    ///
+    /// `None` e a resposta honesta: a instalacao ainda nao sabe de quem e.
+    #[test]
+    fn x_user_id_forjado_nao_preenche_instalacao_sem_dono() {
+        let state = state_de_teste_com_dono(None);
+        let h = headers(&[("x-user-id", "vitima")]);
+
+        assert_eq!(resolve_user_id(&h, &state), None);
+    }
+
+    /// Um bearer arbitrario tambem nao e identidade.
+    ///
+    /// O comportamento antigo (`"For other tokens, use the token itself as
+    /// user_id"`) nunca distinguiu ninguem de verdade: qualquer um podia
+    /// mandar qualquer token. Era um nome escolhido pelo chamador.
+    #[test]
+    fn bearer_arbitrario_nao_vira_identidade() {
+        let state = state_de_teste_com_dono(Some("dono-real"));
+        let h = headers(&[("authorization", "Bearer sou-quem-eu-quiser")]);
+
+        let resolvido = resolve_user_id(&h, &state);
+
+        assert_ne!(
+            resolvido.as_deref(),
+            Some("sou-quem-eu-quiser"),
+            "o token do chamador nao pode virar o `user_id`"
+        );
+        assert_eq!(resolvido.as_deref(), Some("dono-real"));
+    }
+
+    /// E o caminho que precisa continuar funcionando: `garra-local`.
+    ///
+    /// Criterio de aceitacao explicito da #1012 — "nenhuma regressao nos
+    /// caminhos `garra-local` e allowlist".
+    #[test]
+    fn garra_local_continua_resolvendo_o_dono() {
+        let state = state_de_teste_com_dono(Some("dono-real"));
+        let h = headers(&[("authorization", "Bearer garra-local")]);
+
+        assert_eq!(resolve_user_id(&h, &state).as_deref(), Some("dono-real"));
+    }
+
     /// E um typo comum continua legivel, que e a razao de o campo existir.
     #[test]
     fn rotulo_de_modo_preserva_typo_curto() {
@@ -1062,9 +1201,20 @@ mod tests {
         assert_ne!(fp, token_fingerprint("garra-tok-9f3c1d7ab24e0059"));
     }
 
+    /// `Authorization: Bearer ` sem nada depois nao gera linha de log.
+    ///
+    /// Antes da #1012 o guard aqui era "token vazio nao vira user_id". Agora
+    /// nenhum token vira user_id, e o que sobra a proteger e o ruido: um
+    /// cliente mal configurado mandando bearer vazio em toda requisicao
+    /// encheria o log com o fingerprint da string vazia — o mesmo em todas.
+    #[tracing_test::traced_test]
     #[test]
-    fn empty_token_resolves_to_none() {
-        assert_eq!(resolve_token_user_id(""), None);
+    fn bearer_vazio_nao_gera_linha_de_log() {
+        note_ignored_bearer("");
+        assert!(
+            !logs_contain("was ignored"),
+            "bearer vazio nao deveria produzir log"
+        );
     }
 
     #[test]

--- a/crates/garraia-gateway/src/parrot_ws.rs
+++ b/crates/garraia-gateway/src/parrot_ws.rs
@@ -95,7 +95,7 @@ async fn handle_parrot_socket(socket: WebSocket, state: SharedState) {
         // Build history and call the agent (streaming: deltas viram frames
         // "chunk"; o texto final segue num "response" autoritativo).
         let history = state.session_history(SESSION_ID);
-        let continuity_key = state.continuity_key(None);
+        let continuity_key = state.continuity_key();
 
         let (delta_tx, delta_rx) = tokio::sync::mpsc::channel::<String>(100);
         let agents = state.agents.clone();

--- a/crates/garraia-gateway/src/server.rs
+++ b/crates/garraia-gateway/src/server.rs
@@ -1169,9 +1169,7 @@ async fn execute_scheduled_task(
         .await;
 
     let history = state.session_history(&task.session_id);
-    let continuity_key = state
-        .continuity_key(Some(task.user_id.as_str()))
-        .map(|k| k.as_str().to_string());
+    let continuity_key = state.continuity_key().map(|k| k.as_str().to_string());
 
     let response_text = state
         .agents

--- a/crates/garraia-gateway/src/state.rs
+++ b/crates/garraia-gateway/src/state.rs
@@ -486,7 +486,21 @@ impl AppState {
 
     /// Resolve the continuity key used by the cross-channel memory bus.
     /// When disabled, returns `None` and memory remains session-scoped.
-    pub fn continuity_key(&self, _user_id: Option<&str>) -> Option<String> {
+    ///
+    /// **O barramento e global, nao por usuario** (#1012). Ate 2026-09-07 esta
+    /// funcao recebia um `_user_id` que nunca usava — o `_` era a unica coisa
+    /// separando o leitor da conclusao errada de que a chave era escopada por
+    /// pessoa. Quatorze chamadores passavam identidade real (Telegram, Slack,
+    /// WhatsApp, Discord, iMessage), e todos recebiam a mesma
+    /// `bus:shared-global` de volta.
+    ///
+    /// O parametro foi removido em vez de passar a ser usado: honra-lo mudaria
+    /// o significado de `memory.shared_continuity` para quem ja o ligou, e
+    /// "shared" e literalmente o que a opcao promete. Sem o parametro, a
+    /// assinatura para de sugerir uma garantia que nao existe — e o dia em que
+    /// alguem quiser um barramento por pessoa, tera de escrever uma funcao
+    /// nova e decidir isso de proposito.
+    pub fn continuity_key(&self) -> Option<String> {
         if self.config.memory.shared_continuity {
             Some("bus:shared-global".to_string())
         } else {
@@ -587,7 +601,7 @@ impl AppState {
         let channel = channel_id.unwrap_or("web");
         let user = user_id.unwrap_or("anonymous");
         let metadata = self
-            .continuity_key(user_id)
+            .continuity_key()
             .map(|k| serde_json::json!({ "continuity_key": k }))
             .unwrap_or_else(|| serde_json::json!({}));
 
@@ -688,7 +702,7 @@ impl AppState {
         let channel = channel_id.unwrap_or("web");
         let user = user_id.unwrap_or("anonymous");
         let metadata = self
-            .continuity_key(user_id)
+            .continuity_key()
             .map(|k| serde_json::json!({ "continuity_key": k }))
             .unwrap_or_else(|| serde_json::json!({}));
 
@@ -1463,7 +1477,7 @@ mod tests {
             Arc::new(AgentRuntime::new()),
             ChannelRegistry::new(),
         );
-        let key = state.continuity_key(Some("user1"));
+        let key = state.continuity_key();
         assert_eq!(key, Some("bus:shared-global".to_string()));
     }
 
@@ -1476,7 +1490,7 @@ mod tests {
             Arc::new(AgentRuntime::new()),
             ChannelRegistry::new(),
         );
-        let key = state.continuity_key(Some("user1"));
+        let key = state.continuity_key();
         assert_eq!(key, None);
     }
 

--- a/crates/garraia-gateway/src/state.rs
+++ b/crates/garraia-gateway/src/state.rs
@@ -490,9 +490,11 @@ impl AppState {
     /// **O barramento e global, nao por usuario** (#1012). Ate 2026-09-07 esta
     /// funcao recebia um `_user_id` que nunca usava — o `_` era a unica coisa
     /// separando o leitor da conclusao errada de que a chave era escopada por
-    /// pessoa. Quatorze chamadores passavam identidade real (Telegram, Slack,
-    /// WhatsApp, Discord, iMessage), e todos recebiam a mesma
-    /// `bus:shared-global` de volta.
+    /// pessoa. Dos quatorze chamadores, **sete** passavam um id por pessoa
+    /// literal (Telegram x2, Slack, WhatsApp, Discord, iMessage, e a
+    /// `task.user_id` do A2A em `server.rs`), tres repassavam o parametro que
+    /// receberam, e quatro ja passavam `None` — e todos os quatorze recebiam a
+    /// mesma `bus:shared-global` de volta.
     ///
     /// O parametro foi removido em vez de passar a ser usado: honra-lo mudaria
     /// o significado de `memory.shared_continuity` para quem ja o ligou, e

--- a/crates/garraia-gateway/src/ws.rs
+++ b/crates/garraia-gateway/src/ws.rs
@@ -377,7 +377,7 @@ async fn process_text_message(
         .hydrate_session_history(session_id, Some("web"), None)
         .await;
     let history: Vec<ChatMessage> = state.session_history(session_id);
-    let continuity_key = state.continuity_key(None);
+    let continuity_key = state.continuity_key();
 
     // Route through agent runtime (with optional provider override)
     let reply = match state

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -336,8 +336,10 @@ que a identidade real do `garraia-auth` chegar a este caminho legado.
 
 **Mitigacao**: a identidade e a do dono da instalacao local (allowlist), ou
 `None`. O `X-User-Id` deixou de ser lido; um bearer que nao seja `garra-local`
-e ignorado (com fingerprint no log, nunca o token — §invariante herdado de
-2026-08-29). `None` e a resposta honesta para instalacao sem dono: preenche-la
+e ignorado (com fingerprint no log, nunca o token — invariante herdado de
+2026-08-29), e o **valor do dono tambem nao sai no log**: a primeira versao
+desta correcao o logava em toda requisicao, o que era pior que o codigo
+vulneravel, que so o logava quando um `garra-local` era apresentado. `None` e a resposta honesta para instalacao sem dono: preenche-la
 com o header seria inventar um dono. Guards em
 `openai_api.rs`: `x_user_id_forjado_nao_vira_identidade`,
 `x_user_id_forjado_nao_preenche_instalacao_sem_dono`,
@@ -345,8 +347,10 @@ com o header seria inventar um dono. Guards em
 `garra_local_continua_resolvendo_o_dono` para a nao-regressao.
 
 **Tambem**: `AppState::continuity_key` recebia um `_user_id` que **nunca
-usava**, e quatorze chamadores passavam identidade real (Telegram, Slack,
-WhatsApp, Discord, iMessage) recebendo a mesma `bus:shared-global` de volta. O
+usava**. Dos quatorze chamadores, **sete** passavam um id por pessoa literal
+(Telegram x2, Slack, WhatsApp, Discord, iMessage, e a `task.user_id` do A2A em
+`server.rs:1173`), tres repassavam o parametro recebido e quatro ja passavam
+`None` — e os quatorze recebiam a mesma `bus:shared-global` de volta. O
 parametro foi removido em vez de passar a ser honrado: honra-lo mudaria o
 significado de `memory.shared_continuity` para quem ja o ligou, e "shared" e o
 que a opcao promete. O barramento e global **por desenho**, e agora a
@@ -357,6 +361,7 @@ assinatura diz isso.
 | **S** Spoofing | `curl -H 'X-User-Id: vitima' localhost:3000/v1/chat/completions` grava a sessão sob o nome da vítima. | Header não é lido; identidade vem da allowlist local. Guard de regressão contra o código vulnerável. | — |
 | **S** Spoofing | Bearer arbitrário vira `user_id` ("custom API keys identify users"). | Bearer não-`garra-local` é ignorado; só o fingerprint vai ao log. | Se a rota algum dia precisar de auth real, verificar contra `garraia-auth` e devolver 401 — decisão de produto, quebra todo cliente local existente. |
 | **I** Information disclosure | Bearer de terceiro escrito no log de toda requisição. | `token_fingerprint` (6 bytes de SHA-256); guard `api_token_never_reaches_the_log`. | — |
+| **I** Information disclosure | O **dono** escrito no log de toda requisição. No WhatsApp o dono é o próprio número de telefone (`bootstrap/whatsapp.rs:88`, `claim_owner(&from_number)`); no iMessage, número ou Apple ID. | O valor nunca sai: o log diz só se houve dono ou não. Guard `o_valor_do_dono_nao_vai_para_o_log`. | — |
 | **E** Elevation of privilege | Barramento de memória "por usuário" que na verdade é global, ligado por quem leu a assinatura. | Parâmetro removido: a assinatura não sugere mais escopo por pessoa. | Barramento por pessoa, se desejado, exige função nova e decisão explícita. |
 
 **O que ficou fora, de propósito**: promover `Security Gate (BOLA & Tenant

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -305,6 +305,67 @@ vem de conjunto fechado.
 
 ---
 
+## 5.9. Identidade em `/v1/chat/completions` — auth-free nao e identidade livre (#1012)
+
+Fechado em 2026-09-07. `POST /v1/chat/completions` e a rota de compatibilidade
+OpenAI: e o que um plugin de editor, um `curl`, ou qualquer cliente que fale o
+protocolo da OpenAI aponta para o gateway local. Ela **nao tem camada de auth**
+(`router.rs:204`, sem `layer`; so `governor_layer` e CORS) — e isso e desenho,
+nao esquecimento: e a mesma postura de todo o `/api/*` descrita na §5.7.
+
+O defeito nao era a ausencia de auth. Era `resolve_user_id` derivar a
+identidade **gravada** das duas coisas que o proprio chamador escreve:
+
+1. `Authorization: Bearer <token>` — para qualquer token que nao fosse
+   `garra-local`, **o proprio token virava o `user_id`**, com o comentario no
+   fonte *"this allows custom API keys to identify users"*. Nunca identificou
+   ninguem: a rota nao verifica o token contra nada, entao equivalia a deixar
+   o chamador escolher o proprio nome.
+2. Sem `Authorization`, o header `X-User-Id` era usado **cru**.
+
+**Severidade: latente, nao ativa.** Rastreado ate o fim, o `user_id` nao abria
+leitura de dado alheio: o unico consumidor e `hydrate_session_history`, que so
+grava `session.user_id` e a coluna `user` do upsert; a carga de historico e
+chaveada por `session_id`. O impacto era **atribuicao falsa** — a sessao e o
+registro no banco ficavam sob uma identidade que ninguem provou.
+
+Vale fechar porque e a mesma forma do buraco que a #1010 fechou de proposito
+*antes* de ligar execucao nele. A arma engatilha sozinha no dia em que
+qualquer leitura passar a filtrar por `user_id` em vez de `session_id`, ou em
+que a identidade real do `garraia-auth` chegar a este caminho legado.
+
+**Mitigacao**: a identidade e a do dono da instalacao local (allowlist), ou
+`None`. O `X-User-Id` deixou de ser lido; um bearer que nao seja `garra-local`
+e ignorado (com fingerprint no log, nunca o token — §invariante herdado de
+2026-08-29). `None` e a resposta honesta para instalacao sem dono: preenche-la
+com o header seria inventar um dono. Guards em
+`openai_api.rs`: `x_user_id_forjado_nao_vira_identidade`,
+`x_user_id_forjado_nao_preenche_instalacao_sem_dono`,
+`bearer_arbitrario_nao_vira_identidade`, e
+`garra_local_continua_resolvendo_o_dono` para a nao-regressao.
+
+**Tambem**: `AppState::continuity_key` recebia um `_user_id` que **nunca
+usava**, e quatorze chamadores passavam identidade real (Telegram, Slack,
+WhatsApp, Discord, iMessage) recebendo a mesma `bus:shared-global` de volta. O
+parametro foi removido em vez de passar a ser honrado: honra-lo mudaria o
+significado de `memory.shared_continuity` para quem ja o ligou, e "shared" e o
+que a opcao promete. O barramento e global **por desenho**, e agora a
+assinatura diz isso.
+
+| STRIDE | Cenário concreto | Mitigação atual | Gap / Planejada |
+|---|---|---|---|
+| **S** Spoofing | `curl -H 'X-User-Id: vitima' localhost:3000/v1/chat/completions` grava a sessão sob o nome da vítima. | Header não é lido; identidade vem da allowlist local. Guard de regressão contra o código vulnerável. | — |
+| **S** Spoofing | Bearer arbitrário vira `user_id` ("custom API keys identify users"). | Bearer não-`garra-local` é ignorado; só o fingerprint vai ao log. | Se a rota algum dia precisar de auth real, verificar contra `garraia-auth` e devolver 401 — decisão de produto, quebra todo cliente local existente. |
+| **I** Information disclosure | Bearer de terceiro escrito no log de toda requisição. | `token_fingerprint` (6 bytes de SHA-256); guard `api_token_never_reaches_the_log`. | — |
+| **E** Elevation of privilege | Barramento de memória "por usuário" que na verdade é global, ligado por quem leu a assinatura. | Parâmetro removido: a assinatura não sugere mais escopo por pessoa. | Barramento por pessoa, se desejado, exige função nova e decisão explícita. |
+
+**O que ficou fora, de propósito**: promover `Security Gate (BOLA & Tenant
+Isolation)` a required check da `main` (hoje os obrigatórios são quatro —
+`docs/security/protect-main-ruleset.md`). É mudança de branch protection, que
+é do dono.
+
+---
+
 ## 6. Mobile apps (`apps/garraia-mobile`)
 
 **Divergência JWT TTL (conhecida)**: o path mobile legacy (`crates/garraia-gateway/src/mobile_auth.rs`, wired via GAR-335) emite JWT com TTL de **30 dias** (`JWT_EXPIRY_SECS = 30 * 24 * 3600`), distinto do access token de 15 min do `garraia-auth` workspace (plans 0011/0012). Coexistência é temporária — consolidação depende de GAR-413 (migrate workspace) + migração dos clientes mobile para `/v1/auth/*`. Enquanto coexistem, a janela de hijack de session mobile é 48× maior que a do fluxo workspace. Risco documentado, mitigação parcial via `flutter_secure_storage` (Keystore/Keychain) + refresh token rotation planejada.


### PR DESCRIPTION
## Descrição

`POST /v1/chat/completions` derivava a identidade **gravada** das duas coisas que o próprio chamador escreve:

1. `Authorization: Bearer <token>` — para qualquer token diferente de `garra-local`, **o próprio token virava o `user_id`**. O comentário no fonte dizia *"this allows custom API keys to identify users"*, o que nunca foi verdade: a rota não verifica o token contra nada, então equivalia a deixar o chamador escolher o próprio nome.
2. Sem `Authorization`, o header `X-User-Id` era usado **cru**.

A rota é auth-free por desenho, como todo o `/api/*` (`threat-model.md` §5.7), e **isso não muda aqui**. Auth-free significa "não exige credencial", e não "aceita a identidade que o chamador afirmar": um header forjável que *decide* o `user_id` gravado é pior que nenhum, porque parece identidade sem ser.

## Confirmei cada afirmação da issue antes de mexer

- `router.rs:204` registra `post(openai_api::chat_completions)` **sem camada** — o router inteiro só tem `governor_layer` e CORS. Não há auth nesse caminho.
- **Severidade "latente, não ativa" está certa.** Verifiquei eu mesmo, não só pela issue: `session_store.rs:516` é `SELECT ... FROM messages WHERE session_id = ?1`. O `user_id` vai para três lugares e nenhum afeta leitura — `session.user_id` em memória, a coluna `user` do upsert, e metadata JSON. O impacto era **atribuição falsa**, não leitura cruzada.

Vale fechar porque é a mesma forma do buraco que a #1010 fechou de propósito *antes* de ligar execução nele.

## A decisão de produto — a §2, não a §3

A issue propõe duas saídas mutuamente exclusivas. Implementei a **§2**:

| | O que faz | Custo |
|---|---|---|
| **§2 — auth-free explícito** (este PR) | Identidade é o dono da allowlist local, ou `None`. `X-User-Id` deixa de ser lido; bearer não-`garra-local` é ignorado. | Nenhum cliente quebra. |
| **§3 — exigir auth** | Verificar contra `garraia-auth`, devolver 401. | **Quebra todo cliente local existente** — plugin de editor, `curl`, qualquer coisa apontada para o gateway. |

A §2 é o código passando a corresponder ao rumo já escrito (`threat-model.md` §5.7: "todo o `/api/*` é auth-free por decisão de design"). A §3 é mudança de produto e não faço sozinho — **se você quiser, digo num PR próprio.**

`None` é a resposta honesta para instalação sem dono: preenchê-la com o header seria inventar um dono.

## Uma coisa é maior do que a issue diz

`continuity_key(&self, _user_id:)` não é só uma armadilha para o próximo leitor. São **quatorze** call sites, e **sete** passam um id por pessoa literal — Telegram ×2, Slack, WhatsApp, Discord, iMessage, e a `task.user_id` do A2A em `server.rs:1173`. Todos recebiam a mesma `bus:shared-global` de volta.

Removi o parâmetro em vez de honrá-lo: honrá-lo mudaria o significado de `memory.shared_continuity` para quem já o ligou, e *shared* é literalmente o que a opção promete. Sem o parâmetro, a assinatura para de sugerir um escopo que não existe, e um barramento por pessoa passa a exigir função nova e decisão explícita.

## O que a auditoria achou — incluindo uma regressão que eu introduzi

**ALTO — a primeira versão desta correção logava PII em toda requisição.**

O código vulnerável logava o dono **só** quando um `garra-local` era apresentado. A minha correção passou a resolver o dono em *toda* requisição e logava o valor junto — ou seja, **logava mais vezes que o código que substituía.** E o dono nem sempre é um id opaco:

```rust
// bootstrap/whatsapp.rs:88
list.claim_owner(&from_number);   // número de telefone E164
// bootstrap/imessage.rs:59
list.claim_owner(&sender_id);     // número ou Apple ID
```

Regra absoluta 6. O log agora diz só *se* houve dono, que é o que quem depura precisa saber — o valor está no `allowlist.json`, que a mesma pessoa pode abrir.

**BAIXO — eu tinha escrito "quatorze chamadores passavam identidade real"**, e isso estava no threat model, que é o registro que sobrevive ao código. São 14 call sites, mas 7 passam id literal, 3 repassam o parâmetro recebido e 4 já passavam `None`. A conclusão não muda; a contagem sim. Corrigida nos três lugares onde eu a tinha escrito, e [na issue](https://github.com/michelbr84/GarraRUST/issues/1012).

**INFO** — a auditoria notou que `garra_local_continua_resolvendo_o_dono` passa também com o código vulnerável. Está correto e é o propósito dele: é o guard de **não-regressão** exigido pelo critério de aceitação da issue ("nenhuma regressão nos caminhos `garra-local` e allowlist"), não um teste discriminante. Os outros quatro discriminam.

## Os testes ficam vermelhos com a correção revertida

Verifiquei um por um, revertendo só a linha que cada um guarda:

```
x_user_id_forjado_nao_vira_identidade              → Some("vitima")   FAILED
x_user_id_forjado_nao_preenche_instalacao_sem_dono → Some("vitima")   FAILED
bearer_arbitrario_nao_vira_identidade              → o token          FAILED
o_valor_do_dono_nao_vai_para_o_log                 → "+15551234567"   FAILED
```

### E meu próprio teste escreveu no estado real da máquina

A primeira versão do helper usava a allowlist que `AppState::new` carrega do disco — e `claim_owner` chama `save()`. O teste do dono gravou `dono-real` no `allowlist.json` **real**, e o teste seguinte, o que exige uma instalação *sem* dono, leu esse dono de volta e falhou.

Foi o teste falhando que me mostrou. Um teste que escreve no estado real do operador está errado mesmo quando passa — é a mesma classe de bug que o #1017 corrigiu no benchmark, uma hora antes. O helper agora usa `Allowlist::restricted`, que nasce com `path: None`, e `save()` sai cedo sem path.

## Tipo de mudança

- [x] `fix` + `sec`: hardening de identidade

## Classe de Risco

- [x] **Classe B (Médio)**: muda o que é **gravado** como identidade numa rota sem auth. Nenhum cliente quebra (a rota continua aceitando as mesmas requisições e respondendo o mesmo), e nenhuma leitura muda de resultado — a carga de histórico é por `session_id`.

## Checklist de Segurança e Qualidade

- [x] `cargo +1.95 fmt --all -- --check` limpo
- [x] `cargo +1.95 clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings` sem erros
- [x] `cargo +1.95 test --workspace --exclude garraia-desktop` — única falha é a ambiental `migration_001_applies_and_schema_is_sane`, que exige `docker.sock`
- [x] Nenhum `unwrap()` em produção — `resolve_user_id` usa `.ok().and_then()`; os `.expect()` estão em `#[cfg(test)]`
- [x] Nenhuma PII em log — o token só como fingerprint, o dono não sai de forma nenhuma
- [x] Nenhuma migração, nenhuma rota nova, nenhum campo de config
- [x] `scripts/changelog/assemble.py --check` OK
- [x] Auditoria `@security-auditor` completa; os dois achados acionáveis corrigidos neste PR

## Mudanças na API pública

- `AppState::continuity_key` perde o parâmetro: `continuity_key(&self)`. 14 call sites atualizados.
- Comportamento: `X-User-Id` e bearer arbitrário deixam de influenciar o `user_id` gravado. Uma instalação sem dono passa a gravar sem `user_id` em vez do valor forjado.

## Como testar

```bash
cargo +1.95 test -p garraia-gateway --lib openai_api

# o defeito, contra o binário:
curl -s -X POST localhost:3000/v1/chat/completions -H 'X-User-Id: vitima' \
  -H 'Content-Type: application/json' \
  -d '{"model":"x","messages":[{"role":"user","content":"oi"}]}'
# a sessão não fica mais gravada sob "vitima"
```

## Plano de Rollback

`git revert` dos dois commits. `resolve_user_id` volta a ler os headers, e `continuity_key` volta a receber o parâmetro que ignora. Nada persistido, nada de migração.

## O que fica com você

Além da escolha §2 vs §3 acima, deixei **fora de propósito** o item §5 da issue: promover `Security Gate (BOLA & Tenant Isolation)` a required check. É mudança de branch protection — os quatro obrigatórios de hoje estão em `docs/security/protect-main-ruleset.md` — e isso é seu.

Closes #1012

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF

---
_Generated by [Claude Code](https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF)_