### PR TITLE
fix(db): aviso de recall vazio nomeia a causa certa; docs dos 4 filtros do recall

### DIFF
--- a/changelog.d/fixed/1037-recall-warning-escopo.md
+++ b/changelog.d/fixed/1037-recall-warning-escopo.md
@@ -1,0 +1,12 @@
+- **O aviso de recall vazio nomeia a causa certa (#1037).** Quando o indice
+  vetorial achava vizinhos e nenhum sobrevivia ao reescopo, o log culpava
+  "troca de modelo de embeddings sem reindexacao" em todos os casos — inclusive
+  no mais comum, sessao nova com memoria de outras sessoes, onde reindexar nao
+  muda nada. Agora o store conta os candidatos por modelo antes de avisar:
+  `WARN` de troca de modelo so quando nenhum candidato tem o modelo ativo
+  (com os modelos encontrados); `INFO` "fora do escopo pedido" quando a
+  memoria existe com o modelo certo mas e de outra sessao, com os filtros
+  aplicados (tenant, sessao, continuidade); e `WARN` de vetor orfao quando o
+  indice aponta para ids sem linha. A secao Isolamento de `docs/src/memory.md`
+  passa a documentar os quatro filtros do recall — inclusive o de `session_id`,
+  que era o omitido — e o que `memory.shared_continuity` faz de fato (#1038).

--- a/crates/garraia-db/src/memory_store.rs
+++ b/crates/garraia-db/src/memory_store.rs
@@ -104,6 +104,67 @@ pub struct RecallQuery {
     pub limit: usize,
 }
 
+/// Por que o caminho KNN do recall voltou vazio depois do reescopo (#1037).
+///
+/// O vec0 devolve vizinhos por distancia; `fetch_entries_by_ids_scoped`
+/// reaplica tenant, sessao, continuidade, modelo e prazo. Quando nada
+/// sobrevive ha tres causas com acoes opostas, e o log tem de nomear a certa:
+/// o aviso antigo culpava "troca de modelo" em todas, e o operador reindexava
+/// horas de embeddings sem resolver nada — enquanto o caso real de troca de
+/// modelo virava ruido, porque disparava em toda sessao nova.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum KnnDrop {
+    /// Nenhum candidato tem o modelo da query: o indice pertence a outro
+    /// modelo. E o caso de `garra memory reindex` (#954).
+    ModelMismatch {
+        wanted: String,
+        /// Modelos encontrados entre os candidatos, com contagem. `None` e
+        /// entrada legada sem modelo gravado.
+        found: Vec<(Option<String>, usize)>,
+    },
+    /// Candidatos com o modelo certo existem, mas ficaram fora do escopo
+    /// pedido (sessao, continuidade, tenant) ou venceram o prazo. A memoria
+    /// existe; nao e caso de reindexar.
+    ScopedOut { same_model: usize, total: usize },
+    /// O indice devolveu ids que nao existem em `memory_entries`: vetor
+    /// orfao. E o caso de `garra memory stats` e do reparo do indice (#960).
+    IndexOrphans { knn_candidates: usize },
+}
+
+impl KnnDrop {
+    /// Classifica a partir do que o indice devolveu e do que o banco tem.
+    ///
+    /// `found` e a contagem por `embedding_model` das linhas que existem
+    /// entre os ids do KNN, **sem** filtro de escopo; `wanted` e o modelo da
+    /// query (`None` em recall so-texto, onde "modelo trocado" nao tem
+    /// sentido e so o escopo pode ter derrubado).
+    pub(crate) fn classify(
+        wanted: Option<&str>,
+        found: Vec<(Option<String>, usize)>,
+        knn_candidates: usize,
+    ) -> Self {
+        let total: usize = found.iter().map(|(_, n)| n).sum();
+        if total == 0 {
+            return Self::IndexOrphans { knn_candidates };
+        }
+        let same_model = match wanted {
+            Some(w) => found
+                .iter()
+                .filter(|(m, _)| m.as_deref() == Some(w))
+                .map(|(_, n)| n)
+                .sum(),
+            None => total,
+        };
+        match wanted {
+            Some(w) if same_model == 0 => Self::ModelMismatch {
+                wanted: w.to_string(),
+                found,
+            },
+            _ => Self::ScopedOut { same_model, total },
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionContext {
     pub session_id: String,
@@ -1000,18 +1061,12 @@ impl MemoryStore {
                     return self.score_and_rank(candidates, &query, limit);
                 }
 
-                // O KNN achou vizinhos, mas nenhum sobreviveu ao escopo. Com
-                // filtro de modelo ativo isso é o sintoma clássico de troca de
-                // modelo sem reindexar (#954): o índice inteiro pertence ao
-                // modelo antigo. Avisar alto — o operador não tem outro sinal.
-                if let Some(model) = query.embedding_model.as_deref() {
-                    tracing::warn!(
-                        model,
-                        knn_candidates = knn_results.len(),
-                        "recall: nenhum vizinho KNN pertence ao modelo ativo/escopo — \
-                         provável troca de modelo de embeddings sem reindexação"
-                    );
-                }
+                // O KNN achou vizinhos, mas nenhum sobreviveu ao reescopo.
+                // Sao tres causas com acoes opostas — indice de outro modelo
+                // (#954: reindexar), memoria de outra sessao (#1037: nada a
+                // fazer) ou vetor orfao (#960: reparar o indice) — e o aviso
+                // antigo culpava a primeira em todas. Nomear a certa.
+                self.explain_knn_drop(&candidate_ids, &query, knn_results.len());
             }
             // Fall through to SQL-based retrieval if KNN returned nothing
         }
@@ -1099,6 +1154,93 @@ impl MemoryStore {
             .take(limit)
             .map(|(_, entry)| entry)
             .collect())
+    }
+
+    /// Conta, por `embedding_model`, as linhas de `memory_entries` entre `ids`
+    /// — **sem** filtro de escopo, de proposito: e a pergunta "o que o indice
+    /// apontou existe, e de que modelo e?", que o reescopo acabou de
+    /// responder com "nada" e que o diagnostico precisa refazer sem ele.
+    fn count_models_among(&self, ids: &[&str]) -> Result<Vec<(Option<String>, usize)>> {
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let conn = self.connection()?;
+        let placeholders: String = ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!(
+            "SELECT embedding_model, COUNT(*) FROM memory_entries
+             WHERE id IN ({placeholders})
+             GROUP BY embedding_model"
+        );
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| Error::Database(format!("failed to prepare model count: {e}")))?;
+        let values: Vec<rusqlite::types::Value> = ids
+            .iter()
+            .map(|id| rusqlite::types::Value::from(id.to_string()))
+            .collect();
+        let rows = stmt
+            .query_map(rusqlite::params_from_iter(values), |row| {
+                let model: Option<String> = row.get(0)?;
+                let count: i64 = row.get(1)?;
+                Ok((model, usize::try_from(count).unwrap_or(0)))
+            })
+            .map_err(|e| Error::Database(format!("failed to count models: {e}")))?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(|e| Error::Database(format!("failed to collect model counts: {e}")))
+    }
+
+    /// Diz no log **por que** o KNN achou vizinhos e o reescopo nao deixou
+    /// nenhum (#1037): a causa certa, no nivel certo, com os filtros que
+    /// derrubaram — para o operador ver o escopo sem abrir o codigo.
+    ///
+    /// Nivel por causa: troca de modelo e vetor orfao sao `warn` (exigem
+    /// acao); memoria de outra sessao e `info`, porque e o escopo por sessao
+    /// funcionando como projetado e acontece em toda sessao nova — como
+    /// `warn`, virava ruido que desmoralizava o caso real.
+    fn explain_knn_drop(&self, ids: &[&str], query: &RecallQuery, knn_candidates: usize) {
+        let found = match self.count_models_among(ids) {
+            Ok(found) => found,
+            Err(e) => {
+                tracing::debug!(erro = %e, "recall: diagnostico do KNN vazio falhou");
+                return;
+            }
+        };
+        match KnnDrop::classify(query.embedding_model.as_deref(), found, knn_candidates) {
+            KnnDrop::ModelMismatch { wanted, found } => {
+                let found: Vec<String> = found
+                    .iter()
+                    .map(|(m, n)| format!("{}={n}", m.as_deref().unwrap_or("<sem modelo>")))
+                    .collect();
+                tracing::warn!(
+                    model = %wanted,
+                    knn_candidates,
+                    found = ?found,
+                    "recall: nenhum vizinho KNN pertence ao modelo ativo — provavel \
+                     troca de modelo de embeddings sem reindexacao; rode \
+                     `garra memory reindex`"
+                );
+            }
+            KnnDrop::ScopedOut { same_model, total } => {
+                tracing::info!(
+                    knn_candidates,
+                    total,
+                    same_model,
+                    tenant_id = query.tenant_id.as_deref().unwrap_or("<nenhum>"),
+                    session_id = query.session_id.as_deref().unwrap_or("<nenhum>"),
+                    continuity_key = query.continuity_key.as_deref().unwrap_or("<nenhum>"),
+                    "recall: vizinhos KNN existem com o modelo ativo, mas ficaram fora do \
+                     escopo pedido (sessao/continuidade/tenant) ou venceram o prazo — \
+                     memoria de outras sessoes; nao e caso de reindexar"
+                );
+            }
+            KnnDrop::IndexOrphans { knn_candidates } => {
+                tracing::warn!(
+                    knn_candidates,
+                    "recall: o indice vetorial devolveu ids sem linha em memory_entries — \
+                     vetores orfaos; confira `garra memory stats`"
+                );
+            }
+        }
     }
 
     /// Fetch memory entries by their IDs, reaplicando os filtros da query.
@@ -1505,7 +1647,7 @@ impl<T> Pipe for T {}
 
 #[cfg(test)]
 mod tests {
-    use super::{MemoryRole, MemoryStore, NewMemoryEntry, RecallQuery};
+    use super::{KnnDrop, MemoryRole, MemoryStore, NewMemoryEntry, RecallQuery};
     use chrono::{Duration, Utc};
 
     fn entry(
@@ -1594,6 +1736,119 @@ mod tests {
         assert_eq!(gauge.vector_index_rows, 0);
         assert_eq!(gauge.entries_with_embedding, 0);
         assert_eq!(gauge.entries_without_embedding, 0);
+    }
+
+    /// #1037: o aviso de KNN vazio culpava "troca de modelo" mesmo quando os
+    /// candidatos tinham o modelo certo e so o escopo os derrubou. A
+    /// classificacao e pura para ser afirmavel sem capturar log.
+    #[test]
+    fn knn_drop_distingue_modelo_escopo_e_orfaos() {
+        // Todos os 20 candidatos sao do modelo ativo: e escopo, nao modelo.
+        assert_eq!(
+            KnnDrop::classify(Some("m1"), vec![(Some("m1".into()), 20)], 20),
+            KnnDrop::ScopedOut {
+                same_model: 20,
+                total: 20
+            }
+        );
+        // Nenhum candidato tem o modelo ativo: troca de modelo sem reindexar.
+        assert_eq!(
+            KnnDrop::classify(Some("m2"), vec![(Some("m1".into()), 18), (None, 2)], 20),
+            KnnDrop::ModelMismatch {
+                wanted: "m2".into(),
+                found: vec![(Some("m1".into()), 18), (None, 2)],
+            }
+        );
+        // Mistura: ha candidatos do modelo ativo, entao o que derrubou foi o
+        // escopo — os de outro modelo sao so contexto.
+        assert_eq!(
+            KnnDrop::classify(
+                Some("m1"),
+                vec![(Some("m1".into()), 3), (Some("m0".into()), 17)],
+                20
+            ),
+            KnnDrop::ScopedOut {
+                same_model: 3,
+                total: 20
+            }
+        );
+        // Recall so-texto nao tem modelo para "trocar": so escopo.
+        assert_eq!(
+            KnnDrop::classify(None, vec![(Some("m1".into()), 5)], 5),
+            KnnDrop::ScopedOut {
+                same_model: 5,
+                total: 5
+            }
+        );
+        // O indice apontou para ids que nao existem: orfaos, independente
+        // do modelo pedido.
+        assert_eq!(
+            KnnDrop::classify(Some("m1"), vec![], 7),
+            KnnDrop::IndexOrphans { knn_candidates: 7 }
+        );
+    }
+
+    /// O cenario do #1037 de ponta a ponta: memoria gravada na sessao A com
+    /// o modelo ativo, recall na sessao B com o mesmo modelo. O KNN acha os
+    /// vizinhos, o escopo derruba todos, e a contagem por modelo — a base do
+    /// diagnostico — diz que eles sao do modelo certo. Reindexar nao mudaria
+    /// nada, e o log nao pode mais dizer que mudaria.
+    #[tokio::test]
+    async fn recall_em_sessao_nova_deixa_os_vizinhos_de_fora_por_escopo_nao_por_modelo() {
+        let store = MemoryStore::in_memory_with_vectors().expect("store com vetores");
+        assert!(store.knn_enabled());
+
+        let mut ids = Vec::new();
+        for texto in ["meu codinome e falcao", "moro na rua das flores"] {
+            ids.push(
+                store
+                    .remember(entry(
+                        "sessao-a",
+                        None,
+                        texto,
+                        MemoryRole::User,
+                        Some(vec![0.9, 0.1, 0.0, 0.0]),
+                    ))
+                    .await
+                    .expect("remember"),
+            );
+        }
+
+        let consulta = |sessao: &str| RecallQuery {
+            tenant_id: None,
+            query_text: Some("codinome".to_string()),
+            query_embedding: Some(vec![0.9, 0.1, 0.0, 0.0]),
+            embedding_model: Some("unit-test".to_string()),
+            session_id: Some(sessao.to_string()),
+            continuity_key: None,
+            limit: 5,
+        };
+
+        // Na propria sessao a memoria volta.
+        let na_a = store.recall(consulta("sessao-a")).await.expect("recall a");
+        assert_eq!(na_a.len(), 2);
+
+        // Na sessao nova, nada — e o escopo por sessao, nao o modelo.
+        let na_b = store.recall(consulta("sessao-b")).await.expect("recall b");
+        assert!(na_b.is_empty(), "escopo por sessao: {na_b:?}");
+
+        let refs: Vec<&str> = ids.iter().map(String::as_str).collect();
+        let found = store
+            .count_models_among(&refs)
+            .expect("contagem por modelo");
+        assert_eq!(found, vec![(Some("unit-test".to_string()), 2)]);
+        assert_eq!(
+            KnnDrop::classify(Some("unit-test"), found.clone(), refs.len()),
+            KnnDrop::ScopedOut {
+                same_model: 2,
+                total: 2
+            }
+        );
+        // E com outro modelo na query o diagnostico vira o de troca de modelo.
+        assert!(matches!(
+            KnnDrop::classify(Some("outro-modelo"), found, refs.len()),
+            KnnDrop::ModelMismatch { .. }
+        ));
     }
 
     /// O `remember_sync` grava a linha e insere no indice em best-effort:

--- a/docs/src/memory.md
+++ b/docs/src/memory.md
@@ -89,6 +89,8 @@ enabled = true
 # Nome de uma entrada da seção [embeddings]. Sem isto, a memória grava
 # e busca textualmente, sem semântica.
 embedding_provider = "local"
+# Rotula as entradas com a chave `bus:shared-global`. NAO amplia o recall do
+# agente para outras sessoes hoje — ver "Isolamento" e #1052.
 shared_continuity = false
 
 [memory.ingestion]
@@ -180,12 +182,37 @@ Detalhes e consultas PromQL em [telemetry.md](../telemetry.md).
 
 ## Isolamento
 
-Cada entrada carrega um `tenant_id`, e o recall filtra por ele. Uma sessão
-nunca vê a memória de outro tenant.
+O recall aplica **quatro** filtros a cada consulta, e devolve só a interseção
+deles:
 
-O recall também filtra pelo **modelo de embedding** que gerou o vetor: vetores
-de modelos diferentes não são comparáveis, e misturá-los produz similaridade
-sem sentido. Ao trocar de modelo, rode `garra memory reindex`.
+1. **`tenant_id`.** Cada entrada carrega um; o runtime usa sempre `default`.
+   Uma sessão nunca vê a memória de outro tenant.
+2. **`session_id`.** O recall do agente manda **sempre** o id da sessão atual
+   (`recall_context` em `garraia-agents`), e a busca só devolve entradas
+   gravadas nela. É o comportamento com a configuração padrão: um fato dito
+   no Telegram não aparece numa sessão nova do app ou do `garra chat`, e
+   vice-versa. Não é memória quebrada — é escopo por sessão, funcionando como
+   foi escrito. `GET /api/memory/search` e `garra memory search` **não**
+   mandam sessão, por isso acham o que o agente "não lembra".
+3. **`continuity_key`.** Com `memory.shared_continuity = true` o gateway grava
+   cada entrada com a chave `bus:shared-global` e a manda junto no recall — mas
+   **em conjunto** com o `session_id`, não no lugar dele. Hoje, portanto, a
+   flag **não** amplia o recall do agente para outras sessões: só rotula as
+   entradas. O caminho que lê por continuidade sem sessão
+   (`get_continuity_context`) existe no store e não é chamado pelo runtime.
+   Ver #1052.
+4. **`embedding_model`.** Vetores de modelos diferentes não são comparáveis, e
+   misturá-los produz similaridade sem sentido. Ao trocar de modelo, rode
+   `garra memory reindex`.
+
+Entrada com `ttl_expires_at` vencido também sai do recall na hora (#959).
+
+Quando o índice vetorial acha vizinhos e nenhum sobrevive aos filtros, o log
+diz **qual** filtro derrubou (#1037): `WARN … troca de modelo` só quando
+nenhum vizinho é do modelo ativo (e lista os modelos encontrados); `INFO …
+fora do escopo pedido` quando a memória existe com o modelo certo mas é de
+outra sessão — caso em que reindexar não muda nada; `WARN … vetores orfaos`
+quando o índice aponta para ids sem linha (`garra memory stats`).
 
 ## API HTTP
 
@@ -217,5 +244,8 @@ nunca achá-la.
 
 - **Não há `clear`, `export` nem `disable`.** Para apagar, use `delete` (uma
   entrada) ou `compact` (por idade); para levar embora, `backup`.
+- **Não há memória compartilhada entre sessões no recall do agente.**
+  `shared_continuity` rotula as entradas, mas o recall segue restrito à sessão
+  atual (#1052).
 - **O retriever do `garraia-learning` é um stub.** A busca semântica de
   *skills* (distinta da memória de conversa) espera a Fase 2.1 — ver ADR 0002.


### PR DESCRIPTION
## Descrição

**#1037.** O caminho KNN do recall avisava *"provável troca de modelo de embeddings sem reindexação"* sempre que os vizinhos achados não sobreviviam ao reescopo — inclusive no caso mais comum, sessão nova com memória de outras sessões, onde reindexar não muda nada. O operador era levado a reindexar horas de embeddings, e o caso real de troca de modelo virava ruído (disparava em toda sessão nova).

Agora o store conta os candidatos por `embedding_model` **sem escopo** (é a pergunta certa: "o que o índice apontou existe, e de que modelo é?") e classifica em `KnnDrop`:

| Causa | Nível | Mensagem | Ação |
|---|---|---|---|
| `ModelMismatch` — nenhum candidato tem o modelo ativo | `WARN` | troca de modelo sem reindexação, com os modelos encontrados (`found=["nomic-embed-text=20"]`) | `garra memory reindex` |
| `ScopedOut` — candidatos com o modelo certo, fora do escopo | `INFO` | fora do escopo pedido, com `tenant_id`/`session_id`/`continuity_key` e as contagens | nenhuma: é memória de outra sessão |
| `IndexOrphans` — ids sem linha em `memory_entries` | `WARN` | vetores órfãos | `garra memory stats` |

`INFO` para o caso de escopo é decisão: é o escopo por sessão funcionando como projetado, acontece em toda sessão nova, e como `WARN` desmoralizava o caso real. A classificação é pura (`KnnDrop::classify`) e testada em 5 cenários; um teste de store reproduz a issue de ponta a ponta (sessão A grava com o modelo ativo, sessão B recalla, KNN acha, escopo derruba, contagem diz "modelo certo").

**#1038.** `docs/src/memory.md` § Isolamento passa a documentar os **quatro** filtros do recall — `tenant_id`, **`session_id`** (o omitido: o recall do agente é sempre por sessão; `GET /api/memory/search` e `garra memory search` não mandam sessão, por isso "acham o que o agente não lembra"), `continuity_key` e `embedding_model` — mais o prazo (#959) e o que cada aviso novo significa. Cruzado com a seção Configuração.

**Achado ao documentar → #1052.** A issue #1038 assume que `memory.shared_continuity = true` compartilha a memória entre sessões. Não compartilha: o runtime manda `session_id` **e** `continuity_key` no recall e os dois filtros são `AND` (SQL e KNN), então só entradas da própria sessão sobrevivem; `get_continuity_context`, o único caminho que lê por chave sem sessão, não é chamado por ninguém. A doc descreve o comportamento **real** (a flag rotula, não amplia) e aponta a issue, onde está a proposta de correção — decisão do dono, porque muda a semântica da flag para quem já a ligou.

Closes #1037
Closes #1038

## Tipo de mudança

- [ ] `feat`: Nova funcionalidade
- [x] `fix`: Correção de bug
- [ ] `refactor`: Refatoração sem mudança de comportamento
- [x] `docs`: Documentação apenas
- [x] `test`: Adição ou correção de testes
- [ ] `perf`: Melhoria de performance
- [ ] `chore`: Manutenção (deps, CI, build)
- [ ] `sec`: Correção ou hardening de segurança

## Classe de Risco

- [x] **Classe A (Baixo Risco)**: só o **log** do recall muda (uma consulta `COUNT … GROUP BY` extra, só no caminho já vazio) e a documentação. O resultado do recall é idêntico; nenhum filtro mudou.
- [ ] **Classe B (Médio Risco)**
- [ ] **Classe C (Alto Risco)**

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo fmt --check` executado e limpo
- [x] `cargo clippy -p garraia-db --all-targets -- -D warnings` sem erros
- [x] `cargo test -p garraia-db --lib -- knn_drop recall_em_sessao_nova` 2/2
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo, API key, token ou credencial commitada — o log novo carrega ids de sessão e nomes de modelo, nunca conteúdo de memória
- [x] Nenhuma migração Postgres

### Para alterações de Alto Risco (Classe C)

- [ ] N/A

## Mudanças na API pública e Schema

- Nenhuma. `KnnDrop` é `pub(crate)`.

## Como testar

1. `cargo test -p garraia-db --lib -- knn_drop recall_em_sessao_nova`.
2. Repro da issue: gateway com memória de outras sessões, sessão nova, uma mensagem → no log, em vez do `WARN … troca de modelo`, um `INFO … fora do escopo pedido … session_id=<nova> same_model=20 total=20`.
3. Trocar o modelo de embeddings no config sem reindexar → `WARN … troca de modelo … found=["<modelo antigo>=20"]`.

## Plano de Rollback

Revert do PR. Só log e docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVnUdw6gJJLtcmWxzxMtFz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVnUdw6gJJLtcmWxzxMtFz)_