### PR TITLE
fix(release): o .gitignore engolia o script de notas, e a release ia quebrar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,8 +113,15 @@ venv/
 *.wasm
 
 # Release artifacts
-dist/
-release/
+#
+# Ancorados na raiz de proposito. Sem a barra inicial, o padrao casa em
+# QUALQUER profundidade — e `release/` sem ancora engolia `scripts/release/`,
+# que e codigo-fonte. O `git add -A` pulava o arquivo em silencio, e o
+# `release.yml` ficava referenciando um script que nao existia no repo.
+# O que estes padroes querem ignorar e o diretorio de staging que o
+# `release.yml` cria na raiz (`mkdir -p release`), nada aninhado.
+/dist/
+/release/
 
 # Planning / drafts (internal)
 # Por default, conteúdo de plans/ é ignorado para não vazar drafts locais.

--- a/scripts/release/notes.py
+++ b/scripts/release/notes.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Extrai a prosa de abertura de uma versao do CHANGELOG para o corpo da release.
+
+A secao inteira nao serve: a da v0.3.9 tem 1298 linhas e 90 KB, perto do teto
+de 125 KB do corpo de release do GitHub e ilegivel como pagina. A prosa de
+abertura — o que vem entre o `## [X.Y.Z]` e a primeira subsecao `###` — e o
+resumo escrito para humano, e e ela que vai para a release. O detalhe fica no
+CHANGELOG, linkado.
+
+Nunca falha: sem secao, sem prosa ou sem arquivo, emite um corpo minimo. Uma
+release nao pode ser bloqueada por causa das proprias notas.
+"""
+import re
+import sys
+
+def main() -> int:
+    versao = sys.argv[1] if len(sys.argv) > 1 else ""
+    caminho = sys.argv[2] if len(sys.argv) > 2 else "CHANGELOG.md"
+    limpa = versao.lstrip("v")
+    repo = "https://github.com/michelbr84/GarraRUST"
+    rodape = (
+        f"\n---\n\n**Changelog completo desta versao:** "
+        f"[CHANGELOG.md]({repo}/blob/main/CHANGELOG.md)\n"
+    )
+
+    try:
+        with open(caminho, encoding="utf-8") as f:
+            s = f.read()
+    except OSError:
+        print(f"## {versao}\n{rodape}")
+        return 0
+
+    m = re.search(rf"^## \[{re.escape(limpa)}\][^\n]*\n", s, re.M)
+    if not m:
+        print(f"## {versao}\n{rodape}")
+        return 0
+
+    resto = s[m.end():]
+    fim = re.search(r"^## \[", resto, re.M)
+    secao = resto[: fim.start()] if fim else resto
+    corte = re.search(r"^### ", secao, re.M)
+    prosa = (secao[: corte.start()] if corte else secao).strip()
+
+    print((prosa if prosa else f"## {versao}") + "\n" + rodape)
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## O defeito

O #1020 adicionou ao `release.yml` um passo que roda `scripts/release/notes.py` e passa o resultado como `body_path`. **O passo mergeou; o script não.**

```
$ git ls-tree origin/main -- scripts/release/notes.py
(vazio)

$ git show origin/main:.github/workflows/release.yml | grep body_path
879:          body_path: RELEASE_NOTES.md
```

O `main` está referenciando um arquivo que não existe nele.

## Por quê

```
$ git check-ignore -v scripts/release/notes.py
.gitignore:117:release/	scripts/release/notes.py
```

O padrão era `release/`, **sem barra inicial**. Um padrão sem âncora no `.gitignore` casa em **qualquer profundidade**, então `scripts/release/` estava ignorado junto com o diretório de staging da raiz. O `git add -A` pulou o arquivo **em silêncio** — sem aviso, sem erro.

## O que teria acontecido

Se eu tivesse empurrado o tag `v0.3.9` como estava, o passo `Build release notes from CHANGELOG` falharia com `No such file or directory`. Como ele roda **antes** do `Create Release` e o job usa `set -euo pipefail`, o job inteiro morreria: **sem release, sem binários, sem `SHA256SUMS`, e sem os `<asset>.sha256` que o `garra update` exige** (`update.rs:127`).

Peguei conferindo o `main` **antes** de taguear, não depois.

## A correção

Ancorar. O que esses padrões querem ignorar é o diretório de staging que o próprio `release.yml` cria na raiz:

```
$ grep -n "mkdir -p release" .github/workflows/release.yml
48:          mkdir -p release
86:          mkdir -p release
115:          mkdir -p release
```

`/release/` faz exatamente isso e para de alcançar código-fonte.

`dist/` levou a mesma âncora — é a mesma forma de armadilha esperando a próxima pessoa. Verifiquei que hoje não há nenhum `dist/` aninhado no repo, e que **`scripts/release/` era o único `release/` aninhado**, então a mudança não des-ignora mais nada.

## Verificação

```
$ git check-ignore -v scripts/release/notes.py
(nada — não ignorado)

$ git diff --cached --name-only | grep -c scripts/release/notes.py
1

$ python3 scripts/release/notes.py v0.3.9 CHANGELOG.md | wc -c
2372
```

O script já teve os modos de falha verificados no #1020: versão inexistente, arquivo inexistente, prosa vazia e argumento faltando saem todos com exit 0 e corpo mínimo.

## Tipo de mudança

- [x] `fix`: corrige um `main` que referencia arquivo inexistente

## Classe de Risco

- [x] **Classe A (Baixo Risco)**: um padrão de `.gitignore` ganha âncora e um script de 60 linhas entra no repo. Nenhum código de produto muda.

## Checklist

- [x] Nenhuma mudança de Rust — `fmt`/`clippy`/`test` inalterados
- [x] O único `release/` aninhado era `scripts/release/`; nenhum `dist/` aninhado existe
- [x] Nenhum segredo, nenhuma migração, nenhuma rota
- [x] Regra absoluta 15 preservada: a lista de assets do `release.yml` está intocada

## Depois deste merge

Aí sim o tag:

```bash
git tag v0.3.9 <sha-do-merge>
git push origin v0.3.9
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF

---
_Generated by [Claude Code](https://claude.ai/code/session_01497Lw2nMCbnCJTK5vkpPiF)_