### PR TITLE
feat(cli): garraia update avisa de binários antigos sombreados no PATH

### DIFF
--- a/changelog.d/added/1030-update-avisa-binarios-sombreados.md
+++ b/changelog.d/added/1030-update-avisa-binarios-sombreados.md
@@ -1,0 +1,9 @@
+- **`garraia update` avisa de binarios antigos no PATH (#1030).** O update
+  trocava so o proprio binario; um `/usr/bin/garraia` de outra instalacao
+  seguia la, intocado e sem aviso — e era ele que scripts, cron e terminais
+  com PATH diferente passavam a rodar. Depois de atualizar, o comando varre
+  os diretorios do PATH e os de sistema (`/usr/local/bin`, `/usr/bin`) por
+  outros `garraia`/`garra`, pergunta a versao de cada um (com timeout) e
+  avisa os que diferem, com caminho, versao, se ele vem antes ou depois do
+  atualizado no PATH e o comando para remover. `garraia update
+  --check-binaries` roda so a varredura, sem baixar nada.

--- a/crates/garraia-cli/src/main.rs
+++ b/crates/garraia-cli/src/main.rs
@@ -18,6 +18,7 @@ mod team;
 mod tracing_setup;
 mod ui;
 mod update;
+mod update_scan;
 mod verify;
 mod wizard;
 

--- a/crates/garraia-cli/src/main.rs
+++ b/crates/garraia-cli/src/main.rs
@@ -192,6 +192,9 @@ enum Commands {
         /// Skip confirmation prompt
         #[arg(long, short = 'y')]
         yes: bool,
+        /// Only scan the PATH for other garraia/garra binaries (no download)
+        #[arg(long)]
+        check_binaries: bool,
     },
 
     /// Roll back to the previous version
@@ -1897,11 +1900,18 @@ async fn async_main(
                 }
             }
         }
-        Commands::Update { yes } => {
+        Commands::Update {
+            yes,
+            check_binaries,
+        } => {
             init_tracing(&effective_level);
-            match update::run_update(yes).await {
-                Ok(_) => {}
-                Err(e) => println!("update failed: {}", e),
+            let result = if check_binaries {
+                update::run_check_binaries().await
+            } else {
+                update::run_update(yes).await.map(|_| ())
+            };
+            if let Err(e) = result {
+                println!("update failed: {}", e);
             }
         }
         Commands::Rollback => {

--- a/crates/garraia-cli/src/update.rs
+++ b/crates/garraia-cli/src/update.rs
@@ -1,5 +1,6 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 
@@ -255,7 +256,188 @@ pub async fn run_update(yes: bool) -> Result<bool> {
     println!("Updated to v{latest}.");
     println!("Restart the daemon to apply: garraia restart");
 
+    // #1030: o update so troca ESTE binario. Um `/usr/bin/garraia` de outra
+    // instalacao segue no PATH, intocado e sem aviso — e e ele que scripts,
+    // cron e terminais com PATH diferente passam a rodar.
+    if let Some(report) = report_other_binaries(&current_exe, latest).await {
+        println!();
+        println!("{report}");
+    }
+
     Ok(true)
+}
+
+/// Run `garraia update --check-binaries`: so a varredura do PATH, sem rede.
+pub async fn run_check_binaries() -> Result<()> {
+    let current_exe =
+        std::env::current_exe().context("cannot determine current executable path")?;
+    match report_other_binaries(&current_exe, current_version()).await {
+        Some(report) => println!("{report}"),
+        None => println!(
+            "Nenhum outro binario {} no PATH alem de {}.",
+            BINARY_NAMES.join("/"),
+            current_exe.display()
+        ),
+    }
+    Ok(())
+}
+
+/// Nomes com que o GarraIA aparece no PATH: o binario e o alias curto.
+const BINARY_NAMES: &[&str] = &["garraia", "garra"];
+
+/// Onde os pacotes de sistema instalam, mesmo que o PATH deste shell nao os
+/// liste (o do cron e do systemd lista).
+#[cfg(unix)]
+const SYSTEM_BIN_DIRS: &[&str] = &["/usr/local/bin", "/usr/bin"];
+#[cfg(not(unix))]
+const SYSTEM_BIN_DIRS: &[&str] = &[];
+
+/// Um binario do GarraIA no PATH que nao e o que acabou de ser atualizado.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OtherBinary {
+    pub path: PathBuf,
+    /// `true` quando o diretorio dele vem ANTES do diretorio do atualizado
+    /// no PATH: e ele, nao o atualizado, que `garraia` resolve neste shell.
+    pub precedes: bool,
+}
+
+/// Procura outros `garraia`/`garra` nos diretorios do PATH e nos de sistema,
+/// excluindo o proprio `current` (por caminho canonico, entao um symlink
+/// `garra -> garraia` ao lado do atualizado nao e "outro").
+///
+/// O PATH entra como lista em vez de ser lido aqui, para o teste montar o
+/// cenario inteiro num diretorio temporario.
+pub fn find_other_binaries(
+    path_dirs: &[PathBuf],
+    system_dirs: &[PathBuf],
+    current: &Path,
+) -> Vec<OtherBinary> {
+    let canonical = |p: &Path| fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
+    let current_canon = canonical(current);
+    let current_dir = current_canon.parent().map(Path::to_path_buf);
+    let current_dir_index = path_dirs
+        .iter()
+        .position(|d| current_dir.as_deref() == Some(canonical(d).as_path()));
+
+    let names: Vec<String> = BINARY_NAMES
+        .iter()
+        .map(|n| format!("{n}{}", std::env::consts::EXE_SUFFIX))
+        .collect();
+
+    let mut seen: Vec<PathBuf> = vec![current_canon.clone()];
+    let mut found = Vec::new();
+    let candidates = path_dirs
+        .iter()
+        .enumerate()
+        .map(|(i, d)| (d, Some(i)))
+        .chain(system_dirs.iter().map(|d| (d, None)));
+    for (dir, index) in candidates {
+        for name in &names {
+            let candidate = dir.join(name);
+            if !candidate.is_file() {
+                continue;
+            }
+            let canon = canonical(&candidate);
+            if seen.contains(&canon) {
+                continue;
+            }
+            seen.push(canon);
+            let precedes = match (index, current_dir_index) {
+                (Some(i), Some(cur)) => i < cur,
+                // Fora do PATH deste shell, ou o atualizado fora do PATH:
+                // nao ha "antes"; e so um outro binario.
+                _ => false,
+            };
+            found.push(OtherBinary {
+                path: candidate,
+                precedes,
+            });
+        }
+    }
+    found
+}
+
+/// A versao que um binario achado no PATH diz ter. Roda `--version` com
+/// timeout: e um executavel que o usuario ja tem no PATH com o nome do
+/// GarraIA, e um binario quebrado nao pode travar o update.
+async fn probe_version(path: &Path) -> Option<String> {
+    let out = tokio::time::timeout(
+        Duration::from_secs(3),
+        tokio::process::Command::new(path).arg("--version").output(),
+    )
+    .await
+    .ok()?
+    .ok()?;
+    parse_version_output(&String::from_utf8_lossy(&out.stdout))
+}
+
+/// `garraia 0.3.4` (ou `garraia v0.3.4`) → `0.3.4`. So a primeira linha.
+fn parse_version_output(stdout: &str) -> Option<String> {
+    let first = stdout.lines().find(|l| !l.trim().is_empty())?;
+    let last = first.split_whitespace().last()?;
+    let v = strip_v(last);
+    (!v.is_empty() && v.chars().next().is_some_and(|c| c.is_ascii_digit())).then(|| v.to_string())
+}
+
+/// O aviso do #1030, pronto para imprimir. `None` quando nao ha o que dizer:
+/// nenhum outro binario, ou so copias da mesma versao (inofensivas).
+pub fn shadow_report(
+    current: &Path,
+    current_version: &str,
+    others: &[(OtherBinary, Option<String>)],
+) -> Option<String> {
+    let mut lines = Vec::new();
+    for (other, version) in others {
+        if version.as_deref() == Some(current_version) {
+            continue;
+        }
+        let ver = version.as_deref().unwrap_or("versao desconhecida");
+        if other.precedes {
+            lines.push(format!(
+                "⚠ Binario antigo tem precedencia no PATH: {} ({ver}) vem ANTES de {} ({current_version}) — `garraia` continua rodando a versao antiga.",
+                other.path.display(),
+                current.display()
+            ));
+        } else {
+            lines.push(format!(
+                "⚠ Binario antigo detectado: {} ({ver}) sombreado por {} ({current_version}).",
+                other.path.display(),
+                current.display()
+            ));
+        }
+        lines.push(format!("  Remova com: {}", remove_hint(&other.path)));
+    }
+    (!lines.is_empty()).then(|| lines.join("\n"))
+}
+
+fn remove_hint(path: &Path) -> String {
+    if cfg!(windows) {
+        return format!("Remove-Item \"{}\"", path.display());
+    }
+    let needs_root = path.starts_with("/usr") || path.starts_with("/opt");
+    format!(
+        "{}rm {}",
+        if needs_root { "sudo " } else { "" },
+        path.display()
+    )
+}
+
+/// PATH real + diretorios de sistema, sondando a versao de cada achado.
+async fn report_other_binaries(current: &Path, current_version: &str) -> Option<String> {
+    let path_dirs: Vec<PathBuf> = std::env::var_os("PATH")
+        .map(|p| std::env::split_paths(&p).collect())
+        .unwrap_or_default();
+    let system_dirs: Vec<PathBuf> = SYSTEM_BIN_DIRS.iter().map(PathBuf::from).collect();
+    let others = find_other_binaries(&path_dirs, &system_dirs, current);
+    if others.is_empty() {
+        return None;
+    }
+    let mut probed = Vec::with_capacity(others.len());
+    for other in others {
+        let version = probe_version(&other.path).await;
+        probed.push((other, version));
+    }
+    shadow_report(current, current_version, &probed)
 }
 
 /// Run `garraia rollback`.
@@ -359,6 +541,123 @@ fn sha256_digest(data: &[u8]) -> [u8; 32] {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn touch_exe(path: &Path) {
+        fs::write(path, b"#!/bin/sh\nexit 0\n").expect("write fake binary");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(path, fs::Permissions::from_mode(0o755)).expect("chmod");
+        }
+    }
+
+    /// #1030: o update trocava so o proprio binario e nada dizia sobre o
+    /// `/usr/bin/garraia` de outra instalacao. A varredura acha os outros,
+    /// pula o proprio (e symlinks para ele) e diz quem vem antes no PATH.
+    #[test]
+    fn find_other_binaries_skips_itself_and_orders_by_path() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let local = tmp.path().join("local-bin");
+        let system = tmp.path().join("usr-bin");
+        let other = tmp.path().join("other-bin");
+        for d in [&local, &system, &other] {
+            fs::create_dir_all(d).expect("mkdir");
+        }
+        let exe = format!("garraia{}", std::env::consts::EXE_SUFFIX);
+        let current = local.join(&exe);
+        touch_exe(&current);
+        touch_exe(&system.join(&exe));
+        touch_exe(&other.join(format!("garra{}", std::env::consts::EXE_SUFFIX)));
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&current, local.join("garra")).expect("symlink");
+
+        // PATH: other-bin vem ANTES de local-bin; usr-bin so pela lista de sistema.
+        let found = find_other_binaries(
+            &[other.clone(), local.clone()],
+            std::slice::from_ref(&system),
+            &current,
+        );
+
+        let paths: Vec<&Path> = found.iter().map(|o| o.path.as_path()).collect();
+        assert!(
+            !paths
+                .iter()
+                .any(|p| *p == current || p.ends_with("local-bin/garra")),
+            "o proprio (e o symlink para ele) nao sao 'outros': {paths:?}"
+        );
+        let garra = found
+            .iter()
+            .find(|o| o.path.starts_with(&other))
+            .expect("garra em other-bin");
+        assert!(garra.precedes, "other-bin vem antes de local-bin no PATH");
+        let sys = found
+            .iter()
+            .find(|o| o.path.starts_with(&system))
+            .expect("garraia em usr-bin");
+        assert!(!sys.precedes, "fora do PATH deste shell nao ha 'antes'");
+        assert_eq!(found.len(), 2, "{paths:?}");
+    }
+
+    #[test]
+    fn parse_version_output_reads_clap_style_lines() {
+        assert_eq!(
+            parse_version_output("garraia 0.3.4\n").as_deref(),
+            Some("0.3.4")
+        );
+        assert_eq!(
+            parse_version_output("\ngarra v0.4.0").as_deref(),
+            Some("0.4.0")
+        );
+        assert_eq!(parse_version_output("not a version"), None);
+        assert_eq!(parse_version_output(""), None);
+    }
+
+    #[test]
+    fn shadow_report_names_precedence_and_skips_same_version() {
+        let current = Path::new("/home/u/.local/bin/garraia");
+        let old = OtherBinary {
+            path: PathBuf::from("/usr/bin/garraia"),
+            precedes: false,
+        };
+        let first = OtherBinary {
+            path: PathBuf::from("/opt/garra/garra"),
+            precedes: true,
+        };
+        let same = OtherBinary {
+            path: PathBuf::from("/tmp/dup/garraia"),
+            precedes: true,
+        };
+
+        let report = shadow_report(
+            current,
+            "0.3.9",
+            &[
+                (old.clone(), Some("0.3.4".into())),
+                (first.clone(), None),
+                (same, Some("0.3.9".into())),
+            ],
+        )
+        .expect("ha o que avisar");
+
+        assert!(
+            report.contains(
+                "/usr/bin/garraia (0.3.4) sombreado por /home/u/.local/bin/garraia (0.3.9)"
+            ),
+            "{report}"
+        );
+        assert!(report.contains("sudo rm /usr/bin/garraia"), "{report}");
+        assert!(
+            report.contains("/opt/garra/garra (versao desconhecida) vem ANTES de"),
+            "{report}"
+        );
+        assert!(
+            !report.contains("/tmp/dup"),
+            "mesma versao nao e problema: {report}"
+        );
+
+        // So copias da mesma versao: nada a dizer.
+        assert!(shadow_report(current, "0.3.9", &[(old, Some("0.3.9".into()))]).is_none());
+    }
 
     // Regra 15 do CLAUDE.md: estes nomes são superfície de compatibilidade.
     // Renomear qualquer um quebra `garra update` de toda instalação em campo.

--- a/crates/garraia-cli/src/update.rs
+++ b/crates/garraia-cli/src/update.rs
@@ -1,8 +1,9 @@
 use std::fs;
-use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::path::PathBuf;
 
 use anyhow::{Context, Result, bail};
+
+use crate::update_scan::{BINARY_NAMES, report_other_binaries};
 
 const GITHUB_REPO: &str = "michelbr84/GarraRUST";
 const RELEASES_API: &str = "https://api.github.com/repos/michelbr84/GarraRUST/releases/latest";
@@ -66,7 +67,7 @@ fn asset_name_for(os: &str, arch: &str) -> Result<&'static str> {
 }
 
 /// Strip leading 'v' from a version tag.
-fn strip_v(tag: &str) -> &str {
+pub(crate) fn strip_v(tag: &str) -> &str {
     tag.strip_prefix('v').unwrap_or(tag)
 }
 
@@ -282,164 +283,6 @@ pub async fn run_check_binaries() -> Result<()> {
     Ok(())
 }
 
-/// Nomes com que o GarraIA aparece no PATH: o binario e o alias curto.
-const BINARY_NAMES: &[&str] = &["garraia", "garra"];
-
-/// Onde os pacotes de sistema instalam, mesmo que o PATH deste shell nao os
-/// liste (o do cron e do systemd lista).
-#[cfg(unix)]
-const SYSTEM_BIN_DIRS: &[&str] = &["/usr/local/bin", "/usr/bin"];
-#[cfg(not(unix))]
-const SYSTEM_BIN_DIRS: &[&str] = &[];
-
-/// Um binario do GarraIA no PATH que nao e o que acabou de ser atualizado.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct OtherBinary {
-    pub path: PathBuf,
-    /// `true` quando o diretorio dele vem ANTES do diretorio do atualizado
-    /// no PATH: e ele, nao o atualizado, que `garraia` resolve neste shell.
-    pub precedes: bool,
-}
-
-/// Procura outros `garraia`/`garra` nos diretorios do PATH e nos de sistema,
-/// excluindo o proprio `current` (por caminho canonico, entao um symlink
-/// `garra -> garraia` ao lado do atualizado nao e "outro").
-///
-/// O PATH entra como lista em vez de ser lido aqui, para o teste montar o
-/// cenario inteiro num diretorio temporario.
-pub fn find_other_binaries(
-    path_dirs: &[PathBuf],
-    system_dirs: &[PathBuf],
-    current: &Path,
-) -> Vec<OtherBinary> {
-    let canonical = |p: &Path| fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
-    let current_canon = canonical(current);
-    let current_dir = current_canon.parent().map(Path::to_path_buf);
-    let current_dir_index = path_dirs
-        .iter()
-        .position(|d| current_dir.as_deref() == Some(canonical(d).as_path()));
-
-    let names: Vec<String> = BINARY_NAMES
-        .iter()
-        .map(|n| format!("{n}{}", std::env::consts::EXE_SUFFIX))
-        .collect();
-
-    let mut seen: Vec<PathBuf> = vec![current_canon.clone()];
-    let mut found = Vec::new();
-    let candidates = path_dirs
-        .iter()
-        .enumerate()
-        .map(|(i, d)| (d, Some(i)))
-        .chain(system_dirs.iter().map(|d| (d, None)));
-    for (dir, index) in candidates {
-        for name in &names {
-            let candidate = dir.join(name);
-            if !candidate.is_file() {
-                continue;
-            }
-            let canon = canonical(&candidate);
-            if seen.contains(&canon) {
-                continue;
-            }
-            seen.push(canon);
-            let precedes = match (index, current_dir_index) {
-                (Some(i), Some(cur)) => i < cur,
-                // Fora do PATH deste shell, ou o atualizado fora do PATH:
-                // nao ha "antes"; e so um outro binario.
-                _ => false,
-            };
-            found.push(OtherBinary {
-                path: candidate,
-                precedes,
-            });
-        }
-    }
-    found
-}
-
-/// A versao que um binario achado no PATH diz ter. Roda `--version` com
-/// timeout: e um executavel que o usuario ja tem no PATH com o nome do
-/// GarraIA, e um binario quebrado nao pode travar o update.
-async fn probe_version(path: &Path) -> Option<String> {
-    let out = tokio::time::timeout(
-        Duration::from_secs(3),
-        tokio::process::Command::new(path).arg("--version").output(),
-    )
-    .await
-    .ok()?
-    .ok()?;
-    parse_version_output(&String::from_utf8_lossy(&out.stdout))
-}
-
-/// `garraia 0.3.4` (ou `garraia v0.3.4`) → `0.3.4`. So a primeira linha.
-fn parse_version_output(stdout: &str) -> Option<String> {
-    let first = stdout.lines().find(|l| !l.trim().is_empty())?;
-    let last = first.split_whitespace().last()?;
-    let v = strip_v(last);
-    (!v.is_empty() && v.chars().next().is_some_and(|c| c.is_ascii_digit())).then(|| v.to_string())
-}
-
-/// O aviso do #1030, pronto para imprimir. `None` quando nao ha o que dizer:
-/// nenhum outro binario, ou so copias da mesma versao (inofensivas).
-pub fn shadow_report(
-    current: &Path,
-    current_version: &str,
-    others: &[(OtherBinary, Option<String>)],
-) -> Option<String> {
-    let mut lines = Vec::new();
-    for (other, version) in others {
-        if version.as_deref() == Some(current_version) {
-            continue;
-        }
-        let ver = version.as_deref().unwrap_or("versao desconhecida");
-        if other.precedes {
-            lines.push(format!(
-                "⚠ Binario antigo tem precedencia no PATH: {} ({ver}) vem ANTES de {} ({current_version}) — `garraia` continua rodando a versao antiga.",
-                other.path.display(),
-                current.display()
-            ));
-        } else {
-            lines.push(format!(
-                "⚠ Binario antigo detectado: {} ({ver}) sombreado por {} ({current_version}).",
-                other.path.display(),
-                current.display()
-            ));
-        }
-        lines.push(format!("  Remova com: {}", remove_hint(&other.path)));
-    }
-    (!lines.is_empty()).then(|| lines.join("\n"))
-}
-
-fn remove_hint(path: &Path) -> String {
-    if cfg!(windows) {
-        return format!("Remove-Item \"{}\"", path.display());
-    }
-    let needs_root = path.starts_with("/usr") || path.starts_with("/opt");
-    format!(
-        "{}rm {}",
-        if needs_root { "sudo " } else { "" },
-        path.display()
-    )
-}
-
-/// PATH real + diretorios de sistema, sondando a versao de cada achado.
-async fn report_other_binaries(current: &Path, current_version: &str) -> Option<String> {
-    let path_dirs: Vec<PathBuf> = std::env::var_os("PATH")
-        .map(|p| std::env::split_paths(&p).collect())
-        .unwrap_or_default();
-    let system_dirs: Vec<PathBuf> = SYSTEM_BIN_DIRS.iter().map(PathBuf::from).collect();
-    let others = find_other_binaries(&path_dirs, &system_dirs, current);
-    if others.is_empty() {
-        return None;
-    }
-    let mut probed = Vec::with_capacity(others.len());
-    for other in others {
-        let version = probe_version(&other.path).await;
-        probed.push((other, version));
-    }
-    shadow_report(current, current_version, &probed)
-}
-
 /// Run `garraia rollback`.
 pub fn run_rollback() -> Result<()> {
     let current_exe =
@@ -541,123 +384,6 @@ fn sha256_digest(data: &[u8]) -> [u8; 32] {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn touch_exe(path: &Path) {
-        fs::write(path, b"#!/bin/sh\nexit 0\n").expect("write fake binary");
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            fs::set_permissions(path, fs::Permissions::from_mode(0o755)).expect("chmod");
-        }
-    }
-
-    /// #1030: o update trocava so o proprio binario e nada dizia sobre o
-    /// `/usr/bin/garraia` de outra instalacao. A varredura acha os outros,
-    /// pula o proprio (e symlinks para ele) e diz quem vem antes no PATH.
-    #[test]
-    fn find_other_binaries_skips_itself_and_orders_by_path() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        let local = tmp.path().join("local-bin");
-        let system = tmp.path().join("usr-bin");
-        let other = tmp.path().join("other-bin");
-        for d in [&local, &system, &other] {
-            fs::create_dir_all(d).expect("mkdir");
-        }
-        let exe = format!("garraia{}", std::env::consts::EXE_SUFFIX);
-        let current = local.join(&exe);
-        touch_exe(&current);
-        touch_exe(&system.join(&exe));
-        touch_exe(&other.join(format!("garra{}", std::env::consts::EXE_SUFFIX)));
-        #[cfg(unix)]
-        std::os::unix::fs::symlink(&current, local.join("garra")).expect("symlink");
-
-        // PATH: other-bin vem ANTES de local-bin; usr-bin so pela lista de sistema.
-        let found = find_other_binaries(
-            &[other.clone(), local.clone()],
-            std::slice::from_ref(&system),
-            &current,
-        );
-
-        let paths: Vec<&Path> = found.iter().map(|o| o.path.as_path()).collect();
-        assert!(
-            !paths
-                .iter()
-                .any(|p| *p == current || p.ends_with("local-bin/garra")),
-            "o proprio (e o symlink para ele) nao sao 'outros': {paths:?}"
-        );
-        let garra = found
-            .iter()
-            .find(|o| o.path.starts_with(&other))
-            .expect("garra em other-bin");
-        assert!(garra.precedes, "other-bin vem antes de local-bin no PATH");
-        let sys = found
-            .iter()
-            .find(|o| o.path.starts_with(&system))
-            .expect("garraia em usr-bin");
-        assert!(!sys.precedes, "fora do PATH deste shell nao ha 'antes'");
-        assert_eq!(found.len(), 2, "{paths:?}");
-    }
-
-    #[test]
-    fn parse_version_output_reads_clap_style_lines() {
-        assert_eq!(
-            parse_version_output("garraia 0.3.4\n").as_deref(),
-            Some("0.3.4")
-        );
-        assert_eq!(
-            parse_version_output("\ngarra v0.4.0").as_deref(),
-            Some("0.4.0")
-        );
-        assert_eq!(parse_version_output("not a version"), None);
-        assert_eq!(parse_version_output(""), None);
-    }
-
-    #[test]
-    fn shadow_report_names_precedence_and_skips_same_version() {
-        let current = Path::new("/home/u/.local/bin/garraia");
-        let old = OtherBinary {
-            path: PathBuf::from("/usr/bin/garraia"),
-            precedes: false,
-        };
-        let first = OtherBinary {
-            path: PathBuf::from("/opt/garra/garra"),
-            precedes: true,
-        };
-        let same = OtherBinary {
-            path: PathBuf::from("/tmp/dup/garraia"),
-            precedes: true,
-        };
-
-        let report = shadow_report(
-            current,
-            "0.3.9",
-            &[
-                (old.clone(), Some("0.3.4".into())),
-                (first.clone(), None),
-                (same, Some("0.3.9".into())),
-            ],
-        )
-        .expect("ha o que avisar");
-
-        assert!(
-            report.contains(
-                "/usr/bin/garraia (0.3.4) sombreado por /home/u/.local/bin/garraia (0.3.9)"
-            ),
-            "{report}"
-        );
-        assert!(report.contains("sudo rm /usr/bin/garraia"), "{report}");
-        assert!(
-            report.contains("/opt/garra/garra (versao desconhecida) vem ANTES de"),
-            "{report}"
-        );
-        assert!(
-            !report.contains("/tmp/dup"),
-            "mesma versao nao e problema: {report}"
-        );
-
-        // So copias da mesma versao: nada a dizer.
-        assert!(shadow_report(current, "0.3.9", &[(old, Some("0.3.9".into()))]).is_none());
-    }
 
     // Regra 15 do CLAUDE.md: estes nomes são superfície de compatibilidade.
     // Renomear qualquer um quebra `garra update` de toda instalação em campo.

--- a/crates/garraia-cli/src/update_scan.rs
+++ b/crates/garraia-cli/src/update_scan.rs
@@ -1,0 +1,291 @@
+//! `garraia update` trocava so o proprio binario; um `/usr/bin/garraia` de
+//! outra instalacao seguia no PATH, intocado e sem aviso (#1030). Este modulo
+//! e a varredura pos-update: acha os outros `garraia`/`garra`, pergunta a
+//! versao de cada um e diz quem sombreia quem. So imprime — remover e do
+//! operador.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use crate::update::strip_v;
+
+/// Nomes com que o GarraIA aparece no PATH: o binario e o alias curto.
+pub(crate) const BINARY_NAMES: &[&str] = &["garraia", "garra"];
+
+/// Onde os pacotes de sistema instalam, mesmo que o PATH deste shell nao os
+/// liste (o do cron e do systemd lista).
+#[cfg(unix)]
+const SYSTEM_BIN_DIRS: &[&str] = &["/usr/local/bin", "/usr/bin"];
+#[cfg(not(unix))]
+const SYSTEM_BIN_DIRS: &[&str] = &[];
+
+/// Um binario do GarraIA no PATH que nao e o que acabou de ser atualizado.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OtherBinary {
+    pub path: PathBuf,
+    /// `true` quando o diretorio dele vem ANTES do diretorio do atualizado
+    /// no PATH: e ele, nao o atualizado, que `garraia` resolve neste shell.
+    pub precedes: bool,
+}
+
+/// Procura outros `garraia`/`garra` nos diretorios do PATH e nos de sistema,
+/// excluindo o proprio `current` (por caminho canonico, entao um symlink
+/// `garra -> garraia` ao lado do atualizado nao e "outro").
+///
+/// O PATH entra como lista em vez de ser lido aqui, para o teste montar o
+/// cenario inteiro num diretorio temporario.
+pub(crate) fn find_other_binaries(
+    path_dirs: &[PathBuf],
+    system_dirs: &[PathBuf],
+    current: &Path,
+) -> Vec<OtherBinary> {
+    let canonical = |p: &Path| fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
+    let current_canon = canonical(current);
+    let current_dir = current_canon.parent().map(Path::to_path_buf);
+    let current_dir_index = path_dirs
+        .iter()
+        .position(|d| current_dir.as_deref() == Some(canonical(d).as_path()));
+
+    let names: Vec<String> = BINARY_NAMES
+        .iter()
+        .map(|n| format!("{n}{}", std::env::consts::EXE_SUFFIX))
+        .collect();
+
+    let mut seen: Vec<PathBuf> = vec![current_canon.clone()];
+    let mut found = Vec::new();
+    let candidates = path_dirs
+        .iter()
+        .enumerate()
+        .map(|(i, d)| (d, Some(i)))
+        .chain(system_dirs.iter().map(|d| (d, None)));
+    for (dir, index) in candidates {
+        for name in &names {
+            let candidate = dir.join(name);
+            if !candidate.is_file() {
+                continue;
+            }
+            let canon = canonical(&candidate);
+            if seen.contains(&canon) {
+                continue;
+            }
+            seen.push(canon);
+            let precedes = match (index, current_dir_index) {
+                (Some(i), Some(cur)) => i < cur,
+                // Fora do PATH deste shell, ou o atualizado fora do PATH:
+                // nao ha "antes"; e so um outro binario.
+                _ => false,
+            };
+            found.push(OtherBinary {
+                path: candidate,
+                precedes,
+            });
+        }
+    }
+    found
+}
+
+/// A versao que um binario achado no PATH diz ter. Roda `--version` com
+/// timeout: e um executavel que o usuario ja tem no PATH com o nome do
+/// GarraIA, e um binario quebrado nao pode travar o update.
+async fn probe_version(path: &Path) -> Option<String> {
+    let out = tokio::time::timeout(
+        Duration::from_secs(3),
+        tokio::process::Command::new(path).arg("--version").output(),
+    )
+    .await
+    .ok()?
+    .ok()?;
+    parse_version_output(&String::from_utf8_lossy(&out.stdout))
+}
+
+/// `garraia 0.3.4` (ou `garraia v0.3.4`) → `0.3.4`. So a primeira linha.
+fn parse_version_output(stdout: &str) -> Option<String> {
+    let first = stdout.lines().find(|l| !l.trim().is_empty())?;
+    let last = first.split_whitespace().last()?;
+    let v = strip_v(last);
+    (!v.is_empty() && v.chars().next().is_some_and(|c| c.is_ascii_digit())).then(|| v.to_string())
+}
+
+/// O aviso do #1030, pronto para imprimir. `None` quando nao ha o que dizer:
+/// nenhum outro binario, ou so copias da mesma versao (inofensivas).
+pub(crate) fn shadow_report(
+    current: &Path,
+    current_version: &str,
+    others: &[(OtherBinary, Option<String>)],
+) -> Option<String> {
+    let mut lines = Vec::new();
+    for (other, version) in others {
+        if version.as_deref() == Some(current_version) {
+            continue;
+        }
+        let ver = version.as_deref().unwrap_or("versao desconhecida");
+        if other.precedes {
+            lines.push(format!(
+                "⚠ Binario antigo tem precedencia no PATH: {} ({ver}) vem ANTES de {} ({current_version}) — `garraia` continua rodando a versao antiga.",
+                other.path.display(),
+                current.display()
+            ));
+        } else {
+            lines.push(format!(
+                "⚠ Binario antigo detectado: {} ({ver}) sombreado por {} ({current_version}).",
+                other.path.display(),
+                current.display()
+            ));
+        }
+        lines.push(format!("  Remova com: {}", remove_hint(&other.path)));
+    }
+    (!lines.is_empty()).then(|| lines.join("\n"))
+}
+
+fn remove_hint(path: &Path) -> String {
+    if cfg!(windows) {
+        return format!("Remove-Item \"{}\"", path.display());
+    }
+    let needs_root = path.starts_with("/usr") || path.starts_with("/opt");
+    format!(
+        "{}rm {}",
+        if needs_root { "sudo " } else { "" },
+        path.display()
+    )
+}
+
+/// PATH real + diretorios de sistema, sondando a versao de cada achado.
+pub(crate) async fn report_other_binaries(current: &Path, current_version: &str) -> Option<String> {
+    let path_dirs: Vec<PathBuf> = std::env::var_os("PATH")
+        .map(|p| std::env::split_paths(&p).collect())
+        .unwrap_or_default();
+    let system_dirs: Vec<PathBuf> = SYSTEM_BIN_DIRS.iter().map(PathBuf::from).collect();
+    let others = find_other_binaries(&path_dirs, &system_dirs, current);
+    if others.is_empty() {
+        return None;
+    }
+    let mut probed = Vec::with_capacity(others.len());
+    for other in others {
+        let version = probe_version(&other.path).await;
+        probed.push((other, version));
+    }
+    shadow_report(current, current_version, &probed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn touch_exe(path: &Path) {
+        fs::write(path, b"#!/bin/sh\nexit 0\n").expect("write fake binary");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(path, fs::Permissions::from_mode(0o755)).expect("chmod");
+        }
+    }
+
+    /// #1030: o update trocava so o proprio binario e nada dizia sobre o
+    /// `/usr/bin/garraia` de outra instalacao. A varredura acha os outros,
+    /// pula o proprio (e symlinks para ele) e diz quem vem antes no PATH.
+    #[test]
+    fn find_other_binaries_skips_itself_and_orders_by_path() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let local = tmp.path().join("local-bin");
+        let system = tmp.path().join("usr-bin");
+        let other = tmp.path().join("other-bin");
+        for d in [&local, &system, &other] {
+            fs::create_dir_all(d).expect("mkdir");
+        }
+        let exe = format!("garraia{}", std::env::consts::EXE_SUFFIX);
+        let current = local.join(&exe);
+        touch_exe(&current);
+        touch_exe(&system.join(&exe));
+        touch_exe(&other.join(format!("garra{}", std::env::consts::EXE_SUFFIX)));
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&current, local.join("garra")).expect("symlink");
+
+        // PATH: other-bin vem ANTES de local-bin; usr-bin so pela lista de sistema.
+        let found = find_other_binaries(
+            &[other.clone(), local.clone()],
+            std::slice::from_ref(&system),
+            &current,
+        );
+
+        let paths: Vec<&Path> = found.iter().map(|o| o.path.as_path()).collect();
+        assert!(
+            !paths
+                .iter()
+                .any(|p| *p == current || p.ends_with("local-bin/garra")),
+            "o proprio (e o symlink para ele) nao sao 'outros': {paths:?}"
+        );
+        let garra = found
+            .iter()
+            .find(|o| o.path.starts_with(&other))
+            .expect("garra em other-bin");
+        assert!(garra.precedes, "other-bin vem antes de local-bin no PATH");
+        let sys = found
+            .iter()
+            .find(|o| o.path.starts_with(&system))
+            .expect("garraia em usr-bin");
+        assert!(!sys.precedes, "fora do PATH deste shell nao ha 'antes'");
+        assert_eq!(found.len(), 2, "{paths:?}");
+    }
+
+    #[test]
+    fn parse_version_output_reads_clap_style_lines() {
+        assert_eq!(
+            parse_version_output("garraia 0.3.4\n").as_deref(),
+            Some("0.3.4")
+        );
+        assert_eq!(
+            parse_version_output("\ngarra v0.4.0").as_deref(),
+            Some("0.4.0")
+        );
+        assert_eq!(parse_version_output("not a version"), None);
+        assert_eq!(parse_version_output(""), None);
+    }
+
+    #[test]
+    fn shadow_report_names_precedence_and_skips_same_version() {
+        let current = Path::new("/home/u/.local/bin/garraia");
+        let old = OtherBinary {
+            path: PathBuf::from("/usr/bin/garraia"),
+            precedes: false,
+        };
+        let first = OtherBinary {
+            path: PathBuf::from("/opt/garra/garra"),
+            precedes: true,
+        };
+        let same = OtherBinary {
+            path: PathBuf::from("/tmp/dup/garraia"),
+            precedes: true,
+        };
+
+        let report = shadow_report(
+            current,
+            "0.3.9",
+            &[
+                (old.clone(), Some("0.3.4".into())),
+                (first.clone(), None),
+                (same, Some("0.3.9".into())),
+            ],
+        )
+        .expect("ha o que avisar");
+
+        assert!(
+            report.contains(
+                "/usr/bin/garraia (0.3.4) sombreado por /home/u/.local/bin/garraia (0.3.9)"
+            ),
+            "{report}"
+        );
+        assert!(report.contains("sudo rm /usr/bin/garraia"), "{report}");
+        assert!(
+            report.contains("/opt/garra/garra (versao desconhecida) vem ANTES de"),
+            "{report}"
+        );
+        assert!(
+            !report.contains("/tmp/dup"),
+            "mesma versao nao e problema: {report}"
+        );
+
+        // So copias da mesma versao: nada a dizer.
+        assert!(shadow_report(current, "0.3.9", &[(old, Some("0.3.9".into()))]).is_none());
+    }
+}


### PR DESCRIPTION
## Descrição

**#1030.** `garraia update` trocava só o próprio binário. Um `/usr/bin/garraia` de outra instalação seguia lá, intocado e sem aviso — e era ele que scripts, cron, units do systemd e terminais com PATH diferente passavam a rodar (caso real de 2026-09-07: `~/.local/bin` em 0.3.9, `/usr/bin` em 0.3.4, descoberto só em auditoria manual).

Depois de instalar, o comando:

1. **Varre** os diretórios do `PATH` e os de sistema (`/usr/local/bin`, `/usr/bin`, mesmo fora do PATH deste shell — o do cron os tem) por outros `garraia`/`garra` (`.exe` no Windows), pulando o próprio por caminho **canônico** — um symlink `garra → garraia` ao lado do atualizado não é "outro".
2. **Pergunta a versão** a cada achado (`--version`, timeout de 3 s: é um executável que o usuário já tem no PATH com o nome do GarraIA, e um binário quebrado não pode travar o update).
3. **Avisa** os que diferem, dizendo o que importa: caminho, versão, se ele vem **antes** ou depois do atualizado no PATH (antes é o caso pior — `garraia` continua rodando a versão antiga), e o comando para remover (`sudo rm` sob `/usr` e `/opt`). Cópias da mesma versão não geram aviso.

```
⚠ Binario antigo detectado: /usr/bin/garraia (0.3.4) sombreado por /home/u/.local/bin/garraia (0.3.9).
  Remova com: sudo rm /usr/bin/garraia
```

`garraia update --check-binaries` roda só a varredura, sem rede (item 3 da issue).

A varredura recebe o PATH como lista e o relatório é uma função pura, então os três testes montam o cenário num tempdir (PATH com o "outro" antes, diretório de sistema fora do PATH, symlink para o próprio) sem tocar o ambiente.

Closes #1030

## Tipo de mudança

- [x] `feat`: Nova funcionalidade
- [ ] `fix`: Correção de bug
- [ ] `refactor`: Refatoração sem mudança de comportamento
- [ ] `docs`: Documentação apenas
- [x] `test`: Adição ou correção de testes
- [ ] `perf`: Melhoria de performance
- [ ] `chore`: Manutenção (deps, CI, build)
- [ ] `sec`: Correção ou hardening de segurança

## Classe de Risco

- [x] **Classe A (Baixo Risco)**: só a CLI, depois do update já concluído; leitura do filesystem e um `--version` com timeout. Nada é removido — o comando **sugere** o `rm`, não o executa. Sem gateway, auth, schema.
- [ ] **Classe B (Médio Risco)**
- [ ] **Classe C (Alto Risco)**

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo fmt --check` executado e limpo
- [x] `cargo clippy -p garraia --all-targets -- -D warnings` sem erros
- [x] `cargo test -p garraia --bin garra -- update::tests` 7/7 (3 novos)
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo, API key, token ou credencial commitada
- [x] Nenhuma migração Postgres

### Para alterações de Alto Risco (Classe C)

- [ ] N/A

## Mudanças na API pública e Schema

- CLI: `garraia update` ganha a flag `--check-binaries`. Saída do update ganha o bloco de aviso quando há outro binário de versão diferente. Nenhuma API HTTP.

## Como testar

1. `cargo test -p garraia --bin garra -- update::tests`.
2. Com um `garraia` antigo em `/usr/bin` e o atual em `~/.local/bin`: `garraia update --check-binaries` → o aviso acima. Sem outro binário: "Nenhum outro binario garraia/garra no PATH".
3. `garraia update` real: o mesmo aviso aparece depois de "Updated to vX".

## Plano de Rollback

Revert do PR. A varredura é pós-instalação e só imprime; o update em si não muda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVnUdw6gJJLtcmWxzxMtFz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVnUdw6gJJLtcmWxzxMtFz)_