### PR TITLE
feat(mobile): copiar mensagem, código, memória e log com um toque

### DIFF
--- a/apps/garraia-mobile/lib/screens/activity_screen.dart
+++ b/apps/garraia-mobile/lib/screens/activity_screen.dart
@@ -8,6 +8,7 @@ import '../runtime/runtime_providers.dart';
 import '../theme/garra_theme.dart';
 import '../theme/garra_tokens.dart';
 import '../widgets/garra_bottom_nav.dart';
+import '../widgets/copy_to_clipboard.dart';
 import '../widgets/garra_page.dart';
 import 'memory_screen.dart' show SectionHeader;
 
@@ -99,26 +100,48 @@ class ActivityScreen extends ConsumerWidget {
                 style: garraText(size: 12, color: GarraColors.warn),
               ),
             ),
-            data: (lines) => Container(
-              margin: const EdgeInsets.symmetric(horizontal: 16),
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: GarraColors.bgElevated,
-                borderRadius: BorderRadius.circular(GarraRadius.card),
-                border: Border.all(color: GarraColors.panelBorder),
-              ),
-              child: SelectableText(
-                lines.isEmpty
-                    ? '(empty)'
-                    : lines.reversed.take(80).toList().reversed.join('\n'),
-                style: garraText(
-                  size: 11,
-                  mono: true,
-                  color: GarraColors.textMuted,
-                  height: 1.4,
+            data: (lines) {
+              final text = lines.isEmpty
+                  ? '(empty)'
+                  : lines.reversed.take(80).toList().reversed.join('\n');
+              return Container(
+                margin: const EdgeInsets.symmetric(horizontal: 16),
+                padding: const EdgeInsets.fromLTRB(12, 12, 12, 12),
+                decoration: BoxDecoration(
+                  color: GarraColors.bgElevated,
+                  borderRadius: BorderRadius.circular(GarraRadius.card),
+                  border: Border.all(color: GarraColors.panelBorder),
                 ),
-              ),
-            ),
+                child: Stack(
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.only(right: 28),
+                      child: SelectableText(
+                        text,
+                        style: garraText(
+                          size: 11,
+                          mono: true,
+                          color: GarraColors.textMuted,
+                          height: 1.4,
+                        ),
+                      ),
+                    ),
+                    Positioned(
+                      top: -6,
+                      right: -6,
+                      child: CopyIconButton(
+                        key: const ValueKey('copy-log'),
+                        text: text,
+                        tooltip: 'Copiar log',
+                        toast: 'Log copiado',
+                        color: GarraColors.textMuted,
+                        size: 16,
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            },
           ),
         ],
       ),

--- a/apps/garraia-mobile/lib/screens/memory_screen.dart
+++ b/apps/garraia-mobile/lib/screens/memory_screen.dart
@@ -6,6 +6,7 @@ import '../runtime/models.dart';
 import '../runtime/runtime_providers.dart';
 import '../theme/garra_theme.dart';
 import '../theme/garra_tokens.dart';
+import '../widgets/copy_to_clipboard.dart';
 import '../widgets/garra_page.dart';
 
 part 'memory_screen.g.dart';
@@ -109,6 +110,74 @@ class _MemoryRow extends StatelessWidget {
         if (entry.role.isNotEmpty) entry.role,
         if (entry.createdAt.isNotEmpty) entry.createdAt.split('T').first,
       ].join(' · '),
+      trailing: const Icon(
+        Icons.chevron_right_rounded,
+        color: GarraColors.textDim,
+      ),
+      // The row truncates; the sheet shows the whole memory and copies it.
+      // Deleting a memory needs `DELETE /api/memory/{id}` on the gateway and
+      // lands with it, in the same sheet.
+      onTap: () => showModalBottomSheet<void>(
+        context: context,
+        showDragHandle: true,
+        isScrollControlled: true,
+        builder: (_) => MemorySheet(entry: entry),
+      ),
+    );
+  }
+}
+
+/// Full text of one memory, selectable, with a copy button.
+class MemorySheet extends StatelessWidget {
+  final MemoryEntry entry;
+  const MemorySheet({super.key, required this.entry});
+
+  @override
+  Widget build(BuildContext context) {
+    final meta = [
+      if (entry.role.isNotEmpty) entry.role,
+      if (entry.createdAt.isNotEmpty) entry.createdAt.replaceFirst('T', ' '),
+    ].join(' · ');
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(20, 0, 20, 16),
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxHeight: MediaQuery.sizeOf(context).height * 0.75,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (meta.isNotEmpty)
+                Text(
+                  meta,
+                  style: garraText(size: 12.5, color: GarraColors.textMuted),
+                ),
+              const SizedBox(height: 10),
+              Flexible(
+                child: SingleChildScrollView(
+                  child: SelectableText(
+                    entry.content,
+                    style: garraText(size: 14.5, height: 1.45),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 14),
+              FilledButton.icon(
+                key: const ValueKey('copy-memory'),
+                onPressed: () => copyToClipboard(
+                  context,
+                  entry.content,
+                  toast: 'Memoria copiada',
+                ),
+                icon: const Icon(Icons.copy_rounded, size: 18),
+                label: const Text('Copiar'),
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/apps/garraia-mobile/lib/widgets/chat_bubble.dart
+++ b/apps/garraia-mobile/lib/widgets/chat_bubble.dart
@@ -1,13 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:intl/intl.dart';
-
-import 'brand/wolf_mark.dart';
+import 'package:markdown/markdown.dart' as md;
 
 import '../runtime/models.dart';
+import 'brand/wolf_mark.dart';
+import 'copy_to_clipboard.dart';
 
 /// Modern chat bubble with markdown rendering for AI messages,
 /// timestamps, and avatar for assistant messages.
+///
+/// Copying: every bubble carries a small copy button next to its timestamp
+/// (`copy-message`), both texts are selectable for partial copies, and a
+/// fenced code block gets its own button (`copy-code`) that copies just the
+/// code. Field report from v0.4.0: long-press selection existed on the
+/// assistant side only and nothing hinted at it; the user's own messages
+/// could not be copied at all.
 class ChatBubble extends StatelessWidget {
   final ChatMessage message;
 
@@ -68,7 +76,7 @@ class ChatBubble extends StatelessWidget {
                       ),
                     ),
                     child: _isUser
-                        ? Text(
+                        ? SelectableText(
                             message.content,
                             style: TextStyle(color: cs.onPrimary, fontSize: 15),
                           )
@@ -77,15 +85,26 @@ class ChatBubble extends StatelessWidget {
                             textColor: cs.onSurface,
                           ),
                   ),
-                  const SizedBox(height: 2),
                   Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 4),
-                    child: Text(
-                      _formattedTime,
-                      style: TextStyle(
-                        color: cs.onSurface.withValues(alpha: 0.35),
-                        fontSize: 10,
-                      ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          _formattedTime,
+                          style: TextStyle(
+                            color: cs.onSurface.withValues(alpha: 0.35),
+                            fontSize: 10,
+                          ),
+                        ),
+                        CopyIconButton(
+                          key: const ValueKey('copy-message'),
+                          text: message.content,
+                          tooltip: 'Copiar mensagem',
+                          toast: 'Mensagem copiada',
+                          color: cs.onSurface.withValues(alpha: 0.45),
+                        ),
+                      ],
                     ),
                   ),
                 ],
@@ -111,6 +130,7 @@ class _MarkdownBody extends StatelessWidget {
     return MarkdownBody(
       data: content,
       selectable: true,
+      builders: {'code': _CodeBlockBuilder(textColor: textColor)},
       styleSheet: MarkdownStyleSheet(
         p: TextStyle(color: textColor, fontSize: 15, height: 1.4),
         code: TextStyle(
@@ -158,6 +178,62 @@ class _MarkdownBody extends StatelessWidget {
           decoration: TextDecoration.underline,
         ),
       ),
+    );
+  }
+}
+
+/// Fenced code blocks with a copy button.
+///
+/// Registered on the `code` tag: inline code (no newline) returns `null` and
+/// keeps the default rendering; a block replaces the default scrollable text
+/// with the same text plus a button that copies **only the code**, which is
+/// what someone on a phone wants from a snippet the model produced. The
+/// `pre` frame (`codeblockDecoration`) still wraps it.
+class _CodeBlockBuilder extends MarkdownElementBuilder {
+  final Color textColor;
+
+  _CodeBlockBuilder({required this.textColor});
+
+  @override
+  Widget? visitElementAfterWithContext(
+    BuildContext context,
+    md.Element element,
+    TextStyle? preferredStyle,
+    TextStyle? parentStyle,
+  ) {
+    final raw = element.textContent;
+    if (!raw.contains('\n')) return null;
+    final code = raw.trimRight();
+    return Stack(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(12, 12, 40, 12),
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: SelectableText(
+              code,
+              style: TextStyle(
+                color: textColor,
+                fontFamily: 'JetBrainsMono',
+                fontSize: 13,
+                height: 1.45,
+              ),
+            ),
+          ),
+        ),
+        Positioned(
+          top: 2,
+          right: 2,
+          child: CopyIconButton(
+            key: const ValueKey('copy-code'),
+            text: code,
+            tooltip: 'Copiar codigo',
+            toast: 'Codigo copiado',
+            color: textColor.withValues(alpha: 0.6),
+            size: 16,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/apps/garraia-mobile/lib/widgets/copy_to_clipboard.dart
+++ b/apps/garraia-mobile/lib/widgets/copy_to_clipboard.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Copies [text] and confirms with a short SnackBar.
+///
+/// One place for the gesture so every "copy" in the app — a chat bubble, a
+/// code block, a memory, the runtime log — feels the same and is tested the
+/// same way (the widget tests mock `Clipboard.setData`).
+Future<void> copyToClipboard(
+  BuildContext context,
+  String text, {
+  String toast = 'Copiado',
+}) async {
+  await Clipboard.setData(ClipboardData(text: text));
+  if (!context.mounted) return;
+  ScaffoldMessenger.maybeOf(context)
+    ?..hideCurrentSnackBar()
+    ..showSnackBar(
+      SnackBar(content: Text(toast), duration: const Duration(seconds: 1)),
+    );
+}
+
+/// The small copy affordance used next to timestamps and on code blocks.
+class CopyIconButton extends StatelessWidget {
+  final String text;
+  final String tooltip;
+  final String toast;
+  final Color? color;
+  final double size;
+
+  const CopyIconButton({
+    super.key,
+    required this.text,
+    required this.tooltip,
+    required this.toast,
+    this.color,
+    this.size = 14,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      padding: EdgeInsets.zero,
+      constraints: BoxConstraints(minWidth: size + 12, minHeight: size + 8),
+      iconSize: size,
+      visualDensity: VisualDensity.compact,
+      tooltip: tooltip,
+      icon: Icon(Icons.copy_rounded, color: color),
+      onPressed: () => copyToClipboard(context, text, toast: toast),
+    );
+  }
+}

--- a/apps/garraia-mobile/pubspec.lock
+++ b/apps/garraia-mobile/pubspec.lock
@@ -545,7 +545,7 @@ packages:
     source: hosted
     version: "1.3.0"
   markdown:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: markdown
       sha256: ee85086ad7698b42522c6ad42fe195f1b9898e4d974a1af4576c1a3a176cada9

--- a/apps/garraia-mobile/pubspec.yaml
+++ b/apps/garraia-mobile/pubspec.yaml
@@ -33,6 +33,9 @@ dependencies:
   # Markdown rendering (AI messages). Discontinued upstream but functional;
   # tracked as debt for 0.4.x — swap to a maintained fork once one stabilises.
   flutter_markdown: ^0.7.4+3
+  # Direct because chat_bubble.dart implements a MarkdownElementBuilder
+  # (typed on md.Element) for the copy button on fenced code blocks.
+  markdown: ^7.3.1
 
   # Biometric auth
   local_auth: ^2.3.0

--- a/apps/garraia-mobile/test/chat_bubble_test.dart
+++ b/apps/garraia-mobile/test/chat_bubble_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:garraia_mobile/runtime/models.dart';
+import 'package:garraia_mobile/screens/memory_screen.dart';
+import 'package:garraia_mobile/theme/garra_theme.dart';
+import 'package:garraia_mobile/widgets/chat_bubble.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final copied = <String>[];
+
+  setUp(() {
+    copied.clear();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+          if (call.method == 'Clipboard.setData') {
+            copied.add((call.arguments as Map)['text'] as String);
+          }
+          return null;
+        });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+
+  Widget wrap(Widget child) => MaterialApp(
+    theme: garraTheme(),
+    home: Scaffold(body: ListView(children: [child])),
+  );
+
+  testWidgets('user bubble is selectable and copies whole message', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrap(
+        const ChatBubble(
+          message: ChatMessage(role: 'user', content: 'oi garra'),
+        ),
+      ),
+    );
+    expect(find.byType(SelectableText), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('copy-message')));
+    await tester.pump();
+    expect(copied, ['oi garra']);
+    expect(find.text('Mensagem copiada'), findsOneWidget);
+  });
+
+  testWidgets('assistant code block gets its own copy button', (tester) async {
+    const content = 'Veja:\n\n```dart\nvoid main() {}\nprint(1);\n```\n';
+    await tester.pumpWidget(
+      wrap(
+        const ChatBubble(
+          message: ChatMessage(role: 'assistant', content: content),
+        ),
+      ),
+    );
+    expect(find.byKey(const ValueKey('copy-message')), findsOneWidget);
+    expect(find.byKey(const ValueKey('copy-code')), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('copy-code')));
+    await tester.pump();
+    expect(copied, ['void main() {}\nprint(1);']);
+
+    await tester.tap(find.byKey(const ValueKey('copy-message')));
+    await tester.pump();
+    expect(copied.last, content);
+  });
+
+  testWidgets('inline code keeps the default rendering (no code button)', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrap(
+        const ChatBubble(
+          message: ChatMessage(role: 'assistant', content: 'use `garra start`'),
+        ),
+      ),
+    );
+    expect(find.byKey(const ValueKey('copy-code')), findsNothing);
+  });
+
+  testWidgets('memory sheet shows the full text and copies it', (tester) async {
+    const entry = MemoryEntry(
+      id: 'm1',
+      role: 'assistant',
+      content: 'O usuario prefere respostas curtas.',
+      createdAt: '2026-09-07T20:00:00Z',
+    );
+    await tester.pumpWidget(wrap(const MemorySheet(entry: entry)));
+    expect(find.text(entry.content), findsOneWidget);
+    await tester.tap(find.byKey(const ValueKey('copy-memory')));
+    await tester.pump();
+    expect(copied, [entry.content]);
+  });
+}

--- a/changelog.d/added/1041-copiar-no-chat.md
+++ b/changelog.d/added/1041-copiar-no-chat.md
@@ -1,0 +1,9 @@
+- **Copiar mensagem, codigo, memoria e log com um toque (#1041).** Relato de
+  campo da v0.4.0: nao havia como copiar uma mensagem inteira — o texto do
+  assistente era selecionavel por long-press sem nenhuma dica, e a bolha do
+  usuario era `Text` puro. Toda bolha ganha um botao de copiar ao lado do
+  horario e a do usuario vira selecionavel; bloco de codigo cercado ganha o
+  proprio botao, que copia so o codigo; tocar numa memoria abre o texto completo
+  com botao Copiar; o log da Activity tambem copia. Um so helper
+  (`copyToClipboard`) para o app inteiro, com testes que interceptam
+  `Clipboard.setData`.


### PR DESCRIPTION
## Descrição

Relato de campo da v0.4.0: *"deve ser mais fácil copiar textos no chat; deve existir um lugar no balão para copiar o texto inteiro"*. Verificado no código: o texto do assistente era selecionável por long-press (`MarkdownBody(selectable: true)`) sem nenhuma dica visual, a bolha do usuário era `Text` puro — impossível de copiar — e não havia um único uso de `Clipboard` no app.

- **`lib/widgets/copy_to_clipboard.dart`**: `copyToClipboard()` (`Clipboard.setData` + SnackBar curto) e `CopyIconButton`. Um gesto só para o app inteiro, testado de um jeito só.
- **`ChatBubble`**: botão de copiar ao lado do horário em **toda** bolha (`copy-message`); a bolha do usuário vira `SelectableText`, então cópia parcial também funciona dos dois lados.
- **Bloco de código cercado** ganha o próprio botão (`copy-code`) via `MarkdownElementBuilder` registrado no tag `code`: copia **só o código**, que é o que quem está no celular quer de um snippet. Código inline devolve `null` e mantém o render padrão; a moldura `pre` (`codeblockDecoration`) continua. `markdown` passa a dependência direta porque o builder tipa `md.Element`.
- **Memória**: tocar na linha abre `MemorySheet` com o texto completo (a linha truncava sem recurso), selecionável, e botão Copiar (`copy-memory`). Apagar entra junto com `DELETE /api/memory/{id}` no gateway, na mesma folha (PR seguinte).
- **Activity**: botão de copiar o log inteiro (`copy-log`).

Sem `SelectionArea` em volta da lista de propósito: competiria com os gestos de seleção dos `SelectableText`, e o botão explícito já é a affordance pedida.

## Tipo de mudança

- [x] `feat`: Nova funcionalidade
- [ ] `fix`: Correção de bug
- [ ] `refactor`: Refatoração sem mudança de comportamento
- [ ] `docs`: Documentação apenas
- [x] `test`: Adição ou correção de testes
- [ ] `perf`: Melhoria de performance
- [ ] `chore`: Manutenção (deps, CI, build)
- [ ] `sec`: Correção ou hardening de segurança

## Classe de Risco

- [x] **Classe A (Baixo Risco)**: só UI do app Flutter; nenhuma mudança no gateway, em rede, auth ou persistência. A única dependência nova (`markdown`) já estava na árvore como transitiva do `flutter_markdown`, na mesma versão do lock.
- [ ] **Classe B (Médio Risco)**
- [ ] **Classe C (Alto Risco)**

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo fmt --check` — N/A (sem Rust neste PR)
- [x] `cargo clippy` — N/A
- [x] `cargo test` — N/A; `flutter analyze` sem issues e `flutter test` 19/19 (4 testes novos com mock de `Clipboard.setData`)
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo, API key, token ou credencial commitada
- [x] Nenhuma migração Postgres

### Para alterações de Alto Risco (Classe C)

- [ ] N/A

## Mudanças na API pública e Schema

- Nenhuma mudança na API pública. `pubspec.yaml` ganha `markdown: ^7.3.1` (direta; já era transitiva na mesma versão).

## Como testar

1. `cd apps/garraia-mobile && flutter pub get && dart run build_runner build --delete-conflicting-outputs && flutter analyze && flutter test`.
2. APK do workflow **Mobile** deste PR: no chat, cada balão tem o ícone de copiar ao lado do horário; tocar mostra "Mensagem copiada" e o texto vai para a área de transferência (cole em qualquer app). Long-press em qualquer bolha seleciona trecho.
3. Peça ao Garra um bloco de código: o bloco ganha o ícone no canto; tocar copia só o código.
4. Memory → tocar numa memória abre a folha com o texto completo e o botão Copiar. Activity → ícone de copiar no canto do log.

## Plano de Rollback

Revert do PR. Só UI; nenhum estado persistido, nenhuma API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVnUdw6gJJLtcmWxzxMtFz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVnUdw6gJJLtcmWxzxMtFz)_