### PR TITLE
ci: fila de merge em main (merge_group + regra merge_queue)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main, develop, master]
   pull_request:
     branches: [main, develop, master]
+  # Merge queue: os 4 checks obrigatorios (Format Check, Clippy Linting,
+  # Test (ubuntu-latest), Test (windows-latest)) vivem todos neste workflow,
+  # entao ele precisa rodar tambem no ref temporario que a fila cria
+  # (refs/heads/gh-readonly-queue/main/...). Sem este trigger a fila espera
+  # para sempre por checks que nunca sao reportados.
+  merge_group:
+    branches: [main]
 
 # Cancel superseded in-flight runs on the same PR to avoid empilhar FAILUREs
 # em Dependabot rebases e PRs que serão fechados (ex.: #289/#286/#291 hoje

--- a/.github/workflows/security-gate-bola.yml
+++ b/.github/workflows/security-gate-bola.yml
@@ -14,6 +14,11 @@ on:
     branches: [main]
   push:
     branches: [main]
+  # Este job e um dos checks obrigatorios da ruleset de `main`, entao a fila
+  # de merge precisa ve-lo reportar no ref temporario que ela cria. Sem este
+  # trigger a fila espera para sempre. Ver docs/security/protect-main-ruleset.md.
+  merge_group:
+    branches: [main]
 
 concurrency:
   group: bola-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/docs/security/protect-main-ruleset.json
+++ b/docs/security/protect-main-ruleset.json
@@ -30,7 +30,7 @@
     {
       "type": "required_status_checks",
       "parameters": {
-        "strict_required_status_checks_policy": true,
+        "strict_required_status_checks_policy": false,
         "required_status_checks": [
           {
             "context": "Format Check"
@@ -45,6 +45,18 @@
             "context": "Test (windows-latest)"
           }
         ]
+      }
+    },
+    {
+      "type": "merge_queue",
+      "parameters": {
+        "check_response_timeout_minutes": 60,
+        "grouping_strategy": "ALLGREEN",
+        "max_entries_to_build": 5,
+        "max_entries_to_merge": 5,
+        "merge_method": "SQUASH",
+        "min_entries_to_merge": 1,
+        "min_entries_to_merge_wait_minutes": 5
       }
     }
   ],

--- a/docs/security/protect-main-ruleset.json
+++ b/docs/security/protect-main-ruleset.json
@@ -43,6 +43,9 @@
           },
           {
             "context": "Test (windows-latest)"
+          },
+          {
+            "context": "Security Gate (BOLA & Tenant Isolation)"
           }
         ]
       }

--- a/docs/security/protect-main-ruleset.md
+++ b/docs/security/protect-main-ruleset.md
@@ -20,14 +20,45 @@ A ruleset aplica os seguintes controles à branch `main`:
 | `deletion` | A branch `main` não pode ser deletada. |
 | `non_fast_forward` | Force push em `main` é bloqueado. |
 | `pull_request` | Toda mudança em `main` precisa passar por PR (review opcional, sem dismissal automático). |
-| `required_status_checks` (strict) | Os 4 jobs CI abaixo precisam ficar verdes na cabeça da PR antes do merge. |
+| `required_status_checks` | Os 4 jobs CI abaixo precisam ficar verdes antes do merge. |
+| `merge_queue` | Merge em `main` só acontece pela fila; cada entrada é testada em cima da anterior. |
 
-Required status checks (todos obrigatórios, `strict_required_status_checks_policy: true`):
+Required status checks (todos obrigatórios):
 
 - `Format Check`
 - `Clippy Linting`
 - `Test (ubuntu-latest)`
 - `Test (windows-latest)`
+
+### Merge queue (desde 2026-09-08)
+
+A fila substitui o `strict_required_status_checks_policy`, que passou a
+`false` no mesmo commit. Os dois davam a mesma garantia — "o código testado
+é o código que vai para `main`" — mas por caminhos opostos: o `strict`
+**rejeitava** toda PR que não estivesse na cabeça de `main`, o que serializava
+os merges (cada merge invalidava as demais PRs abertas, obrigando um
+`update-branch` + rodada nova de CI por PR, ~25 min cada). A fila **constrói**
+o merge: o GitHub cria um ref temporário `refs/heads/gh-readonly-queue/main/…`
+com a PR já rebaseada sobre a entrada anterior, roda os 4 checks ali, e só
+então mergeia. Duas PRs independentes entram juntas em vez de esperar uma
+pela outra, e nada entra em `main` sem ter sido testado no estado final.
+
+Parâmetros escolhidos:
+
+| Parâmetro | Valor | Por quê |
+|---|---|---|
+| `merge_method` | `SQUASH` | é o método usado em todos os merges do repo; o título do squash vem do título da PR (por isso Conventional Commits no título) |
+| `grouping_strategy` | `ALLGREEN` | uma entrada vermelha não derruba as demais do lote |
+| `check_response_timeout_minutes` | `60` | o CI completo leva ~25 min; 60 dá folga para fila de runners sem travar a fila |
+| `max_entries_to_build` / `max_entries_to_merge` | `5` | teto de runners paralelos gastos pela fila |
+| `min_entries_to_merge` | `1` | uma PR sozinha não espera por companhia |
+| `min_entries_to_merge_wait_minutes` | `5` | janela curta para agrupar PRs que chegam juntas |
+
+**Pré-requisito no CI:** os 4 checks obrigatórios vivem todos em
+`.github/workflows/ci.yml`, que precisa do trigger `merge_group:` — sem ele a
+fila espera para sempre por checks que nunca são reportados. Esse trigger foi
+adicionado no mesmo commit desta mudança. Ao mover um check obrigatório para
+outro workflow, adicionar `merge_group:` lá também.
 
 `bypass_actors` está vazio — **ninguém** tem bypass automático. Mudanças em
 `main` sempre passam pelo fluxo PR + CI verde.
@@ -96,7 +127,8 @@ Padrão correto para os bloqueios mais comuns:
 
 | Sintoma | Root cause provável | Resposta correta |
 |---|---|---|
-| `head branch is not up to date` | Branch divergiu de `main` após push | `gh pr update-branch <PR>` + esperar nova rodada CI |
+| `head branch is not up to date` | Branch divergiu de `main` após push | Com a fila ligada isso deixa de bloquear (a fila rebaseia sozinha). Se aparecer mesmo assim: `gh pr update-branch <PR>` + esperar nova rodada CI |
+| PR sai da fila com check vermelho | Bug genuíno, ou base quebrada | Ler o run do ref `gh-readonly-queue/main/…`, corrigir e re-enfileirar. Nunca desabilitar a fila para passar |
 | 1+ status check vermelho | Bug genuíno na branch | Fix the bug, push, esperar verde |
 | Auto-merge não disponível | Repo desabilitou auto-merge | `gh pr merge --squash <PR>` manualmente após CI verde |
 | Required check faltando | CI não rodou aquele job | Investigar o workflow, não bypassar |

--- a/docs/security/protect-main-ruleset.md
+++ b/docs/security/protect-main-ruleset.md
@@ -20,15 +20,21 @@ A ruleset aplica os seguintes controles à branch `main`:
 | `deletion` | A branch `main` não pode ser deletada. |
 | `non_fast_forward` | Force push em `main` é bloqueado. |
 | `pull_request` | Toda mudança em `main` precisa passar por PR (review opcional, sem dismissal automático). |
-| `required_status_checks` | Os 4 jobs CI abaixo precisam ficar verdes antes do merge. |
+| `required_status_checks` | Os 5 jobs CI abaixo precisam ficar verdes antes do merge. |
 | `merge_queue` | Merge em `main` só acontece pela fila; cada entrada é testada em cima da anterior. |
 
-Required status checks (todos obrigatórios):
+Required status checks (todos obrigatórios), e em qual workflow cada um vive:
 
-- `Format Check`
-- `Clippy Linting`
-- `Test (ubuntu-latest)`
-- `Test (windows-latest)`
+| Check | Workflow |
+|---|---|
+| `Format Check` | `.github/workflows/ci.yml` |
+| `Clippy Linting` | `.github/workflows/ci.yml` |
+| `Test (ubuntu-latest)` | `.github/workflows/ci.yml` |
+| `Test (windows-latest)` | `.github/workflows/ci.yml` |
+| `Security Gate (BOLA & Tenant Isolation)` | `.github/workflows/security-gate-bola.yml` |
+
+O `Security Gate` foi adicionado à ruleset live em 2026-09-05 e não estava no
+JSON versionado — drift reconciliado aqui, no sentido "o GitHub estava certo".
 
 ### Merge queue (desde 2026-09-08)
 
@@ -54,11 +60,19 @@ Parâmetros escolhidos:
 | `min_entries_to_merge` | `1` | uma PR sozinha não espera por companhia |
 | `min_entries_to_merge_wait_minutes` | `5` | janela curta para agrupar PRs que chegam juntas |
 
-**Pré-requisito no CI:** os 4 checks obrigatórios vivem todos em
-`.github/workflows/ci.yml`, que precisa do trigger `merge_group:` — sem ele a
-fila espera para sempre por checks que nunca são reportados. Esse trigger foi
-adicionado no mesmo commit desta mudança. Ao mover um check obrigatório para
-outro workflow, adicionar `merge_group:` lá também.
+**Pré-requisito no CI: todo workflow que hospeda um check obrigatório precisa
+do trigger `merge_group:`.** Sem ele a fila espera para sempre por um check
+que nunca é reportado, porque a fila roda num ref temporário
+(`refs/heads/gh-readonly-queue/main/…`) que não dispara `pull_request` nem
+`push`. Hoje são dois workflows, `ci.yml` e `security-gate-bola.yml`, e os
+dois ganharam o trigger no mesmo commit desta mudança.
+
+**Ao adicionar um check obrigatório novo, faça os três passos juntos:** o
+`merge_group:` no workflow dele, a entrada no JSON versionado, e o `gh api PUT`.
+Pular o primeiro trava a fila; pular o segundo cria drift — foi o que aconteceu
+com o `Security Gate` entre 2026-09-05 e hoje, e só apareceu quando um merge
+foi recusado com "5 of 5 required status checks are expected" enquanto o doc
+dizia que eram 4.
 
 `bypass_actors` está vazio — **ninguém** tem bypass automático. Mudanças em
 `main` sempre passam pelo fluxo PR + CI verde.


### PR DESCRIPTION
## Descrição

Com `strict_required_status_checks_policy: true`, cada merge em `main` invalida as demais PRs abertas: é preciso `update-branch` + rodada nova de CI (~25 min) por PR, uma de cada vez. Com os ~13 PRs planejados para fechar as issues restantes, isso é cerca de 5 h só de espera em série.

A fila de merge dá a mesma garantia por outro caminho. O `strict` **rejeitava** toda PR que não estivesse na cabeça de `main`; a fila **constrói** o merge — o GitHub cria um ref temporário `refs/heads/gh-readonly-queue/main/…` com a PR já rebaseada sobre a entrada anterior, roda os 4 checks obrigatórios ali e só então mergeia. Duas PRs independentes entram juntas, e nada chega em `main` sem ter sido testado no estado final.

Três arquivos:

- `.github/workflows/ci.yml` — trigger `merge_group:`. Os 4 checks obrigatórios (`Format Check`, `Clippy Linting`, `Test (ubuntu-latest)`, `Test (windows-latest)`) vivem todos neste workflow; sem o trigger a fila esperaria para sempre por checks que nunca são reportados. O `concurrency` já estava correto para isso: `cancel-in-progress` só liga em `pull_request`, então rodada da fila nunca é cancelada. Os dois `if: github.event_name == 'pull_request'` do arquivo estão no job `dependency-review` e no step de comentário do `coverage`, nenhum obrigatório.
- `docs/security/protect-main-ruleset.json` — regra `merge_queue` (squash, `ALLGREEN`, timeout de 60 min para o CI de ~25 min) e `strict_required_status_checks_policy: false`, que a fila substitui.
- `docs/security/protect-main-ruleset.md` — o porquê de cada parâmetro, o pré-requisito do trigger e uma linha nova na tabela de bloqueios (PR que sai da fila vermelha: ler o run do ref `gh-readonly-queue`, corrigir e re-enfileirar; nunca desligar a fila para passar).

Aplicar a ruleset continua sendo passo manual do dono, pelo processo já documentado na seção "Como aplicar / atualizar" — nenhum `--admin`, nenhum `bypass_actors`, nenhuma edição pela UI:

```bash
gh api -X PUT repos/michelbr84/GarraRUST/rulesets/15901595 \
  --input docs/security/protect-main-ruleset.json
```

Até esse passo acontecer, o JSON versionado fica adiantado em relação à live e nada muda no comportamento dos merges — é o caso "JSON adiantado" que a própria seção de drift detection prevê.

## Tipo de mudança

- [x] `chore`: Manutenção (deps, CI, build)

## Classe de Risco

- [x] **Classe B (Médio Risco)**: Atualizações de dependências em produção, refatorações internas sem alteração de schema ou de API pública.

Não é Classe C: nenhum controle é removido. O `strict` sai porque a fila passa a garantir a mesma propriedade, e `bypass_actors` segue vazio.

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo fmt --check` executado e limpo — sem mudança em código Rust
- [x] `cargo clippy` sem erros — sem mudança em código Rust
- [x] `cargo test` passando localmente — sem mudança em código Rust
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo, API key, token ou credencial commitada
- [x] Nenhuma migração Postgres

YAML e JSON validados por parser (`yaml.safe_load` e `json.load`); o bloco `on:` resolve para `push`, `pull_request`, `merge_group`.

## Mudanças na API pública e Schema

- Nenhuma mudança na API pública

## Como testar

1. `python3 -c "import json; json.load(open('docs/security/protect-main-ruleset.json'))"` — JSON válido.
2. `python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/ci.yml')); print(list(d[True].keys()))"` — imprime `['push', 'pull_request', 'merge_group']`.
3. Depois do merge, o dono aplica a ruleset com o `gh api PUT` acima e confere com a seção Drift detection do mesmo doc: o `diff` tem de sair vazio.
4. Primeira PR enfileirada: conferir que os 4 checks aparecem no run do ref `gh-readonly-queue/main/…` e que a fila mergeia sozinha.

## Plano de Rollback

Reverter este commit devolve o `strict: true` e remove o trigger. Se a ruleset já tiver sido aplicada, rodar o mesmo `gh api PUT` com o JSON revertido — a fila é desligada e os merges voltam a ser seriais. Nenhum estado é perdido: PRs na fila voltam para "aguardando merge manual".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVnUdw6gJJLtcmWxzxMtFz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVnUdw6gJJLtcmWxzxMtFz)_