### PR TITLE
fix(gateway): POST /api/sessions aplica mode e working_dir em vez de engoli-los

### DIFF
--- a/changelog.d/fixed/1028-mode-na-criacao-da-sessao.md
+++ b/changelog.d/fixed/1028-mode-na-criacao-da-sessao.md
@@ -1,0 +1,8 @@
+- **`POST /api/sessions` aplica o `mode` pedido em vez de engoli-lo (#1028).** O
+  corpo aceitava qualquer campo e descartava o que nao conhecia: `{"mode":
+  "search"}` devolvia 201 e a sessao nascia sem politica nenhuma — a escrita de
+  arquivo que o modo devia bloquear passava. Agora `mode` e validado pela mesma
+  funcao do `POST /api/mode/select` (nativos e customizados), gravado como modo
+  escolhido antes da resposta e ecoado nela; nome desconhecido e 400 sem criar
+  sessao, e sem `session_store` e 503 em vez de fingir que aplicou. Quem nao
+  manda `mode` nao ve diferenca.

--- a/changelog.d/fixed/1028-mode-na-criacao-da-sessao.md
+++ b/changelog.d/fixed/1028-mode-na-criacao-da-sessao.md
@@ -1,8 +1,11 @@
-- **`POST /api/sessions` aplica o `mode` pedido em vez de engoli-lo (#1028).** O
-  corpo aceitava qualquer campo e descartava o que nao conhecia: `{"mode":
+- **`POST /api/sessions` aplica `mode` e `working_dir` em vez de engoli-los (#1028).**
+  O corpo aceitava qualquer campo e descartava o que nao conhecia: `{"mode":
   "search"}` devolvia 201 e a sessao nascia sem politica nenhuma — a escrita de
-  arquivo que o modo devia bloquear passava. Agora `mode` e validado pela mesma
-  funcao do `POST /api/mode/select` (nativos e customizados), gravado como modo
-  escolhido antes da resposta e ecoado nela; nome desconhecido e 400 sem criar
-  sessao, e sem `session_store` e 503 em vez de fingir que aplicou. Quem nao
-  manda `mode` nao ve diferenca.
+  arquivo que o modo devia bloquear passava — e `working_dir` nunca chegava as
+  ferramentas de arquivo (o handler que o aceitava nunca foi roteado). Agora
+  `mode` e validado pela mesma funcao do `POST /api/mode/select` (nativos e
+  customizados), gravado como modo escolhido antes da resposta e ecoado nela;
+  `working_dir` passa por `project_root::confine` como o `path` de projeto e a
+  resposta ecoa o canonicalizado. Nome de modo desconhecido ou diretorio fora
+  das raizes e 400 sem criar sessao; `mode` sem `session_store` e 503 em vez de
+  fingir que aplicou. Quem nao manda nenhum dos dois nao ve diferenca.

--- a/crates/garraia-gateway/src/api.rs
+++ b/crates/garraia-gateway/src/api.rs
@@ -24,6 +24,15 @@ pub struct CreateSessionRequest {
     /// de a resposta sair (#1028). Antes o campo era descartado pelo serde:
     /// 201, sessao sem politica nenhuma, e o cliente achando que restringiu.
     pub mode: Option<String>,
+    /// Diretorio de trabalho da sessao: a base dos caminhos relativos que as
+    /// ferramentas de arquivo recebem (`resolve_tool_path`).
+    ///
+    /// Passa por `project_root::confine`, a mesma regra do `path` de projeto:
+    /// tem de ser um diretorio existente sob uma das raizes permitidas
+    /// (`GARRAIA_PROJECT_ROOTS`; padrao, o home). Era descartado pelo serde
+    /// como o `mode` — o `create_session_with_project` que o aceitava nunca
+    /// foi roteado (ver `docs/security/threat-model.md` §5.5).
+    pub working_dir: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -33,6 +42,9 @@ pub struct CreateSessionResponse {
     /// O modo gravado, na grafia canonica (`search`, `Auditor`); `null`
     /// quando nao foi pedido.
     pub mode: Option<String>,
+    /// O diretorio **confinado** (canonicalizado), que e o que a sessao usa —
+    /// nunca o cru do corpo; `null` quando nao foi pedido.
+    pub working_dir: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -96,6 +108,37 @@ pub async fn create_session(
             }
         },
     };
+    // `working_dir` e a mesma superficie do `path` de projeto — string crua do
+    // corpo que vira diretorio de trabalho — e passa pelo mesmo confinamento.
+    // Um corpo de 400 so, para todas as variantes (nao existe, fora da raiz,
+    // symlink para fora), como no `POST /api/projects`: um erro por variante
+    // viraria oraculo de existencia de diretorio (threat-model §5.5).
+    let working_dir = match body
+        .working_dir
+        .as_deref()
+        .map(crate::project_root::confine)
+    {
+        Some(Ok(p)) => Some(p.to_string_lossy().into_owned()),
+        Some(Err(_)) => {
+            warn!(
+                working_dir = ?body.working_dir,
+                "recusado POST /api/sessions: working_dir fora das raizes permitidas"
+            );
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": "working_dir is not an allowed directory",
+                    "hint": format!(
+                        "o caminho precisa ser um diretorio existente sob uma das raizes \
+                         permitidas (padrao: o home do usuario; configuravel em {})",
+                        crate::project_root::ROOTS_ENV
+                    ),
+                })),
+            )
+                .into_response();
+        }
+        None => None,
+    };
     let store_para_modo = match (&mode, &state.session_store) {
         (None, _) => None,
         (Some(_), Some(store)) => Some(std::sync::Arc::clone(store)),
@@ -113,10 +156,13 @@ pub async fn create_session(
     let session_id = state.create_session();
 
     // If an agent_id was requested, tag it on the session metadata
-    if let Some(ref agent_id) = body.agent_id
-        && let Some(mut session) = state.sessions.get_mut(&session_id)
-    {
-        session.channel_id = Some(format!("api:{agent_id}"));
+    if let Some(mut session) = state.sessions.get_mut(&session_id) {
+        if let Some(ref agent_id) = body.agent_id {
+            session.channel_id = Some(format!("api:{agent_id}"));
+        }
+        if let Some(ref wd) = working_dir {
+            session.working_dir = Some(wd.clone());
+        }
     }
 
     if let (Some(nome), Some(store)) = (&mode, &store_para_modo) {
@@ -190,6 +236,7 @@ pub async fn create_session(
             session_id,
             agent_id: body.agent_id,
             mode,
+            working_dir,
         }),
     )
         .into_response()
@@ -1127,8 +1174,13 @@ mod create_session_tests {
             post_sessions(&st, serde_json::json!({ "agent_id": "reachy_voice" })).await;
         assert_eq!(status, StatusCode::CREATED, "{corpo}");
         assert!(corpo["mode"].is_null());
+        assert!(corpo["working_dir"].is_null());
         assert_eq!(corpo["agent_id"], "reachy_voice");
         let id = corpo["session_id"].as_str().expect("session_id");
         assert_eq!(modo_escolhido(&st, id).await, None);
+        assert_eq!(
+            st.sessions.get(id).and_then(|s| s.working_dir.clone()),
+            None
+        );
     }
 }

--- a/crates/garraia-gateway/src/api.rs
+++ b/crates/garraia-gateway/src/api.rs
@@ -18,12 +18,21 @@ use crate::state::SharedState;
 pub struct CreateSessionRequest {
     /// Optional named agent to use for this session.
     pub agent_id: Option<String>,
+    /// Modo do agente ja na criacao (`code`, `search`, um customizado...).
+    ///
+    /// Validado exatamente como no `POST /api/mode/select` e gravado antes
+    /// de a resposta sair (#1028). Antes o campo era descartado pelo serde:
+    /// 201, sessao sem politica nenhuma, e o cliente achando que restringiu.
+    pub mode: Option<String>,
 }
 
 #[derive(Serialize)]
 pub struct CreateSessionResponse {
     pub session_id: String,
     pub agent_id: Option<String>,
+    /// O modo gravado, na grafia canonica (`search`, `Auditor`); `null`
+    /// quando nao foi pedido.
+    pub mode: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -65,6 +74,42 @@ pub async fn create_session(
     headers: HeaderMap,
     Json(body): Json<CreateSessionRequest>,
 ) -> impl IntoResponse {
+    // #1028: o `mode` do corpo era engolido em silencio. Resolve-o ANTES de
+    // criar a sessao, para um 400 nao deixar sessao orfa, e recusa-se a
+    // fingir quando nao ha onde gravar: e o `session_store` que o executor
+    // consulta para aplicar a politica de ferramentas (#988), entao sem ele
+    // "modo aplicado" seria a mesma mentira de antes, so que com 201.
+    let mode = match body.mode.as_deref() {
+        None => None,
+        Some(pedido) => match resolver_nome_de_modo(&state, pedido).await {
+            Some(nome) => Some(nome),
+            None => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "error": format!(
+                            "Invalid mode '{pedido}'. Use GET /api/modes to see available modes."
+                        ),
+                    })),
+                )
+                    .into_response();
+            }
+        },
+    };
+    let store_para_modo = match (&mode, &state.session_store) {
+        (None, _) => None,
+        (Some(_), Some(store)) => Some(std::sync::Arc::clone(store)),
+        (Some(_), None) => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({
+                    "error": "mode cannot be applied: session store unavailable",
+                })),
+            )
+                .into_response();
+        }
+    };
+
     let session_id = state.create_session();
 
     // If an agent_id was requested, tag it on the session metadata
@@ -72,6 +117,33 @@ pub async fn create_session(
         && let Some(mut session) = state.sessions.get_mut(&session_id)
     {
         session.channel_id = Some(format!("api:{agent_id}"));
+    }
+
+    if let (Some(nome), Some(store)) = (&mode, &store_para_modo) {
+        // `set_agent_mode` exige a linha da sessao no banco; o upsert cria-a
+        // com o mesmo `{}` que `hydrate_session_history` usaria depois — o
+        // metadado e mesclado, nao substituido, entao nada se perde.
+        let gravado = {
+            let store = store.lock().await;
+            store
+                .upsert_session(&session_id, "api", "anonymous", &serde_json::json!({}))
+                .and_then(|_| store.set_agent_mode(&session_id, nome))
+        };
+        if let Err(e) = gravado {
+            warn!(
+                session_id = %session_id,
+                erro = %e,
+                "falhou ao gravar o modo pedido na criacao da sessao"
+            );
+            // Sem a sessao meio-configurada: o cliente pediu um modo e nao
+            // o teve, entao nao recebe um id que pareca valido.
+            state.sessions.remove(&session_id);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "failed to apply mode" })),
+            )
+                .into_response();
+        }
     }
 
     // GAR-202: Issue a session token and set cookie.
@@ -117,8 +189,10 @@ pub async fn create_session(
         Json(CreateSessionResponse {
             session_id,
             agent_id: body.agent_id,
+            mode,
         }),
     )
+        .into_response()
 }
 
 /// DELETE /api/sessions/:id — logout / revoke all tokens for a session.
@@ -419,6 +493,27 @@ async fn nome_de_modo_customizado(state: &SharedState, pedido: &str) -> Option<S
         .map(|m| m.name.clone())
 }
 
+/// O nome que vai para o banco quando `pedido` e um modo valido.
+///
+/// Valida contra os nativos **e** os customizados (#986). Antes so
+/// `AgentMode::from_str` valia, entao um modo customizado criado pelo
+/// `POST /api/modes/custom` nao podia ser selecionado — o CRUD existia e
+/// desembocava em 400.
+///
+/// O nome nativo e minusculo por convencao; o customizado e o que o usuario
+/// escreveu, e nao pode ser achatado. A validacao tenta nativo primeiro, o que
+/// tambem impede um customizado chamado `code` de sequestrar o nativo.
+///
+/// E uma funcao so porque tem dois chamadores — `POST /api/mode/select` e,
+/// desde o #1028, `POST /api/sessions` — e duas copias da mesma regra e como
+/// elas passam a divergir.
+async fn resolver_nome_de_modo(state: &SharedState, pedido: &str) -> Option<String> {
+    if AgentMode::from_str(pedido).is_some() {
+        return Some(pedido.to_lowercase());
+    }
+    nome_de_modo_customizado(state, pedido).await
+}
+
 /// POST /api/mode/select — select mode for a session.
 /// Header: X-Session-Id (optional) - if not provided, uses a default session ID.
 pub async fn select_mode(
@@ -426,27 +521,7 @@ pub async fn select_mode(
     headers: HeaderMap,
     Json(body): Json<SelectModeRequest>,
 ) -> impl IntoResponse {
-    // Valida contra os nativos **e** os customizados (#986).
-    //
-    // Antes so `AgentMode::from_str` valia, entao um modo customizado criado
-    // pelo `POST /api/modes/custom` nao podia ser selecionado — o CRUD existia
-    // e desembocava em 400.
-    //
-    // O nome nativo e minusculo por convencao; o customizado e o que o usuario
-    // escreveu, e nao pode ser achatado. Por isso os dois nomes andam juntos:
-    // `mode_str` e o que vai para o banco, e a validacao tenta nativo primeiro.
-    let nativo = AgentMode::from_str(&body.mode);
-    let customizado = if nativo.is_none() {
-        nome_de_modo_customizado(&state, &body.mode).await
-    } else {
-        None
-    };
-    let mode_str = match (&nativo, &customizado) {
-        (Some(_), _) => body.mode.to_lowercase(),
-        (None, Some(nome)) => nome.clone(),
-        (None, None) => String::new(),
-    };
-    if mode_str.is_empty() {
+    let Some(mode_str) = resolver_nome_de_modo(&state, &body.mode).await else {
         let mode_str = body.mode.clone();
         return (
             StatusCode::BAD_REQUEST,
@@ -459,7 +534,7 @@ pub async fn select_mode(
                 ),
             })),
         );
-    }
+    };
 
     // Get session ID from X-Session-Id header or use default
     let session_id = headers
@@ -905,4 +980,155 @@ pub async fn delete_custom_mode(
             message: "Session store not available".to_string(),
         })),
     )
+}
+
+#[cfg(test)]
+mod create_session_tests {
+    use std::sync::Arc;
+
+    use axum::extract::{ConnectInfo, State};
+    use axum::response::IntoResponse;
+    use garraia_agents::AgentRuntime;
+    use garraia_channels::ChannelRegistry;
+    use garraia_config::AppConfig;
+    use garraia_db::SessionStore;
+    use tokio::sync::Mutex;
+
+    use super::*;
+    use crate::state::{AppState, CUSTOM_MODE_USER_ID};
+
+    fn state_sem_store() -> SharedState {
+        Arc::new(AppState::new(
+            AppConfig::default(),
+            Arc::new(AgentRuntime::new()),
+            ChannelRegistry::new(),
+        ))
+    }
+
+    fn state_com_store() -> SharedState {
+        let mut st = AppState::new(
+            AppConfig::default(),
+            Arc::new(AgentRuntime::new()),
+            ChannelRegistry::new(),
+        );
+        st.session_store = Some(Arc::new(Mutex::new(
+            SessionStore::in_memory().expect("store em memoria"),
+        )));
+        Arc::new(st)
+    }
+
+    /// Chama o handler como o Axum chamaria e devolve (status, corpo JSON).
+    async fn post_sessions(
+        st: &SharedState,
+        corpo: serde_json::Value,
+    ) -> (StatusCode, serde_json::Value) {
+        let req: CreateSessionRequest = serde_json::from_value(corpo).expect("corpo valido");
+        let resp = create_session(
+            State(Arc::clone(st)),
+            ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 40000))),
+            HeaderMap::new(),
+            Json(req),
+        )
+        .await
+        .into_response();
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .expect("corpo da resposta");
+        (
+            status,
+            serde_json::from_slice(&bytes).expect("resposta em JSON"),
+        )
+    }
+
+    async fn modo_escolhido(st: &SharedState, session_id: &str) -> Option<String> {
+        let store = st.session_store.as_ref().expect("store");
+        let store = store.lock().await;
+        // `get_chosen_agent_mode` e o que liga a politica de ferramentas
+        // (#988) — e o que o #1028 viu nao acontecer.
+        store
+            .get_chosen_agent_mode(session_id)
+            .expect("ler o modo escolhido")
+    }
+
+    /// #1028: `{"mode": "search"}` gravava nada. Agora grava, na grafia
+    /// canonica, e e o modo **escolhido** — o que o executor consulta.
+    #[tokio::test]
+    async fn mode_nativo_e_gravado_na_criacao() {
+        let st = state_com_store();
+        let (status, corpo) = post_sessions(&st, serde_json::json!({ "mode": "Search" })).await;
+        assert_eq!(status, StatusCode::CREATED, "{corpo}");
+        assert_eq!(corpo["mode"], "search");
+        let id = corpo["session_id"].as_str().expect("session_id");
+        assert!(st.sessions.contains_key(id));
+        assert_eq!(modo_escolhido(&st, id).await.as_deref(), Some("search"));
+    }
+
+    #[tokio::test]
+    async fn mode_customizado_e_aceito_com_a_grafia_gravada() {
+        let st = state_com_store();
+        {
+            let store = st.session_store.as_ref().expect("store");
+            let store = store.lock().await;
+            store
+                .create_custom_mode(
+                    CUSTOM_MODE_USER_ID,
+                    "Auditor",
+                    None,
+                    "review",
+                    &serde_json::json!({}),
+                    None,
+                    &serde_json::json!({}),
+                )
+                .expect("criar modo customizado");
+        }
+        let (status, corpo) = post_sessions(&st, serde_json::json!({ "mode": "auditor" })).await;
+        assert_eq!(status, StatusCode::CREATED, "{corpo}");
+        assert_eq!(corpo["mode"], "Auditor", "a grafia gravada, nao a digitada");
+        let id = corpo["session_id"].as_str().expect("session_id");
+        assert_eq!(modo_escolhido(&st, id).await.as_deref(), Some("Auditor"));
+    }
+
+    /// Modo desconhecido e 400 **sem** sessao orfa — a validacao vem antes
+    /// do `create_session`, de proposito.
+    #[tokio::test]
+    async fn mode_desconhecido_da_400_e_nao_cria_sessao() {
+        let st = state_com_store();
+        for ruim in ["turbo", ""] {
+            let (status, corpo) = post_sessions(&st, serde_json::json!({ "mode": ruim })).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST, "{ruim:?}: {corpo}");
+            assert!(
+                corpo["error"]
+                    .as_str()
+                    .unwrap_or("")
+                    .contains("GET /api/modes"),
+                "{corpo}"
+            );
+        }
+        assert!(st.sessions.is_empty(), "400 nao pode deixar sessao criada");
+    }
+
+    /// Sem `session_store` nao ha onde a politica ser lida depois; dizer 201
+    /// aqui seria repetir o bug com outra cara.
+    #[tokio::test]
+    async fn mode_sem_store_da_503_em_vez_de_fingir() {
+        let st = state_sem_store();
+        let (status, corpo) = post_sessions(&st, serde_json::json!({ "mode": "code" })).await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE, "{corpo}");
+        assert!(st.sessions.is_empty());
+    }
+
+    /// O contrato de quem nao manda `mode` nao muda: 201, `mode: null`, e
+    /// nenhum modo escolhido — nem mesmo uma linha no banco.
+    #[tokio::test]
+    async fn sem_mode_continua_como_antes() {
+        let st = state_com_store();
+        let (status, corpo) =
+            post_sessions(&st, serde_json::json!({ "agent_id": "reachy_voice" })).await;
+        assert_eq!(status, StatusCode::CREATED, "{corpo}");
+        assert!(corpo["mode"].is_null());
+        assert_eq!(corpo["agent_id"], "reachy_voice");
+        let id = corpo["session_id"].as_str().expect("session_id");
+        assert_eq!(modo_escolhido(&st, id).await, None);
+    }
 }

--- a/crates/garraia-gateway/tests/projects_test.rs
+++ b/crates/garraia-gateway/tests/projects_test.rs
@@ -450,44 +450,62 @@ async fn update_project_rejects_path_outside_allowed_roots() {
     assert_eq!(after["project"]["path"], good.to_str().unwrap());
 }
 
-/// `working_dir` **não** é uma superfície viva hoje, e este teste fixa isso.
+/// `working_dir` em `POST /api/sessions` passa pelo mesmo confinamento do
+/// `path` de projeto (#1028 — o campo era descartado pelo serde junto com o
+/// `mode`; o `create_session_with_project` que o aceitava nunca foi roteado).
 ///
-/// `POST /api/sessions` roteia para `api::create_session` (`router.rs:116-118`),
-/// cujo `CreateSessionRequest` tem só `agent_id` — o `working_dir` do corpo é
-/// descartado pelo serde e nunca vira diretório. O
-/// `projects_handler::create_session_with_project`, que aceita `working_dir`,
-/// é `pub` mas **não está roteado em lugar nenhum**.
-///
-/// Ele já foi endurecido junto com o resto (confina o `working_dir` antes de
-/// usá-lo), então rotear depois não reabre o buraco. Se alguém trocar a rota
-/// para ele, este teste passa a ver um 400 no lugar do 201 e é o sinal de
-/// reavaliar o que aqui está escrito.
+/// Fora das raízes é 400 com o **mesmo corpo** do `POST /api/projects`, sem
+/// sessão criada; e a resposta nunca ecoa um caminho não confinado.
 #[tokio::test]
 #[serial]
-async fn post_sessions_does_not_expose_working_dir_today() {
+async fn post_sessions_confines_working_dir() {
     let env = start_test_gateway().await;
     let base = &env.base;
     let client = reqwest::Client::new();
 
+    for fora in ["/etc", "../../etc", "/nao/existe/mesmo"] {
+        let resp = client
+            .post(format!("{base}/api/sessions"))
+            .json(&json!({ "working_dir": fora }))
+            .send()
+            .await
+            .expect("request should succeed");
+        assert_eq!(resp.status(), 400, "{fora}: fora das raizes tem de ser 400");
+        let body: serde_json::Value = resp.json().await.expect("valid JSON");
+        assert_eq!(
+            body["error"], "working_dir is not an allowed directory",
+            "{fora}: {body}"
+        );
+        assert!(
+            body.get("session_id").is_none(),
+            "400 nao pode devolver sessao: {body}"
+        );
+    }
+}
+
+/// O caminho feliz: diretório real sob a raiz permitida vira o `working_dir`
+/// da sessão, e a resposta ecoa o **canonicalizado** — é ele que as
+/// ferramentas de arquivo recebem como base dos caminhos relativos.
+#[tokio::test]
+#[serial]
+async fn post_sessions_accepts_working_dir_inside_the_allowed_root() {
+    let env = start_test_gateway().await;
+    let base = &env.base;
+    let client = reqwest::Client::new();
+
+    let good = env.root.join("workspace");
+    std::fs::create_dir_all(&good).expect("create dir");
+
     let resp = client
         .post(format!("{base}/api/sessions"))
-        .json(&json!({ "working_dir": "/etc" }))
+        .json(&json!({ "working_dir": good.to_str().unwrap() }))
         .send()
         .await
         .expect("request should succeed");
-
-    assert_eq!(
-        resp.status(),
-        201,
-        "a rota viva ignora working_dir; um 400 aqui significa que \
-         create_session_with_project foi roteado — reavalie o comentario acima"
-    );
-
+    assert_eq!(resp.status(), 201);
     let body: serde_json::Value = resp.json().await.expect("valid JSON");
-    assert!(
-        body.get("working_dir").is_none_or(|v| v.is_null()),
-        "a resposta nao deve ecoar um working_dir nao confinado: {body}"
-    );
+    assert_eq!(body["working_dir"], good.to_str().unwrap(), "{body}");
+    assert!(body["session_id"].is_string(), "{body}");
 }
 
 /// O caminho feliz continua funcionando: diretório real sob a raiz permitida

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -213,12 +213,17 @@ o GET.
 | **I** Information disclosure | Resposta distingue "não existe" de "fora das raízes", virando oráculo de existência de diretório. | 400 com corpo idêntico para todas as variantes de erro, como o 401 byte-idêntico de `/v1/auth/login`. | — |
 | **T** Tampering | Symlink dentro da raiz apontando para fora, criado entre o registro e a leitura (TOCTOU). | `canonicalize` resolve o symlink, e a re-validação em `list_project_files` roda no momento da leitura. | Janela residual entre o `canonicalize` e o `read_dir` é inerente ao filesystem; reduzida, não eliminada. |
 
-**Nota sobre `working_dir`**: `projects_handler::create_session_with_project`
-aceita um `working_dir` e foi endurecido junto, mas **não está roteado** —
-`POST /api/sessions` vai para `api::create_session`, cujo `CreateSessionRequest`
-só tem `agent_id`, então o campo é descartado pelo serde. Não era superfície
-viva; o guard existe para o dia em que a rota mudar, e
-`post_sessions_does_not_expose_working_dir_today` fixa esse estado.
+**Nota sobre `working_dir`**: desde o #1028, `POST /api/sessions`
+(`api::create_session`) aceita `working_dir` e o passa por
+`project_root::confine` **antes** de criar a sessão — fora das raízes é 400 com
+um corpo só para todas as variantes (não existe, fora da raiz, symlink para
+fora), como no `POST /api/projects`, sem sessão órfã, e a resposta ecoa só o
+caminho canonicalizado. Antes o campo era descartado pelo serde (a rota viva só
+conhecia `agent_id`); o `projects_handler::create_session_with_project`, que já
+o confinava, segue **não roteado**. Guards:
+`post_sessions_confines_working_dir` e
+`post_sessions_accepts_working_dir_inside_the_allowed_root` em
+`tests/projects_test.rs`.
 
 ## 5.75. Saída de ferramenta escrita no terminal (#995)
 

--- a/docs/src/api-reference.md
+++ b/docs/src/api-reference.md
@@ -264,7 +264,8 @@ Cria uma nova sessão. O id é gerado pelo gateway (UUID); quando
 ```json
 {
   "agent_id": "reachy_voice",
-  "mode": "search"
+  "mode": "search",
+  "working_dir": "/home/joao/projetos/alpha"
 }
 ```
 
@@ -273,22 +274,32 @@ Cria uma nova sessão. O id é gerado pelo gateway (UUID); quando
   `architect`, `code`, `ask`, `debug`, `orchestrator`, `review`, `edit`) ou o
   nome de um modo customizado (`POST /api/modes/custom`). É validado como no
   `POST /api/mode/select` e gravado como modo **escolhido**, então a política
-  de ferramentas dele já vale na primeira mensagem (#1028). Outros campos do
-  corpo são ignorados.
+  de ferramentas dele já vale na primeira mensagem (#1028).
+- `working_dir` — diretório de trabalho da sessão: a base dos caminhos
+  relativos que as ferramentas de arquivo (`file_read`, `list_dir`,
+  `repo_search`, …) recebem. Tem de ser um diretório existente sob uma das
+  raízes permitidas (`GARRAIA_PROJECT_ROOTS`; padrão, o home do usuário) —
+  a mesma regra do `path` de `POST /api/projects`.
+
+Outros campos do corpo são ignorados.
 
 **Response 201:**
 ```json
 {
   "session_id": "0f3b7c1e-2d4a-4b8e-9c6f-1a2b3c4d5e6f",
   "agent_id": "reachy_voice",
-  "mode": "search"
+  "mode": "search",
+  "working_dir": "/home/joao/projetos/alpha"
 }
 ```
 
 `mode` volta na grafia gravada (`search`; um customizado vem como foi criado,
-ex.: `Auditor`) e é `null` quando não foi pedido.
+ex.: `Auditor`) e `working_dir` volta canonicalizado (symlinks resolvidos);
+ambos são `null` quando não foram pedidos.
 
-**Response 400:** `mode` desconhecido — nenhuma sessão é criada.
+**Response 400:** `mode` desconhecido, ou `working_dir` fora das raízes
+permitidas (um corpo só para todas as variantes, como no `POST /api/projects`,
+para não virar oráculo de existência de diretório) — nenhuma sessão é criada.
 
 **Response 503:** `mode` pedido sem `session_store` disponível (não há onde
 gravar a política, então o gateway não finge que aplicou).

--- a/docs/src/api-reference.md
+++ b/docs/src/api-reference.md
@@ -255,28 +255,43 @@ Retorna o estado atual do runtime do agente.
 
 ### POST /api/sessions
 
-Cria uma nova sessão explicitamente.
+Cria uma nova sessão. O id é gerado pelo gateway (UUID); quando
+`gateway.session_tokens_required` está ligado, a resposta traz também o cookie
+`garraia_session` que as chamadas seguintes precisam repetir (ou mandar como
+`Authorization: Bearer`).
 
-**Body:**
+**Body** (todos os campos opcionais):
 ```json
 {
-  "session_id": "projeto-alpha",
-  "metadata": {
-    "user": "joao",
-    "channel": "api"
-  }
+  "agent_id": "reachy_voice",
+  "mode": "search"
 }
 ```
 
-**Response 200:**
+- `agent_id` — agente nomeado para a sessão.
+- `mode` — modo do agente já na criação: um nativo (`auto`, `search`,
+  `architect`, `code`, `ask`, `debug`, `orchestrator`, `review`, `edit`) ou o
+  nome de um modo customizado (`POST /api/modes/custom`). É validado como no
+  `POST /api/mode/select` e gravado como modo **escolhido**, então a política
+  de ferramentas dele já vale na primeira mensagem (#1028). Outros campos do
+  corpo são ignorados.
+
+**Response 201:**
 ```json
 {
-  "session_id": "projeto-alpha",
-  "created_at": "2026-04-06T10:15:00Z"
+  "session_id": "0f3b7c1e-2d4a-4b8e-9c6f-1a2b3c4d5e6f",
+  "agent_id": "reachy_voice",
+  "mode": "search"
 }
 ```
 
-**Response 409:** Session ID já existe.
+`mode` volta na grafia gravada (`search`; um customizado vem como foi criado,
+ex.: `Auditor`) e é `null` quando não foi pedido.
+
+**Response 400:** `mode` desconhecido — nenhuma sessão é criada.
+
+**Response 503:** `mode` pedido sem `session_store` disponível (não há onde
+gravar a política, então o gateway não finge que aplicou).
 
 ---
 


### PR DESCRIPTION
## Descrição

#1028, verificado ao vivo na auditoria de 2026-09-07: `POST /api/sessions` aceitava qualquer campo e descartava o que não conhecia. `{"mode": "search"}` devolvia 201 e a sessão nascia sem política nenhuma — o consumidor achava que restringiu a sessão a leitura e o `file_write` passava.

Investigando, o `working_dir` sofria do **mesmo** bug: o único handler que o aceitava (`projects_handler::create_session_with_project`) nunca foi roteado — o guard `post_sessions_does_not_expose_working_dir_today` fixava exatamente isso — então **nenhuma rota viva** punha `SessionState::working_dir`, e as ferramentas de arquivo nunca recebiam uma base para caminho relativo. Como a issue é "engole campos desconhecidos", os dois entram aqui.

**`mode`** (commit `fe18203`)
- `CreateSessionRequest.mode: Option<String>`, resolvido por `resolver_nome_de_modo` — a validação do `POST /api/mode/select` (#986) extraída para função: nativo em minúsculas, customizado na grafia gravada, nativo tenta primeiro. Um chamador só antes, dois agora, uma regra.
- Validado **antes** de `create_session()`: nome desconhecido é 400 sem sessão órfã.
- Gravado com `upsert_session` + `set_agent_mode` (é o modo **escolhido**, o que `get_chosen_agent_mode` devolve e o executor consulta para a `ToolPolicy`, #988), e ecoado na resposta.
- `mode` pedido sem `session_store` é **503**: é dele que a política é lida; 201 aqui seria o mesmo bug com outra cara. Falha ao gravar é 500 e a sessão em memória é removida.
- Quem não manda `mode` não vê diferença (teste fixa: 201, `mode: null`, nenhuma linha no banco).

**`working_dir`** (commit `fca9fb7`)
- `CreateSessionRequest.working_dir`, sob `project_root::confine` — diretório existente sob `GARRAIA_PROJECT_ROOTS` (padrão, o home), a mesma regra do `path` de `POST /api/projects`. Validado antes de criar a sessão.
- 400 com **um corpo só** para todas as variantes (não existe, fora da raiz, symlink para fora), como no `POST /api/projects`, para não virar oráculo de existência de diretório (threat-model §5.5). A resposta ecoa o **canonicalizado**, nunca o cru.
- O guard de integração vira dois: `post_sessions_confines_working_dir` (`/etc`, `../../etc`, inexistente → 400 sem `session_id`) e `post_sessions_accepts_working_dir_inside_the_allowed_root` (201 com o caminho confinado).

Opção 2 da issue (`deny_unknown_fields`) ficou de fora de propósito: quebraria clientes que mandam campos extras hoje inofensivos, e os dois campos que importavam passam a ser aceitos.

**Relação com #1039:** aquele PR leva `SessionState::working_dir` até o `ToolContext` (`exec_context_for`). Este é quem **põe** o valor na sessão. Independentes; os dois juntos fecham o caminho HTTP → sessão → ferramenta.

Docs: `docs/src/api-reference.md` descrevia para `POST /api/sessions` um contrato que nunca existiu (`session_id` no corpo, 200, 409) — passa a descrever o real; nota do threat-model §5.5 atualizada.

Closes #1028

## Tipo de mudança

- [ ] `feat`: Nova funcionalidade
- [x] `fix`: Correção de bug
- [ ] `refactor`: Refatoração sem mudança de comportamento
- [x] `docs`: Documentação apenas
- [x] `test`: Adição ou correção de testes
- [ ] `perf`: Melhoria de performance
- [ ] `chore`: Manutenção (deps, CI, build)
- [x] `sec`: Correção ou hardening de segurança

## Classe de Risco

- [ ] **Classe A (Baixo Risco)**
- [x] **Classe B (Médio Risco)**: endpoint REST público existente, mudança **aditiva** (dois campos opcionais que antes eram descartados). Sem auth, RLS, migrations ou RBAC. `working_dir` entra pela mesma função de confinamento já auditada para `POST /api/projects`; `mode` pela mesma validação já usada em `POST /api/mode/select`.
- [ ] **Classe C (Alto Risco)**

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo fmt --check` executado e limpo
- [x] `cargo clippy -p garraia-gateway --all-targets -- -D warnings` sem erros
- [x] `cargo test -p garraia-gateway --lib -- create_session_tests` 5/5; `cargo test -p garraia-gateway --test projects_test -- post_sessions` 2/2
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo, API key, token ou credencial commitada
- [x] Nenhuma migração Postgres

### Para alterações de Alto Risco (Classe C)

- [ ] N/A

## Mudanças na API pública e Schema

- `POST /api/sessions` **body**: `mode` e `working_dir` opcionais (eram descartados). **Response 201**: ganha `mode` e `working_dir` (o gravado / o canonicalizado; `null` quando não pedidos). Novos **400** (modo desconhecido; diretório fora das raízes) e **503** (`mode` sem `session_store`). Sem `mode`/`working_dir`: contrato inalterado.
- Sem schema, sem migration.

## Como testar

1. `cargo test -p garraia-gateway --lib -- create_session_tests` e `cargo test -p garraia-gateway --test projects_test -- post_sessions`.
2. `garra start` → `POST /api/sessions {"mode":"search"}` → 201 com `"mode":"search"`; `GET /api/mode/current` com `X-Session-Id` → `search` (antes: `null`); pedir escrita de arquivo na sessão → `file_write` bloqueado pela policy.
3. `POST /api/sessions {"mode":"turbo"}` → 400, nenhuma sessão em `GET /api/sessions`.
4. `POST /api/sessions {"working_dir":"/etc"}` → 400 (`working_dir is not an allowed directory`); com um diretório do seu home → 201 ecoando o caminho canonicalizado. Com #1039 junto: "liste os arquivos" → `list_dir` relativo ao diretório.

## Plano de Rollback

Revert do PR. Sem schema, sem migration, sem estado novo além do `agent_mode` já existente na metadata da sessão. Clientes que não mandam os campos não são afetados em nenhuma direção.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVnUdw6gJJLtcmWxzxMtFz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVnUdw6gJJLtcmWxzxMtFz)_