### PR TITLE
docs(memory): os docs de memoria contradiziam o binario, em dois arquivos

### DIFF
--- a/changelog.d/fixed/1017-docs-de-memoria.md
+++ b/changelog.d/fixed/1017-docs-de-memoria.md
@@ -1,0 +1,15 @@
+- **Os docs de memoria contradiziam o binario, em dois arquivos.**
+  `docs/src/memory.md` afirmava "**Nao ha `garra memory add`**" — falso desde
+  que o comando entrou (#958). E `docs/memory.md`, para onde **o wiki do
+  projeto aponta duas vezes** como "Sistema de memoria", ainda descrevia o
+  sistema que nunca foi construido: um `facts.json` com array de fatos
+  datados, as chaves `auto_extract` e `max_facts`, e os comandos
+  `garraia memory clear`, `export` e `disable`. A reescrita do #963 conferiu
+  cada afirmacao contra o codigo, mas conferiu a pagina do book; esta copia
+  ficou para tras e seguiu sendo servida a quem chegava pelo wiki.
+- `docs/memory.md` vira redirecionamento para a pagina viva — apaga-lo
+  quebraria os links do wiki. `docs/src/memory.md` ganha a secao do
+  `garra memory add`, com o que importa: o embedding e gerado **na hora**,
+  porque uma entrada sem vetor nao aparece na busca semantica e um comando de
+  semear que deixasse a entrada invisivel ate um segundo comando seria uma
+  armadilha.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,168 +1,33 @@
 # Memory System
 
-GarraIA has a comprehensive memory system that allows the agent to learn and remember information.
+> **Esta página foi substituída.** O conteúdo vivo e conferido está em
+> **[`docs/src/memory.md`](src/memory.md)** — a página do book, em português.
 
-## Overview
+## Por que este arquivo ainda existe
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│                    MEMORY SYSTEM                               │
-├─────────────────────────────────────────────────────────────┤
-│                                                              │
-│  ┌─────────────────┐  ┌─────────────────┐                  │
-│  │   facts.json    │  │   memory.db     │                  │
-│  │  (extracted)    │  │   (SQLite)      │                  │
-│  └─────────────────┘  └─────────────────┘                  │
-│          │                    │                             │
-│          ▼                    ▼                             │
-│  ┌─────────────────────────────────────────┐               │
-│  │         Embeddings (Ollama/local)       │               │
-│  └─────────────────────────────────────────┘               │
-│                        │                                    │
-│                        ▼                                    │
-│         ┌─────────────────────────────┐                    │
-│         │      Agent Context          │                    │
-│         └─────────────────────────────┘                    │
-│                                                              │
-└─────────────────────────────────────────────────────────────┘
+Porque o wiki do projeto aponta para ele como "Sistema de memória", e apagá-lo
+quebraria esses links. Ele fica como redirecionamento, não como documentação.
+
+## O que ele dizia, e por que não pode mais dizer
+
+Até 2026-09-07 este arquivo descrevia um sistema que **nunca foi construído**:
+um `facts.json` com array de fatos datados, as chaves de configuração
+`auto_extract` e `max_facts`, e os comandos `garraia memory clear`,
+`garraia memory export` e `garraia memory disable`.
+
+Nada disso existe. A reescrita da página do book (#963) foi feita conferindo
+cada afirmação contra o código; esta cópia ficou para trás e seguiu sendo
+servida ao leitor que chegava pelo wiki.
+
+O que existe de verdade, hoje:
+
+```text
+garra memory stats | list | add | search | reindex | backup | pin | ttl | delete | compact
 ```
 
-## Components
+`add` é recente (#958) — foi construído, não herdado daquela lista. Não há
+`clear`, `export` nem `disable`: para apagar use `delete` (uma entrada) ou
+`compact` (por idade); para levar embora, `backup`.
 
-### facts.json
-
-Automatically extracted facts from conversations:
-
-```json
-[
-  {
-    "fact": "User prefers responses in Portuguese",
-    "context": "When asked about language preference",
-    "source": "telegram:123456",
-    "timestamp": "2026-02-27T10:00:00Z"
-  }
-]
-```
-
-### memory.db
-
-SQLite database with:
-- Conversation history
-- Session data
-- Vector search (sqlite-vec)
-
-### Embeddings
-
-Semantic search using:
-- Ollama (local)
-- OpenAI
-- Cohere
-
-## Configuration
-
-```yaml
-memory:
-  enabled: true
-  embedding_provider: ollama-embed   # key of the `embeddings` entry below
-  # fact extraction runs on every turn — there is no auto_extract/interval/max_facts knob
-
-embeddings:
-  ollama-embed:
-    provider: ollama
-    model: nomic-embed-text
-    base_url: "http://localhost:11434"
-    dimensions: 768
-```
-
-## CLI Commands
-
-### List Facts
-
-```bash
-garraia memory list
-```
-
-### Search Facts
-
-```bash
-garraia memory search <query>
-```
-
-### Add Fact Manually
-
-```bash
-garraia memory add "User prefers short responses"
-```
-
-### Clear Memory
-
-```bash
-garraia memory clear
-```
-
-### Export Memory
-
-```bash
-garraia memory export
-```
-
-## How It Works
-
-### Fact Extraction
-
-1. After each conversation, LLM analyzes messages
-2. Important facts are identified
-3. Facts stored with context and source
-4. Facts included in future prompts
-
-### Semantic Search
-
-1. User query converted to embedding
-2. Similar facts found via vector search
-3. Relevant facts added to context
-4. Agent responds with context awareness
-
-## Data Location
-
-```
-~/.config/garraia/            # <config-dir>; ~/.garraia only on legacy installs
-├── memoria/
-│   ├── fatos.json          # Extracted facts
-│   └── embeddings/         # Embedding cache
-├── data/
-│   ├── memory.db           # SQLite memory
-│   └── sessions.db         # Session data
-```
-
-## Memory API
-
-### Search
-
-```bash
-curl -X POST http://127.0.0.1:3888/api/memory/search \
-  -H "Content-Type: application/json" \
-  -d '{"query": "user preferences", "limit": 5}'
-```
-
-### Add
-
-```bash
-curl -X POST http://127.0.0.1:3888/api/memory \
-  -H "Content-Type: application/json" \
-  -d '{"fact": "User likes coffee", "context": "mentioned in chat"}'
-```
-
-## Disable Memory
-
-To disable memory:
-
-```yaml
-memory:
-  enabled: false
-```
-
-Or use CLI:
-
-```bash
-garraia memory disable
-```
+Os detalhes — o caminho de um turno, a configuração real, o que ainda não
+existe — estão em [`docs/src/memory.md`](src/memory.md).

--- a/docs/src/memory.md
+++ b/docs/src/memory.md
@@ -9,6 +9,9 @@ real de cada comando, chave de configuração e arquivo.
 > com array de fatos datados, chaves `auto_extract` e `max_facts`. Nada disso
 > existiu. A reescrita (#963) foi feita conferindo cada afirmação contra o
 > código; onde algo é parcial ou tem limite conhecido, está dito.
+>
+> Desde 2026-09-07 o `garra memory add` **existe** (#958) — construído, não
+> herdado daquela lista. `clear`, `export` e `disable` seguem sem existir.
 
 ## O caminho de um turno
 
@@ -192,9 +195,27 @@ GET    /api/memory/search?q=...    # busca
 DELETE /api/memory                 # limpa
 ```
 
+## Semear a memória à mão
+
+```bash
+garra memory add "O condominio fica na rua das Flores" --session projeto-x
+```
+
+O embedding é gerado **na hora**: uma entrada sem vetor não aparece na busca
+semântica, e um comando de semear que deixasse a entrada invisível até um
+segundo comando seria uma armadilha. Sem provider de embeddings configurado
+ele grava assim mesmo, **diz** que gravou sem vetor, e aponta o `reindex`.
+
+`--no-embed` pula o embedding de propósito (semeadura em massa, para
+`reindex` depois). `--session` e `--user` preenchem os campos homônimos, e a
+sessão tem default `cli-seed`, para que o que você semeia seja distinguível
+do que veio de conversa. O `tenant_id` é sempre `default`, o mesmo que o
+runtime usa — semear noutro faria a entrada existir e o recall do agente
+nunca achá-la.
+
 ## O que ainda não existe
 
-- **Não há `garra memory add`.** Entradas nascem de conversas ou da extração
-  de fatos; não há inserção manual pela CLI.
+- **Não há `clear`, `export` nem `disable`.** Para apagar, use `delete` (uma
+  entrada) ou `compact` (por idade); para levar embora, `backup`.
 - **O retriever do `garraia-learning` é um stub.** A busca semântica de
   *skills* (distinta da memória de conversa) espera a Fase 2.1 — ver ADR 0002.


### PR DESCRIPTION
## Descrição

Achado ao conferir uma frase que eu mesmo tinha escrito no PR #1017: fui verificar se `garra memory add` estava documentado, e encontrei o contrário do esperado — a documentação **nega** que o comando exista.

### 1. `docs/src/memory.md` — a página viva do book

```
- **Não há `garra memory add`.** Entradas nascem de conversas ou da extração
  de fatos; não há inserção manual pela CLI.
```

Era verdade quando foi escrito. Deixou de ser hoje, quando o #1017 mergeou. A frase ficou.

### 2. `docs/memory.md` — o caso pior

Ele descreve um `facts.json` com array de fatos datados, as chaves `auto_extract` e `max_facts`, e os comandos `garraia memory clear`, `export` e `disable`.

**É exatamente o sistema que a "Nota histórica" da página do book diz que nunca foi construído.** A reescrita do #963 conferiu cada afirmação contra o código — mas conferiu a página do book; esta cópia ficou para trás.

**E ela não é um órfão.** O wiki do projeto aponta para ela **duas vezes** como "Sistema de memória":

```
wiki/Guias-de-Integracao.md:38  → .../blob/main/docs/memory.md
wiki/Arquitetura-e-ADRs.md:7    → .../blob/main/docs/memory.md
```

Quem chegava pelo wiki lia a ficção; quem chegava pelo book lia o que existe. Ela **não** está no `SUMMARY.md`, então nem aparecia no book — era servida só pelo caminho que ninguém revisava.

## O que este PR faz

**`docs/memory.md` vira redirecionamento**, não some. Apagá-lo quebraria os dois links do wiki — que vive em outro repositório e que eu não vou editar às cegas. O arquivo passa a dizer o que existe de verdade, por que ele ainda está ali, e aponta para a página viva. 168 linhas de ficção viram 33 de redirecionamento.

**`docs/src/memory.md` ganha a seção do comando** e perde a negação. A seção diz as três coisas que o `--help` não diz:

- **o embedding é gerado na hora, e por quê** — uma entrada sem vetor não aparece na busca semântica, então um comando de semear que a deixasse invisível até um segundo comando seria uma armadilha;
- **`--session` tem default `cli-seed`**, para que o que você semeia seja distinguível do que veio de conversa;
- **o `tenant_id` é sempre `default`**, o mesmo que o runtime usa — semear noutro faria a entrada existir e o recall do agente nunca achá-la.

A "Nota histórica" também ganha uma linha: `add` voltou a existir, mas **construído**, não herdado daquela lista. `clear`, `export` e `disable` seguem sem existir.

## Verificação

Cada flag documentada foi conferida contra o binário, não contra a minha lembrança do que eu tinha escrito:

```
$ garra memory add --help
  --session <SESSION>   [default: cli-seed]
  --user <USER>
  --no-embed
```

E uma varredura dos dois arquivos contra a lista real de subcomandos, para garantir que nenhum comando inexistente sobrou citado como se existisse. As três ocorrências restantes de `clear`/`export`/`disable` estão todas na negativa ("não há", "nada disso existe").

## Tipo de mudança

- [x] `docs`: correção de documentação que contradizia o produto

## Classe de Risco

- [x] **Classe A (Baixo Risco)**: nenhum código muda. Nenhum arquivo é apagado, então nenhum link externo quebra.

## Checklist de Segurança e Qualidade

- [x] Nenhuma mudança de código — `fmt`/`clippy`/`test` inalterados
- [x] `scripts/changelog/assemble.py --check` OK
- [x] Nenhum segredo, nenhuma credencial, nenhum caminho interno nos docs
- [x] Os dois links do wiki continuam resolvendo

## Plano de Rollback

`git revert`. Volta a ficção, o que não é desejável, mas nada quebra.

## O que fica em aberto

O wiki (`wiki/`) aponta para o `docs/memory.md` como se ele fosse a página principal de memória. O ideal seria apontar direto para `docs/src/memory.md` — mas isso é edição do wiki, e prefiro que você decida se quer que eu mexa lá.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF

---
_Generated by [Claude Code](https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF)_