### PR TITLE
feat(agents): web_search com backend plugável — SearXNG self-hosted sem chave

### DIFF
--- a/changelog.d/added/1034-web-search-searxng.md
+++ b/changelog.d/added/1034-web-search-searxng.md
@@ -1,0 +1,11 @@
+- **`web_search` funciona sem chave, via SearXNG self-hosted (#1034).** A tool
+  era acoplada a API do Brave e so entrava no runtime com `BRAVE_API_KEY`;
+  sem a chave o agente nao tinha busca nenhuma. O backend virou plugavel
+  (`SearchBackend::{Brave, Searxng}`), com a nova secao `agent.web_search`
+  (`backend: brave|searxng`, `searxng_url`, ou `GARRAIA_SEARXNG_URL`). Sem a
+  secao a regra e a de sempre (Brave com chave); sem chave e com URL, SearXNG;
+  `backend` explicito ganha e, se faltar o que ele precisa, a tool fica de
+  fora e `garra config check` aponta. O SearXNG (`/search?format=json`)
+  devolve `title`/`url`/`content` mapeados para o mesmo schema do Brave; a URL
+  passa pelo guard de SSRF com loopback e LAN liberados e link-local/metadata
+  de nuvem bloqueados, com cliente pinado como o `web_fetch`.

--- a/crates/garraia-agents/src/tools/web_search_tool.rs
+++ b/crates/garraia-agents/src/tools/web_search_tool.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use garraia_common::ssrf::{self, IpScope, UrlPolicy};
 use garraia_common::{Error, Result};
 use serde::Deserialize;
 use std::time::Duration;
@@ -9,21 +10,63 @@ const SEARCH_TIMEOUT_SECS: u64 = 15;
 const DEFAULT_COUNT: u64 = 5;
 const MAX_COUNT: u64 = 10;
 
-/// Realiza buscas na web utilizando a API do Brave Search.
+/// De onde a `web_search` tira os resultados (#1034).
+///
+/// Ate o #1034 so havia o Brave, e a tool so era registrada com a chave dele
+/// — sem chave, o agente nao tinha busca nenhuma. O SearXNG e o caminho sem
+/// chave: um meta-buscador self-hosted que agrega DDG, Google, Bing e afins.
+#[derive(Debug, Clone)]
+pub enum SearchBackend {
+    /// Brave Search API: host fixo, chave no header.
+    Brave { api_key: String },
+    /// SearXNG (`GET {base_url}/search?format=json`). Sem chave. A URL e do
+    /// operador, e por isso passa pelo guard de SSRF com [`IpScope::AllowPrivate`]:
+    /// loopback e LAN sao o caso de uso, link-local e metadata de nuvem nao.
+    Searxng { base_url: String },
+}
+
+impl SearchBackend {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Brave { .. } => "brave",
+            Self::Searxng { .. } => "searxng",
+        }
+    }
+}
+
+/// Realiza buscas na web pelo backend configurado.
 pub struct WebSearchTool {
     client: reqwest::Client,
-    api_key: String,
+    backend: SearchBackend,
 }
 
 impl WebSearchTool {
+    /// Brave, como sempre foi. Mantido para os chamadores existentes.
     pub fn new(api_key: String) -> Self {
+        Self::with_backend(SearchBackend::Brave { api_key })
+    }
+
+    pub fn with_backend(backend: SearchBackend) -> Self {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(SEARCH_TIMEOUT_SECS))
             .build()
             .unwrap_or_default();
 
-        Self { client, api_key }
+        Self { client, backend }
     }
+
+    pub fn backend_name(&self) -> &'static str {
+        self.backend.name()
+    }
+}
+
+/// Um resultado ja no formato comum aos backends — o modelo ve o mesmo
+/// schema seja qual for a origem.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SearchResult {
+    title: String,
+    url: String,
+    description: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -41,6 +84,165 @@ struct BraveWebResult {
     title: String,
     url: String,
     description: String,
+}
+
+impl From<BraveWebResult> for SearchResult {
+    fn from(r: BraveWebResult) -> Self {
+        Self {
+            title: r.title,
+            url: r.url,
+            description: r.description,
+        }
+    }
+}
+
+/// Resposta do `/search?format=json` do SearXNG — so os campos usados.
+/// `content` e a descricao; falta em resultado de imagem ou mapa, por isso
+/// `default`.
+#[derive(Debug, Deserialize)]
+struct SearxngResponse {
+    #[serde(default)]
+    results: Vec<SearxngResult>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SearxngResult {
+    #[serde(default)]
+    title: String,
+    url: String,
+    #[serde(default)]
+    content: String,
+}
+
+impl From<SearxngResult> for SearchResult {
+    fn from(r: SearxngResult) -> Self {
+        Self {
+            title: r.title,
+            url: r.url,
+            description: r.content,
+        }
+    }
+}
+
+/// O que uma busca devolveu: resultados, ou um erro que o modelo deve ver
+/// como resposta da tool (HTTP fora de 2xx, URL recusada) em vez de como
+/// falha do turno.
+enum Fetched {
+    Results(Vec<SearchResult>),
+    Failed(String),
+}
+
+/// Politica do SearXNG: http e https (self-hosted na LAN costuma ser http),
+/// loopback e faixas privadas liberadas — sao o caso de uso —, link-local,
+/// CGNAT, multicast e unspecified continuam bloqueados (threat-model §5.6).
+/// A URL vem da config, mas a config pode vir de `PATCH /api/settings`, e o
+/// guard e o que impede um `169.254.169.254` de virar alvo de busca.
+fn searxng_policy() -> UrlPolicy {
+    UrlPolicy::http_public(
+        Duration::from_secs(SEARCH_TIMEOUT_SECS),
+        concat!("GarraIA/", env!("CARGO_PKG_VERSION"), " web-search"),
+    )
+    .with_ip_scope(IpScope::AllowPrivate)
+}
+
+/// A lista numerada que o modelo recebe — igual para os dois backends.
+fn format_results(results: &[SearchResult]) -> String {
+    let mut output = String::new();
+    for (i, result) in results.iter().enumerate() {
+        output.push_str(&format!(
+            "{}. **{}** — {}\n   {}\n\n",
+            i + 1,
+            result.title,
+            result.url,
+            result.description,
+        ));
+    }
+    output.trim_end().to_string()
+}
+
+impl WebSearchTool {
+    async fn brave(&self, api_key: &str, query: &str, count: u64) -> Result<Fetched> {
+        let response = self
+            .client
+            .get("https://api.search.brave.com/res/v1/web/search")
+            .header("X-Subscription-Token", api_key)
+            .header("Accept", "application/json")
+            .query(&[("q", query), ("count", &count.to_string())])
+            .send()
+            .await
+            .map_err(|e| Error::Agent(format!("falha na requisição de busca: {e}")))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            return Ok(Fetched::Failed(format!(
+                "Erro na API Brave Search: HTTP {status}"
+            )));
+        }
+
+        let body: BraveSearchResponse = response
+            .json()
+            .await
+            .map_err(|e| Error::Agent(format!("falha ao interpretar resposta da busca: {e}")))?;
+
+        Ok(Fetched::Results(
+            body.web
+                .map(|w| w.results.into_iter().map(Into::into).collect())
+                .unwrap_or_default(),
+        ))
+    }
+
+    /// Nao usa `self.client`: cada busca constroi um cliente pinado nos
+    /// enderecos que `vet_url` validou, como o `web_fetch` — e o que fecha a
+    /// janela de DNS rebinding para uma URL que o operador pode trocar.
+    async fn searxng(&self, base_url: &str, query: &str, count: u64) -> Result<Fetched> {
+        let endpoint = format!("{}/search", base_url.trim_end_matches('/'));
+        let policy = searxng_policy();
+        let vetted = match ssrf::vet_url(&endpoint, &policy) {
+            Ok(v) => v,
+            Err(e) => return Ok(Fetched::Failed(format!("URL do SearXNG recusada: {e}"))),
+        };
+        let client = match ssrf::pinned_client(&vetted, &policy) {
+            Ok(c) => c,
+            Err(e) => return Ok(Fetched::Failed(format!("URL do SearXNG recusada: {e}"))),
+        };
+
+        let response = client
+            .get(vetted.url.clone())
+            .header("Accept", "application/json")
+            .query(&[("q", query), ("format", "json")])
+            .send()
+            .await
+            .map_err(|e| Error::Agent(format!("falha na requisição de busca: {e}")))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            // 403 e o que o SearXNG devolve quando `json` nao esta em
+            // `search.formats` — a causa mais comum de "nao funciona".
+            let hint = if status.as_u16() == 403 {
+                " — a instancia precisa de `json` em `search.formats` (settings.yml)"
+            } else {
+                ""
+            };
+            return Ok(Fetched::Failed(format!(
+                "Erro no SearXNG: HTTP {status}{hint}"
+            )));
+        }
+
+        let body: SearxngResponse = response
+            .json()
+            .await
+            .map_err(|e| Error::Agent(format!("falha ao interpretar resposta da busca: {e}")))?;
+
+        // O SearXNG nao aceita `count`; devolve a pagina inteira e o corte e
+        // aqui, para o modelo receber o mesmo tamanho dos dois backends.
+        Ok(Fetched::Results(
+            body.results
+                .into_iter()
+                .take(usize::try_from(count).unwrap_or(DEFAULT_COUNT as usize))
+                .map(Into::into)
+                .collect(),
+        ))
+    }
 }
 
 #[async_trait]
@@ -86,45 +288,20 @@ impl Tool for WebSearchTool {
             .unwrap_or(DEFAULT_COUNT)
             .clamp(1, MAX_COUNT);
 
-        let response = self
-            .client
-            .get("https://api.search.brave.com/res/v1/web/search")
-            .header("X-Subscription-Token", &self.api_key)
-            .header("Accept", "application/json")
-            .query(&[("q", query), ("count", &count.to_string())])
-            .send()
-            .await
-            .map_err(|e| Error::Agent(format!("falha na requisição de busca: {e}")))?;
-
-        let status = response.status();
-        if !status.is_success() {
-            return Ok(ToolOutput::error(format!(
-                "Erro na API Brave Search: HTTP {status}"
-            )));
-        }
-
-        let body: BraveSearchResponse = response
-            .json()
-            .await
-            .map_err(|e| Error::Agent(format!("falha ao interpretar resposta da busca: {e}")))?;
-
-        let results = match body.web {
-            Some(web) if !web.results.is_empty() => web.results,
-            _ => return Ok(ToolOutput::error("Nenhum resultado encontrado.")),
+        let fetched = match &self.backend {
+            SearchBackend::Brave { api_key } => self.brave(api_key, query, count).await?,
+            SearchBackend::Searxng { base_url } => self.searxng(base_url, query, count).await?,
         };
 
-        let mut output = String::new();
-        for (i, result) in results.iter().enumerate() {
-            output.push_str(&format!(
-                "{}. **{}** — {}\n   {}\n\n",
-                i + 1,
-                result.title,
-                result.url,
-                result.description,
-            ));
-        }
+        let results = match fetched {
+            Fetched::Failed(msg) => return Ok(ToolOutput::error(msg)),
+            Fetched::Results(r) if r.is_empty() => {
+                return Ok(ToolOutput::error("Nenhum resultado encontrado."));
+            }
+            Fetched::Results(r) => r,
+        };
 
-        Ok(ToolOutput::success(output.trim_end()))
+        Ok(ToolOutput::success(format_results(&results)))
     }
 }
 
@@ -145,10 +322,16 @@ mod tests {
 
     #[test]
     fn retorna_erro_quando_query_ausente() {
-        let tool = WebSearchTool::new("test-key".into());
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let result = rt.block_on(tool.execute(&contexto_teste(), serde_json::json!({})));
-        assert!(result.is_err());
+        for tool in [
+            WebSearchTool::new("test-key".into()),
+            WebSearchTool::with_backend(SearchBackend::Searxng {
+                base_url: "http://127.0.0.1:8081".into(),
+            }),
+        ] {
+            let result = rt.block_on(tool.execute(&contexto_teste(), serde_json::json!({})));
+            assert!(result.is_err(), "{}", tool.backend_name());
+        }
     }
 
     #[test]
@@ -166,33 +349,97 @@ mod tests {
     #[test]
     fn formata_resultados_corretamente() {
         let results = [
-            BraveWebResult {
+            SearchResult {
                 title: "Rust Lang".into(),
                 url: "https://www.rust-lang.org".into(),
                 description: "Uma linguagem de programação de sistemas.".into(),
             },
-            BraveWebResult {
+            SearchResult {
                 title: "Crates.io".into(),
                 url: "https://crates.io".into(),
                 description: "O repositório de pacotes Rust.".into(),
             },
         ];
-
-        let mut output = String::new();
-        for (i, result) in results.iter().enumerate() {
-            output.push_str(&format!(
-                "{}. **{}** — {}\n   {}\n\n",
-                i + 1,
-                result.title,
-                result.url,
-                result.description,
-            ));
-        }
-        let output = output.trim_end();
+        let output = format_results(&results);
 
         assert!(output.starts_with("1. **Rust Lang**"));
         assert!(output.contains("2. **Crates.io**"));
         assert!(output.contains("https://crates.io"));
         assert!(output.contains("O repositório de pacotes Rust."));
+        assert!(!output.ends_with('\n'));
+    }
+
+    /// #1034: o JSON do SearXNG (`title`, `url`, `content`, mais campos que
+    /// nao usamos) vira o mesmo `SearchResult` do Brave — `content` e a
+    /// descricao, e um resultado sem `content` nao derruba o parse.
+    #[test]
+    fn searxng_json_mapeia_content_para_description() {
+        let body = r#"{
+            "query": "rust",
+            "number_of_results": 2,
+            "results": [
+                {"title": "Rust", "url": "https://www.rust-lang.org", "content": "A language.", "engines": ["duckduckgo"], "score": 9.1},
+                {"title": "Sem descricao", "url": "https://example.org"}
+            ],
+            "suggestions": []
+        }"#;
+        let parsed: SearxngResponse = serde_json::from_str(body).expect("json do searxng");
+        let results: Vec<SearchResult> = parsed.results.into_iter().map(Into::into).collect();
+        assert_eq!(
+            results,
+            vec![
+                SearchResult {
+                    title: "Rust".into(),
+                    url: "https://www.rust-lang.org".into(),
+                    description: "A language.".into(),
+                },
+                SearchResult {
+                    title: "Sem descricao".into(),
+                    url: "https://example.org".into(),
+                    description: String::new(),
+                },
+            ]
+        );
+    }
+
+    /// A URL do SearXNG e do operador, entao loopback e LAN passam; o que
+    /// nunca e alvo legitimo (metadata de nuvem em link-local, esquema que
+    /// nao e http) continua recusado antes de qualquer conexao. Offline:
+    /// `vet_url` decide no parse ou no bloqueio de IP.
+    #[test]
+    fn searxng_policy_libera_loopback_e_bloqueia_link_local() {
+        let policy = searxng_policy();
+        assert!(ssrf::vet_url("http://127.0.0.1:8081/search", &policy).is_ok());
+        assert!(ssrf::vet_url("http://192.168.1.10:8080/search", &policy).is_ok());
+        assert!(ssrf::vet_url("http://169.254.169.254/search", &policy).is_err());
+        assert!(ssrf::vet_url("file:///etc/passwd", &policy).is_err());
+        assert!(ssrf::vet_url("ftp://127.0.0.1/search", &policy).is_err());
+    }
+
+    /// Uma base recusada vira resposta de erro da tool, nao erro do turno —
+    /// o modelo fica sabendo e segue sem busca.
+    #[test]
+    fn base_url_recusada_vira_erro_da_tool() {
+        let tool = WebSearchTool::with_backend(SearchBackend::Searxng {
+            base_url: "http://169.254.169.254".into(),
+        });
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let out = rt
+            .block_on(tool.execute(&contexto_teste(), serde_json::json!({"query": "x"})))
+            .expect("erro da tool, nao do turno");
+        assert!(out.is_error, "{out:?}");
+        assert!(out.content.contains("recusada"), "{}", out.content);
+    }
+
+    #[test]
+    fn backend_name_diz_qual_esta_ativo() {
+        assert_eq!(WebSearchTool::new("k".into()).backend_name(), "brave");
+        assert_eq!(
+            WebSearchTool::with_backend(SearchBackend::Searxng {
+                base_url: "http://127.0.0.1:8081".into()
+            })
+            .backend_name(),
+            "searxng"
+        );
     }
 }

--- a/crates/garraia-config/src/check.rs
+++ b/crates/garraia-config/src/check.rs
@@ -527,6 +527,47 @@ fn validate(config: &AppConfig) -> Vec<Finding> {
         }
     }
 
+    // agent.web_search (#1034): um backend explicito que nao tem o que precisa
+    // deixa a tool de fora no boot — e melhor saber aqui do que descobrir pelo
+    // agente dizendo que nao tem busca. A URL do SearXNG so precisa parecer
+    // URL; o guard de SSRF decide o resto na hora da busca.
+    {
+        use crate::model::WebSearchBackend;
+        let ws = &config.agent.web_search;
+        let has_searxng_url = ws
+            .searxng_url
+            .as_deref()
+            .is_some_and(|u| !u.trim().is_empty())
+            || std::env::var("GARRAIA_SEARXNG_URL").is_ok_and(|u| !u.trim().is_empty());
+        if let Some(url) = ws.searxng_url.as_deref().map(str::trim)
+            && !url.is_empty()
+            && !url.starts_with("http://")
+            && !url.starts_with("https://")
+        {
+            push_warn(
+                &mut findings,
+                "agent.web_search.searxng_url",
+                format!(
+                    "agent.web_search.searxng_url should be an http:// or https:// URL (got `{}`)",
+                    sanitise_for_display(url)
+                ),
+            );
+        }
+        match ws.backend {
+            Some(WebSearchBackend::Searxng) if !has_searxng_url => push_err(
+                &mut findings,
+                "agent.web_search.backend",
+                "agent.web_search.backend=searxng but neither agent.web_search.searxng_url nor GARRAIA_SEARXNG_URL is set; web_search will not be registered".into(),
+            ),
+            Some(WebSearchBackend::Brave) if !config.llm.contains_key("brave") => push_warn(
+                &mut findings,
+                "agent.web_search.backend",
+                "agent.web_search.backend=brave but there is no `llm.brave` entry; the key must then come from the vault or BRAVE_API_KEY".into(),
+            ),
+            _ => {}
+        }
+    }
+
     // llm.*: a provider entry whose API key resolves nowhere is skipped at
     // startup, leaving the gateway up with zero usable providers — the failure
     // mode that made `garraia init` → `garraia start` unusable. It is an Error,
@@ -1577,6 +1618,57 @@ mod tests {
                 .iter()
                 .any(|f| f.severity == Severity::Error && f.field == "agent.default_provider"),
             "findings = {findings:?}"
+        );
+    }
+
+    /// #1034: `backend: searxng` sem URL deixaria a tool de fora no boot em
+    /// silencio; aqui vira erro. URL que nao parece URL e aviso. E a secao
+    /// ausente (o default) nao produz nada.
+    #[test]
+    fn agent_web_search_backend_needs_its_input() {
+        use crate::model::WebSearchBackend;
+
+        let quiet = validate(&AppConfig::default());
+        assert!(
+            !quiet
+                .iter()
+                .any(|f| f.field.starts_with("agent.web_search")),
+            "findings = {quiet:?}"
+        );
+
+        let mut cfg = AppConfig::default();
+        cfg.agent.web_search.backend = Some(WebSearchBackend::Searxng);
+        let findings = validate(&cfg);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.severity == Severity::Error && f.field == "agent.web_search.backend"),
+            "findings = {findings:?}"
+        );
+
+        cfg.agent.web_search.searxng_url = Some("127.0.0.1:8081".into());
+        let findings = validate(&cfg);
+        assert!(
+            !findings
+                .iter()
+                .any(|f| f.severity == Severity::Error && f.field == "agent.web_search.backend"),
+            "com URL o erro some: {findings:?}"
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.severity == Severity::Warning
+                    && f.field == "agent.web_search.searxng_url"),
+            "sem esquema e aviso: {findings:?}"
+        );
+
+        cfg.agent.web_search.searxng_url = Some("http://127.0.0.1:8081".into());
+        let findings = validate(&cfg);
+        assert!(
+            !findings
+                .iter()
+                .any(|f| f.field.starts_with("agent.web_search")),
+            "configuracao completa e limpa: {findings:?}"
         );
     }
 

--- a/crates/garraia-config/src/model.rs
+++ b/crates/garraia-config/src/model.rs
@@ -648,6 +648,37 @@ pub struct AgentConfig {
     /// Example: `"google/gemini-2.0-flash-exp:free"` (free, supports tools).
     #[serde(default)]
     pub tools_model: Option<String>,
+    /// #1034: de onde a tool `web_search` tira os resultados. Sem esta secao
+    /// o comportamento e o de sempre: a tool so existe quando uma chave do
+    /// Brave resolve (`llm.brave.api_key`, cofre ou `BRAVE_API_KEY`).
+    #[serde(default)]
+    pub web_search: WebSearchConfig,
+}
+
+/// Backend da tool `web_search` (#1034).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WebSearchBackend {
+    /// Brave Search API — precisa de chave (`llm.brave.api_key` ou `BRAVE_API_KEY`).
+    Brave,
+    /// SearXNG self-hosted, sem chave — precisa de `searxng_url` (ou
+    /// `GARRAIA_SEARXNG_URL`) e da instancia com `format: json` habilitado.
+    Searxng,
+}
+
+/// Secao `agent.web_search` (#1034).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WebSearchConfig {
+    /// `brave` | `searxng`. Explicito ganha, e se faltar o que ele precisa a
+    /// tool fica de fora (cair no outro em silencio seria surpresa). Sem
+    /// valor: Brave se houver chave, senao SearXNG se houver URL.
+    #[serde(default)]
+    pub backend: Option<WebSearchBackend>,
+    /// Base da instancia SearXNG, ex.: `http://127.0.0.1:8081`. Loopback e
+    /// LAN sao alvos legitimos aqui (self-hosted); link-local, CGNAT e a
+    /// metadata de nuvem continuam bloqueados pelo guard de SSRF.
+    #[serde(default)]
+    pub searxng_url: Option<String>,
 }
 
 /// A named agent configuration for multi-agent routing.

--- a/crates/garraia-gateway/src/bootstrap/mod.rs
+++ b/crates/garraia-gateway/src/bootstrap/mod.rs
@@ -565,14 +565,32 @@ pub fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
     runtime.register_tool(Box::new(FileWriteTool::new(None)));
     runtime.register_tool(Box::new(WebFetchTool::new(None)));
 
-    // Web search (Brave Search API) — only registered when an API key is available
+    // Web search (#1034): Brave (chave) ou SearXNG (URL, sem chave). Sem a
+    // secao `agent.web_search`, o comportamento e o de sempre — so com chave
+    // do Brave. `GARRAIA_SEARXNG_URL` e o equivalente da env para a URL.
     let brave_config_key = config.llm.get("brave").and_then(|c| c.api_key.clone());
-    if let Some(key) = resolve_api_key(
+    let brave_key = resolve_api_key(
         brave_config_key.as_deref(),
         "BRAVE_API_KEY",
         "BRAVE_API_KEY",
-    ) {
-        runtime.register_tool(Box::new(WebSearchTool::new(key)));
+    );
+    let searxng_url = config
+        .agent
+        .web_search
+        .searxng_url
+        .clone()
+        .or_else(|| std::env::var("GARRAIA_SEARXNG_URL").ok())
+        .filter(|u| !u.trim().is_empty());
+    match select_web_search_backend(config.agent.web_search.backend, brave_key, searxng_url) {
+        Some(backend) => {
+            info!(backend = backend.name(), "web_search registrada");
+            runtime.register_tool(Box::new(WebSearchTool::with_backend(backend)));
+        }
+        None if config.agent.web_search.backend.is_some() => warn!(
+            "agent.web_search.backend configurado sem a chave/URL que ele precisa; \
+             web_search fica de fora (veja `garra config check`)"
+        ),
+        None => {}
     }
 
     // --- Memory ---
@@ -1242,9 +1260,67 @@ pub fn build_embedding_provider(config: &AppConfig) -> Option<Arc<dyn EmbeddingP
     Some(Arc::new(resilient))
 }
 
+/// Qual backend de busca registrar (#1034).
+///
+/// Escolha explicita ganha e, se faltar o que ela precisa, ninguem e
+/// registrado: cair para o outro backend em silencio seria surpresa para quem
+/// configurou um de proposito. Sem escolha, Brave com chave (como sempre foi)
+/// e, so entao, SearXNG com URL.
+pub(crate) fn select_web_search_backend(
+    choice: Option<garraia_config::model::WebSearchBackend>,
+    brave_key: Option<String>,
+    searxng_url: Option<String>,
+) -> Option<garraia_agents::tools::web_search_tool::SearchBackend> {
+    use garraia_agents::tools::web_search_tool::SearchBackend;
+    use garraia_config::model::WebSearchBackend;
+
+    let brave = |api_key: String| SearchBackend::Brave { api_key };
+    let searxng = |base_url: String| SearchBackend::Searxng { base_url };
+    match choice {
+        Some(WebSearchBackend::Brave) => brave_key.map(brave),
+        Some(WebSearchBackend::Searxng) => searxng_url.map(searxng),
+        None => brave_key.map(brave).or_else(|| searxng_url.map(searxng)),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #1034: a regra de escolha do backend de busca, sem subir gateway.
+    #[test]
+    fn web_search_backend_selection() {
+        use garraia_agents::tools::web_search_tool::SearchBackend;
+        use garraia_config::model::WebSearchBackend;
+
+        let k = || Some("brave-key".to_string());
+        let u = || Some("http://127.0.0.1:8081".to_string());
+
+        // Sem secao: Brave com chave, como antes; sem chave, SearXNG com URL;
+        // sem nada, nada.
+        assert!(matches!(
+            select_web_search_backend(None, k(), u()),
+            Some(SearchBackend::Brave { .. })
+        ));
+        assert!(matches!(
+            select_web_search_backend(None, None, u()),
+            Some(SearchBackend::Searxng { ref base_url }) if base_url == "http://127.0.0.1:8081"
+        ));
+        assert!(select_web_search_backend(None, None, None).is_none());
+
+        // Explicito ganha mesmo com o outro disponivel...
+        assert!(matches!(
+            select_web_search_backend(Some(WebSearchBackend::Searxng), k(), u()),
+            Some(SearchBackend::Searxng { .. })
+        ));
+        assert!(matches!(
+            select_web_search_backend(Some(WebSearchBackend::Brave), k(), u()),
+            Some(SearchBackend::Brave { .. })
+        ));
+        // ...e sem o que precisa nao cai para o outro.
+        assert!(select_web_search_backend(Some(WebSearchBackend::Searxng), k(), None).is_none());
+        assert!(select_web_search_backend(Some(WebSearchBackend::Brave), None, u()).is_none());
+    }
 
     /// O literal "no-key" que existia aqui tratava LM Studio e a OpenAI
     /// oficial igual. Contra a oficial isso e 401 em toda chamada; contra o

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,6 +108,12 @@ agent:
     - file_write
     - web_fetch
     - web_search
+  # Backend of `web_search` (#1034). Omit the section to keep the old rule:
+  # Brave when a key resolves, otherwise no search tool. `searxng` needs no
+  # key — point it at a self-hosted instance with `json` in search.formats.
+  web_search:
+    backend: searxng                 # brave | searxng
+    searxng_url: http://127.0.0.1:8081   # or GARRAIA_SEARXNG_URL
 
 # Multi-agent Configuration
 # Named agents are resolved via `agent_router` (explicit agent_id > channel

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -33,7 +33,7 @@ O runtime do agente inclui 6 ferramentas nativas que o modelo de linguagem (LLM)
 | `file_read`          | Lê o conteúdo de arquivos (máximo de 1 MB, com proteção contra acesso fora do diretório permitido)    |
 | `file_write`         | Escreve conteúdo em arquivos (máximo de 1 MB, com proteção contra acesso fora do diretório permitido) |
 | `web_fetch`          | Obtém páginas da web (timeout de 30 segundos, resposta máxima de 1 MB)                                |
-| `web_search`         | Realiza buscas usando a API Brave Search (requer `BRAVE_API_KEY`)                                     |
+| `web_search`         | Realiza buscas via Brave Search (`BRAVE_API_KEY`) ou SearXNG self-hosted (`agent.web_search.searxng_url`) |
 | `schedule_heartbeat` | Agenda a reativação futura do agente (máximo de 30 dias, limite de 5 agendamentos pendentes)          |
 
 Consulte [Ferramentas](./tools.md) para a referência completa.

--- a/docs/src/tools.md
+++ b/docs/src/tools.md
@@ -124,16 +124,30 @@ para restringir acesso.
 
 ## web\_search
 
-Pesquisa na internet usando a API Brave Search.
+Pesquisa na internet por um de dois backends (#1034):
 
-Disponível apenas quando `BRAVE\\\_API\\\_KEY` está configurada.
+* **Brave Search API** — precisa de chave (`llm.brave.api_key`, cofre ou
+  `BRAVE_API_KEY`). Era o único até a v0.4.0.
+* **SearXNG** self-hosted — sem chave. Aponte `agent.web_search.searxng_url`
+  (ou `GARRAIA_SEARXNG_URL`) para a instância, ex.: `http://127.0.0.1:8081`.
+  A instância precisa de `json` em `search.formats` (`settings.yml`); sem
+  isso ela responde 403 e a tool diz exatamente isso.
+
+Sem `agent.web_search.backend`, o gateway usa Brave se houver chave, senão
+SearXNG se houver URL, senão a tool **não é registrada**. Com `backend`
+explícito, só aquele — e se faltar a chave/URL dele, a tool fica de fora e
+`garra config check` avisa.
+
+A URL do SearXNG passa pelo guard de SSRF com faixas privadas liberadas
+(loopback e LAN são o caso de uso); link-local, CGNAT e a metadata de nuvem
+continuam recusados, e a conexão é pinada nos endereços validados.
 
 |Propriedade|Valor|
 |-|-|
 |Timeout|15 segundos|
 |Resultados padrão|5|
 |Resultados máximos|10|
-|Requer|BRAVE\_API\_KEY|
+|Requer|`BRAVE_API_KEY` **ou** `agent.web_search.searxng_url`|
 
 **Entrada:**
 


### PR DESCRIPTION
## Descrição

**#1034.** A `WebSearchTool` era acoplada à API do Brave e só entrava no runtime com a chave dele; sem chave o agente **não tinha busca nenhuma** (verificado em produção na v0.3.9). O backend virou plugável, com SearXNG self-hosted como caminho sem chave.

**`garraia-agents` — `SearchBackend::{Brave, Searxng}`**
- SearXNG: `GET {base_url}/search?format=json` → `results[].{title,url,content}` mapeados para o mesmo `SearchResult` do Brave (`content` → `description`; resultado sem `content` não derruba o parse). O modelo vê um schema só, seja qual for a origem. O SearXNG não aceita `count`; o corte é feito aqui para os dois backends devolverem o mesmo tamanho.
- `WebSearchTool::new(key)` segue igual (Brave) para os chamadores existentes; `with_backend(..)` para o resto. `backend_name()` para o log.
- **SSRF (regra 14 do CLAUDE.md):** a URL é do operador, mas a config pode vir de `PATCH /api/settings`, então a base passa por `ssrf::vet_url` com `IpScope::AllowPrivate` — loopback e LAN são o caso de uso (a instância do dono está em `127.0.0.1:8081`); link-local (`169.254.169.254`), CGNAT, multicast e unspecified continuam bloqueados — e cada busca usa um `pinned_client` nos endereços validados, como o `web_fetch`. Base recusada vira **erro da tool** (o modelo fica sabendo e segue), não erro do turno.
- 403 do SearXNG ganha a dica de `json` em `search.formats` (`settings.yml`), a causa mais comum de "não funciona".

**`garraia-config` — `agent.web_search`**
- `backend: brave | searxng` e `searxng_url` (ou env `GARRAIA_SEARXNG_URL`). Sem a seção o comportamento é o de sempre.
- `garra config check`: `backend: searxng` sem URL é **erro** (a tool ficaria de fora no boot em silêncio); URL sem `http(s)://` é aviso; `backend: brave` sem `llm.brave` é aviso (a chave ainda pode vir do cofre ou da env).

**`garraia-gateway` — registro**
- `select_web_search_backend` (pura, testada): explícito ganha e, se faltar o que ele precisa, **ninguém** é registrado, com `warn!` no boot — cair no outro em silêncio seria surpresa para quem configurou de propósito. Sem escolha: Brave com chave (como sempre foi), senão SearXNG com URL, senão nada.

Docs: `docs/src/tools.md` (seção `web_search`), `docs/src/architecture.md`, `docs/configuration.md` (exemplo da seção).

**Fora deste PR:** o `garra chat` da CLI registra o Brave só via chave (e o #1044 passa a registrá-lo também); a mesma seleção na CLI é um follow-up pequeno depois de #1044 entrar, para não conflitar com ele.

Closes #1034

## Tipo de mudança

- [x] `feat`: Nova funcionalidade
- [ ] `fix`: Correção de bug
- [ ] `refactor`: Refatoração sem mudança de comportamento
- [x] `docs`: Documentação apenas
- [x] `test`: Adição ou correção de testes
- [ ] `perf`: Melhoria de performance
- [ ] `chore`: Manutenção (deps, CI, build)
- [x] `sec`: Correção ou hardening de segurança

## Classe de Risco

- [ ] **Classe A (Baixo Risco)**
- [x] **Classe B (Médio Risco)**: campo novo de configuração e uma requisição HTTP de saída cuja URL vem da config. Sem auth, RLS, migrations, RBAC. A saída passa pelo guard de SSRF do projeto com o escopo já usado para Ollama/MCP self-hosted; testes offline provam que loopback/LAN passam e link-local/`file:`/`ftp:` são recusados antes de qualquer conexão.
- [ ] **Classe C (Alto Risco)**

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo fmt --check` executado e limpo
- [x] `cargo clippy -p garraia-config -p garraia-agents -p garraia-gateway --all-targets -- -D warnings` sem erros
- [x] `cargo test -p garraia-agents --lib -- web_search_tool` 8/8 (4 novos); `cargo test -p garraia-config --lib -- web_search` 1/1; `cargo test -p garraia-gateway --lib -- web_search_backend_selection` 1/1
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo, API key, token ou credencial commitada — o log do boot diz só o nome do backend
- [x] Nenhuma migração Postgres

### Para alterações de Alto Risco (Classe C)

- [ ] N/A

## Mudanças na API pública e Schema

- Config: `agent.web_search.backend`, `agent.web_search.searxng_url` (novos, opcionais); env `GARRAIA_SEARXNG_URL`.
- `garraia_agents::tools::web_search_tool::SearchBackend` (novo), `WebSearchTool::with_backend`, `WebSearchTool::backend_name`; `WebSearchTool::new` inalterado.
- `garraia_config::model::{WebSearchBackend, WebSearchConfig}` (novos).

## Como testar

1. Os três `cargo test` acima.
2. SearXNG local com `json` em `search.formats`: `agent.web_search.searxng_url: http://127.0.0.1:8081` (sem `backend`, sem chave do Brave) → `garra start` loga `web_search registrada backend=searxng`; `GET /api/capabilities` → `tools` inclui `web_search`; no chat, "pesquise X" → resultados numerados com título/URL/descrição.
3. `searxng_url: http://169.254.169.254` → a tool responde "URL do SearXNG recusada" (sem conexão). `backend: searxng` sem URL → `garra config check` erra e o boot avisa.
4. Com `BRAVE_API_KEY` e sem a seção: tudo como antes.

## Plano de Rollback

Revert do PR. Sem a seção nova, a config antiga continua válida (serde default), e `WebSearchTool::new` é o mesmo de antes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVnUdw6gJJLtcmWxzxMtFz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVnUdw6gJJLtcmWxzxMtFz)_