### PR TITLE
fix(memory): continuity_key substitui o escopo de sessao no recall (#1042)

### DIFF
--- a/changelog.d/fixed/1042-shared-continuity-escopo.md
+++ b/changelog.d/fixed/1042-shared-continuity-escopo.md
@@ -1,0 +1,6 @@
+- memoria: com `shared_continuity` ligado, o recall do agente passa a usar a
+  chave de continuidade **no lugar** do escopo de sessao, e nao somada a ele.
+  O store faz AND entre os dois filtros, entao a flag nao compartilhava nada:
+  uma sessao nova so enxergava o que ela mesma tinha gravado sob a mesma
+  chave. Com a flag desligada nada muda — o escopo por sessao continua
+  valendo. (#1042)

--- a/crates/garraia-agents/src/runtime.rs
+++ b/crates/garraia-agents/src/runtime.rs
@@ -615,13 +615,24 @@ impl AgentRuntime {
             .then(|| self.embedding_model())
             .flatten();
 
+        // #1042: os dois escopos se somavam (o store faz AND entre
+        // `session_id` e `continuity_key`, `memory_store.rs` SQL e KNN), entao
+        // ligar `shared_continuity` nao compartilhava nada: uma sessao nova so
+        // enxergava o que ela mesma tinha gravado sob a mesma chave. A chave de
+        // continuidade **substitui** o escopo de sessao — e o que ela promete,
+        // e o que `get_continuity_context` ja fazia do outro lado.
+        let session_scope = match continuity_key {
+            Some(_) => None,
+            None => session_id.map(|s| s.to_string()),
+        };
+
         let resultado = memory
             .recall(RecallQuery {
                 tenant_id: None,
                 query_text: Some(query_text.to_string()),
                 query_embedding,
                 embedding_model,
-                session_id: session_id.map(|s| s.to_string()),
+                session_id: session_scope,
                 continuity_key: continuity_key.map(|s| s.to_string()),
                 limit,
             })
@@ -3387,6 +3398,113 @@ mod tests {
         // Same checks as above but using Default
         assert!(runtime.providers.read().unwrap().is_empty());
         assert!(runtime.default_provider.read().unwrap().is_none());
+    }
+
+    // ─── issue #1042: continuity_key substitui o escopo de sessao ──────────
+    //
+    // Antes destes testes nenhum caso passava `session_id: Some` **e**
+    // `continuity_key: Some` ao mesmo tempo, que e exatamente o que os tres
+    // call sites de producao fazem. O AND do store tornava a flag
+    // `shared_continuity` um no-op entre sessoes.
+
+    /// Grava na sessao A com a chave compartilhada e recupera na sessao B.
+    /// Com o AND (o comportamento anterior), a linha da sessao A ficava fora
+    /// do resultado porque `session_id = "sessao-b"` nunca casa com ela.
+    #[tokio::test]
+    async fn recall_com_continuity_key_atravessa_sessoes() {
+        let store = Arc::new(garraia_db::MemoryStore::in_memory_with_vectors().expect("store"));
+        let mut rt = AgentRuntime::new();
+        rt.set_memory_provider(store);
+
+        rt.remember_turn(
+            "sessao-a",
+            Some("bus:shared-global"),
+            None,
+            "o gato da Maria se chama Frajola",
+            "",
+        )
+        .await
+        .expect("remember_turn");
+
+        let achados = rt
+            .recall_context("gato", Some("sessao-b"), Some("bus:shared-global"), 10)
+            .await
+            .expect("recall_context");
+
+        assert!(
+            achados.iter().any(|m| m.content.contains("Frajola")),
+            "a memoria da sessao A nao atravessou para a sessao B: {achados:?}"
+        );
+    }
+
+    /// O irmao: sem chave de continuidade o escopo de sessao continua valendo,
+    /// e nada atravessa. E o que prova que a mudanca nao abriu a memoria de
+    /// todo mundo para todo mundo.
+    #[tokio::test]
+    async fn recall_sem_continuity_key_nao_atravessa_sessoes() {
+        let store = Arc::new(garraia_db::MemoryStore::in_memory_with_vectors().expect("store"));
+        let mut rt = AgentRuntime::new();
+        rt.set_memory_provider(store);
+
+        rt.remember_turn(
+            "sessao-a",
+            None,
+            None,
+            "o gato da Maria se chama Frajola",
+            "",
+        )
+        .await
+        .expect("remember_turn");
+
+        let achados = rt
+            .recall_context("gato", Some("sessao-b"), None, 10)
+            .await
+            .expect("recall_context");
+
+        assert!(
+            !achados.iter().any(|m| m.content.contains("Frajola")),
+            "sem continuity_key a memoria da sessao A vazou para a sessao B: {achados:?}"
+        );
+
+        // E na propria sessao A ela continua visivel.
+        let na_propria = rt
+            .recall_context("gato", Some("sessao-a"), None, 10)
+            .await
+            .expect("recall_context");
+        assert!(
+            na_propria.iter().any(|m| m.content.contains("Frajola")),
+            "a memoria sumiu da propria sessao que a gravou: {na_propria:?}"
+        );
+    }
+
+    /// Com a chave ligada, a memoria da **propria** sessao continua visivel —
+    /// ela tambem e gravada com a chave, entao trocar o escopo nao esconde
+    /// nada de quem esta conversando agora.
+    #[tokio::test]
+    async fn recall_com_continuity_key_ainda_ve_a_propria_sessao() {
+        let store = Arc::new(garraia_db::MemoryStore::in_memory_with_vectors().expect("store"));
+        let mut rt = AgentRuntime::new();
+        rt.set_memory_provider(store);
+
+        rt.remember_turn(
+            "sessao-a",
+            Some("bus:shared-global"),
+            None,
+            "o gato da Maria se chama Frajola",
+            "",
+        )
+        .await
+        .expect("remember_turn");
+
+        let achados = rt
+            .recall_context("gato", Some("sessao-a"), Some("bus:shared-global"), 10)
+            .await
+            .expect("recall_context");
+
+        assert!(
+            achados.iter().any(|m| m.content.contains("Frajola")),
+            "a memoria da propria sessao sumiu com a chave ligada: {achados:?}"
+        );
     }
 }
 

--- a/crates/garraia-db/src/memory_store.rs
+++ b/crates/garraia-db/src/memory_store.rs
@@ -1236,7 +1236,9 @@ impl MemoryStore {
                     continuity_key = query.continuity_key.as_deref().unwrap_or("<nenhum>"),
                     "recall: vizinhos KNN existem com o modelo ativo, mas ficaram fora do \
                      escopo pedido (sessao/continuidade/tenant) ou venceram o prazo — \
-                     memoria de outras sessoes; nao e caso de reindexar"
+                     memoria de outras sessoes; nao e caso de reindexar. Com \
+                     `shared_continuity` ligado o escopo pedido e a continuity_key, \
+                     nao a sessao (#1042)"
                 );
             }
             KnnDrop::IndexOrphans { knn_candidates } => {


### PR DESCRIPTION
## Descrição

Closes #1042

O store faz AND entre `session_id` e `continuity_key` nos dois caminhos do recall — a query SQL (`crates/garraia-db/src/memory_store.rs`, idioma `(?N IS NULL OR col = ?N)`) e o filtro KNN. Os três call sites de produção em `runtime.rs` passam os dois preenchidos, e `recall_context` repassava ambos sem nenhuma lógica de "um ou outro". Resultado: ligar `shared_continuity` não compartilhava nada. Numa sessão nova a cláusula de sessão sozinha já excluía tudo que as outras sessões tinham gravado, e a cláusula da chave só estreitava mais.

A correção é uma escolha entre os dois escopos em `recall_context`: quando há `continuity_key`, o `RecallQuery` vai com `session_id: None`. A continuidade compartilhada **substitui** o escopo de sessão em vez de se somar a ele — que é o que a flag promete, e o que `get_continuity_context` já fazia do outro lado da mesma tabela. Nada muda em `garra memory`, na API REST, nem no `memory_store`.

Sem a flag, nada muda: `continuity_key` é `None` e o escopo por sessão continua valendo, com o mesmo SQL de antes.

**Por que não regride:** com a flag ligada, as entradas da sessão atual também carregam a chave (ela é gravada na escrita), então a memória da própria sessão continua visível — há um teste só para isso. Entradas antigas com `continuity_key = NULL` seguem invisíveis numa sessão nova, exatamente como já eram sob o AND; a coluna é nullable e não há backfill neste PR.

Junto vai uma frase no log de `KnnDrop::ScopedOut`, que afirmava que o escopo pedido era a sessão. Com a flag ligada passa a ser a `continuity_key`, e o texto agora diz isso.

## Tipo de mudança

- [x] `fix`: Correção de bug

## Classe de Risco

- [x] **Classe B (Médio Risco)**: Atualizações de dependências em produção, refatorações internas sem alteração de schema ou de API pública.

Não toca auth, RLS, migrations nem rota REST. A memória é single-user local (SQLite, `garraia-db`), e o alcance da mudança é o escopo de leitura dentro do banco do próprio usuário, governado por uma flag que o usuário liga.

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo fmt --check` executado e limpo
- [x] `cargo clippy -p garraia-agents -p garraia-db --all-targets -- -D warnings` sem erros
- [x] `cargo test -p garraia-agents --lib` (308 testes) e `-p garraia-db --lib` (96) passando
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo, API key, token ou credencial commitada
- [x] Nenhuma migração Postgres

`python3 scripts/changelog/assemble.py --check` → 13 fragmentos válidos.

## Mudanças na API pública e Schema

- Nenhuma mudança na API pública

`recall_context` mantém a assinatura; muda só o que ela monta internamente.

## Como testar

Três testes novos em `crates/garraia-agents/src/runtime.rs` — os primeiros do repo a passar `session_id: Some` **e** `continuity_key: Some` ao mesmo tempo, que é o que produção sempre fez:

```
cargo test -p garraia-agents --lib recall_
```

1. `recall_com_continuity_key_atravessa_sessoes` — grava na sessão A com a chave, recupera na sessão B com a mesma chave.
2. `recall_sem_continuity_key_nao_atravessa_sessoes` — sem a chave nada atravessa, e a memória segue visível na própria sessão que a gravou.
3. `recall_com_continuity_key_ainda_ve_a_propria_sessao` — a troca de escopo não esconde a conversa em curso.

**Prova por reversão:** trocando a escolha por `let session_scope = session_id.map(...)` (o comportamento anterior), o teste 1 falha e os outros dois passam. Executado antes de abrir o PR.

Ponta a ponta, no aparelho: com `shared_continuity: true`, contar um fato numa sessão e abrir outra sessão nova; o fato é recuperado. Com a flag desligada, não é.

## Plano de Rollback

Reverter o commit. A mudança é uma escolha de escopo em memória, sem estado persistido novo, sem migration e sem formato de dado alterado — reverter devolve o comportamento anterior no próximo recall, sem passo de limpeza.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVnUdw6gJJLtcmWxzxMtFz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVnUdw6gJJLtcmWxzxMtFz)_