### PR TITLE
feat(gateway,mobile): comandos com barra funcionam pelo HTTP e o app sugere ao digitar /

### DIFF
--- a/apps/garraia-mobile/README.md
+++ b/apps/garraia-mobile/README.md
@@ -37,7 +37,7 @@ Emulador Android → PC hospedeiro: use `10.0.2.2:3888` como "Another Garra".
 
 ```bash
 flutter analyze          # zero issues e a regra do CI
-flutter test             # 15 testes: home (capabilities, estados), runtime store, settings, versao
+flutter test             # home (capabilities, estados), runtime store, settings, versao, sugestoes de /
 flutter build web --no-web-resources-cdn   # prova visual no navegador; nao e alvo de produto
 ```
 

--- a/apps/garraia-mobile/lib/router/app_router.dart
+++ b/apps/garraia-mobile/lib/router/app_router.dart
@@ -76,7 +76,12 @@ GoRouter appRouter(Ref ref) {
       GoRoute(path: '/profile', builder: (_, __) => const ProfileScreen()),
 
       // Feature tiles
-      GoRoute(path: '/chat', builder: (_, __) => const ChatScreen()),
+      GoRoute(
+        path: '/chat',
+        // `?draft=` pre-fills the input (Skills → tap a command).
+        builder: (_, state) =>
+            ChatScreen(initialDraft: state.uri.queryParameters['draft']),
+      ),
       GoRoute(
         // Deep link: garraia://chat/:sessionId
         path: '/chat/:sessionId',

--- a/apps/garraia-mobile/lib/runtime/garra_connection.dart
+++ b/apps/garraia-mobile/lib/runtime/garra_connection.dart
@@ -27,7 +27,7 @@ abstract interface class GarraConnection {
 
   // Skills / commands
   Future<List<SkillSummary>> skills();
-  Future<List<String>> slashCommands();
+  Future<List<SlashCommandInfo>> slashCommands();
 
   // Providers / agents / files
   Future<List<ProviderInfo>> providers();

--- a/apps/garraia-mobile/lib/runtime/gateway_connection.dart
+++ b/apps/garraia-mobile/lib/runtime/gateway_connection.dart
@@ -169,9 +169,11 @@ class GatewayConnection implements GarraConnection {
   }
 
   @override
-  Future<List<String>> slashCommands() async {
+  Future<List<SlashCommandInfo>> slashCommands() async {
     final r = await _dio.get<Object>('/api/slash-commands');
-    return unwrapNames(r.data, const ['commands']);
+    return unwrapList(r.data, const [
+      'commands',
+    ]).map(SlashCommandInfo.fromJson).toList();
   }
 
   // ── Providers / agents / files ───────────────────────────────────────────

--- a/apps/garraia-mobile/lib/runtime/models.dart
+++ b/apps/garraia-mobile/lib/runtime/models.dart
@@ -331,3 +331,25 @@ List<String> unwrapNames(Object? body, List<String> keys) {
       .where((s) => s.isNotEmpty)
       .toList();
 }
+
+/// One entry of `GET /api/slash-commands` — `{name, description, source}` from
+/// the gateway's `CommandRegistry`. Older gateways returned bare strings; both
+/// shapes parse, and a leading `/` in the name is dropped either way.
+class SlashCommandInfo {
+  final String name;
+  final String description;
+
+  const SlashCommandInfo({required this.name, this.description = ''});
+
+  factory SlashCommandInfo.fromJson(Object? json) {
+    if (json is Map) {
+      return SlashCommandInfo(
+        name: _stripSlash((json['name'] ?? '').toString()),
+        description: (json['description'] ?? '').toString(),
+      );
+    }
+    return SlashCommandInfo(name: _stripSlash(json.toString()));
+  }
+
+  static String _stripSlash(String s) => s.startsWith('/') ? s.substring(1) : s;
+}

--- a/apps/garraia-mobile/lib/runtime/runtime_providers.dart
+++ b/apps/garraia-mobile/lib/runtime/runtime_providers.dart
@@ -124,3 +124,9 @@ class CurrentSession extends _$CurrentSession {
     state = AsyncData(id);
   }
 }
+
+/// `GET /api/slash-commands` — the registry commands this client may run.
+/// Shared by the chat input (autocomplete) and the Skills screen.
+@riverpod
+Future<List<SlashCommandInfo>> slashCommands(Ref ref) =>
+    requireConnection(ref).slashCommands();

--- a/apps/garraia-mobile/lib/screens/chat_screen.dart
+++ b/apps/garraia-mobile/lib/screens/chat_screen.dart
@@ -58,6 +58,20 @@ class _ChatScreenState extends ConsumerState<ChatScreen>
   }
 
   @override
+  void didUpdateWidget(ChatScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // `/chat?draft=a` then `/chat?draft=b` reuses this State: without this,
+    // the second draft was dropped on the floor (review of #1040).
+    final draft = widget.initialDraft;
+    if (draft != null && draft.isNotEmpty && draft != oldWidget.initialDraft) {
+      _inputCtrl.value = TextEditingValue(
+        text: draft,
+        selection: TextSelection.collapsed(offset: draft.length),
+      );
+    }
+  }
+
+  @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     _inputCtrl.dispose();

--- a/apps/garraia-mobile/lib/screens/chat_screen.dart
+++ b/apps/garraia-mobile/lib/screens/chat_screen.dart
@@ -11,6 +11,7 @@ import '../widgets/chat_bubble.dart';
 import '../widgets/mascot_widget.dart';
 import '../widgets/queue_status_indicator.dart';
 import '../widgets/scroll_to_bottom_button.dart';
+import '../widgets/slash_suggestions.dart';
 import '../widgets/typing_indicator.dart';
 import '../widgets/voice_input_widget.dart';
 
@@ -19,7 +20,10 @@ class ChatScreen extends ConsumerStatefulWidget {
   /// the persisted current session.
   final String? sessionId;
 
-  const ChatScreen({super.key, this.sessionId});
+  /// Text to start the input with (`/chat?draft=/help `), from Skills.
+  final String? initialDraft;
+
+  const ChatScreen({super.key, this.sessionId, this.initialDraft});
 
   @override
   ConsumerState<ChatScreen> createState() => _ChatScreenState();
@@ -38,6 +42,13 @@ class _ChatScreenState extends ConsumerState<ChatScreen>
     super.initState();
     WidgetsBinding.instance.addObserver(this);
     _scrollCtrl.addListener(_onScroll);
+    final draft = widget.initialDraft;
+    if (draft != null && draft.isNotEmpty) {
+      _inputCtrl.value = TextEditingValue(
+        text: draft,
+        selection: TextSelection.collapsed(offset: draft.length),
+      );
+    }
     final id = widget.sessionId;
     if (id != null && id.isNotEmpty) {
       Future.microtask(
@@ -291,6 +302,7 @@ class _InputBar extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           const Divider(height: 1),
+          SlashSuggestions(controller: controller),
           if (showVoiceInput)
             Padding(
               padding: const EdgeInsets.fromLTRB(12, 8, 12, 0),

--- a/apps/garraia-mobile/lib/screens/skills_screen.dart
+++ b/apps/garraia-mobile/lib/screens/skills_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../runtime/models.dart';
@@ -14,10 +15,6 @@ part 'skills_screen.g.dart';
 @riverpod
 Future<List<SkillSummary>> learningSkills(Ref ref) =>
     requireConnection(ref).skills();
-
-@riverpod
-Future<List<String>> slashCommands(Ref ref) =>
-    requireConnection(ref).slashCommands();
 
 /// Extend what Garra can do — learned skills (`/api/learning/skills`) and
 /// the slash-command registry (`/api/slash-commands`).
@@ -68,11 +65,19 @@ class SkillsScreen extends ConsumerWidget {
                 spacing: 8,
                 runSpacing: 8,
                 children: [
+                  // Tapping a command opens the chat with it typed in,
+                  // caret after a trailing space, ready for arguments.
                   for (final c in list)
-                    Chip(
-                      label: Text(
-                        '/${c.replaceFirst('/', '')}',
-                        style: garraText(size: 12.5, mono: true),
+                    Tooltip(
+                      message: c.description,
+                      child: ActionChip(
+                        label: Text(
+                          '/${c.name}',
+                          style: garraText(size: 12.5, mono: true),
+                        ),
+                        onPressed: () => context.go(
+                          '/chat?draft=${Uri.encodeComponent('/${c.name} ')}',
+                        ),
                       ),
                     ),
                 ],

--- a/apps/garraia-mobile/lib/widgets/slash_suggestions.dart
+++ b/apps/garraia-mobile/lib/widgets/slash_suggestions.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../runtime/models.dart';
+import '../runtime/runtime_providers.dart';
+import '../theme/garra_theme.dart';
+
+/// Commands matching what the user is typing.
+///
+/// `text` must start with `/` and contain no whitespace yet: once the name is
+/// complete and an argument begins, suggestions get out of the way. Prefix
+/// match, case-insensitive, registry order preserved. Pure, so it is unit
+/// tested without a widget tree.
+List<SlashCommandInfo> matchSlashCommands(
+  String text,
+  List<SlashCommandInfo> all,
+) {
+  final t = text.trimLeft();
+  if (!t.startsWith('/') || t.contains(RegExp(r'\s'))) return const [];
+  final prefix = t.substring(1).toLowerCase();
+  return [
+    for (final c in all)
+      if (c.name.toLowerCase().startsWith(prefix)) c,
+  ];
+}
+
+/// Strip above the chat input: one chip per registry command matching the
+/// current `/prefix`. Tapping completes the name and leaves the caret after
+/// a trailing space, ready for arguments. Renders nothing while the list is
+/// loading, failed, or the input is not a `/prefix`.
+class SlashSuggestions extends ConsumerWidget {
+  final TextEditingController controller;
+
+  const SlashSuggestions({super.key, required this.controller});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final commands = ref.watch(slashCommandsProvider).value ?? const [];
+    if (commands.isEmpty) return const SizedBox.shrink();
+    return ValueListenableBuilder<TextEditingValue>(
+      valueListenable: controller,
+      builder: (context, value, _) {
+        final matches = matchSlashCommands(value.text, commands);
+        if (matches.isEmpty) return const SizedBox.shrink();
+        return SizedBox(
+          height: 46,
+          child: ListView.separated(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            itemCount: matches.length,
+            separatorBuilder: (_, __) => const SizedBox(width: 6),
+            itemBuilder: (_, i) {
+              final c = matches[i];
+              return Tooltip(
+                message: c.description,
+                child: ActionChip(
+                  visualDensity: VisualDensity.compact,
+                  label: Text(
+                    '/${c.name}',
+                    style: garraText(size: 12.5, mono: true),
+                  ),
+                  onPressed: () {
+                    final text = '/${c.name} ';
+                    controller.value = TextEditingValue(
+                      text: text,
+                      selection: TextSelection.collapsed(offset: text.length),
+                    );
+                  },
+                ),
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+}

--- a/apps/garraia-mobile/test/slash_suggestions_test.dart
+++ b/apps/garraia-mobile/test/slash_suggestions_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:garraia_mobile/runtime/models.dart';
+import 'package:garraia_mobile/runtime/runtime_providers.dart';
+import 'package:garraia_mobile/widgets/slash_suggestions.dart';
+
+const _all = [
+  SlashCommandInfo(name: 'help', description: 'Show available commands'),
+  SlashCommandInfo(name: 'health', description: 'Gateway health'),
+  SlashCommandInfo(name: 'mode', description: 'Get or set the agent mode'),
+];
+
+void main() {
+  group('matchSlashCommands', () {
+    test('prefix match, case-insensitive, registry order', () {
+      expect(matchSlashCommands('/he', _all).map((c) => c.name), [
+        'help',
+        'health',
+      ]);
+      expect(matchSlashCommands('/HE', _all).map((c) => c.name), [
+        'help',
+        'health',
+      ]);
+      expect(matchSlashCommands('/', _all).length, 3);
+    });
+
+    test('goes away once an argument starts or without a slash', () {
+      expect(matchSlashCommands('/mode ', _all), isEmpty);
+      expect(matchSlashCommands('/mode debug', _all), isEmpty);
+      expect(matchSlashCommands('hello', _all), isEmpty);
+      expect(matchSlashCommands('', _all), isEmpty);
+      expect(matchSlashCommands('/zzz', _all), isEmpty);
+    });
+  });
+
+  group('SlashCommandInfo.fromJson', () {
+    test('object and bare-string shapes, leading slash dropped', () {
+      final a = SlashCommandInfo.fromJson({'name': 'help', 'description': 'x'});
+      expect(a.name, 'help');
+      expect(a.description, 'x');
+      expect(SlashCommandInfo.fromJson('/mode').name, 'mode');
+      expect(SlashCommandInfo.fromJson({'name': '/clear'}).name, 'clear');
+    });
+  });
+
+  testWidgets('typing /he shows chips; tapping completes the command', (
+    tester,
+  ) async {
+    final ctrl = TextEditingController();
+    addTearDown(ctrl.dispose);
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [slashCommandsProvider.overrideWith((ref) async => _all)],
+        child: MaterialApp(
+          home: Scaffold(body: SlashSuggestions(controller: ctrl)),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(find.byType(ActionChip), findsNothing);
+
+    ctrl.text = '/he';
+    await tester.pump();
+    expect(find.text('/help'), findsOneWidget);
+    expect(find.text('/health'), findsOneWidget);
+    expect(find.text('/mode'), findsNothing);
+
+    await tester.tap(find.text('/help'));
+    await tester.pump();
+    expect(ctrl.text, '/help ');
+    expect(ctrl.selection.baseOffset, '/help '.length);
+    // Argument position: suggestions step aside.
+    expect(find.byType(ActionChip), findsNothing);
+  });
+}

--- a/apps/garraia-mobile/test/slash_suggestions_test.dart
+++ b/apps/garraia-mobile/test/slash_suggestions_test.dart
@@ -61,7 +61,7 @@ void main() {
     expect(find.byType(ActionChip), findsNothing);
 
     ctrl.text = '/he';
-    await tester.pump();
+    await tester.pumpAndSettle();
     expect(find.text('/help'), findsOneWidget);
     expect(find.text('/health'), findsOneWidget);
     expect(find.text('/mode'), findsNothing);

--- a/changelog.d/fixed/1040-comandos-barra-http.md
+++ b/changelog.d/fixed/1040-comandos-barra-http.md
@@ -1,0 +1,14 @@
+- **Comandos com barra passam a funcionar pelo HTTP, e o app sugere ao
+  digitar `/` (#1040).** No celular, `/help` voltava "nao ha comandos com barra
+  registrados nesta instalacao" — alucinacao: o registry estava cheio (17
+  comandos populados no boot), mas o unico call site de
+  `CommandRegistry::dispatch` era o adapter do Telegram, e pelo HTTP o texto ia
+  cru para o modelo. `POST /api/sessions/{id}/messages` despacha pelo registry
+  quando o texto comeca com um nome registrado (desconhecido segue ao modelo,
+  como antes; papel `User`, entao comandos de owner respondem "permission
+  denied"). `CommandContext` ganha `session_id`, e os comandos de sessao
+  (`/clear`, `/mode`, `/goal`) usam o id do HTTP quando existe. `GET
+  /api/slash-commands` passa a listar o registry em vez de uma tabela paralela
+  de dois itens — acabou a divergencia com `/api/capabilities`. No app,
+  `SlashSuggestions` mostra chips dos comandos que casam com o prefixo digitado
+  e os chips da tela Skills abrem o chat com o comando pronto.

--- a/changelog.d/fixed/1040-comandos-barra-http.md
+++ b/changelog.d/fixed/1040-comandos-barra-http.md
@@ -6,9 +6,14 @@
   cru para o modelo. `POST /api/sessions/{id}/messages` despacha pelo registry
   quando o texto comeca com um nome registrado (desconhecido segue ao modelo,
   como antes; papel `User`, entao comandos de owner respondem "permission
-  denied"). `CommandContext` ganha `session_id`, e os comandos de sessao
-  (`/clear`, `/mode`, `/goal`) usam o id do HTTP quando existe. `GET
-  /api/slash-commands` passa a listar o registry em vez de uma tabela paralela
-  de dois itens — acabou a divergencia com `/api/capabilities`. No app,
+  denied"; `/start`, que reivindica o dono da allowlist do Telegram, nem e
+  aceito pelo HTTP). `CommandContext` ganha `session_id`, e os comandos de
+  sessao (`/clear`, `/mode`, `/goal`) usam o id do HTTP quando existe. `GET
+  /api/slash-commands` e o `commands` de `/api/capabilities` passam a listar o
+  registry no papel do HTTP, em vez de uma tabela paralela de dois itens e da
+  lista completa com comandos de owner. O dispatcher solta o lock do registry
+  antes de executar (o `/help` le o registry de novo; um read segurado sobre
+  outro read trava assim que um writer entra na fila) e `/model` valida o nome.
+  No app,
   `SlashSuggestions` mostra chips dos comandos que casam com o prefixo digitado
   e os chips da tela Skills abrem o chat com o comando pronto.

--- a/crates/garraia-channels/src/commands/mod.rs
+++ b/crates/garraia-channels/src/commands/mod.rs
@@ -54,6 +54,12 @@ pub struct CommandContext {
     pub user_role: Role,
     /// Shared application state (type-erased to avoid coupling to gateway).
     pub state: Option<Arc<dyn std::any::Any + Send + Sync>>,
+    /// The session the command acts on, when the caller already knows it.
+    ///
+    /// `POST /api/sessions/{id}/messages` has the id in the path; channels do
+    /// not, and leave this `None` so session-scoped commands (`/clear`,
+    /// `/mode`, `/goal`) resolve it from `chat_id` as they always did.
+    pub session_id: Option<String>,
 }
 
 // ─── Command result ─────────────────────────────────────────────────

--- a/crates/garraia-channels/src/commands/registry.rs
+++ b/crates/garraia-channels/src/commands/registry.rs
@@ -220,6 +220,7 @@ mod tests {
                 .collect(),
             user_role: role,
             state: None,
+            session_id: None,
         }
     }
 

--- a/crates/garraia-channels/src/commands/registry.rs
+++ b/crates/garraia-channels/src/commands/registry.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use tracing::info;
 
@@ -64,7 +65,9 @@ where
     }
 }
 pub struct CommandRegistry {
-    commands: HashMap<String, Box<dyn SlashCommand>>,
+    /// `Arc`, not `Box`, so [`Self::resolve`] can hand a caller a handle it
+    /// executes **after** releasing the registry lock. See `resolve`.
+    commands: HashMap<String, Arc<dyn SlashCommand>>,
 }
 
 impl CommandRegistry {
@@ -78,7 +81,50 @@ impl CommandRegistry {
     pub fn register(&mut self, cmd: Box<dyn SlashCommand>) {
         let name = cmd.name().to_string();
         info!("registered slash command: /{name}");
-        self.commands.insert(name, cmd);
+        self.commands.insert(name, Arc::from(cmd));
+    }
+
+    /// The command name in `full_text` (`"/model x"` → `"model"`), empty when
+    /// there is none.
+    pub fn command_name(full_text: &str) -> &str {
+        full_text
+            .strip_prefix('/')
+            .unwrap_or(full_text)
+            .split_whitespace()
+            .next()
+            .unwrap_or("")
+    }
+
+    /// The reply for a name nobody registered — one string, shared by every
+    /// dispatcher so the user reads the same thing on every channel.
+    pub fn unknown_command_reply(name: &str) -> String {
+        format!("❓ Unknown command: /{name}\nType /help to see available commands.")
+    }
+
+    /// A cloned handle to the command `full_text` names, or `None`.
+    ///
+    /// Exists so a caller can **drop the registry lock before executing**.
+    /// [`Self::dispatch`] keeps the read guard alive for the whole run; a
+    /// command that reads the registry again while running — `/help` lists
+    /// it — then blocks the moment a writer is waiting (writer-preferring
+    /// `RwLock`: the pending write blocks the inner read, the outer read
+    /// blocks the write). The Telegram adapter carried that latent deadlock
+    /// since GAR-184; exposing commands over HTTP is what made it worth
+    /// closing. Pair with [`Self::run`].
+    pub fn resolve(&self, full_text: &str) -> Option<Arc<dyn SlashCommand>> {
+        self.commands.get(Self::command_name(full_text)).cloned()
+    }
+
+    /// Permission check + execute: the second half of [`Self::dispatch`],
+    /// for a handle obtained through [`Self::resolve`] with the lock gone.
+    pub fn run(cmd: &dyn SlashCommand, ctx: &CommandContext) -> CommandResult {
+        if ctx.user_role < cmd.required_role() {
+            return Err(CommandError::Unauthorized(format!(
+                "Permission denied. Required role: {}",
+                cmd.required_role()
+            )));
+        }
+        cmd.execute(ctx)
     }
 
     /// Look up a command by name (without the `/` prefix).
@@ -126,29 +172,11 @@ impl CommandRegistry {
     ///
     /// Returns a user-facing response string or a `CommandError`.
     pub fn dispatch(&self, ctx: &CommandContext) -> CommandResult {
-        let cmd_name = ctx
-            .full_text
-            .strip_prefix('/')
-            .unwrap_or(&ctx.full_text)
-            .split_whitespace()
-            .next()
-            .unwrap_or("");
-
+        let cmd_name = Self::command_name(&ctx.full_text);
         let Some(cmd) = self.get(cmd_name) else {
-            return Ok(format!(
-                "❓ Unknown command: /{cmd_name}\nType /help to see available commands."
-            ));
+            return Ok(Self::unknown_command_reply(cmd_name));
         };
-
-        // Permission check
-        if ctx.user_role < cmd.required_role() {
-            return Err(CommandError::Unauthorized(format!(
-                "Permission denied. Required role: {}",
-                cmd.required_role()
-            )));
-        }
-
-        cmd.execute(ctx)
+        Self::run(cmd, ctx)
     }
 
     /// Number of registered commands.

--- a/crates/garraia-gateway/src/api.rs
+++ b/crates/garraia-gateway/src/api.rs
@@ -14,6 +14,92 @@ use crate::agent_router;
 use crate::rate_limiter::{TRUSTED_PROXIES_ENV, parse_trusted_proxies, real_client_ip};
 use crate::state::SharedState;
 
+/// The registry's `(name, description)` list as the HTTP surface sees it.
+///
+/// HTTP callers dispatch as [`garraia_channels::Role::User`] (see
+/// [`dispatch_slash_command`]), so discovery lists what that role can run —
+/// advertising `/pair` or `/config` to a caller that gets "permission denied"
+/// would be the old kind of lie in a new place. A poisoned lock yields an
+/// empty list rather than a panic on a read path.
+pub fn registry_commands_for_http(state: &SharedState) -> Vec<(String, String)> {
+    let Ok(registry) = state.command_registry.read() else {
+        return Vec::new();
+    };
+    registry
+        .list_for_role(garraia_channels::Role::User)
+        .into_iter()
+        .map(|(n, d)| (n.to_string(), d.to_string()))
+        .collect()
+}
+
+/// A slash command the registry handled instead of the agent.
+pub struct SlashReply {
+    /// Command name without the `/`.
+    pub command: String,
+    /// User-facing text (a `CommandError` is rendered through its `Display`,
+    /// which is what the Telegram path shows too).
+    pub content: String,
+}
+
+/// Route a message that starts with `/` through the `CommandRegistry`.
+///
+/// Returns `None` when the text is not a registered command — including an
+/// unknown `/something` — so it falls through to the model exactly as
+/// before. Only a name the registry knows is intercepted, which is the
+/// contract that keeps this from changing behaviour for any existing client.
+///
+/// Why this exists: the registry is populated at boot (`server.rs`) with the
+/// full command set, and the only thing that ever called `dispatch` was the
+/// Telegram adapter. `/help` from the phone reached the model as plain text,
+/// and the model answered that "no slash commands are registered" — a
+/// hallucination the user could not tell from the truth.
+///
+/// Role is `User`: `/api/*` carries no identity beyond the session, and the
+/// owner/admin commands (`/pair`, `/users`, `/config`, `/mcp`, `/health`,
+/// `/providers`, `/stats`) answer with "permission denied" here. Elevating an
+/// HTTP caller is a separate decision tied to `gateway.api_key`.
+pub fn dispatch_slash_command(
+    state: &SharedState,
+    session_id: &str,
+    content: &str,
+) -> Option<SlashReply> {
+    let text = content.trim();
+    let name = text.strip_prefix('/')?.split_whitespace().next()?;
+    if name.is_empty() {
+        return None;
+    }
+
+    let Ok(registry) = state.command_registry.read() else {
+        return None;
+    };
+    registry.get(name)?;
+
+    let args: Vec<String> = text
+        .split_whitespace()
+        .skip(1)
+        .map(|s| s.to_string())
+        .collect();
+    let ctx = garraia_channels::CommandContext {
+        user_id: format!("api:{session_id}"),
+        user_name: "api".to_string(),
+        chat_id: 0,
+        full_text: text.to_string(),
+        args,
+        user_role: garraia_channels::Role::User,
+        state: Some(std::sync::Arc::clone(state) as std::sync::Arc<dyn std::any::Any + Send + Sync>),
+        session_id: Some(session_id.to_string()),
+    };
+
+    let content = match registry.dispatch(&ctx) {
+        Ok(reply) => reply,
+        Err(err) => err.to_string(),
+    };
+    Some(SlashReply {
+        command: name.to_string(),
+        content,
+    })
+}
+
 #[derive(Deserialize)]
 pub struct CreateSessionRequest {
     /// Optional named agent to use for this session.
@@ -164,6 +250,21 @@ pub async fn send_message(
         return (
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({ "error": "session not found" })),
+        )
+            .into_response();
+    }
+
+    // Slash commands never reach the model. Not persisted into history either
+    // (same as Telegram): `/help` output is not conversation, and it would
+    // only pollute the context the next turn sends.
+    if let Some(reply) = dispatch_slash_command(&state, &session_id, &body.content) {
+        return (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "session_id": session_id,
+                "content": reply.content,
+                "command": reply.command,
+            })),
         )
             .into_response();
     }
@@ -905,4 +1006,90 @@ pub async fn delete_custom_mode(
             message: "Session store not available".to_string(),
         })),
     )
+}
+
+#[cfg(test)]
+mod slash_dispatch_tests {
+    use super::*;
+    use garraia_agents::AgentRuntime;
+    use garraia_channels::ChannelRegistry;
+    use garraia_config::AppConfig;
+    use std::sync::Arc;
+
+    fn state_with_commands() -> SharedState {
+        let state = Arc::new(crate::state::AppState::new(
+            AppConfig::default(),
+            Arc::new(AgentRuntime::new()),
+            ChannelRegistry::new(),
+        ));
+        crate::commands::register_commands(&mut state.command_registry.write().unwrap());
+        state
+    }
+
+    /// O que o telefone mandou: `/help` chega ao registry e volta a lista
+    /// real, nao uma negacao do modelo.
+    #[test]
+    fn help_is_answered_by_the_registry() {
+        let st = state_with_commands();
+        let reply = dispatch_slash_command(&st, "s1", "/help").expect("comando registrado");
+        assert_eq!(reply.command, "help");
+        for name in ["/help", "/mode", "/clear", "/model"] {
+            assert!(
+                reply.content.contains(name),
+                "{name} ausente em {}",
+                reply.content
+            );
+        }
+        assert!(
+            !reply.content.contains("/pair"),
+            "comando de owner nao aparece para Role::User: {}",
+            reply.content
+        );
+    }
+
+    /// Nome desconhecido e texto comum passam para o modelo.
+    #[test]
+    fn unknown_or_plain_text_falls_through() {
+        let st = state_with_commands();
+        assert!(dispatch_slash_command(&st, "s1", "/naoexiste").is_none());
+        assert!(dispatch_slash_command(&st, "s1", "hello /help").is_none());
+        assert!(dispatch_slash_command(&st, "s1", "/").is_none());
+        assert!(dispatch_slash_command(&st, "s1", "   ").is_none());
+    }
+
+    /// Comando de owner via HTTP: capturado (nao vai ao modelo) e negado com
+    /// a mensagem do registry.
+    #[test]
+    fn owner_commands_are_denied_not_forwarded() {
+        let st = state_with_commands();
+        let reply = dispatch_slash_command(&st, "s1", "/pair").expect("capturado");
+        assert_eq!(reply.command, "pair");
+        assert!(
+            reply.content.contains("Permission denied"),
+            "{}",
+            reply.content
+        );
+    }
+
+    /// Espaco em volta e argumentos: o nome sai limpo e os args chegam.
+    #[test]
+    fn trims_and_splits_arguments() {
+        let st = state_with_commands();
+        let reply = dispatch_slash_command(&st, "s1", "  /modes  ").expect("capturado");
+        assert_eq!(reply.command, "modes");
+    }
+
+    /// A lista de descoberta e a mesma que o dispatch aceita, no mesmo papel.
+    #[test]
+    fn discovery_matches_dispatch_role() {
+        let st = state_with_commands();
+        let names: Vec<String> = registry_commands_for_http(&st)
+            .into_iter()
+            .map(|(n, _)| n)
+            .collect();
+        assert!(names.iter().any(|n| n == "help"));
+        assert!(names.iter().any(|n| n == "mode"));
+        assert!(!names.iter().any(|n| n == "pair"), "{names:?}");
+        assert!(!names.iter().any(|n| n == "config"), "{names:?}");
+    }
 }

--- a/crates/garraia-gateway/src/api.rs
+++ b/crates/garraia-gateway/src/api.rs
@@ -28,9 +28,25 @@ pub fn registry_commands_for_http(state: &SharedState) -> Vec<(String, String)> 
     registry
         .list_for_role(garraia_channels::Role::User)
         .into_iter()
+        .filter(|(n, _)| !HTTP_HIDDEN.contains(n))
         .map(|(n, d)| (n.to_string(), d.to_string()))
         .collect()
 }
+
+/// Registry commands that mean nothing over HTTP and are neither listed nor
+/// dispatched there.
+///
+/// `/start` is Telegram onboarding: on a fresh install it **claims the
+/// bot's owner** for whoever sends it first. Over HTTP the caller's id is a
+/// synthetic `api:<session>` that no channel will ever present, so a LAN
+/// request could take the owner slot and lock the real owner out — the
+/// blocker the security audit of #1040 found. The closure itself refuses
+/// callers with a `session_id` too; this list is the outer wall.
+const HTTP_HIDDEN: &[&str] = &["start"];
+
+/// What `/start` gets over HTTP instead of the registry.
+const START_OVER_HTTP: &str =
+    "/start is Telegram onboarding. Here you are already talking to Garra — just send a message.";
 
 /// A slash command the registry handled instead of the agent.
 pub struct SlashReply {
@@ -69,10 +85,22 @@ pub fn dispatch_slash_command(
         return None;
     }
 
-    let Ok(registry) = state.command_registry.read() else {
-        return None;
+    if HTTP_HIDDEN.contains(&name) {
+        return Some(SlashReply {
+            command: name.to_string(),
+            content: START_OVER_HTTP.to_string(),
+        });
+    }
+
+    // Take a handle and release the lock before running: `/help` reads the
+    // registry again, and a read held across a read is a deadlock the moment
+    // a writer queues up (see `CommandRegistry::resolve`).
+    let cmd = {
+        let Ok(registry) = state.command_registry.read() else {
+            return None;
+        };
+        registry.resolve(text)?
     };
-    registry.get(name)?;
 
     let args: Vec<String> = text
         .split_whitespace()
@@ -90,7 +118,7 @@ pub fn dispatch_slash_command(
         session_id: Some(session_id.to_string()),
     };
 
-    let content = match registry.dispatch(&ctx) {
+    let content = match garraia_channels::CommandRegistry::run(cmd.as_ref(), &ctx) {
         Ok(reply) => reply,
         Err(err) => err.to_string(),
     };
@@ -1091,5 +1119,41 @@ mod slash_dispatch_tests {
         assert!(names.iter().any(|n| n == "mode"));
         assert!(!names.iter().any(|n| n == "pair"), "{names:?}");
         assert!(!names.iter().any(|n| n == "config"), "{names:?}");
+        assert!(!names.iter().any(|n| n == "start"), "{names:?}");
+    }
+
+    /// Bloqueador da auditoria do #1040: `/start` pelo HTTP nao pode virar
+    /// dono da allowlist do Telegram. Nem chega ao registry, e a allowlist
+    /// continua sem dono.
+    #[test]
+    fn start_over_http_never_claims_the_owner() {
+        let st = state_with_commands();
+        assert!(
+            st.allowlist.lock().unwrap().needs_owner(),
+            "instalacao nova: sem dono"
+        );
+        let reply = dispatch_slash_command(&st, "s1", "/start").expect("capturado");
+        assert_eq!(reply.command, "start");
+        assert!(reply.content.contains("Telegram"), "{}", reply.content);
+        let list = st.allowlist.lock().unwrap();
+        assert!(list.needs_owner(), "a allowlist ganhou dono pelo HTTP");
+        assert!(!list.is_owner("api:s1"));
+    }
+
+    /// `/model` recusa lixo (auditoria do #1040, S-2) e aceita nomes reais.
+    #[test]
+    fn model_name_is_validated() {
+        let st = state_with_commands();
+        let bad = dispatch_slash_command(&st, "s1", "/model ../../etc/passwd").expect("capturado");
+        assert!(bad.content.contains("model name"), "{}", bad.content);
+        assert!(st.channel_models.get("s1").is_none());
+
+        let ok =
+            dispatch_slash_command(&st, "s1", "/model qwen2.5:7b-instruct").expect("capturado");
+        assert!(ok.content.contains("qwen2.5:7b-instruct"), "{}", ok.content);
+        assert_eq!(
+            st.channel_models.get("s1").map(|m| m.clone()),
+            Some("qwen2.5:7b-instruct".to_string())
+        );
     }
 }

--- a/crates/garraia-gateway/src/api.rs
+++ b/crates/garraia-gateway/src/api.rs
@@ -1144,16 +1144,30 @@ mod slash_dispatch_tests {
     #[test]
     fn model_name_is_validated() {
         let st = state_with_commands();
-        let bad = dispatch_slash_command(&st, "s1", "/model ../../etc/passwd").expect("capturado");
-        assert!(bad.content.contains("model name"), "{}", bad.content);
-        assert!(st.channel_models.get("s1").is_none());
-
-        let ok =
-            dispatch_slash_command(&st, "s1", "/model qwen2.5:7b-instruct").expect("capturado");
-        assert!(ok.content.contains("qwen2.5:7b-instruct"), "{}", ok.content);
-        assert_eq!(
-            st.channel_models.get("s1").map(|m| m.clone()),
-            Some("qwen2.5:7b-instruct".to_string())
-        );
+        let long = "x".repeat(129);
+        for junk in [
+            "../../etc/passwd",
+            "/etc/passwd",
+            "gpt-4o;id",
+            long.as_str(),
+        ] {
+            let bad =
+                dispatch_slash_command(&st, "s1", &format!("/model {junk}")).expect("capturado");
+            assert!(
+                bad.content.contains("model name"),
+                "{junk}: {}",
+                bad.content
+            );
+            assert!(st.channel_models.get("s1").is_none(), "{junk} foi aceito");
+        }
+        for good in ["openrouter/auto", "claude-3.5-sonnet", "llama3.1:8b"] {
+            let ok =
+                dispatch_slash_command(&st, "s1", &format!("/model {good}")).expect("capturado");
+            assert!(ok.content.contains(good), "{}", ok.content);
+            assert_eq!(
+                st.channel_models.get("s1").map(|m| m.clone()),
+                Some(good.to_string())
+            );
+        }
     }
 }

--- a/crates/garraia-gateway/src/bootstrap/telegram.rs
+++ b/crates/garraia-gateway/src/bootstrap/telegram.rs
@@ -422,7 +422,16 @@ fn handle_command(
         session_id: None,
     };
 
-    match state.command_registry.read().unwrap().dispatch(&ctx) {
+    // Handle first, lock gone, then run — `/help` reads the registry again
+    // (see `CommandRegistry::resolve`).
+    let cmd = state.command_registry.read().unwrap().resolve(full_text);
+    let result = match cmd {
+        Some(cmd) => garraia_channels::CommandRegistry::run(cmd.as_ref(), &ctx),
+        None => Ok(garraia_channels::CommandRegistry::unknown_command_reply(
+            garraia_channels::CommandRegistry::command_name(full_text),
+        )),
+    };
+    match result {
         Ok(response) => Ok(response),
         Err(garraia_channels::CommandError::Unauthorized(msg)) => Ok(format!("⛔ {msg}")),
         Err(garraia_channels::CommandError::InvalidArgs(msg)) => Ok(format!("❌ {msg}")),

--- a/crates/garraia-gateway/src/bootstrap/telegram.rs
+++ b/crates/garraia-gateway/src/bootstrap/telegram.rs
@@ -419,6 +419,7 @@ fn handle_command(
         args,
         user_role: role,
         state: Some(Arc::clone(state) as Arc<dyn std::any::Any + Send + Sync>),
+        session_id: None,
     };
 
     match state.command_registry.read().unwrap().dispatch(&ctx) {

--- a/crates/garraia-gateway/src/capabilities.rs
+++ b/crates/garraia-gateway/src/capabilities.rs
@@ -127,11 +127,14 @@ pub async fn capabilities_handler(State(state): State<SharedState>) -> Json<Capa
         .map(|s| s.to_string())
         .collect();
 
-    let commands: Vec<String> = state
-        .command_registry
-        .read()
-        .map(|r| r.list().into_iter().map(|(n, _d)| n.to_string()).collect())
-        .unwrap_or_default();
+    // The same list `POST /api/sessions/{id}/messages` dispatches and
+    // `GET /api/slash-commands` advertises — one role, one truth. Listing
+    // owner commands here that the HTTP caller cannot run was the old kind
+    // of lie in a third place (review of #1040).
+    let commands: Vec<String> = crate::api::registry_commands_for_http(&state)
+        .into_iter()
+        .map(|(n, _d)| n)
+        .collect();
 
     // Plan 0117 lists four canonical skins. The Settings Registry (PR-8)
     // can later persist user-defined skins server-side.

--- a/crates/garraia-gateway/src/commands.rs
+++ b/crates/garraia-gateway/src/commands.rs
@@ -7,8 +7,12 @@ use garraia_channels::commands::{
 /// A model id as every provider spells it: `gpt-4o`, `qwen2.5:7b-instruct`,
 /// `openrouter/auto`, `claude-3.5`. Anything else is not a model name.
 fn valid_model_name(s: &str) -> bool {
+    // `/` is a namespace separator here (`openrouter/auto`), never a root,
+    // and `..` is not a segment any provider has — so nothing path-shaped.
     !s.is_empty()
         && s.len() <= 128
+        && !s.starts_with('/')
+        && !s.contains("..")
         && s.chars()
             .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | ':' | '/' | '-'))
 }

--- a/crates/garraia-gateway/src/commands.rs
+++ b/crates/garraia-gateway/src/commands.rs
@@ -1,8 +1,17 @@
 use crate::state::AppState;
 use garraia_agents::AgentMode;
 use garraia_channels::commands::{
-    ClosureCommand, CommandContext, CommandRegistry, CommandResult, Role,
+    ClosureCommand, CommandContext, CommandError, CommandRegistry, CommandResult, Role,
 };
+
+/// A model id as every provider spells it: `gpt-4o`, `qwen2.5:7b-instruct`,
+/// `openrouter/auto`, `claude-3.5`. Anything else is not a model name.
+fn valid_model_name(s: &str) -> bool {
+    !s.is_empty()
+        && s.len() <= 128
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | ':' | '/' | '-'))
+}
 /// A sessao sobre a qual um comando age.
 ///
 /// Pelo HTTP (`POST /api/sessions/{id}/messages`) o chamador ja sabe a sessao
@@ -11,6 +20,11 @@ use garraia_channels::commands::{
 /// Pelos canais o campo vem `None` e a resolucao e a de sempre (GAR-202 +
 /// #982): a chave vem do MESMO resolvedor que a execucao usa, porque montar
 /// `telegram-{chat_id}` aqui gravava numa linha que o runtime nunca lia.
+///
+/// Divida conhecida, herdada do `/clear` original: o Discord usa `String`
+/// como chat id, entao `ctx.user_id.parse::<i64>()` da `None` la e a
+/// resolucao cai no caminho do Telegram. Um `session_id` preenchido pelo
+/// adapter do Discord e o jeito certo de fechar isso.
 fn session_id_for(ctx: &CommandContext, state: &AppState) -> String {
     if let Some(id) = &ctx.session_id {
         return id.clone();
@@ -35,6 +49,18 @@ pub fn register_commands(registry: &mut CommandRegistry) {
         Role::User,
         true,
         |ctx: &CommandContext| -> CommandResult {
+            // `claim_owner` below hands the bot to whoever sends the first
+            // `/start` on a fresh install. Only a channel identity may do
+            // that: a caller with a `session_id` came through HTTP with a
+            // synthetic `api:<session>` id, and letting it claim the owner
+            // would lock the real owner out (audit of #1040). `api.rs`
+            // hides `/start` from HTTP already; this is the inner wall.
+            if ctx.session_id.is_some() {
+                return Ok(
+                    "/start is Telegram onboarding. Here you are already talking to Garra."
+                        .to_string(),
+                );
+            }
             let state: &AppState = ctx.state.as_ref().unwrap().downcast_ref::<AppState>().unwrap();
             let mut list = state.allowlist.lock().unwrap();
             let is_allowed = list.is_allowed(&ctx.user_id);
@@ -138,6 +164,14 @@ pub fn register_commands(registry: &mut CommandRegistry) {
                 {
                     state.channel_models.remove(&session_id);
                     Ok("🤖 Model override cleared. Using default.".to_string())
+                } else if !valid_model_name(&new_model) {
+                    // The string goes to the provider as `model_override`
+                    // untouched; keep it shaped like a model id (audit of
+                    // #1040, S-2).
+                    Err(CommandError::InvalidArgs(
+                        "model name: letters, digits and . _ : / - only (max 128 chars)"
+                            .to_string(),
+                    ))
                 } else {
                     state.channel_models.insert(session_id, new_model.clone());
                     Ok(format!("🤖 Model set to: {}", new_model))

--- a/crates/garraia-gateway/src/commands.rs
+++ b/crates/garraia-gateway/src/commands.rs
@@ -3,6 +3,27 @@ use garraia_agents::AgentMode;
 use garraia_channels::commands::{
     ClosureCommand, CommandContext, CommandRegistry, CommandResult, Role,
 };
+/// A sessao sobre a qual um comando age.
+///
+/// Pelo HTTP (`POST /api/sessions/{id}/messages`) o chamador ja sabe a sessao
+/// e a poe em `CommandContext::session_id`; e essa que vale, porque a chave
+/// do Telegram nao existe la — `chat_id` e `0` e `user_id` e `api:<id>`.
+/// Pelos canais o campo vem `None` e a resolucao e a de sempre (GAR-202 +
+/// #982): a chave vem do MESMO resolvedor que a execucao usa, porque montar
+/// `telegram-{chat_id}` aqui gravava numa linha que o runtime nunca lia.
+fn session_id_for(ctx: &CommandContext, state: &AppState) -> String {
+    if let Some(id) = &ctx.session_id {
+        return id.clone();
+    }
+    tokio::task::block_in_place(|| {
+        tokio::runtime::Handle::current().block_on(async {
+            state
+                .telegram_session_id(ctx.chat_id, ctx.user_id.parse::<i64>().ok())
+                .await
+        })
+    })
+}
+
 pub fn register_commands(registry: &mut CommandRegistry) {
     // Overwrite the placeholders with actual logic that accesses AppState
 
@@ -77,13 +98,7 @@ pub fn register_commands(registry: &mut CommandRegistry) {
             // GAR-202 + #982: a chave vem do MESMO resolvedor que a execucao
             // usa. Montar `telegram-{chat_id}` aqui gravava numa linha que o
             // runtime nunca lia — ver `AppState::telegram_session_id`.
-            let session_id = tokio::task::block_in_place(|| {
-                tokio::runtime::Handle::current().block_on(async {
-                    state
-                        .telegram_session_id(ctx.chat_id, ctx.user_id.parse::<i64>().ok())
-                        .await
-                })
-            }); // Note: Discord uses strings, but chat_id is i64 here... we'll just use it for telegram for now
+            let session_id = session_id_for(ctx, state);
             if let Some(mut session) = state.sessions.get_mut(&session_id) {
                 session.history.clear();
             }
@@ -108,13 +123,7 @@ pub fn register_commands(registry: &mut CommandRegistry) {
             // GAR-202 + #982: a chave vem do MESMO resolvedor que a execucao
             // usa. Montar `telegram-{chat_id}` aqui gravava numa linha que o
             // runtime nunca lia — ver `AppState::telegram_session_id`.
-            let session_id = tokio::task::block_in_place(|| {
-                tokio::runtime::Handle::current().block_on(async {
-                    state
-                        .telegram_session_id(ctx.chat_id, ctx.user_id.parse::<i64>().ok())
-                        .await
-                })
-            });
+            let session_id = session_id_for(ctx, state);
             if ctx.args.is_empty() {
                 let current = state.channel_models.get(&session_id);
                 if let Some(m) = current {
@@ -274,13 +283,7 @@ pub fn register_commands(registry: &mut CommandRegistry) {
                 return Ok("⚠️ Estado indisponivel para este comando.".to_string());
             };
 
-            let session_id = tokio::task::block_in_place(|| {
-                tokio::runtime::Handle::current().block_on(async {
-                    state
-                        .telegram_session_id(ctx.chat_id, ctx.user_id.parse::<i64>().ok())
-                        .await
-                })
-            });
+            let session_id = session_id_for(ctx, state);
 
             let mut out = String::from("📊 **Estatisticas**\n");
 
@@ -441,13 +444,7 @@ pub fn register_commands(registry: &mut CommandRegistry) {
             // A mesma chave que a execucao usa (GAR-202 + #982): montar
             // `telegram-{chat_id}` aqui gravaria numa linha que o runtime nunca
             // le.
-            let session_id = tokio::task::block_in_place(|| {
-                tokio::runtime::Handle::current().block_on(async {
-                    state
-                        .telegram_session_id(ctx.chat_id, ctx.user_id.parse::<i64>().ok())
-                        .await
-                })
-            });
+            let session_id = session_id_for(ctx, state);
 
             let Some(store) = &state.session_store else {
                 return Ok("⚠️ Sem armazenamento de sessao: o objetivo nao persiste.".to_string());
@@ -528,13 +525,7 @@ pub fn register_commands(registry: &mut CommandRegistry) {
             // GAR-202 + #982: a chave vem do MESMO resolvedor que a execucao
             // usa. Montar `telegram-{chat_id}` aqui gravava numa linha que o
             // runtime nunca lia — ver `AppState::telegram_session_id`.
-            let session_id = tokio::task::block_in_place(|| {
-                tokio::runtime::Handle::current().block_on(async {
-                    state
-                        .telegram_session_id(ctx.chat_id, ctx.user_id.parse::<i64>().ok())
-                        .await
-                })
-            });
+            let session_id = session_id_for(ctx, state);
 
             if ctx.args.is_empty() {
                 // Show current mode

--- a/crates/garraia-gateway/src/openai_api.rs
+++ b/crates/garraia-gateway/src/openai_api.rs
@@ -458,8 +458,12 @@ pub async fn chat_completions(
     // GAR-184: Resolve slash commands (MCP prompts + /help).
     // /mode is excluded here — it is already handled by the `final_mode` logic above.
     if new_user_text.starts_with('/')
-        && let Some(resolved) =
-            crate::slash_commands::resolve(&new_user_text, state.mcp_manager_arc.as_ref()).await
+        && let Some(resolved) = crate::slash_commands::resolve(
+            &new_user_text,
+            crate::api::registry_commands_for_http(&state),
+            state.mcp_manager_arc.as_ref(),
+        )
+        .await
     {
         match resolved {
             crate::slash_commands::ResolvedCommand::McpPrompt(prompt_msgs) => {

--- a/crates/garraia-gateway/src/openai_api.rs
+++ b/crates/garraia-gateway/src/openai_api.rs
@@ -457,6 +457,13 @@ pub async fn chat_completions(
 
     // GAR-184: Resolve slash commands (MCP prompts + /help).
     // /mode is excluded here — it is already handled by the `final_mode` logic above.
+    //
+    // Only `/help`, `/mode` and MCP prompts are handled on this path. The
+    // registry commands (`/clear`, `/model`, `/goal`, …) are dispatched by
+    // `POST /api/sessions/{id}/messages` (`api::dispatch_slash_command`),
+    // not by the OpenAI-compatible endpoint: a client that speaks this
+    // protocol expects the model to answer, and a `/clear` here reaches the
+    // model as text. Said here so nobody debugs it as a bug (#1040 review).
     if new_user_text.starts_with('/')
         && let Some(resolved) = crate::slash_commands::resolve(
             &new_user_text,

--- a/crates/garraia-gateway/src/router.rs
+++ b/crates/garraia-gateway/src/router.rs
@@ -1415,7 +1415,13 @@ async fn mcp_health(
 async fn list_slash_commands(
     axum::extract::State(state): axum::extract::State<SharedState>,
 ) -> axum::Json<serde_json::Value> {
-    let commands = crate::slash_commands::list_commands(state.mcp_manager_arc.as_ref()).await;
+    // Mesma lista que `POST /api/sessions/{id}/messages` despacha: a do
+    // registry, no papel que o HTTP tem (`Role::User`). Antes vinha de uma
+    // tabela paralela de dois itens e o app mostrava `/help` e `/mode` como
+    // se fossem os unicos comandos da instalacao.
+    let built_ins = crate::api::registry_commands_for_http(&state);
+    let commands =
+        crate::slash_commands::list_commands(built_ins, state.mcp_manager_arc.as_ref()).await;
     axum::Json(serde_json::json!({ "commands": commands }))
 }
 

--- a/crates/garraia-gateway/src/slash_commands.rs
+++ b/crates/garraia-gateway/src/slash_commands.rs
@@ -4,7 +4,11 @@
 //!
 //! ## Sources
 //!
-//! - **Built-in** (`/help`): always available; lists all commands.
+//! - **Built-in**: the gateway's `CommandRegistry` (`commands.rs`, populated
+//!   at boot with `/help`, `/mode`, `/clear`, `/model`, ...). Until v0.4.1 this
+//!   module kept its own two-item table (`help`, `mode`) and
+//!   `GET /api/slash-commands` disagreed with `GET /api/capabilities` about
+//!   which commands existed; the registry is the single source now.
 //! - **MCP prompts**: discovered at runtime from connected MCP servers.
 //!   Each prompt exposed by an MCP server becomes an invocable slash command.
 //!
@@ -62,41 +66,28 @@ pub enum ResolvedCommand {
     McpPrompt(Vec<ChatMessage>),
 }
 
-// ── Built-in commands ─────────────────────────────────────────────────────────
-
-/// Built-in commands that are always available. `/mode` is excluded (handled elsewhere).
-const BUILT_INS: &[(&str, &str)] = &[("help", "List all available slash commands")];
-
 // ── Public API ────────────────────────────────────────────────────────────────
 
-/// List all available slash commands: built-ins + MCP prompts from connected servers.
+/// List all available slash commands: the registry's built-ins + MCP prompts
+/// from connected servers.
 ///
-/// Used by `GET /api/slash-commands` for client auto-complete.
-pub async fn list_commands(mcp: Option<&Arc<McpManager>>) -> Vec<SlashCommand> {
-    let mut commands: Vec<SlashCommand> = BUILT_INS
-        .iter()
-        .map(|(name, desc)| SlashCommand {
-            name: name.to_string(),
-            description: desc.to_string(),
+/// `built_ins` is `(name, description)` straight from
+/// `CommandRegistry::list_for_role` — the caller picks the role, because the
+/// list should match what that caller is allowed to dispatch. Used by
+/// `GET /api/slash-commands` for client auto-complete and by `/help`.
+pub async fn list_commands(
+    built_ins: Vec<(String, String)>,
+    mcp: Option<&Arc<McpManager>>,
+) -> Vec<SlashCommand> {
+    let mut commands: Vec<SlashCommand> = built_ins
+        .into_iter()
+        .map(|(name, description)| SlashCommand {
+            name,
+            description,
             source: CommandSource::BuiltIn,
             args: vec![],
         })
         .collect();
-
-    // Also expose /mode as a built-in (for discovery, even though processing is elsewhere)
-    commands.insert(
-        0,
-        SlashCommand {
-            name: "mode".to_string(),
-            description: "Set agent mode (e.g. /mode debug)".to_string(),
-            source: CommandSource::BuiltIn,
-            args: vec![ArgDef {
-                name: "mode".to_string(),
-                description: Some("Agent mode name".to_string()),
-                required: true,
-            }],
-        },
-    );
 
     if let Some(manager) = mcp {
         for (server, prompts) in manager.list_all_prompts().await {
@@ -130,7 +121,11 @@ pub async fn list_commands(mcp: Option<&Arc<McpManager>>) -> Vec<SlashCommand> {
 /// - The message does not start with `/`.
 /// - The command is `/mode` (handled by `openai_api.rs`).
 /// - The command is not recognized (pass through to LLM as plain text).
-pub async fn resolve(message: &str, mcp: Option<&Arc<McpManager>>) -> Option<ResolvedCommand> {
+pub async fn resolve(
+    message: &str,
+    built_ins: Vec<(String, String)>,
+    mcp: Option<&Arc<McpManager>>,
+) -> Option<ResolvedCommand> {
     if !message.starts_with('/') {
         return None;
     }
@@ -150,7 +145,7 @@ pub async fn resolve(message: &str, mcp: Option<&Arc<McpManager>>) -> Option<Res
 
     // /help — generate list of available commands
     if cmd_lower == "help" {
-        let all = list_commands(mcp).await;
+        let all = list_commands(built_ins, mcp).await;
         let text = format_help(&all);
         return Some(ResolvedCommand::McpPrompt(vec![ChatMessage {
             role: ChatRole::System,
@@ -257,4 +252,61 @@ fn format_help(commands: &[SlashCommand]) -> String {
         ));
     }
     lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn built_ins() -> Vec<(String, String)> {
+        vec![
+            ("clear".into(), "Clear current conversation history".into()),
+            ("help".into(), "Show available commands".into()),
+            ("mode".into(), "Get or set the agent mode".into()),
+        ]
+    }
+
+    /// A lista e a do registry, na ordem do registry, e nada e inventado
+    /// aqui — a tabela paralela de dois itens acabou.
+    #[tokio::test]
+    async fn built_ins_come_from_the_registry_only() {
+        let all = list_commands(built_ins(), None).await;
+        let names: Vec<&str> = all.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, ["clear", "help", "mode"]);
+        assert!(
+            all.iter()
+                .all(|c| matches!(c.source, CommandSource::BuiltIn)),
+            "sem MCP, tudo e built-in"
+        );
+        assert_eq!(all[0].description, "Clear current conversation history");
+    }
+
+    /// Registry vazio + sem MCP = lista vazia, sem `help` fantasma.
+    #[tokio::test]
+    async fn empty_registry_lists_nothing() {
+        assert!(list_commands(Vec::new(), None).await.is_empty());
+    }
+
+    /// `/help` no caminho OpenAI vira um prompt de sistema com todos os
+    /// comandos do registry, nao so os dois antigos.
+    #[tokio::test]
+    async fn help_lists_every_registry_command() {
+        let Some(ResolvedCommand::McpPrompt(msgs)) = resolve("/help", built_ins(), None).await
+        else {
+            panic!("/help resolve para um prompt");
+        };
+        let MessagePart::Text(text) = &msgs[0].content else {
+            panic!("texto");
+        };
+        for name in ["/clear", "/help", "/mode"] {
+            assert!(text.contains(name), "{name} ausente em {text}");
+        }
+    }
+
+    /// Comando desconhecido nao e capturado: passa para o modelo.
+    #[tokio::test]
+    async fn unknown_command_passes_through() {
+        assert!(resolve("/naoexiste", built_ins(), None).await.is_none());
+        assert!(resolve("hello", built_ins(), None).await.is_none());
+    }
 }


### PR DESCRIPTION
## Descrição

Relato de campo da v0.4.0 (APK da release contra `garra start` no Termux): `/help` no chat voltou *"não há comandos com barra registrados nesta instalação. Nem `/help`"*. Investigado: o registry **estava cheio** — `server.rs` popula 17 comandos no boot, incondicionalmente — mas o único call site de `CommandRegistry::dispatch` em todo o repositório era o adapter do Telegram. Pelo HTTP, `/help` chegava ao modelo como texto comum, e a frase acima era alucinação.

Havia ainda uma segunda verdade: `GET /api/slash-commands` listava **2** comandos (`help`, `mode`) de uma tabela paralela em `slash_commands.rs`, enquanto `GET /api/capabilities` listava os 17 do registry. O app consumia a de dois.

**Gateway**

- `api.rs`: `POST /api/sessions/{id}/messages` despacha pelo registry quando o texto começa com um **nome registrado**. Desconhecido (`/foo`) segue ao modelo exatamente como antes — é esse contrato que mantém o comportamento de qualquer cliente existente. Papel `Role::User`: comandos de owner/admin (`/pair`, `/users`, `/config`, `/mcp`, `/health`, `/providers`, `/stats`) respondem "permission denied" em vez de ir ao modelo; elevar um chamador HTTP é decisão separada, ligada ao `gateway.api_key` (ver #1045). Não persiste no histórico, como o Telegram. A resposta ganha `"command"` (aditivo).
- `CommandContext` ganha `session_id: Option<String>` (`garraia-channels`). Os cinco comandos de sessão (`/clear`, `/mode`, `/goal`, …) passam por `session_id_for()`: usa o id do HTTP quando existe, e a resolução por `chat_id` do Telegram quando não — a mesma de sempre (GAR-202 + #982).
- `GET /api/slash-commands`, o `commands` de `GET /api/capabilities` e o `/help` do caminho OpenAI passam a listar o registry via `list_for_role(User)`; a tabela paralela sai. Um papel, uma verdade, nas três superfícies.

**App (`apps/garraia-mobile`)**

- `SlashCommandInfo {name, description}`; `slashCommandsProvider` vai para `runtime_providers.dart`, compartilhado por chat e Skills.
- `SlashSuggestions` acima do campo de texto: chips dos comandos que casam com o `/prefixo` digitado (prefixo, case-insensitive, ordem do registry); tocar completa `/nome ` com o cursor no fim. Some quando começa um argumento.
- Chips da tela Skills viram ação: abrem `/chat?draft=/nome `.

### O que a revisão mudou (commits `d382530` + `5bb2b4c`)

`security-auditor` e `code-reviewer` passaram pelo diff. Um **bloqueador** e três importantes, todos atendidos:

- **`/start` pelo HTTP podia virar dono da allowlist do Telegram.** Numa instalação nova, `/start` faz `claim_owner` para quem mandar primeiro; pelo HTTP o id é o sintético `api:<sessão>`, que nenhum canal apresenta — uma requisição da LAN tomaria o lugar do dono e o trancaria para fora. Duas paredes: `api.rs` esconde `/start` da descoberta e do dispatch HTTP (responde que é onboarding do Telegram) e o próprio closure recusa quem chega com `session_id`. Teste: a allowlist segue sem dono depois de `/start` via HTTP.
- **Lock re-entrante.** O dispatcher segurava o read do registry durante a execução, e o `/help` lê o registry de novo — trava assim que um writer entra na fila. `CommandRegistry` passa a guardar `Arc<dyn SlashCommand>` e ganha `resolve()` (handle) + `run()` (permissão + execute); HTTP **e Telegram** soltam o lock antes de rodar. `dispatch()` continua com a mesma semântica.
- **`/model` valida o nome** (letras, dígitos e `. _ : / -`, sem `..` nem barra inicial, máx. 128): a string ia crua ao provider como `model_override`.
- **`/api/capabilities`** passa a listar comandos no mesmo papel do HTTP — era a terceira lista a divergir, e o fragmento de changelog dizia o contrário.
- `openai_api.rs` documenta que só `/help`, `/mode` e prompts MCP são tratados naquele caminho; os comandos do registry são do `POST /api/sessions/{id}/messages`.
- App: `didUpdateWidget` em `ChatScreen` (o segundo `?draft=` era descartado quando o State era reutilizado); teste de sugestões com `pumpAndSettle`.
- `block_in_place` nos closures: o binário sobe com `tokio::runtime::Runtime::new()` (multi-thread), então é seguro; anotado.
- Fora do escopo, registrado em **#1045**: `gateway.api_key` só é exigida no `/ws`; o REST `/api/*` inteiro fica sem gate na LAN. Pré-existente e mais amplo que este PR.

## Tipo de mudança

- [x] `feat`: Nova funcionalidade
- [x] `fix`: Correção de bug
- [ ] `refactor`: Refatoração sem mudança de comportamento
- [ ] `docs`: Documentação apenas
- [x] `test`: Adição ou correção de testes
- [ ] `perf`: Melhoria de performance
- [ ] `chore`: Manutenção (deps, CI, build)
- [x] `sec`: Correção ou hardening de segurança

## Classe de Risco

- [ ] **Classe A (Baixo Risco)**
- [x] **Classe B (Médio Risco)**: sem auth, RLS, migrations ou RBAC. Toca um endpoint público existente (`POST /api/sessions/{id}/messages`) de forma **aditiva e delimitada**: só um nome já registrado é interceptado; o resto é inalterado. O papel do chamador HTTP é o mínimo (`User`), `/start` nem entra, então nada que exigia owner no Telegram passa a ser possível pelo HTTP.
- [ ] **Classe C (Alto Risco)**

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo fmt --check` executado e limpo
- [x] `cargo clippy -p garraia-channels -p garraia-gateway --all-targets -- -D warnings` sem erros
- [x] `cargo test -p garraia-channels --lib` 14/14; `cargo test -p garraia-gateway --lib` 937/937 (7 de dispatch + 4 de listagem novos)
- [x] `flutter analyze` sem issues; `flutter test` 19/19
- [x] Nenhum `unwrap()` adicionado em código de produção (lock envenenado vira "sem comando", não panic)
- [x] Nenhum segredo, API key, token ou credencial commitada
- [x] Nenhuma migração Postgres

### Para alterações de Alto Risco (Classe C)

- [ ] N/A

## Mudanças na API pública e Schema

- `POST /api/sessions/{id}/messages`: texto que começa com um comando **registrado** (exceto `/start`) é respondido pelo registry (200, `{session_id, content, command}`) sem passar pelo modelo. Texto comum e `/desconhecido`: inalterados.
- `GET /api/slash-commands` e `GET /api/capabilities` → `commands[]`: a lista do registry no papel `User` (era `help` + `mode` fixos / a lista completa). Mesmo shape.
- `garraia_channels::CommandContext`: campo novo `session_id: Option<String>`. `CommandRegistry`: `resolve`, `run`, `command_name`, `unknown_command_reply` novos; `dispatch` inalterado.

## Como testar

1. `cargo test -p garraia-gateway --lib -- slash_dispatch_tests slash_commands::tests` e `cargo test -p garraia-channels --lib`.
2. `garra start` → `POST /api/sessions` → `POST /api/sessions/{id}/messages` com `{"content":"/help"}` → lista real de comandos, com `"command":"help"`; `{"content":"/mode debug"}` → modo gravado na sessão; `{"content":"/pair"}` → "Permission denied"; `{"content":"/start"}` → texto dizendo que é onboarding do Telegram, allowlist intacta; `{"content":"/inventado"}` → resposta do modelo, como antes.
3. `GET /api/slash-commands` e `GET /api/capabilities` → os mesmos comandos de usuário.
4. No app (APK do workflow **Mobile** deste PR): digite `/` no chat → chips aparecem; toque em `/help` → texto vira `/help ` → enviar → resposta do registry. Em Skills, toque num comando → abre o chat com ele digitado; toque em outro → o campo troca.

## Plano de Rollback

Revert do PR. Nenhum schema, nenhuma migration, nenhum estado persistido novo. O app anterior continua funcionando contra o gateway novo (só lê `content`), e o app novo contra gateway antigo degrada para "sem sugestões".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVnUdw6gJJLtcmWxzxMtFz