### PR TITLE
feat(gateway): /ws emite o turno enquanto ele acontece e aceita stop (#1047)

### DIFF
--- a/changelog.d/added/1047-ws-streaming.md
+++ b/changelog.d/added/1047-ws-streaming.md
@@ -1,0 +1,7 @@
+- gateway: o `/ws` passa a emitir o turno enquanto ele acontece. Com
+  `"stream": true` na mensagem, o cliente recebe `delta` a cada pedaco de
+  texto e `tool_started`/`tool_finished` no ciclo de vida de cada ferramenta,
+  e pode cancelar o turno com `{"type":"stop"}` — que responde `stopped` e
+  nao persiste o parcial. Sem a flag, a sequencia de frames e a de sempre: so
+  o `message` final. Como efeito, o socket passa a ser lido durante o turno,
+  entao o heartbeat deixa de passar fome num turno longo. (#1047)

--- a/crates/garraia-gateway/src/ws.rs
+++ b/crates/garraia-gateway/src/ws.rs
@@ -10,7 +10,7 @@ use futures::stream::StreamExt;
 use tokio::time::Instant;
 use tracing::{info, warn};
 
-use garraia_agents::ChatMessage;
+use garraia_agents::{ChatMessage, TurnEvent};
 
 use crate::state::SharedState;
 
@@ -27,6 +27,21 @@ const HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(90);
 const WS_RATE_LIMIT_MAX: u32 = 30;
 /// Sliding window duration for per-WebSocket rate limiting.
 const WS_RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
+
+/// Capacidade do canal de eventos do turno (#1047).
+///
+/// O produtor usa `send().await`, entao um cliente lento nao perde evento:
+/// ele atrasa o turno. Cem eventos e folga suficiente para uma rajada de
+/// deltas enquanto o socket escoa.
+const TURN_EVENT_CHANNEL: usize = 100;
+
+/// Quantas mensagens do cliente ficam na fila enquanto um turno roda.
+///
+/// Antes do #1047 o loop nao lia o socket durante o turno e essas mensagens
+/// esperavam no buffer do TCP. Agora o socket e lido (senao o `stop` nunca
+/// chegaria), entao a fila precisa existir explicitamente — sem ela a
+/// mensagem seria descartada, o que seria uma regressao.
+const MAX_DEFERRED_MESSAGES: usize = 8;
 
 /// WebSocket upgrade handler.
 pub async fn ws_handler(
@@ -69,6 +84,10 @@ pub async fn ws_handler(
 
 async fn handle_socket(socket: WebSocket, state: SharedState) {
     let (mut sender, mut receiver) = socket.split();
+
+    // Declarado aqui, e nao junto do loop principal, porque desde o #1047 o
+    // socket e lido durante o turno — e a primeira mensagem ja e um turno.
+    let mut last_pong = Instant::now();
 
     // Wait for the first message to decide: new session or resume.
     let session_id = match tokio::time::timeout(Duration::from_secs(10), receiver.next()).await {
@@ -218,11 +237,16 @@ async fn handle_socket(socket: WebSocket, state: SharedState) {
                 }
 
                 // Process this first message as a chat message
-                if let Some(reply) = process_text_message(&text, &id, &state, &mut sender).await
-                    && sender
-                        .send(Message::Text(reply.to_string().into()))
-                        .await
-                        .is_err()
+                if drain_turns(
+                    text.to_string(),
+                    &id,
+                    &state,
+                    &mut sender,
+                    &mut receiver,
+                    &mut last_pong,
+                )
+                .await
+                .is_break()
                 {
                     state.disconnect_session(&id);
                     return;
@@ -248,7 +272,6 @@ async fn handle_socket(socket: WebSocket, state: SharedState) {
     };
 
     // Main message loop with heartbeat
-    let mut last_pong = Instant::now();
     let mut heartbeat = tokio::time::interval(HEARTBEAT_INTERVAL);
     // Don't send ping immediately
     heartbeat.tick().await;
@@ -316,11 +339,16 @@ async fn handle_socket(socket: WebSocket, state: SharedState) {
                             break;
                         }
 
-                        if let Some(reply) = process_text_message(&text, &session_id, &state, &mut sender).await
-                            && sender
-                                .send(Message::Text(reply.to_string().into()))
-                                .await
-                                .is_err()
+                        if drain_turns(
+                            text.to_string(),
+                            &session_id,
+                            &state,
+                            &mut sender,
+                            &mut receiver,
+                            &mut last_pong,
+                        )
+                        .await
+                        .is_break()
                         {
                             break;
                         }
@@ -348,18 +376,93 @@ async fn handle_socket(socket: WebSocket, state: SharedState) {
     info!("session disconnected (resumable): {}", session_id);
 }
 
+/// Roda um turno e, em seguida, os que o cliente enfileirou durante ele.
+///
+/// Itera em vez de recursar: `process_text_message` so empurra em
+/// `deferred`, e quem esvazia a fila e este laco.
+///
+/// `Break` significa que o socket morreu — o chamador encerra a conexao.
+async fn drain_turns(
+    first: String,
+    session_id: &str,
+    state: &SharedState,
+    sender: &mut futures::stream::SplitSink<WebSocket, Message>,
+    receiver: &mut futures::stream::SplitStream<WebSocket>,
+    last_pong: &mut Instant,
+) -> std::ops::ControlFlow<()> {
+    let mut pending: std::collections::VecDeque<String> = std::collections::VecDeque::new();
+    pending.push_back(first);
+
+    while let Some(text) = pending.pop_front() {
+        match process_text_message(
+            &text,
+            session_id,
+            state,
+            sender,
+            receiver,
+            last_pong,
+            &mut pending,
+        )
+        .await
+        {
+            TurnOutcome::Reply(reply) => {
+                if sender
+                    .send(Message::Text(reply.to_string().into()))
+                    .await
+                    .is_err()
+                {
+                    return std::ops::ControlFlow::Break(());
+                }
+            }
+            TurnOutcome::Quiet => {}
+            TurnOutcome::ClientGone => return std::ops::ControlFlow::Break(()),
+        }
+    }
+
+    std::ops::ControlFlow::Continue(())
+}
+
+/// O que sobrou de um turno para o loop principal fazer.
+enum TurnOutcome {
+    /// Frame final (`message` ou `error`) a enviar.
+    Reply(serde_json::Value),
+    /// Nada a enviar: a mensagem foi recusada inline, ou o turno foi
+    /// cancelado e o frame `stopped` ja saiu.
+    Quiet,
+    /// O socket morreu no meio do turno; o loop principal termina.
+    ClientGone,
+}
+
 /// Process a text message through validation and the agent runtime.
-/// Returns the JSON reply value, or `None` if the message was rejected inline.
+///
+/// Desde o #1047 o turno roda numa task propria e os eventos (`TextDelta`,
+/// `ToolStarted`, `ToolFinished`) sao drenados enquanto ele acontece. Isso
+/// serve a tres coisas de uma vez: o cliente ve o texto nascendo, o `stop`
+/// chega (antes o loop nao lia o socket durante o turno) e o heartbeat
+/// deixa de passar fome num turno longo.
+///
+/// Os frames intermediarios so saem com `"stream": true` na mensagem do
+/// cliente. Sem a flag a sequencia e a de sempre — so o `message` final —,
+/// e o console web, cujo `default:` imprime frame desconhecido como
+/// mensagem de sistema, nao muda de comportamento.
+///
+/// Mensagens que o cliente mandar durante o turno vao para `deferred`, que o
+/// chamador drena depois. Antes elas esperavam no buffer do TCP; agora que o
+/// socket e lido ativamente, a fila precisa ser explicita.
+#[allow(clippy::too_many_arguments)]
 async fn process_text_message(
     text: &str,
     session_id: &str,
     state: &SharedState,
     sender: &mut futures::stream::SplitSink<WebSocket, Message>,
-) -> Option<serde_json::Value> {
-    let (user_text, provider_id, model_override, _tenant_id) = parse_user_message(text);
+    receiver: &mut futures::stream::SplitStream<WebSocket>,
+    last_pong: &mut Instant,
+    deferred: &mut std::collections::VecDeque<String>,
+) -> TurnOutcome {
+    let msg = parse_user_message(text);
 
     // Input validation
-    let user_text = garraia_security::InputValidator::sanitize(&user_text);
+    let user_text = garraia_security::InputValidator::sanitize(&msg.content);
     if garraia_security::InputValidator::check_prompt_injection(&user_text) {
         warn!("prompt injection detected: session={}", session_id);
         let err = serde_json::json!({
@@ -369,7 +472,7 @@ async fn process_text_message(
             "message": "input rejected: potential prompt injection detected",
         });
         let _ = sender.send(Message::Text(err.to_string().into())).await;
-        return None;
+        return TurnOutcome::Quiet;
     }
 
     // Ensure session exists and hydrate persisted history for web chat.
@@ -378,47 +481,264 @@ async fn process_text_message(
         .await;
     let history: Vec<ChatMessage> = state.session_history(session_id);
     let continuity_key = state.continuity_key();
+    // Lido **antes** do `spawn`: dentro da task seguraria o lock do store
+    // pelo tempo do turno inteiro (mesma licao do `parrot_ws.rs`).
+    let exec = state.exec_context_for(session_id, None).await;
 
-    // Route through agent runtime (with optional provider override)
-    let reply = match state
-        .agents
-        .process_message_with_agent_config(
-            session_id,
-            &user_text,
-            &history,
-            continuity_key.as_deref(),
-            None,
-            provider_id.as_deref(),
-            model_override.as_deref(),
-            None,
-            None,
-            &state.exec_context_for(session_id, None).await,
-        )
-        .await
-    {
-        Ok(response_text) => {
+    let (events_tx, events_rx) = tokio::sync::mpsc::channel::<TurnEvent>(TURN_EVENT_CHANNEL);
+    let agents = state.agents.clone();
+    let sid = session_id.to_string();
+    let text_for_agent = user_text.clone();
+    let provider_id = msg.provider.clone();
+    let model_override = msg.model.clone();
+    let task = tokio::spawn(async move {
+        agents
+            .process_message_streaming_with_events(
+                &sid,
+                &text_for_agent,
+                &history,
+                events_tx,
+                continuity_key.as_deref(),
+                None,
+                provider_id.as_deref(),
+                model_override.as_deref(),
+                None,
+                None,
+                &exec,
+            )
+            .await
+    });
+
+    let turn = run_streaming_turn(
+        sender, receiver, session_id, events_rx, task, msg.stream, last_pong, deferred,
+    )
+    .await;
+
+    match turn {
+        TurnEnd::ClientGone => TurnOutcome::ClientGone,
+        // O parcial nao e persistido: `persist_turn` so roda no caminho de
+        // sucesso, e `remember_turn`/`record_turn_stats` vivem depois do loop
+        // dentro do runtime, entao o abort tambem nao grava memoria.
+        TurnEnd::Stopped => TurnOutcome::Quiet,
+        TurnEnd::Completed(response_text) => {
             state
                 .persist_turn(session_id, Some("web"), None, &user_text, &response_text)
                 .await;
 
-            serde_json::json!({
+            TurnOutcome::Reply(serde_json::json!({
                 "type": "message",
                 "session_id": session_id,
                 "content": response_text,
-            })
+            }))
         }
-        Err(e) => {
-            warn!("agent error: session={}, error={}", session_id, e);
-            serde_json::json!({
+        TurnEnd::Failed(message) => {
+            warn!("agent error: session={}, error={}", session_id, message);
+            TurnOutcome::Reply(serde_json::json!({
                 "type": "error",
                 "session_id": session_id,
                 "code": "agent_error",
-                "message": e.to_string(),
-            })
+                "message": message,
+            }))
         }
-    };
+    }
+}
 
-    Some(reply)
+/// Como o turno terminou, do ponto de vista do socket.
+#[derive(Debug)]
+enum TurnEnd {
+    Completed(String),
+    Failed(String),
+    Stopped,
+    ClientGone,
+}
+
+/// Drena os eventos do turno **enquanto** ele roda, sem parar de ler o
+/// socket.
+///
+/// Tres braços: o canal de eventos, a task do turno e o proprio cliente. Ler
+/// o cliente e o que torna o `stop` possivel — e o mesmo motivo pelo qual o
+/// pong volta a ser contado durante um turno longo.
+///
+/// O frame final so sai depois que `events_rx` fecha, para nenhum `delta`
+/// chegar depois do `message`.
+#[allow(clippy::too_many_arguments)]
+async fn run_streaming_turn<S, R>(
+    sender: &mut S,
+    receiver: &mut R,
+    session_id: &str,
+    mut events_rx: tokio::sync::mpsc::Receiver<TurnEvent>,
+    mut task: tokio::task::JoinHandle<garraia_common::Result<String>>,
+    stream_frames: bool,
+    last_pong: &mut Instant,
+    deferred: &mut std::collections::VecDeque<String>,
+) -> TurnEnd
+where
+    S: futures::Sink<Message> + Unpin,
+    R: futures::Stream<Item = Result<Message, axum::Error>> + Unpin,
+{
+    let mut rx_open = true;
+    let mut finished: Option<Result<garraia_common::Result<String>, tokio::task::JoinError>> = None;
+    let mut stopped = false;
+    let mut client_gone = false;
+
+    while rx_open || finished.is_none() {
+        tokio::select! {
+            event = events_rx.recv(), if rx_open => match event {
+                Some(event) => {
+                    if stream_frames
+                        && !client_gone
+                        && sender
+                            .send(Message::Text(turn_event_frame(session_id, &event).into()))
+                            .await
+                            .is_err()
+                    {
+                        // Cliente foi embora no meio do stream. Abortar aqui
+                        // poupa os tokens do resto do turno, que nao tem mais
+                        // para quem ir.
+                        client_gone = true;
+                        task.abort();
+                    }
+                }
+                None => rx_open = false,
+            },
+            joined = &mut task, if finished.is_none() => {
+                finished = Some(joined);
+            }
+            incoming = receiver.next(), if !client_gone => match incoming {
+                Some(Ok(Message::Text(raw))) => {
+                    *last_pong = Instant::now();
+                    match parse_stop(&raw) {
+                        Some(target)
+                            if target.is_none() || target.as_deref() == Some(session_id) =>
+                        {
+                            stopped = true;
+                            task.abort();
+                        }
+                        Some(_) => {
+                            let err = serde_json::json!({
+                                "type": "error",
+                                "session_id": session_id,
+                                "code": "session_mismatch",
+                                "message": "stop refers to a different session",
+                            });
+                            let _ = sender.send(Message::Text(err.to_string().into())).await;
+                        }
+                        None => {
+                            if deferred.len() < MAX_DEFERRED_MESSAGES {
+                                deferred.push_back(raw.to_string());
+                            } else {
+                                let err = serde_json::json!({
+                                    "type": "error",
+                                    "session_id": session_id,
+                                    "code": "turn_in_progress",
+                                    "message": "too many messages queued while a turn is running",
+                                });
+                                let _ = sender.send(Message::Text(err.to_string().into())).await;
+                            }
+                        }
+                    }
+                }
+                Some(Ok(Message::Pong(_))) => *last_pong = Instant::now(),
+                Some(Ok(Message::Close(_))) | None => {
+                    client_gone = true;
+                    task.abort();
+                }
+                Some(Err(e)) => {
+                    warn!("WebSocket error mid-turn: session={}, error={}", session_id, e);
+                    client_gone = true;
+                    task.abort();
+                }
+                _ => {}
+            },
+        }
+    }
+
+    if client_gone {
+        return TurnEnd::ClientGone;
+    }
+
+    if stopped {
+        if sender
+            .send(Message::Text(stopped_frame(session_id).into()))
+            .await
+            .is_err()
+        {
+            return TurnEnd::ClientGone;
+        }
+        return TurnEnd::Stopped;
+    }
+
+    match finished {
+        Some(Ok(Ok(text))) => TurnEnd::Completed(text),
+        Some(Ok(Err(e))) => TurnEnd::Failed(e.to_string()),
+        Some(Err(e)) if e.is_cancelled() => TurnEnd::Stopped,
+        Some(Err(e)) => {
+            warn!("agent task failed: session={}, error={}", session_id, e);
+            TurnEnd::Failed("internal agent task failure".to_string())
+        }
+        // Inalcancavel: a condicao do `while` so solta com `finished`
+        // preenchido. Tratado como falha em vez de `unreachable!` porque um
+        // panic aqui derrubaria a conexao de um usuario.
+        None => TurnEnd::Failed("turn ended without a result".to_string()),
+    }
+}
+
+/// Um evento do turno virando frame do protocolo `/ws`.
+///
+/// `ToolFinished.output` fica **de fora** de proposito: e a saida inteira da
+/// ferramenta, ja redigida mas grande (dezenas de KiB), e o frame existe para
+/// dizer que a ferramenta terminou, nao para transportar o resultado dela.
+fn turn_event_frame(session_id: &str, event: &TurnEvent) -> String {
+    let value = match event {
+        TurnEvent::TextDelta(content) => serde_json::json!({
+            "type": "delta",
+            "session_id": session_id,
+            "content": content,
+        }),
+        TurnEvent::ToolStarted { name, detail } => serde_json::json!({
+            "type": "tool_started",
+            "session_id": session_id,
+            "name": name,
+            "detail": detail,
+        }),
+        TurnEvent::ToolFinished {
+            name,
+            duration,
+            success,
+            summary,
+            output: _,
+        } => serde_json::json!({
+            "type": "tool_finished",
+            "session_id": session_id,
+            "name": name,
+            "success": success,
+            "summary": summary,
+            "duration_ms": duration.as_millis() as u64,
+        }),
+    };
+    value.to_string()
+}
+
+fn stopped_frame(session_id: &str) -> String {
+    serde_json::json!({ "type": "stopped", "session_id": session_id }).to_string()
+}
+
+/// Um pedido de cancelamento: `{"type": "stop"}`, com `session_id` opcional.
+///
+/// Devolve `None` quando a mensagem nao e um `stop`, e `Some(alvo)` quando e
+/// — com `alvo` sendo `None` para "a sessao em que eu estou".
+fn parse_stop(raw: &str) -> Option<Option<String>> {
+    let value = serde_json::from_str::<serde_json::Value>(raw).ok()?;
+    if value.get("type")?.as_str()? != "stop" {
+        return None;
+    }
+    Some(
+        value
+            .get("session_id")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(str::to_string),
+    )
 }
 
 /// Try to parse a resume request: `{"type": "resume", "session_id": "..."}`.
@@ -465,7 +785,20 @@ fn text_message_too_large(len: usize) -> bool {
 
 /// Try to extract `"content"` plus optional `"provider"`, `"model"`, and `"tenant_id"` from JSON,
 /// otherwise use the raw text as content with no overrides.
-fn parse_user_message(raw: &str) -> (String, Option<String>, Option<String>, Option<String>) {
+/// Uma mensagem do cliente, ja destrinchada.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct UserMessage {
+    content: String,
+    provider: Option<String>,
+    model: Option<String>,
+    tenant_id: Option<String>,
+    /// `"stream": true` liga os frames intermediarios (#1047). Default
+    /// `false`: quem nao pede continua vendo so o `message` final, que e o
+    /// contrato de antes.
+    stream: bool,
+}
+
+fn parse_user_message(raw: &str) -> UserMessage {
     if let Ok(v) = serde_json::from_str::<serde_json::Value>(raw)
         && let Some(text) = v.get("content").and_then(|c| c.as_str())
     {
@@ -485,16 +818,30 @@ fn parse_user_message(raw: &str) -> (String, Option<String>, Option<String>, Opt
             .and_then(|t| t.as_str())
             .filter(|s| !s.is_empty())
             .map(|s| s.to_string());
-        return (text.to_string(), provider, model, tenant_id);
+        let stream = v.get("stream").and_then(|s| s.as_bool()).unwrap_or(false);
+        return UserMessage {
+            content: text.to_string(),
+            provider,
+            model,
+            tenant_id,
+            stream,
+        };
     }
-    (raw.to_string(), None, None, None)
+    UserMessage {
+        content: raw.to_string(),
+        ..UserMessage::default()
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        MAX_WS_TEXT_BYTES, parse_user_message, text_message_too_large, try_parse_resume_with_token,
+        Duration, Instant, MAX_WS_TEXT_BYTES, Message, TurnEnd, parse_stop, parse_user_message,
+        stopped_frame, text_message_too_large, try_parse_resume_with_token, turn_event_frame,
     };
+    use futures::FutureExt;
+    use futures::StreamExt;
+    use garraia_agents::TurnEvent;
 
     /// Reproduz a decisão de autorização do handler de `resume` (#922) sem
     /// subir um socket: a tabela é o contrato, e o caso perigoso é o da
@@ -575,36 +922,393 @@ mod tests {
     #[test]
     fn parse_user_message_extracts_provider() {
         let json = r#"{"content": "hello", "provider": "anthropic"}"#;
-        let (text, provider, model, tenant) = parse_user_message(json);
-        assert_eq!(text, "hello");
-        assert_eq!(provider, Some("anthropic".to_string()));
-        assert_eq!(model, None);
-        assert_eq!(tenant, None);
+        let msg = parse_user_message(json);
+        assert_eq!(msg.content, "hello");
+        assert_eq!(msg.provider, Some("anthropic".to_string()));
+        assert_eq!(msg.model, None);
+        assert_eq!(msg.tenant_id, None);
     }
 
     #[test]
     fn parse_user_message_extracts_provider_and_model() {
         let json = r#"{"content": "hello", "provider": "ollama", "model": "kimi"}"#;
-        let (text, provider, model, _tenant) = parse_user_message(json);
-        assert_eq!(text, "hello");
-        assert_eq!(provider, Some("ollama".to_string()));
-        assert_eq!(model, Some("kimi".to_string()));
+        let msg = parse_user_message(json);
+        assert_eq!(msg.content, "hello");
+        assert_eq!(msg.provider, Some("ollama".to_string()));
+        assert_eq!(msg.model, Some("kimi".to_string()));
     }
 
     #[test]
     fn parse_user_message_no_provider() {
         let json = r#"{"content": "hello"}"#;
-        let (text, provider, model, _tenant) = parse_user_message(json);
-        assert_eq!(text, "hello");
-        assert_eq!(provider, None);
-        assert_eq!(model, None);
+        let msg = parse_user_message(json);
+        assert_eq!(msg.content, "hello");
+        assert_eq!(msg.provider, None);
+        assert_eq!(msg.model, None);
     }
 
     #[test]
     fn parse_user_message_plain_text() {
-        let (text, provider, model, _tenant) = parse_user_message("just plain text");
-        assert_eq!(text, "just plain text");
-        assert_eq!(provider, None);
-        assert_eq!(model, None);
+        let msg = parse_user_message("just plain text");
+        assert_eq!(msg.content, "just plain text");
+        assert_eq!(msg.provider, None);
+        assert_eq!(msg.model, None);
+    }
+
+    // ─── issue #1047: streaming opt-in, frames e cancelamento ──────────────
+
+    /// A flag e opt-in de verdade: quem nao pede nao recebe frame novo. E o
+    /// que mantem o console web — cujo `default:` do `handleServerEvent`
+    /// imprime frame desconhecido como mensagem de sistema — igual ao de
+    /// antes deste PR.
+    #[test]
+    fn stream_e_opt_in_e_default_desligado() {
+        assert!(parse_user_message(r#"{"content": "oi", "stream": true}"#).stream);
+        assert!(!parse_user_message(r#"{"content": "oi", "stream": false}"#).stream);
+        assert!(!parse_user_message(r#"{"content": "oi"}"#).stream);
+        assert!(!parse_user_message("texto cru").stream);
+        // Tipo errado nao liga o streaming por acidente.
+        assert!(!parse_user_message(r#"{"content": "oi", "stream": "sim"}"#).stream);
+    }
+
+    #[test]
+    fn delta_vira_frame_com_o_texto_do_modelo() {
+        let frame: serde_json::Value =
+            serde_json::from_str(&turn_event_frame("s1", &TurnEvent::TextDelta("um ".into())))
+                .expect("frame valido");
+        assert_eq!(frame["type"], "delta");
+        assert_eq!(frame["session_id"], "s1");
+        assert_eq!(frame["content"], "um ");
+    }
+
+    #[test]
+    fn tool_started_vira_frame_com_nome_e_detalhe() {
+        let frame: serde_json::Value = serde_json::from_str(&turn_event_frame(
+            "s1",
+            &TurnEvent::ToolStarted {
+                name: "bash".into(),
+                detail: "cargo test".into(),
+            },
+        ))
+        .expect("frame valido");
+        assert_eq!(frame["type"], "tool_started");
+        assert_eq!(frame["name"], "bash");
+        assert_eq!(frame["detail"], "cargo test");
+    }
+
+    /// `output` fica fora do frame de proposito: e a saida inteira da
+    /// ferramenta, ate dezenas de KiB, e o frame existe para dizer que ela
+    /// terminou — nao para transportar o resultado.
+    #[test]
+    fn tool_finished_leva_o_resumo_e_nunca_a_saida_inteira() {
+        let frame: serde_json::Value = serde_json::from_str(&turn_event_frame(
+            "s1",
+            &TurnEvent::ToolFinished {
+                name: "bash".into(),
+                duration: std::time::Duration::from_millis(1500),
+                success: true,
+                summary: "148 passou".into(),
+                output: "x".repeat(64 * 1024),
+            },
+        ))
+        .expect("frame valido");
+        assert_eq!(frame["type"], "tool_finished");
+        assert_eq!(frame["name"], "bash");
+        assert_eq!(frame["success"], true);
+        assert_eq!(frame["summary"], "148 passou");
+        assert_eq!(frame["duration_ms"], 1500);
+        assert!(
+            frame.get("output").is_none(),
+            "a saida inteira da ferramenta vazou para o frame: {frame}"
+        );
+    }
+
+    #[test]
+    fn stopped_frame_nomeia_a_sessao() {
+        let frame: serde_json::Value =
+            serde_json::from_str(&stopped_frame("s1")).expect("frame valido");
+        assert_eq!(frame["type"], "stopped");
+        assert_eq!(frame["session_id"], "s1");
+    }
+
+    // ─── o laco do turno, sem provider e sem socket ───────────────────────
+    //
+    // `run_streaming_turn` e generico sobre sink e stream justamente para
+    // caber aqui: os canais em memoria fazem o papel do cliente, e o
+    // `JoinHandle` faz o papel do turno. Nada de LLM, nada de rede — o que
+    // se afirma e o laco: ordem dos frames, opt-in, cancelamento e fila.
+
+    type ClienteFalso = futures::channel::mpsc::UnboundedReceiver<Result<Message, axum::Error>>;
+
+    fn cliente(mensagens: &[&str]) -> ClienteFalso {
+        let (tx, rx) = futures::channel::mpsc::unbounded();
+        for m in mensagens {
+            tx.unbounded_send(Ok(Message::Text((*m).to_string().into())))
+                .expect("cliente falso aceita a mensagem");
+        }
+        // O `tx` fica vivo: soltar aqui fecharia o stream e o laco leria
+        // `None`, que ele trata como "cliente foi embora".
+        std::mem::forget(tx);
+        rx
+    }
+
+    /// Os `type` dos frames que sairam, na ordem.
+    fn tipos_dos_frames(rx: futures::channel::mpsc::UnboundedReceiver<Message>) -> Vec<String> {
+        frames(rx)
+            .iter()
+            .map(|f| f["type"].as_str().unwrap_or("?").to_string())
+            .collect()
+    }
+
+    fn frames(rx: futures::channel::mpsc::UnboundedReceiver<Message>) -> Vec<serde_json::Value> {
+        rx.collect::<Vec<_>>()
+            .now_or_never()
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|m| match m {
+                Message::Text(t) => serde_json::from_str(&t).ok(),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn eventos_prontos(eventos: Vec<TurnEvent>) -> tokio::sync::mpsc::Receiver<TurnEvent> {
+        let (tx, rx) = tokio::sync::mpsc::channel(super::TURN_EVENT_CHANNEL);
+        for e in eventos {
+            tx.try_send(e).expect("canal comporta os eventos do teste");
+        }
+        drop(tx);
+        rx
+    }
+
+    /// Com a flag ligada, cada evento vira um frame, na ordem em que o
+    /// runtime os emitiu — e todos saem **antes** do fim do turno, porque o
+    /// laco so devolve depois que o canal de eventos fecha.
+    #[tokio::test]
+    async fn com_a_flag_cada_evento_vira_frame_na_ordem() {
+        let (mut sink, sink_rx) = futures::channel::mpsc::unbounded::<Message>();
+        let mut cliente = cliente(&[]);
+        let mut fila = std::collections::VecDeque::new();
+        let mut pong = Instant::now();
+
+        let eventos = eventos_prontos(vec![
+            TurnEvent::TextDelta("um ".into()),
+            TurnEvent::ToolStarted {
+                name: "eco".into(),
+                detail: "oi".into(),
+            },
+            TurnEvent::ToolFinished {
+                name: "eco".into(),
+                duration: std::time::Duration::from_millis(7),
+                success: true,
+                summary: "ok".into(),
+                output: "saida enorme".into(),
+            },
+            TurnEvent::TextDelta("dois".into()),
+        ]);
+        let task = tokio::spawn(async { Ok("um dois".to_string()) });
+
+        let fim = super::run_streaming_turn(
+            &mut sink,
+            &mut cliente,
+            "s1",
+            eventos,
+            task,
+            true,
+            &mut pong,
+            &mut fila,
+        )
+        .await;
+
+        assert!(
+            matches!(fim, TurnEnd::Completed(ref t) if t == "um dois"),
+            "{fim:?}"
+        );
+        drop(sink);
+        assert_eq!(
+            tipos_dos_frames(sink_rx),
+            ["delta", "tool_started", "tool_finished", "delta"]
+        );
+    }
+
+    /// Sem a flag, o mesmo turno nao emite frame nenhum pelo caminho — o
+    /// cliente so recebe o `message` final, que quem manda e o chamador.
+    /// E esta a garantia de que o console web nao muda.
+    #[tokio::test]
+    async fn sem_a_flag_nenhum_frame_intermediario_sai() {
+        let (mut sink, sink_rx) = futures::channel::mpsc::unbounded::<Message>();
+        let mut cliente = cliente(&[]);
+        let mut fila = std::collections::VecDeque::new();
+        let mut pong = Instant::now();
+
+        let eventos = eventos_prontos(vec![
+            TurnEvent::TextDelta("um ".into()),
+            TurnEvent::TextDelta("dois".into()),
+        ]);
+        let task = tokio::spawn(async { Ok("um dois".to_string()) });
+
+        let fim = super::run_streaming_turn(
+            &mut sink,
+            &mut cliente,
+            "s1",
+            eventos,
+            task,
+            false,
+            &mut pong,
+            &mut fila,
+        )
+        .await;
+
+        assert!(matches!(fim, TurnEnd::Completed(_)), "{fim:?}");
+        drop(sink);
+        assert!(
+            frames(sink_rx).is_empty(),
+            "frame intermediario saiu sem ninguem pedir"
+        );
+    }
+
+    /// O `stop` do cliente aborta a task e responde `stopped`. O turno segue
+    /// pendurado por 60 s se nao for cancelado, entao o `timeout` de 5 s e a
+    /// prova de que o abort aconteceu de verdade.
+    #[tokio::test]
+    async fn stop_do_cliente_cancela_o_turno_e_responde_stopped() {
+        let (mut sink, sink_rx) = futures::channel::mpsc::unbounded::<Message>();
+        let mut cliente = cliente(&[r#"{"type":"stop","session_id":"s1"}"#]);
+        let mut fila = std::collections::VecDeque::new();
+        let mut pong = Instant::now();
+
+        let eventos = eventos_prontos(vec![TurnEvent::TextDelta("parcial".into())]);
+        let task = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            Ok("nunca chega".to_string())
+        });
+
+        let fim = tokio::time::timeout(
+            Duration::from_secs(5),
+            super::run_streaming_turn(
+                &mut sink,
+                &mut cliente,
+                "s1",
+                eventos,
+                task,
+                true,
+                &mut pong,
+                &mut fila,
+            ),
+        )
+        .await
+        .expect("o stop tem de soltar o turno antes dos 5 s");
+
+        assert!(matches!(fim, TurnEnd::Stopped), "{fim:?}");
+        drop(sink);
+        let tipos = tipos_dos_frames(sink_rx);
+        assert_eq!(
+            tipos.last().map(String::as_str),
+            Some("stopped"),
+            "o ultimo frame tinha de ser o stopped: {tipos:?}"
+        );
+        assert!(
+            !tipos.iter().any(|t| t == "message"),
+            "turno cancelado nao manda resposta: {tipos:?}"
+        );
+    }
+
+    /// `stop` que nomeia outra sessao nao cancela nada — responde
+    /// `session_mismatch` e o turno segue.
+    #[tokio::test]
+    async fn stop_de_outra_sessao_nao_cancela() {
+        let (mut sink, sink_rx) = futures::channel::mpsc::unbounded::<Message>();
+        let mut cliente = cliente(&[r#"{"type":"stop","session_id":"outra"}"#]);
+        let mut fila = std::collections::VecDeque::new();
+        let mut pong = Instant::now();
+
+        let eventos = eventos_prontos(vec![]);
+        let task = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            Ok("terminei".to_string())
+        });
+
+        let fim = tokio::time::timeout(
+            Duration::from_secs(5),
+            super::run_streaming_turn(
+                &mut sink,
+                &mut cliente,
+                "s1",
+                eventos,
+                task,
+                true,
+                &mut pong,
+                &mut fila,
+            ),
+        )
+        .await
+        .expect("o turno tinha de terminar sozinho");
+
+        assert!(
+            matches!(fim, TurnEnd::Completed(ref t) if t == "terminei"),
+            "{fim:?}"
+        );
+        drop(sink);
+        let codigos: Vec<String> = frames(sink_rx)
+            .iter()
+            .map(|f| f["code"].as_str().unwrap_or("?").to_string())
+            .collect();
+        assert_eq!(codigos, ["session_mismatch"]);
+    }
+
+    /// Antes do #1047 o socket nao era lido durante o turno e a mensagem
+    /// esperava no buffer do TCP. Agora que ele e lido, a mensagem tem de ir
+    /// para a fila — descarta-la seria a regressao.
+    #[tokio::test]
+    async fn mensagem_durante_o_turno_entra_na_fila_em_vez_de_sumir() {
+        let (mut sink, _sink_rx) = futures::channel::mpsc::unbounded::<Message>();
+        let mut cliente = cliente(&[r#"{"content":"a proxima pergunta"}"#, r#"{"type":"stop"}"#]);
+        let mut fila = std::collections::VecDeque::new();
+        let mut pong = Instant::now();
+
+        let eventos = eventos_prontos(vec![]);
+        let task = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            Ok(String::new())
+        });
+
+        let fim = tokio::time::timeout(
+            Duration::from_secs(5),
+            super::run_streaming_turn(
+                &mut sink,
+                &mut cliente,
+                "s1",
+                eventos,
+                task,
+                true,
+                &mut pong,
+                &mut fila,
+            ),
+        )
+        .await
+        .expect("o stop tem de soltar o turno");
+
+        assert!(matches!(fim, TurnEnd::Stopped), "{fim:?}");
+        assert_eq!(
+            fila.into_iter().collect::<Vec<_>>(),
+            [r#"{"content":"a proxima pergunta"}"#.to_string()],
+        );
+    }
+
+    /// `stop` sem `session_id` vale para a sessao corrente; com `session_id`,
+    /// so para aquela. O resto nao e `stop` e segue para a fila de turnos.
+    #[test]
+    fn parse_stop_distingue_alvo_e_nao_stop() {
+        assert_eq!(parse_stop(r#"{"type":"stop"}"#), Some(None));
+        assert_eq!(
+            parse_stop(r#"{"type":"stop","session_id":"s1"}"#),
+            Some(Some("s1".to_string()))
+        );
+        // String vazia e o mesmo que nao mandar.
+        assert_eq!(parse_stop(r#"{"type":"stop","session_id":""}"#), Some(None));
+        assert_eq!(parse_stop(r#"{"content":"stop"}"#), None);
+        assert_eq!(parse_stop(r#"{"type":"resume"}"#), None);
+        assert_eq!(parse_stop("stop"), None);
+        assert_eq!(parse_stop("{nao e json"), None);
     }
 }

--- a/crates/garraia-gateway/src/ws.rs
+++ b/crates/garraia-gateway/src/ws.rs
@@ -85,9 +85,11 @@ pub async fn ws_handler(
 async fn handle_socket(socket: WebSocket, state: SharedState) {
     let (mut sender, mut receiver) = socket.split();
 
-    // Declarado aqui, e nao junto do loop principal, porque desde o #1047 o
+    // Declarados aqui, e nao junto do loop principal, porque desde o #1047 o
     // socket e lido durante o turno — e a primeira mensagem ja e um turno.
     let mut last_pong = Instant::now();
+    // Per-WebSocket sliding window rate limiter
+    let mut msg_timestamps: std::collections::VecDeque<Instant> = std::collections::VecDeque::new();
 
     // Wait for the first message to decide: new session or resume.
     let session_id = match tokio::time::timeout(Duration::from_secs(10), receiver.next()).await {
@@ -244,6 +246,7 @@ async fn handle_socket(socket: WebSocket, state: SharedState) {
                     &mut sender,
                     &mut receiver,
                     &mut last_pong,
+                    &mut msg_timestamps,
                 )
                 .await
                 .is_break()
@@ -276,9 +279,6 @@ async fn handle_socket(socket: WebSocket, state: SharedState) {
     // Don't send ping immediately
     heartbeat.tick().await;
 
-    // Per-WebSocket sliding window rate limiter
-    let mut msg_timestamps: std::collections::VecDeque<Instant> = std::collections::VecDeque::new();
-
     let mut log_rx = state.log_tx.subscribe();
 
     loop {
@@ -308,20 +308,11 @@ async fn handle_socket(socket: WebSocket, state: SharedState) {
                         }
 
                         // Per-WebSocket sliding window rate limit
-                        let now = Instant::now();
-                        msg_timestamps.retain(|ts| now.duration_since(*ts) < WS_RATE_LIMIT_WINDOW);
-                        if msg_timestamps.len() >= WS_RATE_LIMIT_MAX as usize {
+                        if !rate_limit_admits(&mut msg_timestamps) {
                             warn!("rate limited: session={}, msgs_in_window={}", session_id, msg_timestamps.len());
-                            let err = serde_json::json!({
-                                "type": "error",
-                                "code": "rate_limited",
-                                "message": "too many messages, please slow down",
-                                "retry_after_secs": WS_RATE_LIMIT_WINDOW.as_secs(),
-                            });
-                            let _ = sender.send(Message::Text(err.to_string().into())).await;
+                            let _ = sender.send(Message::Text(rate_limited_frame().into())).await;
                             continue;
                         }
-                        msg_timestamps.push_back(now);
 
                         let text_len = text.len();
                         info!("received message: session={}, len={}", session_id, text_len);
@@ -330,13 +321,22 @@ async fn handle_socket(socket: WebSocket, state: SharedState) {
                                 "dropping oversized ws text message: session={}, len={}, limit={}",
                                 session_id, text_len, MAX_WS_TEXT_BYTES
                             );
-                            let err = serde_json::json!({
-                                "type": "error",
-                                "code": "message_too_large",
-                                "max_bytes": MAX_WS_TEXT_BYTES,
-                            });
-                            let _ = sender.send(Message::Text(err.to_string().into())).await;
+                            let _ = sender.send(Message::Text(too_large_frame().into())).await;
                             break;
+                        }
+
+                        // Um `stop` pode escapar de `run_streaming_turn` — o
+                        // laco de la sai assim que o turno termina, mesmo com
+                        // uma mensagem ainda por ler no socket. Sem este
+                        // guarda ele cairia em `parse_user_message`, que na
+                        // falta de `content` usa o JSON inteiro como texto:
+                        // o modelo receberia `{"type":"stop"}` como pergunta.
+                        // Fora de turno, `stop` e no-op idempotente.
+                        if parse_stop(&text).is_some() {
+                            let _ = sender
+                                .send(Message::Text(stopped_frame(&session_id).into()))
+                                .await;
+                            continue;
                         }
 
                         if drain_turns(
@@ -346,6 +346,7 @@ async fn handle_socket(socket: WebSocket, state: SharedState) {
                             &mut sender,
                             &mut receiver,
                             &mut last_pong,
+                            &mut msg_timestamps,
                         )
                         .await
                         .is_break()
@@ -381,6 +382,11 @@ async fn handle_socket(socket: WebSocket, state: SharedState) {
 /// Itera em vez de recursar: `process_text_message` so empurra em
 /// `deferred`, e quem esvazia a fila e este laco.
 ///
+/// `MAX_DEFERRED_MESSAGES` limita a fila **por turno**, nao por chamada: um
+/// cliente que enfileira o maximo a cada turno mantem o laco rodando. Quem
+/// segura isso e a janela do rate limit, que vale para os dois caminhos de
+/// entrada — e cada volta do laco custa um turno de LLM inteiro.
+///
 /// `Break` significa que o socket morreu — o chamador encerra a conexao.
 async fn drain_turns(
     first: String,
@@ -389,6 +395,7 @@ async fn drain_turns(
     sender: &mut futures::stream::SplitSink<WebSocket, Message>,
     receiver: &mut futures::stream::SplitStream<WebSocket>,
     last_pong: &mut Instant,
+    msg_timestamps: &mut std::collections::VecDeque<Instant>,
 ) -> std::ops::ControlFlow<()> {
     let mut pending: std::collections::VecDeque<String> = std::collections::VecDeque::new();
     pending.push_back(first);
@@ -402,6 +409,7 @@ async fn drain_turns(
             receiver,
             last_pong,
             &mut pending,
+            msg_timestamps,
         )
         .await
         {
@@ -458,6 +466,7 @@ async fn process_text_message(
     receiver: &mut futures::stream::SplitStream<WebSocket>,
     last_pong: &mut Instant,
     deferred: &mut std::collections::VecDeque<String>,
+    msg_timestamps: &mut std::collections::VecDeque<Instant>,
 ) -> TurnOutcome {
     let msg = parse_user_message(text);
 
@@ -510,7 +519,15 @@ async fn process_text_message(
     });
 
     let turn = run_streaming_turn(
-        sender, receiver, session_id, events_rx, task, msg.stream, last_pong, deferred,
+        sender,
+        receiver,
+        session_id,
+        events_rx,
+        task,
+        msg.stream,
+        last_pong,
+        deferred,
+        msg_timestamps,
     )
     .await;
 
@@ -571,6 +588,7 @@ async fn run_streaming_turn<S, R>(
     stream_frames: bool,
     last_pong: &mut Instant,
     deferred: &mut std::collections::VecDeque<String>,
+    msg_timestamps: &mut std::collections::VecDeque<Instant>,
 ) -> TurnEnd
 where
     S: futures::Sink<Message> + Unpin,
@@ -623,6 +641,30 @@ where
                             });
                             let _ = sender.send(Message::Text(err.to_string().into())).await;
                         }
+                        // Os mesmos dois guardas do loop principal, na mesma
+                        // ordem. Sem eles este braco seria um desvio: a
+                        // mensagem que entra durante o turno viraria um turno
+                        // igual aos outros, sem ter passado nem pelo teto de
+                        // tamanho nem pela janela do rate limit.
+                        None if text_message_too_large(raw.len()) => {
+                            warn!(
+                                "dropping oversized ws text message mid-turn: session={}, len={}, limit={}",
+                                session_id,
+                                raw.len(),
+                                MAX_WS_TEXT_BYTES
+                            );
+                            let _ = sender.send(Message::Text(too_large_frame().into())).await;
+                            client_gone = true;
+                            task.abort();
+                        }
+                        None if !rate_limit_admits(msg_timestamps) => {
+                            warn!(
+                                "rate limited mid-turn: session={}, msgs_in_window={}",
+                                session_id,
+                                msg_timestamps.len()
+                            );
+                            let _ = sender.send(Message::Text(rate_limited_frame().into())).await;
+                        }
                         None => {
                             if deferred.len() < MAX_DEFERRED_MESSAGES {
                                 deferred.push_back(raw.to_string());
@@ -658,6 +700,16 @@ where
     }
 
     if stopped {
+        // O `stop` pode chegar depois de a resposta ficar pronta. O cliente
+        // pediu para parar, entao ela e descartada — mas os tokens ja foram
+        // gastos e nada e persistido, o que sem log e invisivel em producao.
+        if let Some(Ok(Ok(ref pronta))) = finished {
+            warn!(
+                "turno cancelado com a resposta ja pronta: session={}, len={}",
+                session_id,
+                pronta.len()
+            );
+        }
         if sender
             .send(Message::Text(stopped_frame(session_id).into()))
             .await
@@ -668,19 +720,62 @@ where
         return TurnEnd::Stopped;
     }
 
+    // Os dois ultimos bracos sao, hoje, inalcancaveis, e estao aqui como rede:
+    // `task.abort()` so acontece com `stopped` ou `client_gone`, e os dois ja
+    // devolveram acima; e a condicao do `while` so solta com `finished`
+    // preenchido. Tratados como desfecho normal em vez de `unreachable!`
+    // porque um panic aqui derrubaria a conexao de um usuario — e porque um
+    // refactor futuro pode torna-los alcancaveis sem ninguem notar.
     match finished {
         Some(Ok(Ok(text))) => TurnEnd::Completed(text),
         Some(Ok(Err(e))) => TurnEnd::Failed(e.to_string()),
-        Some(Err(e)) if e.is_cancelled() => TurnEnd::Stopped,
         Some(Err(e)) => {
+            if e.is_cancelled() {
+                return TurnEnd::Stopped;
+            }
             warn!("agent task failed: session={}, error={}", session_id, e);
             TurnEnd::Failed("internal agent task failure".to_string())
         }
-        // Inalcancavel: a condicao do `while` so solta com `finished`
-        // preenchido. Tratado como falha em vez de `unreachable!` porque um
-        // panic aqui derrubaria a conexao de um usuario.
         None => TurnEnd::Failed("turn ended without a result".to_string()),
     }
+}
+
+/// A janela deslizante do rate limit, num lugar so.
+///
+/// Vive numa funcao porque desde o #1047 ha **dois** caminhos por onde uma
+/// mensagem do cliente entra: o loop principal e o braco do socket dentro de
+/// `run_streaming_turn`. Dois lugares contando de formas diferentes seriam
+/// dois limites diferentes, e o segundo caminho seria um desvio do primeiro.
+///
+/// Devolve `false` quando a mensagem passa do teto; nesse caso ela **nao** e
+/// contabilizada, para uma rajada nao empurrar a janela para frente.
+fn rate_limit_admits(timestamps: &mut std::collections::VecDeque<Instant>) -> bool {
+    let now = Instant::now();
+    timestamps.retain(|ts| now.duration_since(*ts) < WS_RATE_LIMIT_WINDOW);
+    if timestamps.len() >= WS_RATE_LIMIT_MAX as usize {
+        return false;
+    }
+    timestamps.push_back(now);
+    true
+}
+
+fn rate_limited_frame() -> String {
+    serde_json::json!({
+        "type": "error",
+        "code": "rate_limited",
+        "message": "too many messages, please slow down",
+        "retry_after_secs": WS_RATE_LIMIT_WINDOW.as_secs(),
+    })
+    .to_string()
+}
+
+fn too_large_frame() -> String {
+    serde_json::json!({
+        "type": "error",
+        "code": "message_too_large",
+        "max_bytes": MAX_WS_TEXT_BYTES,
+    })
+    .to_string()
 }
 
 /// Um evento do turno virando frame do protocolo `/ws`.
@@ -1046,9 +1141,10 @@ mod tests {
             tx.unbounded_send(Ok(Message::Text((*m).to_string().into())))
                 .expect("cliente falso aceita a mensagem");
         }
-        // O `tx` fica vivo: soltar aqui fecharia o stream e o laco leria
-        // `None`, que ele trata como "cliente foi embora".
-        std::mem::forget(tx);
+        // O `tx` fica vivo ate o fim do processo de teste: solta-lo aqui
+        // fecharia o stream, e o laco leria `None` — que ele trata como
+        // "cliente foi embora", nao como "cliente calado".
+        let _mantem_aberto = std::mem::ManuallyDrop::new(tx);
         rx
     }
 
@@ -1063,7 +1159,10 @@ mod tests {
     fn frames(rx: futures::channel::mpsc::UnboundedReceiver<Message>) -> Vec<serde_json::Value> {
         rx.collect::<Vec<_>>()
             .now_or_never()
-            .unwrap_or_default()
+            // Sem o `drop(sink)` antes daqui a coleta fica pendente e
+            // devolveria `None`; falhar com esta frase e mais util do que
+            // comparar contra uma lista vazia.
+            .expect("solte o sink antes de coletar os frames")
             .into_iter()
             .filter_map(|m| match m {
                 Message::Text(t) => serde_json::from_str(&t).ok(),
@@ -1090,6 +1189,7 @@ mod tests {
         let mut cliente = cliente(&[]);
         let mut fila = std::collections::VecDeque::new();
         let mut pong = Instant::now();
+        let mut janela = std::collections::VecDeque::new();
 
         let eventos = eventos_prontos(vec![
             TurnEvent::TextDelta("um ".into()),
@@ -1117,6 +1217,7 @@ mod tests {
             true,
             &mut pong,
             &mut fila,
+            &mut janela,
         )
         .await;
 
@@ -1140,6 +1241,7 @@ mod tests {
         let mut cliente = cliente(&[]);
         let mut fila = std::collections::VecDeque::new();
         let mut pong = Instant::now();
+        let mut janela = std::collections::VecDeque::new();
 
         let eventos = eventos_prontos(vec![
             TurnEvent::TextDelta("um ".into()),
@@ -1156,6 +1258,7 @@ mod tests {
             false,
             &mut pong,
             &mut fila,
+            &mut janela,
         )
         .await;
 
@@ -1176,6 +1279,7 @@ mod tests {
         let mut cliente = cliente(&[r#"{"type":"stop","session_id":"s1"}"#]);
         let mut fila = std::collections::VecDeque::new();
         let mut pong = Instant::now();
+        let mut janela = std::collections::VecDeque::new();
 
         let eventos = eventos_prontos(vec![TurnEvent::TextDelta("parcial".into())]);
         let task = tokio::spawn(async {
@@ -1194,6 +1298,7 @@ mod tests {
                 true,
                 &mut pong,
                 &mut fila,
+                &mut janela,
             ),
         )
         .await
@@ -1221,6 +1326,7 @@ mod tests {
         let mut cliente = cliente(&[r#"{"type":"stop","session_id":"outra"}"#]);
         let mut fila = std::collections::VecDeque::new();
         let mut pong = Instant::now();
+        let mut janela = std::collections::VecDeque::new();
 
         let eventos = eventos_prontos(vec![]);
         let task = tokio::spawn(async {
@@ -1239,6 +1345,7 @@ mod tests {
                 true,
                 &mut pong,
                 &mut fila,
+                &mut janela,
             ),
         )
         .await
@@ -1256,6 +1363,102 @@ mod tests {
         assert_eq!(codigos, ["session_mismatch"]);
     }
 
+    /// A auditoria do #1047 achou isto: mensagem lida **durante** o turno
+    /// entrava na fila sem passar pela janela do rate limit, entao um cliente
+    /// enfileirava turnos de graca. A janela e a mesma dos dois lados.
+    #[tokio::test]
+    async fn mensagem_durante_o_turno_conta_no_rate_limit() {
+        let (mut sink, sink_rx) = futures::channel::mpsc::unbounded::<Message>();
+        let mut cliente = cliente(&[r#"{"content":"mais uma"}"#, r#"{"type":"stop"}"#]);
+        let mut fila = std::collections::VecDeque::new();
+        let mut pong = Instant::now();
+        // Janela ja no teto, como se o cliente tivesse gasto a cota toda.
+        let mut janela: std::collections::VecDeque<Instant> = std::iter::repeat_with(Instant::now)
+            .take(super::WS_RATE_LIMIT_MAX as usize)
+            .collect();
+
+        let task = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            Ok(String::new())
+        });
+
+        let fim = tokio::time::timeout(
+            Duration::from_secs(5),
+            super::run_streaming_turn(
+                &mut sink,
+                &mut cliente,
+                "s1",
+                eventos_prontos(vec![]),
+                task,
+                true,
+                &mut pong,
+                &mut fila,
+                &mut janela,
+            ),
+        )
+        .await
+        .expect("o stop tem de soltar o turno");
+
+        assert!(matches!(fim, TurnEnd::Stopped), "{fim:?}");
+        assert!(
+            fila.is_empty(),
+            "mensagem passou do teto e mesmo assim entrou na fila: {fila:?}"
+        );
+        drop(sink);
+        let codigos: Vec<String> = frames(sink_rx)
+            .iter()
+            .filter_map(|f| f["code"].as_str().map(str::to_string))
+            .collect();
+        assert_eq!(codigos, ["rate_limited"]);
+    }
+
+    /// O outro guarda que faltava: o teto de tamanho do texto. Um cliente
+    /// enfileirava ate 8 mensagens acima de `MAX_WS_TEXT_BYTES` porque o
+    /// check so existia no loop principal.
+    #[tokio::test]
+    async fn mensagem_gigante_durante_o_turno_e_recusada() {
+        let gigante = format!(
+            r#"{{"content":"{}"}}"#,
+            "a".repeat(super::MAX_WS_TEXT_BYTES + 1)
+        );
+        let (mut sink, sink_rx) = futures::channel::mpsc::unbounded::<Message>();
+        let mut cliente = cliente(&[&gigante]);
+        let mut fila = std::collections::VecDeque::new();
+        let mut pong = Instant::now();
+        let mut janela = std::collections::VecDeque::new();
+
+        let task = tokio::spawn(async {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            Ok(String::new())
+        });
+
+        let fim = tokio::time::timeout(
+            Duration::from_secs(5),
+            super::run_streaming_turn(
+                &mut sink,
+                &mut cliente,
+                "s1",
+                eventos_prontos(vec![]),
+                task,
+                true,
+                &mut pong,
+                &mut fila,
+                &mut janela,
+            ),
+        )
+        .await
+        .expect("a recusa tem de soltar o turno");
+
+        assert!(matches!(fim, TurnEnd::ClientGone), "{fim:?}");
+        assert!(fila.is_empty(), "mensagem gigante entrou na fila: {fila:?}");
+        drop(sink);
+        let codigos: Vec<String> = frames(sink_rx)
+            .iter()
+            .filter_map(|f| f["code"].as_str().map(str::to_string))
+            .collect();
+        assert_eq!(codigos, ["message_too_large"]);
+    }
+
     /// Antes do #1047 o socket nao era lido durante o turno e a mensagem
     /// esperava no buffer do TCP. Agora que ele e lido, a mensagem tem de ir
     /// para a fila — descarta-la seria a regressao.
@@ -1265,6 +1468,7 @@ mod tests {
         let mut cliente = cliente(&[r#"{"content":"a proxima pergunta"}"#, r#"{"type":"stop"}"#]);
         let mut fila = std::collections::VecDeque::new();
         let mut pong = Instant::now();
+        let mut janela = std::collections::VecDeque::new();
 
         let eventos = eventos_prontos(vec![]);
         let task = tokio::spawn(async {
@@ -1283,6 +1487,7 @@ mod tests {
                 true,
                 &mut pong,
                 &mut fila,
+                &mut janela,
             ),
         )
         .await

--- a/docs/src/api-reference.md
+++ b/docs/src/api-reference.md
@@ -518,32 +518,63 @@ Retorna o histórico de chat do usuário mobile.
 
 ### WS /ws
 
-Conexão WebSocket para chat em tempo real com streaming de tokens.
+Conexão WebSocket para chat, opcionalmente com o texto chegando token a token.
 
-**URL de conexão:** `ws://127.0.0.1:3888/ws?token=SEU_TOKEN`
+**URL de conexão:** `ws://127.0.0.1:3888/ws?token=SUA_CHAVE`
 
-**Mensagem de entrada:**
+A chave é a `gateway.api_key`; ela também é aceita como `?api_key=` ou no
+header `Authorization: Bearer`. A query existe porque o handshake WebSocket
+de um navegador não leva header.
+
+#### Mensagens do cliente
+
+Assim que a conexão abre, o servidor manda um `connected` com o `session_id`.
+A primeira mensagem do cliente pode ser um `init` (sessão nova) ou um
+`resume`; qualquer outra coisa já é tratada como um turno de conversa.
+
 ```json
-{
-  "type": "chat",
-  "message": "Explique o que é Rust.",
-  "session_id": "ws-teste"
-}
+{"type": "init"}
+{"type": "resume", "session_id": "…", "session_token": "…"}
+{"content": "Explique o que é Rust.", "stream": true}
+{"type": "stop", "session_id": "…"}
 ```
 
-**Mensagens de saída (streaming):**
-```json
-{"type": "token", "content": "Rust"}
-{"type": "token", "content": " é uma linguagem"}
-{"type": "done", "session_id": "ws-teste", "total_tokens": 150}
-```
+| Campo do turno | Efeito |
+|---|---|
+| `content` | O texto do usuário. Uma mensagem que não seja JSON com `content` é tratada como o próprio texto. |
+| `stream` | `true` liga os frames intermediários abaixo. Ausente ou `false`, a resposta chega só no `message` final — o contrato de sempre. |
+| `provider` | Sobrescreve o provider para este turno. |
+| `model` | Sobrescreve o modelo para este turno. |
 
-| Tipo | Descrição |
-|------|-----------|
-| `token` | Fragmento de token da resposta em streaming |
-| `done` | Resposta completa; inclui `total_tokens` |
-| `error` | Erro durante a geração; inclui `message` |
-| `tool_call` | O agente está chamando uma ferramenta |
-| `tool_result` | Resultado da ferramenta chamada |
+O `stop` cancela o turno em andamento. Sem `session_id` vale para a sessão da
+própria conexão; com `session_id` diferente, o servidor responde
+`session_mismatch` e não cancela nada. Mensagens enviadas enquanto um turno
+roda entram numa fila e são processadas na sequência.
 
-**Response 401:** Token ausente ou inválido (a conexão é recusada antes do upgrade WebSocket).
+#### Mensagens do servidor
+
+| Tipo | Quando | Campos |
+|---|---|---|
+| `connected` | ao abrir a conexão | `session_id`, `session_token` |
+| `resumed` | após um `resume` aceito | `session_id`, `history_length`, `session_token` |
+| `delta` | só com `stream: true` | `session_id`, `content` — um pedaço do texto |
+| `tool_started` | só com `stream: true` | `session_id`, `name`, `detail` |
+| `tool_finished` | só com `stream: true` | `session_id`, `name`, `success`, `summary`, `duration_ms` |
+| `message` | sempre, ao fim do turno | `session_id`, `content` — a resposta inteira |
+| `stopped` | após um `stop` aceito | `session_id` |
+| `error` | falha | `session_id`, `code`, `message` |
+
+`tool_finished` **não** carrega a saída da ferramenta: ela pode ter dezenas de
+KiB, e o frame existe para dizer que a ferramenta terminou.
+
+O `message` final é sempre enviado, com o texto completo, mesmo quando os
+`delta` já entregaram o mesmo conteúdo — é ele o valor autoritativo, e é o que
+mantém um cliente que ignora os frames novos funcionando sem mudança.
+
+Um turno cancelado não é persistido: nem no histórico da sessão, nem na
+memória. O efeito de uma ferramenta que já rodou não é desfeito.
+
+Códigos de `error`: `prompt_injection_detected`, `agent_error`,
+`rate_limited`, `message_too_large`, `session_mismatch`, `turn_in_progress`.
+
+**Response 401:** Chave ausente ou inválida (a conexão é recusada antes do upgrade WebSocket).


### PR DESCRIPTION
## Descrição

Metade servidor de #1047. A outra metade (o app Flutter) vem num PR separado.

O `/ws` era bloqueante: `process_text_message` esperava o turno inteiro dentro do braço `receiver.next()` do `tokio::select!` e só então montava o único frame de resposta. Enquanto isso o loop não lia o socket, então um `stop` nunca chegaria, o heartbeat não ticava e o `log_rx` não era drenado.

Agora o turno roda numa task e os eventos são drenados enquanto ele acontece, com o `/ws/parrot` de molde: `history`, `continuity_key` e `exec` lidos **antes** do spawn, para a task não segurar o lock do store pelo turno inteiro. A função nova `run_streaming_turn` faz select entre três braços — o canal de eventos, a task, e o próprio cliente. Ler o cliente é o que torna o `stop` possível, e também o que faz o pong voltar a ser contado num turno longo.

**Frames novos, todos opt-in por `"stream": true` na mensagem:** `delta`, `tool_started`, `tool_finished`, `stopped`. Sem a flag a sequência é a de sempre, só o `message` final, byte a byte igual. Opt-in porque o `default:` do `handleServerEvent` no console web imprime frame desconhecido como mensagem de sistema — ligar por padrão encheria a tela com uma linha por token.

`tool_finished` não carrega o `output`: é a saída inteira da ferramenta, até dezenas de KiB, e o frame existe para dizer que ela terminou.

`stop` aborta a task. `persist_turn` só roda no caminho de sucesso, e `remember_turn`/`record_turn_stats` vivem depois do loop dentro do runtime, então o parcial não vira histórico nem memória. O efeito de uma ferramenta que já rodou não é desfeito, como no `Ctrl+C` do `garra chat`.

Mensagens que o cliente mandar durante o turno vão para uma fila explícita. Antes elas esperavam no buffer do TCP; agora que o socket é lido, descartá-las seria regressão.

`docs/src/api-reference.md` descrevia um protocolo que nunca existiu (`chat`/`token`/`done`); passa a descrever o real.

### O que a revisão obrigatória encontrou, e que está corrigido no segundo commit

`security-auditor` e `code-reviewer` rodaram antes do push. Três achados reais, todos regressões que o primeiro commit introduziu ao abrir o segundo caminho de entrada:

| Severidade | Achado | Correção |
|---|---|---|
| Média | Mensagem enfileirada durante o turno **não contava** na janela do rate limit. Um cliente enfileirava 8 turnos de graça por ciclo: com turnos rápidos, ~270 chamadas de LLM por minuto contra o teto de 30. | A janela virou `rate_limit_admits`, uma função só, usada nos dois caminhos de entrada. |
| Baixa | Mensagem entre `MAX_WS_TEXT_BYTES` (32 KiB) e o teto de frame do axum (256 KiB) entrava na fila sem passar pelo check de tamanho. | Mesmo guarda dos dois lados, mesma resposta. |
| Corretude | O laço sai assim que o turno termina, mesmo com mensagem por ler. Um `stop` nessa fresta caía no loop principal, e `parse_user_message`, na falta de `content`, usa o JSON inteiro como texto: **o modelo receberia `{"type":"stop"}` como pergunta.** | `stop` fora de turno virou no-op idempotente que responde `stopped`. |

Mais três acertos menores da revisão: `warn!` quando o `stop` chega com a resposta já pronta (tokens gastos, nada persistido, antes invisível em produção); o comentário de "inalcançável" cobrindo os dois braços que são, e não só um; e `expect` no `now_or_never` dos helpers de teste, para o esquecimento de um `drop(sink)` falhar dizendo o que houve em vez de comparar contra lista vazia.

O auditor verificou explicitamente e aprovou: `stop` não cancela turno de outra conexão; `summary` e `detail` já passam por `redact_secrets` na origem (`turn_events.rs`); nada é persistido no caminho cancelado; o backpressure do canal é por conexão; nenhum `unwrap()`/`expect()` novo em produção.

## Tipo de mudança

- [x] `feat`: Nova funcionalidade
- [x] `fix`: Correção de bug — o heartbeat faminto e os três achados acima

## Classe de Risco

- [x] **Classe C (Alto Risco)**: Alterações em autenticação, criptografia, RLS, migrations SQL, endpoints REST públicos, autorização/RBAC.

Tratado como C por conservadorismo: muda o protocolo de um endpoint de rede e o caminho por onde entrada de cliente é lida. Não toca auth, RLS nem migration — o gate de `gateway.api_key` em `ws_handler` está intocado.

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo fmt --all -- --check` executado e limpo
- [x] `cargo clippy -p garraia-gateway --all-targets -- -D warnings` sem erros
- [x] `cargo test -p garraia-gateway --lib` — 965 testes passando
- [x] Nenhum `unwrap()` adicionado em código de produção (verificado pelo `security-auditor`)
- [x] Nenhum segredo, API key, token ou credencial commitada
- [x] Nenhuma migração Postgres

### Para alterações de Alto Risco (Classe C)

- [x] `security-auditor` + `code-reviewer` rodaram **antes** do push; os três achados reais estão corrigidos no commit seguinte
- [x] Nenhuma rota nova, nenhum acesso cross-group novo — o escopo de sessão do `/ws` não muda
- [x] Nenhum campo novo com PII no frame; `tool_finished` exclui `output` de propósito

## Mudanças na API pública e Schema

**Protocolo `/ws`, aditivo.** Campo novo de entrada `stream` (default `false`) e mensagem nova `{"type":"stop"}`. Frames novos de saída `delta`, `tool_started`, `tool_finished`, `stopped`, todos só com `stream: true`. `connected`, `resumed`, `message` e `error` inalterados. Um cliente de hoje que não mande a flag vê exatamente a mesma sequência de antes.

## Como testar

```
cargo test -p garraia-gateway --lib ws::
```

`ws.rs` não tinha nenhum teste assíncrono; os testes de integração de `tests/gateway_integration.rs` estão todos `#[ignore]` desde 2026-04-15 por falta de Postgres no CI, então testes novos lá seriam decoração. `run_streaming_turn` é genérico sobre sink e stream justamente para caber num teste em memória: os canais fazem o papel do cliente e um `JoinHandle` faz o papel do turno, sem LLM e sem rede.

Doze testes novos. Os que carregam a prova:

1. `com_a_flag_cada_evento_vira_frame_na_ordem` — a sequência exata `delta, tool_started, tool_finished, delta`.
2. `sem_a_flag_nenhum_frame_intermediario_sai` — zero frames. É a garantia de que o console web não muda.
3. `stop_do_cliente_cancela_o_turno_e_responde_stopped` — contra um turno de 60 s, sob `timeout` de 5 s.
4. `mensagem_durante_o_turno_conta_no_rate_limit` e `mensagem_gigante_durante_o_turno_e_recusada` — os dois guardas da auditoria.
5. `tool_finished_leva_o_resumo_e_nunca_a_saida_inteira` — afirma que a chave `output` **não existe** no frame.

**Provas por reversão**, todas executadas antes do push: sem o guard da flag, (2) falha; sem o `task.abort()`, (3) estoura o timeout; sem o guarda de rate limit, (4) falha; sem o de tamanho, (5 do par) falha.

Ponta a ponta, manual: `garra start`, abrir o console web, mandar uma mensagem — comportamento idêntico ao de hoje (o console não manda a flag). Com `wscat`, mandar `{"content":"...","stream":true}` e ver os `delta` chegando; mandar `{"type":"stop"}` no meio e ver `stopped`, com `GET /api/sessions/{id}` mostrando que o turno não foi persistido.

## Plano de Rollback

Reverter os dois commits. O protocolo volta ao anterior e nenhum cliente quebra, porque tudo que este PR adiciona é opt-in — um cliente que já mande `stream: true` simplesmente volta a receber só o `message` final, que sempre foi o valor autoritativo. Nenhum estado persistido, nenhuma migration, nenhum formato de dado em disco muda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVnUdw6gJJLtcmWxzxMtFz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVnUdw6gJJLtcmWxzxMtFz)_