### PR TITLE
fix(channels): segredo do LINE só com espaços deixa de validar assinatura

### DIFF
--- a/changelog.d/security/1051-segredo-em-branco.md
+++ b/changelog.d/security/1051-segredo-em-branco.md
@@ -1,0 +1,10 @@
+- **A verificacao de assinatura do LINE deixa de aceitar segredo so com
+  espacos (#1051).** O construtor `LineChannel::new` recusa `channel_secret`
+  em branco desde o PR #1057, mas `line_signature::verify_signature` media
+  "vazio" com `is_empty()` em vez de `trim().is_empty()`. As duas discordavam,
+  e a mais fraca era justamente a exportada: `verify_signature` e API publica
+  reexportada, e `ChannelConfig.settings` e um mapa nao-tipado, entao um
+  `channel_secret = "   "` no TOML passava pela config e a funcao validava
+  contra essa chave — que qualquer um reproduz. O impacto hoje segue nulo (o
+  canal LINE nao chega ao gateway, #1050), mas quem escrever o handler do
+  webhook chamaria a funcao direto, e nesse dia o teatro seria real.

--- a/crates/garraia-channels/src/line_channel/signature.rs
+++ b/crates/garraia-channels/src/line_channel/signature.rs
@@ -93,15 +93,23 @@ pub fn compute_signature(channel_secret: &str, body: &[u8]) -> String {
 /// descarte por tamanho antes disso nao vaza nada util: 32 bytes e o
 /// tamanho publico e fixo de todo HMAC-SHA256.
 ///
-/// Segredo vazio e recusa imediata ([`SignatureError::MissingSecret`]) —
-/// sem isso, uma instalacao mal configurada validaria contra a chave `""`,
-/// que qualquer um pode reproduzir, e a verificacao viraria teatro.
+/// Segredo em branco e recusa imediata ([`SignatureError::MissingSecret`]) —
+/// sem isso, uma instalacao mal configurada validaria contra uma chave que
+/// qualquer um pode reproduzir, e a verificacao viraria teatro.
+///
+/// `trim().is_empty()` e nao `is_empty()`: a mesma regra do construtor
+/// [`super::LineChannel::new`]. Com as duas medindo "vazio" de jeitos
+/// diferentes, `channel_secret = "   "` no TOML era recusado pelo canal mas
+/// aceito por esta funcao — e ela e API publica reexportada (`line_signature`
+/// em `lib.rs`), entao um handler futuro que a chame direto validaria contra
+/// a chave `"   "`. `ChannelConfig.settings` e um mapa nao-tipado, entao esse
+/// valor passa pela config sem ninguem reclamar.
 pub fn verify_signature(
     channel_secret: &str,
     body: &[u8],
     header: &str,
 ) -> Result<(), SignatureError> {
-    if channel_secret.is_empty() {
+    if channel_secret.trim().is_empty() {
         return Err(SignatureError::MissingSecret);
     }
     if header.is_empty() {
@@ -211,6 +219,22 @@ mod tests {
             verify_signature("", BODY, &sig),
             Err(SignatureError::MissingSecret)
         );
+    }
+
+    /// O construtor recusa `channel_secret = "   "` (`mod.rs`), mas esta
+    /// funcao e API publica reexportada e pode ser chamada direto pelo
+    /// handler de webhook do #1050. As duas tem de medir "vazio" igual,
+    /// senao a mais fraca e justamente a exportada.
+    #[test]
+    fn segredo_so_com_espacos_e_recusado_como_o_construtor_recusa() {
+        for branco in ["   ", "\t", "\n", " \t\n "] {
+            let sig = compute_signature(branco, BODY);
+            assert_eq!(
+                verify_signature(branco, BODY, &sig),
+                Err(SignatureError::MissingSecret),
+                "segredo {branco:?} nao pode validar nem a propria assinatura"
+            );
+        }
     }
 
     /// Corpo vazio ainda tem assinatura valida — o LINE assina o corpo


### PR DESCRIPTION
## Descrição

Sobra do #1057, achada revisando o que faltava para fechar a #1051. O PR anterior pôs a checagem de segredo em branco em **dois** lugares, e eles discordam:

- `LineChannel::new` (`mod.rs:61`) recusa com `config.channel_secret.trim().is_empty()`.
- `verify_signature` (`signature.rs:104`) recusava com `channel_secret.is_empty()`.

A mais fraca é justamente a exportada. O módulo é reexportado como `line_signature` em `lib.rs:58-59`, e `ChannelConfig.settings` é um `HashMap<String, Value>` não-tipado (`garraia-config/src/model.rs:389-397`), então um `channel_secret = "   "` no TOML atravessa a config sem ninguém reclamar. Antes desta mudança:

```rust
verify_signature("   ", body, &compute_signature("   ", body)) == Ok(())
```

Ou seja, a função validava contra uma chave que qualquer um reproduz — exatamente o "teatro" que o doc-comment dela diz impedir.

**Impacto hoje é nulo**, pelo mesmo motivo de sempre: o canal LINE não chega ao gateway (`bootstrap/channels.rs` reconhece 5 tipos, e a feature `line` não está ligada em `garraia-gateway/Cargo.toml:12`). Isto importa no dia em que o handler do webhook existir (#1050), porque ele chama esta função direto.

Refs #1051
Refs #1050

## Tipo de mudança

- [ ] `feat`: Nova funcionalidade
- [x] `fix`: Correção de bug
- [ ] `refactor`: Refatoração sem mudança de comportamento
- [ ] `docs`: Documentação apenas
- [x] `test`: Adição ou correção de testes
- [ ] `perf`: Melhoria de performance
- [ ] `chore`: Manutenção (deps, CI, build)
- [x] `sec`: Correção ou hardening de segurança

## Classe de Risco

- [ ] **Classe A (Baixo Risco)**
- [ ] **Classe B (Médio Risco)**
- [x] **Classe C (Alto Risco)**: pelo critério do template a mudança é em criptografia, então entra como C mesmo sendo uma palavra (`is_empty` → `trim().is_empty()`) e estritamente no sentido de fechar. Sem rota, migration, RLS ou RBAC; o código vive atrás da feature `line`, que nenhum bootstrap liga.

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo fmt --all -- --check` executado e limpo
- [x] `cargo clippy -p garraia-channels --features line --all-targets -- -D warnings` sem erros
- [x] `cargo test -p garraia-channels --features line --lib` 29/29 (28 anteriores + 1 novo)
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo commitado — os valores do teste são `"   "`, `"\t"`, `"\n"` e `" \t\n "`, e nenhum motivo de recusa ecoa segredo ou assinatura
- [x] Nenhuma migração Postgres

### Para alterações de Alto Risco (Classe C)

- [ ] Testes de autorização cross-group/cross-tenant — **N/A**: não há tenant, grupo, banco nem rota neste caminho
- [ ] Verificação de políticas RLS `USING` e `WITH CHECK` — **N/A**: nenhum acesso a Postgres
- [ ] Auditoria de eventos de workspace — **N/A**

No lugar desses três, o que cobre o risco é o teste novo, que percorre quatro formas de branco (`"   "`, `"\t"`, `"\n"`, `" \t\n "`) e exige `MissingSecret` em todas, inclusive contra a assinatura calculada com a própria chave em branco.

## Mudanças na API pública e Schema

- Nenhuma assinatura muda. `verify_signature` continua `(&str, &[u8], &str) -> Result<(), SignatureError>`.
- Mudança de comportamento observável: `verify_signature` com segredo só de espaços passa de `Ok(())` para `Err(MissingSecret)`. Nenhum chamador existe fora do próprio módulo — `grep` confirma zero usos de `verify_signature` e `line_signature` em `crates/*/src/` fora de `line_channel/`.

## Como testar

1. `cargo test -p garraia-channels --features line --lib` → 29/29.
2. Contraprova: troque `channel_secret.trim().is_empty()` de volta por `channel_secret.is_empty()` em `signature.rs:104`. O teste `segredo_so_com_espacos_e_recusado_como_o_construtor_recusa` passa a falhar.
3. `cargo check -p garraia-channels` sem a feature → o build default segue intacto.

## Plano de Rollback

Revert do PR. Sem migration, sem rota, sem estado persistido. O revert reabre a divergência entre o construtor e a função exportada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVnUdw6gJJLtcmWxzxMtFz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVnUdw6gJJLtcmWxzxMtFz)_