### PR TITLE
feat(webchat): console manda a gateway.api_key nas chamadas /api/ (#1045)

### DIFF
--- a/changelog.d/changed/1045-console-manda-a-chave.md
+++ b/changelog.d/changed/1045-console-manda-a-chave.md
@@ -1,0 +1,4 @@
+- console web: as chamadas para `/api/*` passam a levar `Authorization:
+  Bearer` com a `gateway.api_key` guardada, a mesma que o console ja mandava
+  como `?token=` no WebSocket. Sem chave configurada nada muda. Prepara o
+  gate do REST, que entra em seguida. (#1045)

--- a/crates/garraia-gateway/src/admin.html
+++ b/crates/garraia-gateway/src/admin.html
@@ -1417,7 +1417,17 @@ function levelBadgeForLog(level) {
 async function pageAudit() {
   if (auditAutoRefresh !== null) { clearInterval(auditAutoRefresh); auditAutoRefresh = null; }
   try {
-    var resp = await fetch('/api/logs');
+    // #1045: com `gateway.api_key` configurada o servidor exige
+    // `Authorization: Bearer` em `/api/*`. O painel de admin autentica por
+    // cookie, que continua sendo exigido — a chave e um segundo fator de
+    // rede, nao um substituto. Esta e a unica chamada `/api/` do admin; o
+    // resto vai por `/admin/api/*`, que o cookie ja cobre.
+    var chaveDoGateway = localStorage.getItem('garraia.gateway_key') || '';
+    var opcoesDeLog = { credentials: 'same-origin', headers: {} };
+    if (chaveDoGateway) {
+      opcoesDeLog.headers['Authorization'] = 'Bearer ' + chaveDoGateway;
+    }
+    var resp = await fetch('/api/logs', opcoesDeLog);
     var data = await resp.json();
     var rawLogs = data.logs || '';
     var lines = rawLogs.split('\n').filter(function(l) { return l.trim().length > 0; });

--- a/crates/garraia-gateway/src/webchat.html
+++ b/crates/garraia-gateway/src/webchat.html
@@ -3094,6 +3094,46 @@ const State = {
   currentTheme: localStorage.getItem('garraia.ui.theme') || 'dark',
 };
 
+// ─── Autenticacao das chamadas /api/ (#1045) ──────────────────────────
+//
+// Quando `gateway.api_key` esta configurada, o servidor passa a exigir
+// `Authorization: Bearer` em `/api/*`. Sao 41 chamadas `fetch('/api/…')`
+// neste arquivo, e editar as 41 significa que esquecer uma quebra uma tela
+// em silencio no dia em que a chave for ligada. O shim cobre por construcao,
+// inclusive o que for adicionado depois.
+//
+// So mexe em requisicao same-origin para `/api/`: nao vaza a chave para
+// terceiros, e nao pisa num `Authorization` que o chamador ja tenha posto.
+// Sem chave guardada, e um passa-direto — `fetch` se comporta como antes.
+(function instalarAuthDeApi() {
+  const fetchOriginal = window.fetch.bind(window);
+  window.fetch = function (entrada, init) {
+    const chave = State.gatewayKey;
+    if (!chave) return fetchOriginal(entrada, init);
+
+    let url;
+    try {
+      url = new URL(
+        typeof entrada === 'string' ? entrada : entrada.url,
+        window.location.href,
+      );
+    } catch {
+      return fetchOriginal(entrada, init);
+    }
+    if (url.origin !== window.location.origin || !url.pathname.startsWith('/api/')) {
+      return fetchOriginal(entrada, init);
+    }
+
+    // `Headers` normaliza o nome, entao um `authorization` minusculo posto
+    // pelo chamador tambem e respeitado.
+    const headers = new Headers((init && init.headers) || (entrada.headers) || undefined);
+    if (!headers.has('Authorization')) {
+      headers.set('Authorization', 'Bearer ' + chave);
+    }
+    return fetchOriginal(entrada, Object.assign({}, init, { headers }));
+  };
+})();
+
 // ─── DOM Refs ────────────────────────────────────────────────────────
 const $ = (id) => document.getElementById(id);
 const chatMessages = $('chat-messages');

--- a/tests/playwright/webchat-api-key.spec.ts
+++ b/tests/playwright/webchat-api-key.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * #1045 (PR-A): o console web manda a `gateway.api_key` nas chamadas `/api/*`.
+ *
+ * Cobre:
+ *  1. Com chave guardada, toda chamada same-origin para `/api/` sai com
+ *     `Authorization: Bearer <chave>`.
+ *  2. Sem chave, nenhuma chamada ganha o header — o shim e um passa-direto.
+ *  3. O shim nao toca o que esta fora de `/api/`, para a chave nao ir junto
+ *     de requisicao que nao precisa dela.
+ *
+ * O PR-B liga o gate no servidor. Este PR entra antes justamente para o
+ * console nao morrer entre os dois merges.
+ */
+
+import { test, expect, Page } from '@playwright/test';
+
+const CHAVE = 'chave-de-teste-do-console';
+
+/** Abre o console ja com (ou sem) a chave em localStorage. */
+async function abrirConsole(page: Page, chave: string | null) {
+  await page.addInitScript((valor) => {
+    if (valor === null) {
+      window.localStorage.removeItem('garraia.gateway_key');
+    } else {
+      window.localStorage.setItem('garraia.gateway_key', valor as string);
+    }
+  }, chave);
+  await page.goto('/');
+  await page.locator('.sidebar').waitFor({ state: 'visible', timeout: 10_000 });
+}
+
+/** Junta as requisicoes da pagina como `{ caminho, authorization }`. */
+function observarRequisicoes(page: Page) {
+  const vistas: { caminho: string; auth: string | undefined }[] = [];
+  page.on('request', (req) => {
+    let url: URL;
+    try {
+      url = new URL(req.url());
+    } catch {
+      return;
+    }
+    vistas.push({ caminho: url.pathname, auth: req.headers()['authorization'] });
+  });
+  return vistas;
+}
+
+test.describe('#1045 PR-A — console manda a chave em /api/*', () => {
+  test('com chave, toda chamada /api/ leva Authorization: Bearer', async ({ page }) => {
+    const vistas = observarRequisicoes(page);
+    await abrirConsole(page, CHAVE);
+    // Uma chamada explicita, alem das que a pagina faz sozinha ao abrir.
+    await page.evaluate(() => fetch('/api/status').then((r) => r.status));
+    await page.waitForTimeout(1_000);
+
+    const deApi = vistas.filter((v) => v.caminho.startsWith('/api/'));
+    expect(deApi.length, 'a pagina nao chamou nenhuma rota /api/').toBeGreaterThan(0);
+
+    const semHeader = deApi.filter((v) => v.auth !== `Bearer ${CHAVE}`).map((v) => v.caminho);
+    expect(semHeader, `chamadas /api/ sem o header: ${semHeader.join(', ')}`).toEqual([]);
+  });
+
+  test('sem chave, nada muda: nenhuma chamada leva Authorization', async ({ page }) => {
+    const vistas = observarRequisicoes(page);
+    await abrirConsole(page, null);
+    await page.evaluate(() => fetch('/api/status').then((r) => r.status));
+    await page.waitForTimeout(1_000);
+
+    const comHeader = vistas.filter((v) => v.auth).map((v) => v.caminho);
+    expect(comHeader, `chamadas com header sem chave configurada: ${comHeader.join(', ')}`).toEqual([]);
+  });
+
+  test('a chave nao vai junto do que esta fora de /api/', async ({ page }) => {
+    const vistas = observarRequisicoes(page);
+    await abrirConsole(page, CHAVE);
+    await page.evaluate(async () => {
+      await fetch('/health').catch(() => {});
+      await fetch('/admin/api/me').catch(() => {});
+    });
+    await page.waitForTimeout(1_000);
+
+    const foraDeApi = vistas.filter((v) => !v.caminho.startsWith('/api/') && v.auth);
+    expect(
+      foraDeApi.map((v) => v.caminho),
+      'a chave saiu numa requisicao que nao e /api/',
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Descrição

PR-A de três em #1045. Este prepara o cliente; o PR-B liga o gate no servidor; o PR-C acerta a documentação.

Hoje a `gateway.api_key` só é exigida no `/ws`. O app mobile já manda `Authorization: Bearer` em toda chamada REST (`gateway_connection.dart`, no `BaseOptions` do Dio) — o servidor é que ignora. O console web não manda em nenhuma. Quando o gate do REST entrar, o console morreria; por isso este PR vem antes dele, e sozinho não muda comportamento nenhum.

São 41 `fetch('/api/…')` no `webchat.html`. Editar as 41 significa que esquecer uma quebra uma tela em silêncio no dia em que a chave for ligada, e que toda chamada nova precisa lembrar do header. Um shim sobre `window.fetch`, instalado logo depois de `State` (antes de qualquer chamada), cobre por construção — inclusive o que for adicionado depois.

O shim é deliberadamente estreito:

- age só quando **há chave guardada** (`State.gatewayKey`, a mesma que já vai como `?token=` no WebSocket);
- age só em requisição **same-origin** e cujo caminho comece com `/api/`;
- **não pisa** num `Authorization` que o chamador já tenha posto;
- em qualquer outro caso é passa-direto, e `fetch` se comporta exatamente como antes.

`admin.html` tem uma única chamada `/api/` (o painel de logs, `/api/logs`); o resto vai por `/admin/api/*`, que o cookie de admin já cobre. Essa uma ganhou o header explicitamente. O cookie continua sendo exigido — a chave é um segundo fator de rede, não um substituto para a sessão de admin.

## Tipo de mudança

- [x] `feat`: Nova funcionalidade

## Classe de Risco

- [x] **Classe B (Médio Risco)**: Atualizações de dependências em produção, refatorações internas sem alteração de schema ou de API pública.

Só cliente. Nenhuma rota, nenhum handler, nenhuma decisão de autorização muda de lado do servidor. O risco a vigiar é o oposto do usual — que a chave vaze para onde não devia —, e é exatamente o que os testes fixam.

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo fmt --check` — sem mudança em código Rust
- [x] `cargo clippy` — sem mudança em código Rust
- [x] `cargo test` — sem mudança em código Rust
- [x] Nenhum `unwrap()` adicionado em código de produção
- [x] Nenhum segredo, API key, token ou credencial commitada
- [x] Nenhuma migração Postgres

A chave nunca é escrita em log nem em URL: ela vai só no header, e só para a própria origem.

## Mudanças na API pública e Schema

- Nenhuma mudança na API pública

## Como testar

Spec Playwright nova, `tests/playwright/webchat-api-key.spec.ts`, com três casos: com chave, toda chamada `/api/` que a página faz leva o header; sem chave, nenhuma leva; e a chave não acompanha o que está fora de `/api/`.

A lógica do shim também foi exercitada isolada em Node, extraindo a função do HTML e chamando-a com um `fetch` falso. Nove casos, todos verdes antes do push:

```
ok  sem chave, /api/status            (nenhum header)
ok  com chave, /api/status            (Bearer k123)
ok  com chave, /health                (nenhum header)
ok  com chave, /admin/api/me          (nenhum header)
ok  outra origem /api/                (nenhum header)
ok  nao pisa no header do chamador    (Bearer meu-proprio preservado)
ok  objeto com .url                   (Request-like funciona)
ok  metodo preservado                 (init nao e perdido)
ok  url invalida passa direto         (nao explode)
```

Manual: `garra start` sem `gateway.api_key`, abrir o console — DevTools mostra as chamadas `/api/` sem `Authorization`, como hoje. Depois configurar a chave, recarregar, e ver o header em todas.

## Plano de Rollback

Reverter o commit. O shim some e o console volta a chamar `/api/` sem header. Como nada no servidor mudou, não há estado, nem sessão, nem dado persistido a limpar. Só é preciso reverter **antes** do PR-B, ou revertê-lo junto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVnUdw6gJJLtcmWxzxMtFz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVnUdw6gJJLtcmWxzxMtFz)_