### PR TITLE
fix(gateway): registra as tools adormecidas, leva working_dir ao turno HTTP e dá ao agente o garra_status

### DIFF
--- a/changelog.d/added/1035-garra-status.md
+++ b/changelog.d/added/1035-garra-status.md
@@ -1,0 +1,11 @@
+- **Ferramenta `garra_status`: o agente passa a conseguir descrever o proprio
+  runtime.** Perguntado o que era, o Garra no celular respondia que "nao consegue
+  inspecionar o estado interno do runtime a partir desta conversa" — e estava
+  certo, nada permitia: `/api/health` e `/api/capabilities` existem para o console,
+  `web_fetch` recusa loopback por desenho (guard de SSRF) e `bash` teria de
+  adivinhar host e porta. A tool le o mesmo `AppState` daqueles endpoints (versao,
+  uptime, provider e modelo ativos, ferramentas registradas, features, canais,
+  modo e diretorio da sessao) sem fazer requisicao nenhuma, entao a superficie de
+  SSRF fica onde estava. Sem segredo na saida: ids de provider e nomes de modelo,
+  nunca chaves. A persona menciona as ferramentas, para o modelo usa-las antes de
+  dizer que nao consegue.

--- a/changelog.d/added/1035-garra-status.md
+++ b/changelog.d/added/1035-garra-status.md
@@ -1,5 +1,5 @@
 - **Ferramenta `garra_status`: o agente passa a conseguir descrever o proprio
-  runtime.** Perguntado o que era, o Garra no celular respondia que "nao consegue
+  runtime (#1035).** Perguntado o que era, o Garra no celular respondia que "nao consegue
   inspecionar o estado interno do runtime a partir desta conversa" — e estava
   certo, nada permitia: `/api/health` e `/api/capabilities` existem para o console,
   `web_fetch` recusa loopback por desenho (guard de SSRF) e `bash` teria de

--- a/changelog.d/fixed/1033-tools-registradas-working-dir.md
+++ b/changelog.d/fixed/1033-tools-registradas-working-dir.md
@@ -1,0 +1,12 @@
+- **Quatro ferramentas do agente existiam e nunca foram registradas; e o
+  diretorio da sessao nao chegava ao turno HTTP (#1033, #1035).** `list_dir`,
+  `repo_search`, `run_tests` e `code_review` tinham schema e testes verdes, mas o
+  unico `new()` delas no repo era dentro dos proprios testes — as whitelists dos
+  modos `search`, `debug` e `review` anunciavam `list_dir` e `repo_search` que o
+  modelo nunca recebia. Agora entram no bootstrap do gateway (`code_review` com o
+  provider e modelo default do boot). E `exec_context_for` passou a levar
+  `SessionState::working_dir` para o `ExecContext`: antes todo turno via
+  `/api/sessions/{id}/messages` saia sem diretorio, e o `resolve_tool_path`
+  recusava qualquer caminho relativo — o Garra no celular dizia que nao conseguia
+  olhar os proprios arquivos, e nao conseguia mesmo. O modo `debug` ganha
+  `run_tests` e o `review` ganha `code_review` na whitelist.

--- a/changelog.d/fixed/1033-tools-registradas-working-dir.md
+++ b/changelog.d/fixed/1033-tools-registradas-working-dir.md
@@ -8,5 +8,11 @@
   `SessionState::working_dir` para o `ExecContext`: antes todo turno via
   `/api/sessions/{id}/messages` saia sem diretorio, e o `resolve_tool_path`
   recusava qualquer caminho relativo — o Garra no celular dizia que nao conseguia
-  olhar os proprios arquivos, e nao conseguia mesmo. O modo `debug` ganha
-  `run_tests` e o `review` ganha `code_review` na whitelist.
+  olhar os proprios arquivos, e nao conseguia mesmo. As tres passam pelo
+  mesmo `resolve_tool_path` do `file_read` (relativo ao diretorio da sessao,
+  `..` recusado, e sem sessao o erro diz que resolveu contra o CWD do
+  processo), `repo_search`
+  busca no diretorio da sessao e `run_tests` respeita
+  `agent.tool_confirmation_enabled` como o `bash` — roda `npm test`, que
+  executa o que o `package.json` mandar. O modo `debug` ganha `run_tests` e o
+  `review` ganha `code_review` na whitelist.

--- a/crates/garraia-agents/src/modes.rs
+++ b/crates/garraia-agents/src/modes.rs
@@ -725,6 +725,7 @@ impl ModeProfile {
                     "repo_search".to_string(),
                     "list_dir".to_string(),
                     "bash".to_string(),
+                    "run_tests".to_string(),
                 ],
                 denied: vec!["file_write".to_string()],
                 required: vec![],
@@ -795,6 +796,7 @@ impl ModeProfile {
                     "git_diff".to_string(),
                     "repo_search".to_string(),
                     "list_dir".to_string(),
+                    "code_review".to_string(),
                 ],
                 denied: vec![
                     "file_write".to_string(),

--- a/crates/garraia-agents/src/persona.rs
+++ b/crates/garraia-agents/src/persona.rs
@@ -64,11 +64,11 @@ próximo passo, sem despejar mensagens técnicas cruas.
 - Não bajula (\"que ótima pergunta!\") nem inventa: é gentil, honesto e \
 competente. Se não sabe, diz que não sabe e sugere um caminho.
 - Respeita o usuário e a privacidade dele.
-- Você tem ferramentas de verdade: ler e escrever arquivos, listar diretórios, \
-  buscar no repositório, rodar comandos e testes, e `garra_status`, que \
-  descreve o seu próprio runtime (versão, provedor, modelo, ferramentas, \
-  diretório da sessão). Quando a pergunta for sobre arquivos, código ou sobre \
-  você mesmo, use-as antes de dizer que não consegue.
+- Você tem ferramentas de verdade. Para olhar (ler arquivo, listar diretório, \
+  buscar no repositório, e `garra_status`, que descreve o seu próprio runtime: \
+  versão, provedor, modelo, ferramentas, diretório da sessão), use-as antes de \
+  dizer que não consegue. Para mudar algo (escrever arquivo, rodar comando ou \
+  teste), só quando a pessoa pedir.
 - Você conhece os agentes Garra, Hera e Forja. Garra é você; se o usuário pedir \
   para conversar com a Hera ou com a Forja, diga que a conversa entre agentes \
   ainda não está disponível nesta instalação e ofereça transmitir o pedido \
@@ -94,11 +94,11 @@ for a friendly touch. Never clutter.
 - Don't flatter (\"what a great question!\") or make things up: be kind, honest, \
 and competent. If you don't know, say so and suggest a path forward.
 - Respect the user and their privacy.
-- You have real tools: read and write files, list directories, search the \
-  repository, run commands and tests, and `garra_status`, which describes your \
-  own runtime (version, provider, model, tools, session working directory). \
-  When the question is about files, code, or yourself, use them before saying \
-  you can't.
+- You have real tools. To look (read a file, list a directory, search the \
+  repository, and `garra_status`, which describes your own runtime: version, \
+  provider, model, tools, session working directory), use them before saying \
+  you can't. To change something (write a file, run a command or tests), only \
+  when the person asks.
 
 Your name is Garra. You exist to make the person's (or family's/team's) life \
 easier.";

--- a/crates/garraia-agents/src/persona.rs
+++ b/crates/garraia-agents/src/persona.rs
@@ -64,6 +64,11 @@ próximo passo, sem despejar mensagens técnicas cruas.
 - Não bajula (\"que ótima pergunta!\") nem inventa: é gentil, honesto e \
 competente. Se não sabe, diz que não sabe e sugere um caminho.
 - Respeita o usuário e a privacidade dele.
+- Você tem ferramentas de verdade: ler e escrever arquivos, listar diretórios, \
+  buscar no repositório, rodar comandos e testes, e `garra_status`, que \
+  descreve o seu próprio runtime (versão, provedor, modelo, ferramentas, \
+  diretório da sessão). Quando a pergunta for sobre arquivos, código ou sobre \
+  você mesmo, use-as antes de dizer que não consegue.
 - Você conhece os agentes Garra, Hera e Forja. Garra é você; se o usuário pedir \
   para conversar com a Hera ou com a Forja, diga que a conversa entre agentes \
   ainda não está disponível nesta instalação e ofereça transmitir o pedido \
@@ -89,6 +94,11 @@ for a friendly touch. Never clutter.
 - Don't flatter (\"what a great question!\") or make things up: be kind, honest, \
 and competent. If you don't know, say so and suggest a path forward.
 - Respect the user and their privacy.
+- You have real tools: read and write files, list directories, search the \
+  repository, run commands and tests, and `garra_status`, which describes your \
+  own runtime (version, provider, model, tools, session working directory). \
+  When the question is about files, code, or yourself, use them before saying \
+  you can't.
 
 Your name is Garra. You exist to make the person's (or family's/team's) life \
 easier.";

--- a/crates/garraia-agents/src/tools/list_dir_tool.rs
+++ b/crates/garraia-agents/src/tools/list_dir_tool.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use garraia_common::Result;
 use std::path::{Path, PathBuf};
 
+use super::tool_context::{process_home_dir, resolve_tool_path};
 use super::{Tool, ToolContext, ToolOutput};
 
 /// Maximum depth for directory traversal
@@ -210,11 +211,9 @@ impl Tool for ListDirTool {
         })
     }
 
-    async fn execute(
-        &self,
-        _context: &ToolContext,
-        input: serde_json::Value,
-    ) -> Result<ToolOutput> {
+    async fn execute(&self, context: &ToolContext, input: serde_json::Value) -> Result<ToolOutput> {
+        // Sem `path`, lista o diretorio da sessao — nunca o CWD do processo
+        // do gateway, que nao significa nada para quem esta no telefone.
         let path_str = input.get("path").and_then(|v| v.as_str()).unwrap_or(".");
 
         let depth = input
@@ -226,18 +225,33 @@ impl Tool for ListDirTool {
 
         let pattern = input.get("pattern").and_then(|v| v.as_str());
 
-        let path = PathBuf::from(path_str);
+        // O mesmo resolvedor do `file_read` (#923): `~` expandido, relativo
+        // juntado ao `working_dir` da sessao, `..` recusado. Auditoria do
+        // #1039: a tool ficou anos sem ser registrada, e quando entrou no
+        // runtime aceitava qualquer caminho cru do modelo.
+        let resolved = match resolve_tool_path(
+            path_str,
+            context.working_dir.as_deref(),
+            process_home_dir().as_deref(),
+        ) {
+            Ok(r) => r,
+            Err(e) => return Ok(ToolOutput::error(e.to_string())),
+        };
+        let path: PathBuf = resolved.path.clone();
 
         // Validate path exists
         if !path.exists() {
             return Ok(ToolOutput::error(format!(
                 "Directory not found: {}",
-                path_str
+                resolved.describe()
             )));
         }
 
         if !path.is_dir() {
-            return Ok(ToolOutput::error(format!("Not a directory: {}", path_str)));
+            return Ok(ToolOutput::error(format!(
+                "Not a directory: {}",
+                resolved.describe()
+            )));
         }
 
         let mut entries = Vec::new();
@@ -286,25 +300,67 @@ mod tests {
         assert!(glob_match("test*", "test_file"));
     }
 
-    #[tokio::test]
-    async fn test_list_dir_current() {
-        let tool = ListDirTool::new(None);
-        let ctx = ToolContext {
+    fn ctx(working_dir: Option<&str>) -> ToolContext {
+        ToolContext {
             session_id: "test".into(),
             user_id: None,
             is_heartbeat: false,
             is_confirmation_approved: false,
-            working_dir: None,
+            working_dir: working_dir.map(str::to_string),
             project_id: None,
-        };
+        }
+    }
+
+    /// `.` e o diretorio da sessao, e sem `path` o default e o mesmo.
+    #[tokio::test]
+    async fn test_list_dir_current() {
+        let tool = ListDirTool::new(None);
+        let ctx = ctx(Some(env!("CARGO_MANIFEST_DIR")));
 
         let output = tool
             .execute(&ctx, serde_json::json!({"path": ".", "depth": 1}))
             .await
             .expect("should not error");
+        assert!(!output.is_error, "{}", output.content);
+        assert!(output.content.contains("Cargo.toml"), "{}", output.content);
 
-        assert!(!output.is_error);
-        assert!(!output.content.is_empty());
+        let output = tool
+            .execute(&ctx, serde_json::json!({"depth": 1}))
+            .await
+            .expect("should not error");
+        assert!(!output.is_error, "{}", output.content);
+        assert!(output.content.contains("Cargo.toml"), "{}", output.content);
+    }
+
+    /// Relativo sem sessao resolve contra o CWD do processo, como o
+    /// `file_read` — e o erro diz isso, para o modelo saber pedir um caminho
+    /// absoluto em vez de tentar de novo.
+    #[tokio::test]
+    async fn test_list_dir_relative_without_session_dir_explains_itself() {
+        let tool = ListDirTool::new(None);
+        let output = tool
+            .execute(&ctx(None), serde_json::json!({"path": "nao_existe_xyz"}))
+            .await
+            .expect("should not error");
+        assert!(output.is_error, "{}", output.content);
+        assert!(
+            output.content.contains("não tem working_dir"),
+            "{}",
+            output.content
+        );
+    }
+
+    /// `..` nunca passa, com ou sem sessao.
+    #[tokio::test]
+    async fn test_list_dir_rejects_parent_dir() {
+        let tool = ListDirTool::new(None);
+        for wd in [Some(env!("CARGO_MANIFEST_DIR")), None] {
+            let output = tool
+                .execute(&ctx(wd), serde_json::json!({"path": "../.."}))
+                .await
+                .expect("should not error");
+            assert!(output.is_error, "{}", output.content);
+        }
     }
 
     #[tokio::test]

--- a/crates/garraia-agents/src/tools/repo_search_tool.rs
+++ b/crates/garraia-agents/src/tools/repo_search_tool.rs
@@ -91,11 +91,7 @@ impl Tool for RepoSearchTool {
         })
     }
 
-    async fn execute(
-        &self,
-        _context: &ToolContext,
-        input: serde_json::Value,
-    ) -> Result<ToolOutput> {
+    async fn execute(&self, context: &ToolContext, input: serde_json::Value) -> Result<ToolOutput> {
         let query = input
             .get("query")
             .and_then(|v| v.as_str())
@@ -115,8 +111,14 @@ impl Tool for RepoSearchTool {
             .and_then(|v| v.as_u64())
             .unwrap_or(DEFAULT_CONTEXT_LINES as u64) as u32;
 
-        // Build and execute the search command
+        // Build and execute the search command. `.` abaixo e o CWD do
+        // processo — o diretorio da sessao, quando ha um, e o que o usuario
+        // quer dizer com "o repositorio" (auditoria do #1039: sem isto, um
+        // gateway lancado de dentro de um repo buscava nesse repo).
         let mut cmd = Command::new("rg");
+        if let Some(wd) = context.working_dir.as_deref() {
+            cmd.current_dir(wd);
+        }
         cmd.arg("--line-number")
             .arg("--no-heading")
             .arg("--color")
@@ -166,6 +168,9 @@ impl Tool for RepoSearchTool {
                 } else {
                     "grep"
                 });
+                if let Some(wd) = context.working_dir.as_deref() {
+                    grep_cmd.current_dir(wd);
+                }
 
                 if cfg!(target_os = "windows") {
                     grep_cmd.arg("/s").arg("/n").arg(query).arg("*.*");
@@ -218,6 +223,32 @@ mod tests {
         let schema = tool.input_schema();
         assert!(schema.get("properties").is_some());
         assert_eq!(schema["required"].as_array().map(|a| a.len()), Some(1));
+    }
+
+    /// A busca acontece no diretorio da sessao, nao no CWD do gateway.
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn searches_in_the_session_dir() {
+        let dir = std::env::temp_dir().join(format!("garra-repo-search-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("tempdir");
+        std::fs::write(dir.join("notas.txt"), "agulha_unica_xyz\n").expect("write");
+
+        let tool = RepoSearchTool::new(Some(10), None);
+        let ctx = ToolContext {
+            session_id: "test".into(),
+            user_id: None,
+            is_heartbeat: false,
+            is_confirmation_approved: false,
+            working_dir: Some(dir.to_string_lossy().into_owned()),
+            project_id: None,
+        };
+        let result = tool
+            .execute(&ctx, serde_json::json!({"query": "agulha_unica_xyz"}))
+            .await
+            .expect("executa");
+        let _ = std::fs::remove_dir_all(&dir);
+        assert!(!result.is_error, "{}", result.content);
+        assert!(result.content.contains("notas.txt"), "{}", result.content);
     }
 
     #[tokio::test]

--- a/crates/garraia-agents/src/tools/run_tests_tool.rs
+++ b/crates/garraia-agents/src/tools/run_tests_tool.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 use std::time::Duration;
 use tokio::process::Command;
 
+use super::tool_context::{process_home_dir, resolve_tool_path};
 use super::{Tool, ToolContext, ToolOutput};
 
 /// Default timeout for test execution
@@ -31,6 +32,11 @@ enum TestFramework {
 /// Auto-detects the test framework based on project files.
 pub struct RunTestsTool {
     timeout: Duration,
+    /// Roda `cargo test` / `npm test` / ... — e `npm test` executa o que o
+    /// `package.json` do diretorio mandar. E execucao arbitraria com outro
+    /// nome, entao segue a mesma regra do `bash` (GAR-187): com
+    /// `agent.tool_confirmation_enabled`, pede confirmacao antes de rodar.
+    confirmation_enabled: bool,
 }
 
 impl RunTestsTool {
@@ -38,6 +44,15 @@ impl RunTestsTool {
     pub fn new(timeout_secs: Option<u64>) -> Self {
         Self {
             timeout: Duration::from_secs(timeout_secs.unwrap_or(DEFAULT_TIMEOUT_SECS)),
+            confirmation_enabled: false,
+        }
+    }
+
+    /// Como [`Self::new`], mas exige confirmacao humana antes de executar.
+    pub fn new_with_confirmation(timeout_secs: Option<u64>) -> Self {
+        Self {
+            confirmation_enabled: true,
+            ..Self::new(timeout_secs)
         }
     }
 
@@ -202,23 +217,43 @@ impl Tool for RunTestsTool {
         })
     }
 
-    async fn execute(
-        &self,
-        _context: &ToolContext,
-        input: serde_json::Value,
-    ) -> Result<ToolOutput> {
+    async fn execute(&self, context: &ToolContext, input: serde_json::Value) -> Result<ToolOutput> {
         let test_name = input.get("test_name").and_then(|v| v.as_str());
+        // Sem `working_dir`, o diretorio da sessao; com, o mesmo resolvedor
+        // do `file_read` (relativo a sessao, `..` recusado). Auditoria do
+        // #1039: o valor vinha cru do modelo e ia direto para `current_dir`.
         let working_dir_str = input
             .get("working_dir")
             .and_then(|v| v.as_str())
             .unwrap_or(".");
-
-        let working_dir = std::path::PathBuf::from(working_dir_str);
+        let resolved = match resolve_tool_path(
+            working_dir_str,
+            context.working_dir.as_deref(),
+            process_home_dir().as_deref(),
+        ) {
+            Ok(r) => r,
+            Err(e) => return Ok(ToolOutput::error(e.to_string())),
+        };
+        let working_dir = resolved.path.clone();
 
         if !working_dir.exists() {
             return Ok(ToolOutput::error(format!(
                 "Working directory not found: {}",
-                working_dir_str
+                resolved.describe()
+            )));
+        }
+
+        if self.confirmation_enabled && !context.is_confirmation_approved {
+            tracing::warn!(
+                dir = %working_dir.display(),
+                session = %context.session_id,
+                "run_tests: requires user confirmation"
+            );
+            return Ok(ToolOutput::confirmation_request(format!(
+                "[CONFIRM_REQUIRED] run_tests vai executar a suite de testes em:\n\
+                 ```\n{}\n```\n\
+                 Responda **sim** para executar ou **nao** para cancelar.",
+                working_dir.display()
             )));
         }
 
@@ -324,5 +359,76 @@ test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
         let tool = RunTestsTool::new(None);
         let schema = tool.input_schema();
         assert!(schema.get("properties").is_some());
+    }
+
+    fn ctx(working_dir: Option<&str>, approved: bool) -> ToolContext {
+        ToolContext {
+            session_id: "test".into(),
+            user_id: None,
+            is_heartbeat: false,
+            is_confirmation_approved: approved,
+            working_dir: working_dir.map(str::to_string),
+            project_id: None,
+        }
+    }
+
+    /// Com confirmacao ligada e sem aprovacao, nada roda: a tool devolve o
+    /// pedido de confirmacao apontando o diretorio da sessao (o default).
+    #[tokio::test]
+    async fn asks_confirmation_before_running_in_the_session_dir() {
+        let dir = env!("CARGO_MANIFEST_DIR");
+        let tool = RunTestsTool::new_with_confirmation(Some(1));
+        let out = tool
+            .execute(&ctx(Some(dir), false), serde_json::json!({}))
+            .await
+            .expect("executa");
+        assert!(out.requires_confirmation, "{}", out.content);
+        assert!(out.content.contains(dir), "{}", out.content);
+    }
+
+    /// `..` e recusado antes de qualquer execucao; relativo sem sessao
+    /// resolve contra o CWD do processo (como o `file_read`) e, quando nao
+    /// existe, o erro explica de onde veio.
+    #[tokio::test]
+    async fn refuses_traversal_and_explains_relative_without_session_dir() {
+        let tool = RunTestsTool::new(Some(1));
+        let out = tool
+            .execute(
+                &ctx(Some(env!("CARGO_MANIFEST_DIR")), true),
+                serde_json::json!({"working_dir": "../.."}),
+            )
+            .await
+            .expect("executa");
+        assert!(out.is_error, "{}", out.content);
+        assert!(out.content.contains("traversal"), "{}", out.content);
+
+        let out = tool
+            .execute(
+                &ctx(None, true),
+                serde_json::json!({"working_dir": "nao_existe_xyz"}),
+            )
+            .await
+            .expect("executa");
+        assert!(out.is_error, "{}", out.content);
+        assert!(
+            out.content.contains("não tem working_dir"),
+            "{}",
+            out.content
+        );
+    }
+
+    /// Diretorio inexistente: erro com o caminho resolvido, sem rodar nada.
+    #[tokio::test]
+    async fn missing_dir_is_an_error_with_the_resolved_path() {
+        let tool = RunTestsTool::new(Some(1));
+        let out = tool
+            .execute(
+                &ctx(Some(env!("CARGO_MANIFEST_DIR")), true),
+                serde_json::json!({"working_dir": "nao_existe_xyz"}),
+            )
+            .await
+            .expect("executa");
+        assert!(out.is_error);
+        assert!(out.content.contains("nao_existe_xyz"), "{}", out.content);
     }
 }

--- a/crates/garraia-gateway/src/bootstrap/mod.rs
+++ b/crates/garraia-gateway/src/bootstrap/mod.rs
@@ -572,7 +572,14 @@ pub fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
     // promessa na policy e nao recebia a ferramenta.
     runtime.register_tool(Box::new(ListDirTool::new(None)));
     runtime.register_tool(Box::new(RepoSearchTool::new(None, None)));
-    runtime.register_tool(Box::new(RunTestsTool::new(None)));
+    // `run_tests` executa o que o projeto mandar (`npm test` roda o script do
+    // package.json), entao respeita a mesma chave de confirmacao do bash.
+    let run_tests = if config.agent.tool_confirmation_enabled {
+        RunTestsTool::new_with_confirmation(None)
+    } else {
+        RunTestsTool::new(None)
+    };
+    runtime.register_tool(Box::new(run_tests));
 
     // `code_review` roda um segundo LLM por dentro, entao precisa de um
     // provider resolvido aqui, e nao de `None`. Usa o default do boot: se o

--- a/crates/garraia-gateway/src/bootstrap/mod.rs
+++ b/crates/garraia-gateway/src/bootstrap/mod.rs
@@ -2,10 +2,10 @@ use std::sync::Arc;
 
 use garraia_agents::tools::Tool;
 use garraia_agents::{
-    AgentRuntime, AnthropicProvider, BashTool, CohereEmbeddingProvider, EmbeddingProvider,
-    FileReadTool, FileWriteTool, LlamaCppProvider, McpManager, NoisePolicy,
-    OllamaEmbeddingProvider, OllamaProvider, OpenAiEmbeddingProvider, OpenAiProvider,
-    ResilientEmbeddingProvider, WebFetchTool, WebSearchTool,
+    AgentRuntime, AnthropicProvider, BashTool, CodeReviewTool, CohereEmbeddingProvider,
+    EmbeddingProvider, FileReadTool, FileWriteTool, ListDirTool, LlamaCppProvider, McpManager,
+    NoisePolicy, OllamaEmbeddingProvider, OllamaProvider, OpenAiEmbeddingProvider, OpenAiProvider,
+    RepoSearchTool, ResilientEmbeddingProvider, RunTestsTool, WebFetchTool, WebSearchTool,
 };
 use garraia_config::{AppConfig, provider_key_env};
 use garraia_db::MemoryStore;
@@ -564,6 +564,35 @@ pub fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
     runtime.register_tool(Box::new(FileReadTool::new(None)));
     runtime.register_tool(Box::new(FileWriteTool::new(None)));
     runtime.register_tool(Box::new(WebFetchTool::new(None)));
+
+    // #1033 / #1035: estas tres existiam, com schema e testes verdes, e nunca
+    // entraram no runtime — o unico `new()` delas no repo era dentro dos
+    // proprios modulos de teste. As whitelists dos modos (`search`, `debug`,
+    // `review`) ja anunciavam `list_dir` e `repo_search`; o modelo via a
+    // promessa na policy e nao recebia a ferramenta.
+    runtime.register_tool(Box::new(ListDirTool::new(None)));
+    runtime.register_tool(Box::new(RepoSearchTool::new(None, None)));
+    runtime.register_tool(Box::new(RunTestsTool::new(None)));
+
+    // `code_review` roda um segundo LLM por dentro, entao precisa de um
+    // provider resolvido aqui, e nao de `None`. Usa o default do boot: se o
+    // operador trocar o default depois, a revisao continua no provider de
+    // quando o gateway subiu — aceitavel para uma ferramenta auxiliar, e
+    // dito aqui para ninguem procurar o porque.
+    match runtime.default_provider_id() {
+        Some(pid) => match runtime
+            .get_provider(&pid)
+            .and_then(|p| p.configured_model().map(str::to_string).map(|m| (p, m)))
+        {
+            Some((provider, model)) => {
+                runtime.register_tool(Box::new(CodeReviewTool::new(provider, model, None)));
+            }
+            None => info!(
+                "code_review not registered: default provider '{pid}' has no configured model"
+            ),
+        },
+        None => info!("code_review not registered: no default provider at boot"),
+    }
 
     // Web search (Brave Search API) — only registered when an API key is available
     let brave_config_key = config.llm.get("brave").and_then(|c| c.api_key.clone());
@@ -1245,6 +1274,34 @@ pub fn build_embedding_provider(config: &AppConfig) -> Option<Arc<dyn EmbeddingP
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #1033 / #1035: as ferramentas de exploracao entram no runtime sem
+    /// depender de provider. `code_review` precisa de um LLM por dentro e,
+    /// com config vazia, fica de fora — sem derrubar o boot e sem aparecer
+    /// na lista que o modelo recebe.
+    #[test]
+    fn build_agent_runtime_registers_exploration_tools() {
+        let runtime = build_agent_runtime(&AppConfig::default());
+        let names = runtime.tool_names();
+        for expected in [
+            "bash",
+            "file_read",
+            "file_write",
+            "web_fetch",
+            "list_dir",
+            "repo_search",
+            "run_tests",
+        ] {
+            assert!(
+                names.iter().any(|n| n == expected),
+                "{expected} ausente em {names:?}"
+            );
+        }
+        assert!(
+            !names.iter().any(|n| n == "code_review"),
+            "sem provider default, code_review nao pode ter sido registrada: {names:?}"
+        );
+    }
 
     /// O literal "no-key" que existia aqui tratava LM Studio e a OpenAI
     /// oficial igual. Contra a oficial isso e 401 em toda chamada; contra o

--- a/crates/garraia-gateway/src/capabilities.rs
+++ b/crates/garraia-gateway/src/capabilities.rs
@@ -10,7 +10,7 @@ use axum::Json;
 use axum::extract::State;
 use serde::Serialize;
 
-use crate::state::SharedState;
+use crate::state::{AppState, SharedState};
 
 /// What the Web Console + future remote clients can rely on. Each list is
 /// computed live from the running gateway (`AgentRuntime`,
@@ -46,6 +46,22 @@ pub struct FeatureInputs {
     pub openclaw: bool,
     pub auth_v1: bool,
     pub memory: bool,
+}
+
+/// What the runtime has wired, read once from the live `AppState`.
+///
+/// Shared by the HTTP handler and by the agent's own `garra_status` tool, so
+/// the console and the model can never disagree about what this gateway can
+/// do — one reading, one truth.
+pub fn feature_inputs(state: &AppState) -> FeatureInputs {
+    FeatureInputs {
+        tts: state.voice_client.is_some(),
+        stt: state.stt_client.is_some(),
+        mcp: state.mcp_manager_arc.is_some(),
+        openclaw: state.openclaw_client.is_some(),
+        auth_v1: state.auth_provider.is_some(),
+        memory: state.agents.memory_provider().is_some(),
+    }
 }
 
 /// Feature flags advertised by `GET /api/capabilities`.
@@ -95,14 +111,7 @@ pub fn feature_flags(inputs: &FeatureInputs) -> Vec<String> {
 /// currently do. Renders the Dashboard "Arquitetura" card + drives the
 /// Skins page enumeration without hardcoded JS lists.
 pub async fn capabilities_handler(State(state): State<SharedState>) -> Json<CapabilitiesResponse> {
-    let features = feature_flags(&FeatureInputs {
-        tts: state.voice_client.is_some(),
-        stt: state.stt_client.is_some(),
-        mcp: state.mcp_manager_arc.is_some(),
-        openclaw: state.openclaw_client.is_some(),
-        auth_v1: state.auth_provider.is_some(),
-        memory: state.agents.memory_provider().is_some(),
-    });
+    let features = feature_flags(&feature_inputs(&state));
 
     let mut providers: Vec<String> = state.agents.provider_ids().to_vec();
     providers.sort();

--- a/crates/garraia-gateway/src/server.rs
+++ b/crates/garraia-gateway/src/server.rs
@@ -651,6 +651,15 @@ impl GatewayServer {
 
         let state = Arc::new(state);
 
+        // `garra_status` reads the live `AppState` (provider, model, tools,
+        // features, channels, session mode), so it can only exist once the
+        // state is shared. Unconditional: every runtime should be able to
+        // describe itself — the v0.4.0 field report was a Garra on a phone
+        // saying it "cannot inspect its own runtime", and nothing let it.
+        state
+            .agents
+            .register_tool(Box::new(crate::tools::GarraStatusTool::new(&state)));
+
         // Issue #921: the proactive-send tool needs `AppState.channels` and the
         // session store, so it can only be built once the state is shared —
         // which is exactly why it lives in this crate and not in

--- a/crates/garraia-gateway/src/state.rs
+++ b/crates/garraia-gateway/src/state.rs
@@ -853,9 +853,20 @@ impl AppState {
     /// e a pessoa.
     pub async fn exec_context_for(&self, session_id: &str, user_id: Option<&str>) -> ExecContext {
         let goal = self.session_goal_for(session_id, user_id).await;
+        // O diretorio da sessao existe desde a Fase 1.3 (`SessionState::working_dir`,
+        // gravado por `POST /api/sessions` com `project_id`/`working_dir`) e nunca
+        // chegava aqui: todo turno HTTP saia com `working_dir: None`, e o
+        // `resolve_tool_path` recusava qualquer caminho relativo com "a sessao
+        // nao tem working_dir". O agente no celular respondia que nao conseguia
+        // olhar os proprios arquivos — e nao conseguia mesmo.
+        let working_dir = self
+            .sessions
+            .get(session_id)
+            .and_then(|s| s.working_dir.clone());
         let Some(nome) = self.chosen_agent_mode_for(session_id).await else {
             return ExecContext {
                 goal,
+                working_dir,
                 ..ExecContext::default()
             };
         };
@@ -864,6 +875,7 @@ impl AppState {
             None => ExecContext::with_mode(Some(nome)),
         };
         exec.goal = goal;
+        exec.working_dir = working_dir;
         exec
     }
 
@@ -1158,6 +1170,45 @@ mod tests {
         st.set_session_store(Arc::clone(&store));
         st.set_chat_session_manager(Arc::new(ChatSessionManager::new(store)));
         st
+    }
+
+    /// O `working_dir` da sessao chega ao `ExecContext` — com e sem modo.
+    ///
+    /// Antes, `exec_context_for` montava o contexto so com objetivo e modo, e
+    /// o diretorio que `POST /api/sessions` grava em `SessionState` morria ali.
+    /// Este teste cobre os dois ramos da funcao, porque o bug era justamente
+    /// um ramo lembrar de um campo e o outro nao.
+    #[tokio::test]
+    async fn working_dir_da_sessao_chega_ao_exec_context() {
+        let dir = tempfile::tempdir().unwrap();
+        let st = state_with_store(dir.path());
+        let sid = "sessao-com-diretorio";
+        st.hydrate_session_history(sid, Some("api"), None).await;
+
+        assert_eq!(
+            st.exec_context_for(sid, None).await.working_dir,
+            None,
+            "sessao sem diretorio nao inventa um"
+        );
+
+        st.sessions
+            .get_mut(sid)
+            .expect("sessao hidratada")
+            .working_dir = Some("/tmp/garra-projeto".to_string());
+
+        // Sem modo escolhido: ramo do early-return.
+        let exec = st.exec_context_for(sid, None).await;
+        assert_eq!(exec.working_dir.as_deref(), Some("/tmp/garra-projeto"));
+        assert_eq!(exec.agent_mode, None);
+
+        // Com modo escolhido: ramo que monta pelo perfil.
+        {
+            let store = st.session_store.as_ref().expect("store").lock().await;
+            store.set_agent_mode(sid, "search").expect("gravar o modo");
+        }
+        let exec = st.exec_context_for(sid, None).await;
+        assert_eq!(exec.working_dir.as_deref(), Some("/tmp/garra-projeto"));
+        assert_eq!(exec.agent_mode.as_deref(), Some("search"));
     }
 
     /// O objetivo da sessao chega ao `ExecContext` (#983).

--- a/crates/garraia-gateway/src/tools/garra_status_tool.rs
+++ b/crates/garraia-gateway/src/tools/garra_status_tool.rs
@@ -78,6 +78,10 @@ impl Tool for GarraStatusTool {
         tools.sort();
 
         let features = feature_flags(&feature_inputs(&state));
+        // The only writers of `channels` after boot are the connect-retry
+        // tasks in `server.rs`; a read here waits for one to finish, which is
+        // milliseconds, never a cycle — the retry task takes nothing this tool
+        // holds.
         let channels: Vec<String> = state
             .channels
             .read()
@@ -141,6 +145,9 @@ mod tests {
     #[tokio::test]
     async fn relata_versao_ferramentas_e_diretorio_da_sessao() {
         let st = state();
+        // Two instances on purpose: the registered one is what `tool_names()`
+        // must list; the local one is executed directly, without the runtime
+        // dispatch, so the test reads the report and nothing else.
         st.agents.register_tool(Box::new(GarraStatusTool::new(&st)));
         let tool = GarraStatusTool::new(&st);
 

--- a/crates/garraia-gateway/src/tools/garra_status_tool.rs
+++ b/crates/garraia-gateway/src/tools/garra_status_tool.rs
@@ -1,0 +1,226 @@
+//! `garra_status` — the agent's view of its own runtime.
+//!
+//! Field report, v0.4.0 on a phone: asked what it was running, the Garra
+//! answered that it "cannot inspect its own runtime from this conversation".
+//! It was right — nothing let it. `/api/health` and `/api/capabilities`
+//! exist for humans and the console; `web_fetch` refuses loopback by design
+//! (SSRF guard, with a regression test); `bash` would have to guess host and
+//! port. This tool closes the gap from the inside: it reads the same
+//! `AppState` those endpoints read, and nothing else. No request is made, so
+//! the SSRF surface stays exactly where it was.
+//!
+//! Secret-free by construction: provider *ids* and model *names* only —
+//! never keys, never URLs with credentials, and no path beyond the session's
+//! own working directory (which the session set itself).
+
+use std::sync::{Arc, Weak};
+
+use async_trait::async_trait;
+use garraia_agents::tools::{Tool, ToolContext, ToolOutput};
+use garraia_common::Result;
+
+use crate::capabilities::{feature_flags, feature_inputs};
+use crate::state::AppState;
+
+pub struct GarraStatusTool {
+    /// Weak for the same reason `TelegramSendTool` is: `AppState` owns the
+    /// runtime, the runtime owns this tool, and a strong handle back would
+    /// close an `Arc` cycle that leaks the whole gateway state.
+    state: Weak<AppState>,
+}
+
+impl GarraStatusTool {
+    pub fn new(state: &Arc<AppState>) -> Self {
+        Self {
+            state: Arc::downgrade(state),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for GarraStatusTool {
+    fn name(&self) -> &str {
+        "garra_status"
+    }
+
+    fn description(&self) -> &str {
+        "Describes the Garra runtime you are running in: version, uptime, active \
+         provider and model, registered tools, advertised features, connected \
+         channels, and this session's mode and working directory. Use it whenever \
+         the user asks what you are, what you can do, or how you are configured — \
+         instead of guessing or saying you cannot inspect yourself. Takes no input."
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        })
+    }
+
+    async fn execute(&self, ctx: &ToolContext, _input: serde_json::Value) -> Result<ToolOutput> {
+        let Some(state) = self.state.upgrade() else {
+            return Ok(ToolOutput::error("gateway state is gone (shutting down?)"));
+        };
+
+        let provider = state.agents.default_provider_id();
+        let model = provider
+            .as_deref()
+            .and_then(|p| state.agents.get_provider(p))
+            .and_then(|p| p.configured_model().map(str::to_string));
+
+        let mut providers = state.agents.provider_ids();
+        providers.sort();
+        providers.dedup();
+
+        let mut tools = state.agents.tool_names();
+        tools.sort();
+
+        let features = feature_flags(&feature_inputs(&state));
+        let channels: Vec<String> = state
+            .channels
+            .read()
+            .await
+            .list()
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect();
+        let mode = state.chosen_agent_mode_for(&ctx.session_id).await;
+
+        let report = serde_json::json!({
+            "version": env!("CARGO_PKG_VERSION"),
+            "uptime_secs": state.boot_time.elapsed().as_secs(),
+            "provider": provider,
+            "model": model,
+            "providers": providers,
+            "tools": tools,
+            "features": features,
+            "channels": channels,
+            "memory_enabled": state.agents.memory_provider().is_some(),
+            "session": {
+                "id": ctx.session_id,
+                "mode": mode,
+                "working_dir": ctx.working_dir,
+                "project_id": ctx.project_id,
+            },
+        });
+
+        let text = serde_json::to_string_pretty(&report).unwrap_or_else(|_| report.to_string());
+        Ok(ToolOutput::success(text))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use garraia_agents::AgentRuntime;
+    use garraia_channels::ChannelRegistry;
+    use garraia_config::AppConfig;
+
+    fn state() -> Arc<AppState> {
+        Arc::new(AppState::new(
+            AppConfig::default(),
+            Arc::new(AgentRuntime::new()),
+            ChannelRegistry::new(),
+        ))
+    }
+
+    fn ctx(working_dir: Option<&str>) -> ToolContext {
+        ToolContext {
+            session_id: "sessao-teste".to_string(),
+            user_id: None,
+            is_heartbeat: false,
+            is_confirmation_approved: false,
+            working_dir: working_dir.map(str::to_string),
+            project_id: None,
+        }
+    }
+
+    /// O relatorio traz o que o console ve — e o que o agente nao via.
+    #[tokio::test]
+    async fn relata_versao_ferramentas_e_diretorio_da_sessao() {
+        let st = state();
+        st.agents.register_tool(Box::new(GarraStatusTool::new(&st)));
+        let tool = GarraStatusTool::new(&st);
+
+        let out = tool
+            .execute(&ctx(Some("/tmp/garra-projeto")), serde_json::json!({}))
+            .await
+            .expect("executa");
+        assert!(!out.is_error, "{}", out.content);
+
+        let json: serde_json::Value = serde_json::from_str(&out.content).expect("json");
+        assert_eq!(json["version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(json["session"]["id"], "sessao-teste");
+        assert_eq!(json["session"]["working_dir"], "/tmp/garra-projeto");
+        assert!(
+            json["tools"]
+                .as_array()
+                .is_some_and(|t| t.iter().any(|n| n == "garra_status")),
+            "a propria ferramenta aparece na lista: {}",
+            json["tools"]
+        );
+        // Os always-on do contrato mobile vem junto.
+        assert!(
+            json["features"]
+                .as_array()
+                .is_some_and(|f| f.iter().any(|n| n == "chat")),
+            "{}",
+            json["features"]
+        );
+    }
+
+    /// Nada de segredo: sem provider configurado, `provider`/`model` sao null,
+    /// e a saida nunca carrega chave — o teste garante que os campos que
+    /// existem sao so os enumerados aqui.
+    #[tokio::test]
+    async fn saida_e_secret_free_e_tem_so_os_campos_previstos() {
+        let st = state();
+        let tool = GarraStatusTool::new(&st);
+        let out = tool
+            .execute(&ctx(None), serde_json::json!({}))
+            .await
+            .expect("executa");
+        let json: serde_json::Value = serde_json::from_str(&out.content).expect("json");
+        let mut keys: Vec<&str> = json
+            .as_object()
+            .expect("objeto")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            [
+                "channels",
+                "features",
+                "memory_enabled",
+                "model",
+                "provider",
+                "providers",
+                "session",
+                "tools",
+                "uptime_secs",
+                "version",
+            ]
+        );
+        assert!(json["provider"].is_null());
+        assert!(json["model"].is_null());
+        assert!(json["session"]["working_dir"].is_null());
+    }
+
+    /// Estado derrubado nao vira panic: a tool devolve erro legivel.
+    #[tokio::test]
+    async fn estado_derrubado_vira_erro_legivel() {
+        let st = state();
+        let tool = GarraStatusTool::new(&st);
+        drop(st);
+        let out = tool
+            .execute(&ctx(None), serde_json::json!({}))
+            .await
+            .expect("executa");
+        assert!(out.is_error);
+        assert!(out.content.contains("gateway state is gone"));
+    }
+}

--- a/crates/garraia-gateway/src/tools/mod.rs
+++ b/crates/garraia-gateway/src/tools/mod.rs
@@ -7,5 +7,7 @@
 //! `garraia_agents::Tool` here instead and close over `Arc<AppState>`.
 
 pub mod channel_send_tool;
+pub mod garra_status_tool;
 
 pub use channel_send_tool::TelegramSendTool;
+pub use garra_status_tool::GarraStatusTool;


### PR DESCRIPTION
## Descrição

Relato de campo da v0.4.0 num aparelho real (APK da release, `garra start` no Termux): perguntado sobre si mesmo, o Garra respondeu que "não consegue inspecionar o estado interno do runtime a partir desta conversa" e que não tinha como olhar os próprios arquivos. Investigado, eram **três causas somadas**, nenhuma delas "as tools não existem no código":

1. **Quatro ferramentas nunca foram registradas** (#1033, #1035). `list_dir`, `repo_search`, `run_tests` e `code_review` tinham schema e testes verdes, mas o único `new()` delas no repositório era dentro dos próprios módulos de teste. As whitelists dos modos `search`, `debug` e `review` já anunciavam `list_dir` e `repo_search` — o modelo via a promessa na policy e não recebia a ferramenta. Agora entram em `bootstrap/mod.rs`; `code_review` roda um segundo LLM por dentro, então é registrada com o provider e modelo default do boot (sem provider, fica de fora com `info!`, sem derrubar o boot).
2. **`working_dir` morria antes do turno HTTP.** `exec_context_for` (`state.rs`) montava o `ExecContext` só com objetivo e modo. O `SessionState::working_dir` nunca chegava ao `ToolContext`, e `resolve_tool_path` recusava qualquer caminho relativo com "a sessão não tem working_dir". Passa a ir junto, nos dois ramos da função (com e sem modo).
   **Correção ao relato (2026-09-07, mais tarde):** achei depois que nenhuma rota viva *punha* o valor na sessão — `POST /api/sessions` descartava `working_dir` (o handler que o aceitava nunca foi roteado; `tests/projects_test.rs` fixava isso). Quem passa a aceitá-lo, confinado a `GARRAIA_PROJECT_ROOTS`, é o **#1049** (#1028). Este PR é o trecho sessão → ferramenta; o #1049 é o trecho HTTP → sessão. São independentes, e o passo 2 de "Como testar" precisa dos dois.
3. **Não existia superfície de introspecção.** `/api/health` e `/api/capabilities` são para o console; `web_fetch` recusa loopback por desenho (guard de SSRF, com teste de regressão); `bash` teria de adivinhar host e porta. Nova tool **`garra_status`** (`crates/garraia-gateway/src/tools/garra_status_tool.rs`) lê o mesmo `AppState` daqueles endpoints — versão, uptime, provider e modelo ativos, tools registradas, features, canais, modo e diretório da sessão — **sem fazer requisição nenhuma**, então a superfície de SSRF fica onde estava. `feature_inputs(&AppState)` foi extraído em `capabilities.rs` e é compartilhado com o handler, para console e modelo nunca divergirem. Registrada em `server.rs` assim que o `AppState` vira `Arc`, com `Weak` para não fechar ciclo (mesmo desenho do `TelegramSendTool`).

Complementos: a persona (pt/en) passa a dizer que há ferramentas — de leitura, para usar antes de dizer que não consegue; de escrita/execução, só a pedido. O modo `debug` ganha `run_tests` e o `review` ganha `code_review` na whitelist.

### O que a revisão mudou (commit `0147c2a`)

`security-auditor` e `code-reviewer` passaram pelo diff. Sem bloqueador; três *should-fix* atendidos:

- **As três tools resolvem caminho pela sessão, como o `file_read`.** `list_dir` e `run_tests` aceitavam o caminho cru do modelo e ignoravam o `ToolContext`; `repo_search` buscava no CWD do processo do gateway. Agora passam pelo mesmo `resolve_tool_path` (#923): `~` expandido, relativo juntado ao `working_dir` da sessão, `..` recusado, e sem sessão o erro diz que resolveu contra o CWD do processo. `repo_search` roda com `current_dir` no diretório da sessão (rg e o fallback grep).
- **`run_tests` respeita `agent.tool_confirmation_enabled`, como o `bash`.** Roda `npm test`, que executa o que o `package.json` mandar — é execução arbitrária com outro nome, e antes passava por fora do gate de confirmação.
- Fragmento `added/` com o número da issue no bold; comentários sobre a contenção do `channels.read()` e o duplo registro no teste de `garra_status`.

Closes #1033
Closes #1035

## Tipo de mudança

- [x] `feat`: Nova funcionalidade
- [x] `fix`: Correção de bug
- [ ] `refactor`: Refatoração sem mudança de comportamento
- [ ] `docs`: Documentação apenas
- [x] `test`: Adição ou correção de testes
- [ ] `perf`: Melhoria de performance
- [ ] `chore`: Manutenção (deps, CI, build)
- [x] `sec`: Correção ou hardening de segurança

## Classe de Risco

- [ ] **Classe A (Baixo Risco)**
- [x] **Classe B (Médio Risco)**: nenhuma alteração em auth, RLS, migrations, RBAC ou rota REST. A superfície que muda é a do **agente**: quatro tools que já existiam passam a estar disponíveis (sob as mesmas policies de modo e o mesmo resolvedor de caminho do `file_read`), uma tool nova só de leitura de estado em memória, e o `working_dir` da sessão passa a ser respeitado pelas tools de arquivo — que já existia como campo e como caminho de resolução, só não era preenchido.
- [ ] **Classe C (Alto Risco)**

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo fmt --check` executado e limpo
- [x] `cargo clippy -p garraia-agents -p garraia-gateway --all-targets -- -D warnings` sem erros (o workspace completo é o gate do CI; este container não compila o desktop)
- [x] `cargo test -p garraia-agents --lib` 301/301 e `cargo test -p garraia-gateway --lib` 931/931 localmente
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo, API key, token ou credencial commitada — a saída de `garra_status` traz ids de provider e nomes de modelo, nunca chaves; teste trava o conjunto exato de campos
- [x] Nenhuma migração Postgres

### Para alterações de Alto Risco (Classe C)

- [ ] N/A

## Mudanças na API pública e Schema

- Nenhuma rota, schema ou campo de configuração novo.
- **Agente:** `list_dir`, `repo_search`, `run_tests`, `code_review` (condicional a provider) e `garra_status` passam a aparecer em `tool_definitions()` e em `/api/capabilities` → `tools`. Aditivo.
- **Comportamento:** turnos via `/api/sessions/{id}/messages`, `/ws`, `/chat` e canais passam a receber o `working_dir` da sessão quando ela tem um. Sessões sem diretório seguem exatamente como antes (`None`).

## Como testar

1. `cargo test -p garraia-gateway --lib -- tools::garra_status_tool state::tests::working_dir bootstrap::tests capabilities::` e `cargo test -p garraia-agents --lib -- tools:: modes:: persona::`.
2. (com **#1049** aplicado, que é quem faz `POST /api/sessions` aceitar o campo) `garra start` → `POST /api/sessions` com `{"working_dir": "/caminho/sob/GARRAIA_PROJECT_ROOTS"}` → mensagem "liste os arquivos deste projeto" → o agente usa `list_dir` com caminho relativo e responde com a árvore (antes: recusa "a sessão não tem working_dir").
3. Mesma sessão → "o que você é e o que você consegue fazer?" → o agente chama `garra_status` e responde com versão, provider, modelo e a lista de tools (antes: "não consigo inspecionar meu runtime").
4. Com `agent.tool_confirmation_enabled = true`, "rode os testes" → o agente pede confirmação antes de executar.
5. `GET /api/capabilities` → `tools` inclui os nomes novos.

## Plano de Rollback

Revert do PR. Nenhum schema, nenhuma migration, nenhuma rota. As tools voltam a ficar fora do runtime e o `working_dir` volta a `None` — o comportamento anterior, sem estado persistido para desfazer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVnUdw6gJJLtcmWxzxMtFz