### PR TITLE
feat(cli): tool MCP garra_agent, agente completo opt-in via env

### DIFF
--- a/changelog.d/added/1075-mcp-garra-agent.md
+++ b/changelog.d/added/1075-mcp-garra-agent.md
@@ -1,0 +1,24 @@
+- **Nova tool MCP `garra_agent`: agente completo com ferramentas, opt-in do
+  operador.** O servidor MCP (`garra mcp-server`) continua expondo o
+  `garra_ask` LLM-only como antes; quando o operador inicia o processo com
+  `GARRAIA_MCP_ENABLE_TOOLS=1`, `tools/list` passa a anunciar tambem o
+  `garra_agent`, que roda um turno de agente completo em sessao nova por
+  chamada — bash (full-auto, apenas o DENY_LIST do safety_gate), file_read,
+  file_write, web_fetch, git_diff e web_search (com chave Brave). Sem a env,
+  nem o anuncio nem o dispatch existem: o servidor rejeita `garra_agent` como
+  tool desconhecida e o comportamento fica identico ao de hoje.
+
+  A resposta vem no envelope `garra.agent.v1`, com o mesmo formato do
+  `garra.ask.v1` mais `session_id` e `tool_calls` (nome, duracao, sucesso,
+  resumo — ja redigidos na origem), tambem em falha e timeout, para o host MCP
+  ver o que o agente executou. `GARRAIA_MCP_MAX_TIMEOUT_SECS` passa a limitar
+  tambem a nova tool (teto proprio de 1800s; default 300s). O handler mora em
+  `mcp_agent.rs`, modulo novo que os testes de auditoria de `mcp_server.rs`
+  nao escaneiam por desenho — o arquivo de dispatch continua sem registrar
+  ferramenta, sem spawnar processo e sem escrever no stdout.
+
+  O system prompt default do agente obriga a relatar na resposta final
+  qualquer ferramenta que falhar ou for bloqueada — nunca reportar sucesso
+  sem saida real e nunca contornar silenciosamente um bloqueio de seguranca
+  (observado em repro real: `file_write` recusado e contornado via redirect
+  bash, com a falha omitida da prosa; ver issue #1075).

--- a/crates/garraia-cli/src/main.rs
+++ b/crates/garraia-cli/src/main.rs
@@ -9,6 +9,7 @@ mod doctor;
 mod glob_cmd;
 mod logs_cmd;
 mod max_power;
+mod mcp_agent;
 mod mcp_server;
 mod memory_cmd;
 mod migrate;

--- a/crates/garraia-cli/src/mcp_agent.rs
+++ b/crates/garraia-cli/src/mcp_agent.rs
@@ -1,0 +1,904 @@
+//! `garra_agent` — full-agent MCP tool (opt-in), companion to the
+//! LLM-only `garra_ask` (GAR-583).
+//!
+//! # Divergencia deliberada dos invariantes do `mcp_server.rs`
+//!
+//! O `mcp_server.rs` e auditado por dois testes que varrem a propria
+//! producao e proibem: registrar ferramentas de runtime, spawnar
+//! subprocessos e escrever no stdout. Este modulo NAO e escaneado por
+//! aqueles testes — e por desenho: aqui o agente registra ferramentas
+//! de verdade (`bash`, `file_read`, `file_write`, `web_fetch`,
+//! `git_diff`, `web_search` opcional) e o `bash` spawna processos via
+//! o `BashTool` nativo do runtime (mesmo safety_gate do gateway).
+//! A auditoria continua valendo para `mcp_server.rs` e `ask.rs`, que
+//! permanecem LLM-only; este modulo existe para o caso em que o
+//! operador QUER o agente completo via MCP.
+//!
+//! # Opt-in do operador
+//!
+//! A tool so e anunciada em `tools/list` e despachada em `tools/call`
+//! quando o processo do servidor MCP inicia com
+//! `GARRAIA_MCP_ENABLE_TOOLS` em {1, true, yes}. Sem a env, a
+//! superficie e identica a de antes: so `garra_ask`, e `garra_agent`
+//! responde "unknown tool".
+//!
+//! # Risco aceito e documentado
+//!
+//! O bash e full-auto (apenas o DENY_LIST do `safety_gate` bloqueia) e
+//! o processo filho herda o ambiente do servidor MCP, sem scrub —
+//! decisao do operador, paridade com o Telegram/gateway. Ver
+//! `docs/cli-mcp-server.md` para a superficie de segredos envolvida.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use garraia_agents::exec_context::ExecContext;
+use garraia_agents::tools::git_diff_tool::GitDiffTool;
+use garraia_agents::{
+    AgentRuntime, BashTool, ChatMessage, FileReadTool, FileWriteTool, TurnEvent, WebFetchTool,
+    WebSearchTool,
+};
+use garraia_config::AppConfig;
+use rmcp::model::Tool;
+use serde::Deserialize;
+use serde_json::{Map as JsonMap, Value as JsonValue, json};
+
+use crate::ask::{AskError, sanitize_provider_error};
+use crate::chat;
+use crate::mcp_server::{PROVIDER_ENUM, ServerPolicy, resolve_overrides, validate_agent_policy};
+
+/// 64 KiB cap on `message` — same bound as `garra_ask` (`crate::ask::STDIN_CAP_BYTES`).
+const AGENT_MESSAGE_MAX_BYTES: usize = 64 * 1024;
+/// 8 KiB cap on the `system_prompt` override — same bound as `garra_ask`.
+const AGENT_SYSTEM_PROMPT_MAX_BYTES: usize = 8 * 1024;
+
+/// Timeout bounds for the agent call. The wall clock covers the ENTIRE
+/// agent loop — every LLM round-trip and every tool execution — so the
+/// range is wider than `garra_ask`'s [1, 600]: multi-step tool work
+/// legitimately runs for minutes. The operator cap
+/// (`GARRAIA_MCP_MAX_TIMEOUT_SECS`) applies on top, clamped to [1, 1800].
+pub(crate) const AGENT_TIMEOUT_SECS_MIN: u64 = 5;
+pub(crate) const AGENT_TIMEOUT_SECS_MAX: u64 = 1800;
+pub(crate) const AGENT_TIMEOUT_SECS_DEFAULT: u64 = 300;
+
+/// Belt-and-braces cap on the per-tool-call summary that reaches the
+/// envelope. The runtime already truncates to 72 chars at the source
+/// (`turn_events::SUMMARY_MAX_CHARS`); this only guards against that
+/// invariant changing out from under us.
+const TOOL_CALL_SUMMARY_MAX_CHARS: usize = 160;
+
+/// How long to keep draining the event channel after the turn future
+/// resolves (success or timeout). The producer side is closed in both
+/// paths, so this normally returns immediately; the bound only matters
+/// if some background task still holds a sender clone — then we take
+/// whatever arrived and move on with partial observability.
+const EVENT_DRAIN_CAP: Duration = Duration::from_millis(500);
+
+/// `garra_agent` — argument shape. `deny_unknown_fields` mirrors the
+/// `additionalProperties: false` constraint in the tool descriptor's
+/// JSON schema (same contract as `GarraAskArgs`).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct GarraAgentArgs {
+    pub message: String,
+    #[serde(default)]
+    pub provider: Option<String>,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub timeout_secs: Option<u64>,
+    #[serde(default)]
+    pub system_prompt: Option<String>,
+    /// Directory against which file-tool relative paths resolve. Bash
+    /// ignores it (runs in the server's CWD) — the generated system
+    /// prompt tells the model to prefix bash commands with `cd` when a
+    /// dir is set.
+    #[serde(default)]
+    pub working_dir: Option<String>,
+}
+
+/// Fully-validated agent options — defaults applied, policy checked.
+#[derive(Debug, Clone)]
+pub(crate) struct AgentOptions {
+    pub message: String,
+    pub provider: String,
+    pub model: String,
+    pub timeout_secs: u64,
+    pub system_prompt: Option<String>,
+    pub working_dir: Option<String>,
+}
+
+/// One executed tool call, as reported to the MCP host in the envelope.
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct ToolCallSummary {
+    pub name: String,
+    pub duration_ms: u64,
+    pub success: bool,
+    pub summary: String,
+}
+
+/// Pure outcome of the agent one-shot. `tool_calls` travels on BOTH
+/// branches so the host keeps partial observability when the run fails
+/// or times out mid-loop.
+#[derive(Debug, Clone)]
+pub(crate) enum AgentOutcome {
+    Success {
+        answer: String,
+        provider: String,
+        model: String,
+        latency_ms: u128,
+        session_id: String,
+        tool_calls: Vec<ToolCallSummary>,
+    },
+    Failure {
+        error: AskError,
+        provider: String,
+        model: String,
+        tool_calls: Vec<ToolCallSummary>,
+    },
+}
+
+impl AgentOutcome {
+    pub(crate) fn is_ok(&self) -> bool {
+        matches!(self, Self::Success { .. })
+    }
+
+    /// Build the `garra.agent.v1` JSON envelope for this outcome.
+    pub(crate) fn to_envelope(&self) -> serde_json::Value {
+        match self {
+            Self::Success {
+                answer,
+                provider,
+                model,
+                latency_ms,
+                session_id,
+                tool_calls,
+            } => {
+                agent_success_envelope(answer, provider, model, *latency_ms, session_id, tool_calls)
+            }
+            Self::Failure {
+                error,
+                provider,
+                model,
+                tool_calls,
+            } => agent_error_envelope(
+                error.kind_str(),
+                &error.message(),
+                provider,
+                model,
+                tool_calls,
+            ),
+        }
+    }
+}
+
+/// `garra.agent.v1` — success envelope. Same shape as `garra.ask.v1`
+/// plus `session_id` and the `tool_calls` summary.
+pub(crate) fn agent_success_envelope(
+    answer: &str,
+    provider: &str,
+    model: &str,
+    latency_ms: u128,
+    session_id: &str,
+    tool_calls: &[ToolCallSummary],
+) -> serde_json::Value {
+    json!({
+        "schema": "garra.agent.v1",
+        "ok": true,
+        "answer": answer,
+        "provider": provider,
+        "model": model,
+        "latency_ms": latency_ms,
+        "session_id": session_id,
+        "tool_calls": tool_calls,
+    })
+}
+
+/// `garra.agent.v1` — error envelope. `kind` reuses the stable
+/// `AskError` labels (usage|no_provider|provider_error|timeout|io).
+pub(crate) fn agent_error_envelope(
+    kind: &str,
+    message: &str,
+    provider: &str,
+    model: &str,
+    tool_calls: &[ToolCallSummary],
+) -> serde_json::Value {
+    json!({
+        "schema": "garra.agent.v1",
+        "ok": false,
+        "provider": provider,
+        "model": model,
+        "tool_calls": tool_calls,
+        "error": {
+            "kind": kind,
+            "message": message,
+        }
+    })
+}
+
+/// GAR-583 sibling — build the `garra_agent` tool descriptor (advertised
+/// in `tools/list` only when the opt-in env is set).
+pub(crate) fn garra_agent_tool() -> Tool {
+    let schema_value = json!({
+        "type": "object",
+        "properties": {
+            "message": {
+                "type": "string",
+                "description": "The task or instruction for the full agent. Max 64 KiB.",
+                "minLength": 1,
+                "maxLength": AGENT_MESSAGE_MAX_BYTES
+            },
+            "provider": {
+                "type": "string",
+                "enum": PROVIDER_ENUM,
+                "default": "openrouter",
+                "description": "LLM provider. Default 'openrouter'."
+            },
+            "model": {
+                "type": "string",
+                "default": "openrouter/free",
+                "description": "Model name. Default 'openrouter/free'. Pass 'openrouter/auto' explicitly for complex tasks — never automatic."
+            },
+            "timeout_secs": {
+                "type": "integer",
+                "default": AGENT_TIMEOUT_SECS_DEFAULT,
+                "minimum": AGENT_TIMEOUT_SECS_MIN,
+                "maximum": AGENT_TIMEOUT_SECS_MAX,
+                "description": "Wall-clock cap for the ENTIRE agent loop including tool execution. Range [5, 1800]. Default 300."
+            },
+            "system_prompt": {
+                "type": "string",
+                "maxLength": AGENT_SYSTEM_PROMPT_MAX_BYTES,
+                "description": "Optional system prompt override. If omitted, a default generated from the registered tools is used."
+            },
+            "working_dir": {
+                "type": "string",
+                "description": "Directory against which file tool relative paths resolve. Bash runs in the server's CWD and ignores this — prefix bash commands with `cd` when needed."
+            }
+        },
+        "required": ["message"],
+        "additionalProperties": false
+    });
+    // Dev/CI only: mirrors the feature-gated "echo" entry of `garra_ask`
+    // (PR #859) so the full agent can be smoke-tested without an API key.
+    #[cfg(feature = "dev-echo-provider")]
+    let schema_value = {
+        let mut v = schema_value;
+        if let Some(e) = v
+            .pointer_mut("/properties/provider/enum")
+            .and_then(|e| e.as_array_mut())
+        {
+            e.push(json!("echo"));
+        }
+        v
+    };
+    // serde_json::Value::Object guaranteed by the literal above.
+    let schema_map: JsonMap<String, JsonValue> = match schema_value {
+        JsonValue::Object(map) => map,
+        _ => unreachable!("schema literal is an object"),
+    };
+    Tool::new(
+        "garra_agent",
+        "Run the GarraIA assistant as a FULL AGENT with tool access (shell, files, git, web) — one-shot, fresh session per call. Unlike garra_ask (LLM-only), this tool can execute real commands and read/write files on the operator's machine. Opt-in: only advertised when GARRAIA_MCP_ENABLE_TOOLS is set on the server process. Returns a `garra.agent.v1` JSON envelope as text content, including a tool_calls summary.",
+        Arc::new(schema_map),
+    )
+}
+
+/// Validate `GarraAgentArgs` bounds. Same error shape as
+/// `mcp_server::validate_args` — the MCP host sees it in
+/// `CallToolResult` as `invalid_params`.
+pub(crate) fn validate_agent_args(args: &GarraAgentArgs) -> Result<(), String> {
+    if args.message.trim().is_empty() {
+        return Err("message must be non-empty".to_string());
+    }
+    if args.message.len() > AGENT_MESSAGE_MAX_BYTES {
+        return Err(format!(
+            "message exceeds 64 KiB cap ({AGENT_MESSAGE_MAX_BYTES} bytes)"
+        ));
+    }
+    if let Some(ts) = args.timeout_secs
+        && !(AGENT_TIMEOUT_SECS_MIN..=AGENT_TIMEOUT_SECS_MAX).contains(&ts)
+    {
+        return Err(format!(
+            "timeout_secs out of range [{AGENT_TIMEOUT_SECS_MIN}, {AGENT_TIMEOUT_SECS_MAX}]"
+        ));
+    }
+    if let Some(ref sp) = args.system_prompt
+        && sp.len() > AGENT_SYSTEM_PROMPT_MAX_BYTES
+    {
+        return Err(format!(
+            "system_prompt exceeds {AGENT_SYSTEM_PROMPT_MAX_BYTES}-byte cap"
+        ));
+    }
+    Ok(())
+}
+
+/// Directories the file tools may touch, from the operator's
+/// `GARRAIA_MCP_ALLOWED_DIRS` (comma-separated); falls back to the
+/// server process CWD. Fail-open to `None` (whole filesystem) when the
+/// CWD cannot be read — unrestricted `bash` is the real boundary
+/// anyway (documented: `allowed_dirs` is a UX belt, not a boundary).
+fn allowed_dirs() -> Option<Vec<std::path::PathBuf>> {
+    if let Ok(raw) = std::env::var("GARRAIA_MCP_ALLOWED_DIRS") {
+        let dirs: Vec<std::path::PathBuf> = raw
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(std::path::PathBuf::from)
+            .collect();
+        if !dirs.is_empty() {
+            return Some(dirs);
+        }
+    }
+    match std::env::current_dir() {
+        Ok(cwd) => Some(vec![cwd]),
+        Err(e) => {
+            tracing::warn!("cannot resolve CWD for file tools allowed_dirs: {e}");
+            None
+        }
+    }
+}
+
+/// Register the same tool set the gateway bootstrap wires
+/// (`garraia-gateway/src/bootstrap/mod.rs`): full-auto bash (DENY_LIST
+/// only — the operator opt-in chose Telegram parity), file read/write,
+/// web fetch, git diff, and web search when a Brave key is available.
+/// `ListDirTool` is skipped on purpose: `bash ls` + the file tools
+/// cover it, and a tighter tool list helps weaker models route.
+fn build_tools(config: &AppConfig) -> Vec<Box<dyn garraia_agents::Tool>> {
+    let dirs = allowed_dirs();
+    let mut tools: Vec<Box<dyn garraia_agents::Tool>> = vec![
+        Box::new(BashTool::new(None)),
+        Box::new(FileReadTool::new(dirs.clone())),
+        Box::new(FileWriteTool::new(dirs)),
+        Box::new(WebFetchTool::new(None)),
+        Box::new(GitDiffTool::new(None, None)),
+    ];
+    let brave_config_key = config.llm.get("brave").and_then(|c| c.api_key.clone());
+    let brave = brave_config_key
+        .or_else(|| std::env::var("BRAVE_API_KEY").ok())
+        .filter(|k| !k.trim().is_empty());
+    if let Some(key) = brave {
+        tools.push(Box::new(WebSearchTool::new(key)));
+    }
+    tools
+}
+
+/// Default system prompt, generated from the tools actually registered
+/// (name + description of each), the effective working dir, and the
+/// bash-CWD caveat. Structure mirrors the CLI chat recipe
+/// (`chat.rs`) — weak models only call tools when the prompt names them.
+pub(crate) fn agent_system_prompt(tools: &[(String, String)], working_dir: Option<&str>) -> String {
+    let mut prompt = String::from(
+        "Voce e o GarraIA, um assistente pessoal de IA criado em Rust. \
+         Voce esta rodando como agente COMPLETO via MCP e pode executar \
+         ferramentas de verdade (shell, arquivos, git, web) para cumprir a tarefa. \
+         Seja prestativo, conciso e amigavel. Responda no idioma do usuario.\n\n\
+         ## Ferramentas disponiveis\n\
+         Voce tem acesso a estas ferramentas que pode usar quando necessario:\n",
+    );
+    for (name, description) in tools {
+        prompt.push_str(&format!("- **{name}**: {}\n", description.trim()));
+    }
+    prompt.push_str(
+        "\nIMPORTANTE: Quando a tarefa envolver arquivos, comandos ou dados reais, \
+         USE as ferramentas para investigar em vez de apenas descrever. \
+         Use 'bash' com 'ls' para listar arquivos e 'file_read' para ler conteudo. \
+         Nao invente resultados — execute e reporte o que aconteceu de verdade. \
+         Se uma ferramenta falhar ou for bloqueada, relate isso na resposta \
+         final: nunca reporte sucesso sem saida real e nunca contorne \
+         silenciosamente um bloqueio de seguranca.\n",
+    );
+    if let Some(dir) = working_dir {
+        prompt.push_str(&format!(
+            "\n## Contexto do diretorio\n\
+             O chamador indicou o diretorio de trabalho: {dir}\n\
+             As ferramentas de arquivo (file_read/file_write) resolvem caminhos \
+             relativos contra este diretorio. O 'bash', porem, roda no diretorio \
+             do processo do servidor e IGNORA este campo — quando precisar operar \
+             nele via bash, prefixe o comando com `cd {dir} && `.\n"
+        ));
+    }
+    prompt
+}
+
+/// Pure reducer over the turn events: one envelope summary per finished
+/// tool call, in emission order. `ToolStarted`/`TextDelta` are skipped;
+/// summaries are re-truncated defensively (the runtime already redacts
+/// and truncates at the source).
+pub(crate) fn events_to_summaries(events: &[TurnEvent]) -> Vec<ToolCallSummary> {
+    events
+        .iter()
+        .filter_map(|e| match e {
+            TurnEvent::ToolFinished {
+                name,
+                duration,
+                success,
+                summary,
+                ..
+            } => Some(ToolCallSummary {
+                name: name.clone(),
+                duration_ms: u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
+                success: *success,
+                summary: truncate_chars(summary, TOOL_CALL_SUMMARY_MAX_CHARS),
+            }),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Truncate by chars (never bytes — paths and summaries carry accents),
+/// mirroring `turn_events::truncar`.
+fn truncate_chars(text: &str, max: usize) -> String {
+    if text.chars().count() <= max {
+        return text.to_string();
+    }
+    let mut out: String = text.chars().take(max.saturating_sub(1)).collect();
+    out.push('…');
+    out
+}
+
+/// Full-agent one-shot: resolve the provider, build a fresh
+/// `AgentRuntime` WITH tools, run a single turn on an empty history,
+/// and return the outcome with the tool-call summary.
+///
+/// Shape mirrors [`crate::ask::ask_oneshot`]. Differences by design:
+/// tools are registered (the caller opted in via env), the events
+/// channel carries the full turn flow, and the wall-clock timeout
+/// covers the whole loop.
+async fn agent_oneshot(config: &AppConfig, opts: &AgentOptions) -> AgentOutcome {
+    let start = Instant::now();
+
+    // 1. Resolve provider (same pipeline as `garra_ask`).
+    let (provider_name, model_name, provider) =
+        match chat::select_explicit_provider(config, &opts.provider, Some(&opts.model), None) {
+            Ok(triple) => triple,
+            Err(e) => {
+                return AgentOutcome::Failure {
+                    error: AskError::NoProvider(sanitize_provider_error(&format!("{e:#}"))),
+                    provider: opts.provider.clone(),
+                    model: opts.model.clone(),
+                    tool_calls: Vec::new(),
+                };
+            }
+        };
+
+    // 2. Build the runtime: provider + full tool set. `register_tool`
+    //    takes `&self` (Arc-safe); the `&mut` setters must run before.
+    let tools = build_tools(config);
+    let tool_pairs: Vec<(String, String)> = tools
+        .iter()
+        .map(|t| (t.name().to_string(), t.description().to_string()))
+        .collect();
+    let mut runtime = AgentRuntime::new();
+    runtime.register_provider(provider);
+    for tool in tools {
+        runtime.register_tool(tool);
+    }
+    runtime.set_system_prompt(agent_system_prompt(
+        &tool_pairs,
+        opts.working_dir.as_deref(),
+    ));
+    runtime.set_max_tokens(4096);
+
+    // 3. One-shot call: fresh session, empty history, wall-clock timeout
+    //    over the whole loop. The events channel gives us the tool
+    //    lifecycle for the envelope's `tool_calls` summary.
+    let session_id = format!("mcp-{}", uuid::Uuid::new_v4());
+    let history: Vec<ChatMessage> = Vec::new();
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<TurnEvent>(512);
+    let exec = ExecContext::with_working_dir(opts.working_dir.clone());
+
+    let call = runtime.process_message_streaming_with_events(
+        &session_id,
+        &opts.message,
+        &history,
+        tx,
+        None,
+        None,
+        Some(&provider_name),
+        Some(&model_name),
+        opts.system_prompt.as_deref(),
+        None,
+        &exec,
+    );
+    let result = tokio::time::timeout(Duration::from_secs(opts.timeout_secs), call).await;
+    let latency_ms = start.elapsed().as_millis();
+
+    // Drain remaining events. The producer side is closed in both paths
+    // (turn finished and dropped its sender clone; or the future was
+    // dropped by the timeout) — `recv` returns `None` immediately. The
+    // cap only bites if a background task still holds a clone.
+    let mut events: Vec<TurnEvent> = Vec::new();
+    let _ = tokio::time::timeout(EVENT_DRAIN_CAP, async {
+        while let Some(e) = rx.recv().await {
+            events.push(e);
+        }
+    })
+    .await;
+    let tool_calls = events_to_summaries(&events);
+
+    match result {
+        Ok(Ok(answer)) => AgentOutcome::Success {
+            answer,
+            provider: provider_name,
+            model: model_name,
+            latency_ms,
+            session_id,
+            tool_calls,
+        },
+        Ok(Err(e)) => AgentOutcome::Failure {
+            error: AskError::ProviderError(sanitize_provider_error(&format!("{e:#}"))),
+            provider: provider_name,
+            model: model_name,
+            tool_calls,
+        },
+        Err(_elapsed) => AgentOutcome::Failure {
+            error: AskError::Timeout(opts.timeout_secs),
+            provider: provider_name,
+            model: model_name,
+            tool_calls,
+        },
+    }
+}
+
+/// MCP handler for `tools/call garra_agent`. Validation errors that are
+/// the CALLER's fault (bad `working_dir`, policy violations) come back
+/// as `Err` → the dispatcher maps them to `invalid_params`; runtime
+/// outcomes (including provider errors and timeouts) come back as the
+/// `garra.agent.v1` envelope + `is_ok` flag, packed like the
+/// `garra_ask` arm.
+pub(crate) async fn handle_agent_call(
+    config: &AppConfig,
+    policy: &ServerPolicy,
+    args: GarraAgentArgs,
+) -> Result<(serde_json::Value, bool), String> {
+    // GAR-587 parity: apply schema defaults before the policy check.
+    let (provider, model) = resolve_overrides(args.provider, args.model);
+    let timeout_secs = args
+        .timeout_secs
+        .unwrap_or_else(|| policy.agent_default_timeout_secs());
+    validate_agent_policy(config, policy, &provider, &model, timeout_secs)?;
+    if let Some(ref dir) = args.working_dir {
+        let is_dir = std::fs::metadata(dir).map(|m| m.is_dir()).unwrap_or(false);
+        if !is_dir {
+            return Err(format!(
+                "working_dir does not exist or is not a directory: {dir}"
+            ));
+        }
+    }
+    let opts = AgentOptions {
+        message: args.message,
+        provider,
+        model,
+        timeout_secs,
+        system_prompt: args.system_prompt,
+        working_dir: args.working_dir,
+    };
+    let outcome = agent_oneshot(config, &opts).await;
+    let envelope = outcome.to_envelope();
+    Ok((envelope, outcome.is_ok()))
+}
+
+#[cfg(test)]
+mod tests {
+    //! Pure tests. Zero network, zero env-mutation, zero filesystem.
+
+    use super::*;
+
+    // ─── Tool descriptor ──────────────────────────────────────────────
+
+    #[test]
+    fn tool_descriptor_name_is_garra_agent() {
+        let t = garra_agent_tool();
+        assert_eq!(t.name.as_ref(), "garra_agent");
+    }
+
+    #[test]
+    fn tool_descriptor_describes_full_agent_and_envelope() {
+        let t = garra_agent_tool();
+        let desc = t.description.expect("description present");
+        assert!(desc.contains("FULL AGENT"));
+        assert!(desc.contains("garra.agent.v1"));
+        assert!(desc.contains("garra_ask"));
+        assert!(desc.contains("GARRAIA_MCP_ENABLE_TOOLS"));
+    }
+
+    #[test]
+    fn tool_descriptor_message_is_required() {
+        let t = garra_agent_tool();
+        let schema = (*t.input_schema).clone();
+        let required = schema
+            .get("required")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .expect("required array present");
+        assert!(required.iter().any(|v| v.as_str() == Some("message")));
+    }
+
+    #[test]
+    fn tool_descriptor_timeout_range_is_5_to_1800_default_300() {
+        let t = garra_agent_tool();
+        let schema = (*t.input_schema).clone();
+        let ts = schema
+            .get("properties")
+            .and_then(|p| p.get("timeout_secs"))
+            .cloned()
+            .expect("timeout_secs property present");
+        assert_eq!(ts.get("minimum").and_then(|v| v.as_u64()), Some(5));
+        assert_eq!(ts.get("maximum").and_then(|v| v.as_u64()), Some(1800));
+        assert_eq!(ts.get("default").and_then(|v| v.as_u64()), Some(300));
+    }
+
+    #[test]
+    fn tool_descriptor_default_model_is_openrouter_free() {
+        let t = garra_agent_tool();
+        let schema = (*t.input_schema).clone();
+        let model_default = schema
+            .get("properties")
+            .and_then(|p| p.get("model"))
+            .and_then(|m| m.get("default"))
+            .and_then(|d| d.as_str());
+        assert_eq!(model_default, Some("openrouter/free"));
+    }
+
+    #[test]
+    fn tool_descriptor_has_working_dir() {
+        let t = garra_agent_tool();
+        let schema = (*t.input_schema).clone();
+        let wd = schema
+            .get("properties")
+            .and_then(|p| p.get("working_dir"))
+            .cloned()
+            .expect("working_dir property present");
+        assert_eq!(wd.get("type").and_then(|v| v.as_str()), Some("string"));
+    }
+
+    #[test]
+    fn tool_descriptor_additional_properties_is_false() {
+        let t = garra_agent_tool();
+        let schema = (*t.input_schema).clone();
+        let ap = schema.get("additionalProperties").and_then(|v| v.as_bool());
+        assert_eq!(ap, Some(false));
+    }
+
+    // ─── Argument deserialization ─────────────────────────────────────
+
+    fn parse_args(v: serde_json::Value) -> Result<GarraAgentArgs, String> {
+        serde_json::from_value(v).map_err(|e| e.to_string())
+    }
+
+    #[test]
+    fn args_deserialize_minimum_required() {
+        let a = parse_args(json!({"message": "list files"})).unwrap();
+        assert_eq!(a.message, "list files");
+        assert!(a.provider.is_none());
+        assert!(a.model.is_none());
+        assert!(a.timeout_secs.is_none());
+        assert!(a.system_prompt.is_none());
+        assert!(a.working_dir.is_none());
+    }
+
+    #[test]
+    fn args_reject_additional_properties() {
+        let err = parse_args(json!({"message": "hi", "rogue": "x"})).unwrap_err();
+        assert!(
+            err.contains("rogue") || err.contains("unknown field"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn args_explicit_model_accepted_at_deser_layer() {
+        let a = parse_args(json!({"message": "x", "model": "openrouter/auto"})).unwrap();
+        assert_eq!(a.model.as_deref(), Some("openrouter/auto"));
+    }
+
+    #[test]
+    fn args_working_dir_deserializes() {
+        let a = parse_args(json!({"message": "x", "working_dir": "/tmp"})).unwrap();
+        assert_eq!(a.working_dir.as_deref(), Some("/tmp"));
+    }
+
+    // ─── Argument validation ──────────────────────────────────────────
+
+    fn make_args(message: &str, timeout_secs: Option<u64>) -> GarraAgentArgs {
+        GarraAgentArgs {
+            message: message.to_string(),
+            provider: None,
+            model: None,
+            timeout_secs,
+            system_prompt: None,
+            working_dir: None,
+        }
+    }
+
+    #[test]
+    fn validate_agent_args_rejects_empty_message() {
+        let err = validate_agent_args(&make_args("   ", None)).unwrap_err();
+        assert!(err.contains("non-empty"));
+    }
+
+    #[test]
+    fn validate_agent_args_rejects_message_over_64kib() {
+        let err = validate_agent_args(&make_args(&"a".repeat(AGENT_MESSAGE_MAX_BYTES + 1), None))
+            .unwrap_err();
+        assert!(err.contains("64"));
+    }
+
+    #[test]
+    fn validate_agent_args_timeout_bounds_are_5_to_1800() {
+        assert!(validate_agent_args(&make_args("x", Some(4))).is_err());
+        assert!(validate_agent_args(&make_args("x", Some(1801))).is_err());
+        assert!(validate_agent_args(&make_args("x", Some(5))).is_ok());
+        assert!(validate_agent_args(&make_args("x", Some(1800))).is_ok());
+    }
+
+    #[test]
+    fn validate_agent_args_rejects_system_prompt_over_8kib() {
+        let mut a = make_args("x", None);
+        a.system_prompt = Some("a".repeat(AGENT_SYSTEM_PROMPT_MAX_BYTES + 1));
+        let err = validate_agent_args(&a).unwrap_err();
+        assert!(err.contains("system_prompt"));
+    }
+
+    // ─── events_to_summaries (pure reducer) ───────────────────────────
+
+    fn finished(name: &str, ms: u64, success: bool, summary: &str) -> TurnEvent {
+        TurnEvent::ToolFinished {
+            name: name.to_string(),
+            duration: Duration::from_millis(ms),
+            success,
+            summary: summary.to_string(),
+            output: String::new(),
+        }
+    }
+
+    #[test]
+    fn events_to_summaries_keeps_only_tool_finished_in_order() {
+        let events = vec![
+            TurnEvent::TextDelta("oi ".into()),
+            TurnEvent::ToolStarted {
+                name: "bash".into(),
+                detail: "ls".into(),
+            },
+            finished("bash", 120, true, "3 files"),
+            finished("file_read", 5, true, "conteudo"),
+        ];
+        let got = events_to_summaries(&events);
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].name, "bash");
+        assert_eq!(got[0].duration_ms, 120);
+        assert!(got[0].success);
+        assert_eq!(got[0].summary, "3 files");
+        assert_eq!(got[1].name, "file_read");
+    }
+
+    #[test]
+    fn events_to_summaries_truncates_long_summary() {
+        let events = vec![finished("bash", 1, true, &"ç".repeat(200))];
+        let got = events_to_summaries(&events);
+        assert!(got[0].summary.chars().count() <= TOOL_CALL_SUMMARY_MAX_CHARS);
+        assert!(got[0].summary.ends_with('…'));
+    }
+
+    #[test]
+    fn events_to_summaries_passthrough_failure_flag() {
+        let events = vec![finished("bash", 30, false, "exit 1")];
+        let got = events_to_summaries(&events);
+        assert!(!got[0].success);
+    }
+
+    #[test]
+    fn events_to_summaries_empty_on_no_events() {
+        assert!(events_to_summaries(&[]).is_empty());
+    }
+
+    // ─── agent_system_prompt ──────────────────────────────────────────
+
+    #[test]
+    fn system_prompt_names_every_registered_tool() {
+        let pairs = vec![
+            ("bash".to_string(), "Executa comandos".to_string()),
+            ("file_read".to_string(), "Le arquivos".to_string()),
+        ];
+        let prompt = agent_system_prompt(&pairs, None);
+        assert!(prompt.contains("bash"));
+        assert!(prompt.contains("file_read"));
+        assert!(prompt.contains("## Ferramentas disponiveis"));
+    }
+
+    #[test]
+    fn system_prompt_includes_working_dir_and_bash_caveat() {
+        let pairs = vec![("bash".to_string(), "Executa comandos".to_string())];
+        let prompt = agent_system_prompt(&pairs, Some("/tmp/projeto"));
+        assert!(prompt.contains("/tmp/projeto"));
+        assert!(prompt.contains("cd /tmp/projeto"));
+        assert!(
+            prompt.contains("IGNORA"),
+            "deve avisar que bash ignora o campo"
+        );
+    }
+
+    #[test]
+    fn system_prompt_obriga_relatar_falhas_de_ferramenta() {
+        let pairs = vec![("bash".to_string(), "Executa comandos".to_string())];
+        let prompt = agent_system_prompt(&pairs, None);
+        assert!(
+            prompt.contains("nunca reporte sucesso sem saida real"),
+            "prompt deve obrigar a relatar falhas de ferramenta"
+        );
+        assert!(
+            prompt.contains("bloqueada"),
+            "prompt deve cobrir ferramenta bloqueada (ex.: file_write fora de allowed_dirs)"
+        );
+    }
+
+    // ─── Envelopes (garra.agent.v1) ───────────────────────────────────
+
+    #[test]
+    fn agent_success_envelope_shape() {
+        let calls = vec![ToolCallSummary {
+            name: "bash".into(),
+            duration_ms: 120,
+            success: true,
+            summary: "3 files".into(),
+        }];
+        let env = agent_success_envelope(
+            "feito",
+            "openrouter",
+            "openrouter/free",
+            1500,
+            "mcp-abc",
+            &calls,
+        );
+        assert_eq!(env["schema"], "garra.agent.v1");
+        assert_eq!(env["ok"], true);
+        assert_eq!(env["answer"], "feito");
+        assert_eq!(env["provider"], "openrouter");
+        assert_eq!(env["model"], "openrouter/free");
+        assert_eq!(env["session_id"], "mcp-abc");
+        assert_eq!(env["tool_calls"][0]["name"], "bash");
+        assert_eq!(env["tool_calls"][0]["duration_ms"], 120);
+        assert!(env.get("error").is_none());
+    }
+
+    #[test]
+    fn agent_error_envelope_carries_tool_calls_and_kind() {
+        let calls = vec![ToolCallSummary {
+            name: "bash".into(),
+            duration_ms: 4000,
+            success: true,
+            summary: "trabalhando".into(),
+        }];
+        let env = agent_error_envelope(
+            "timeout",
+            "exceeded 5s timeout",
+            "openrouter",
+            "openrouter/free",
+            &calls,
+        );
+        assert_eq!(env["schema"], "garra.agent.v1");
+        assert_eq!(env["ok"], false);
+        assert_eq!(env["error"]["kind"], "timeout");
+        assert_eq!(env["error"]["message"], "exceeded 5s timeout");
+        assert_eq!(env["tool_calls"][0]["name"], "bash");
+        assert!(env.get("answer").is_none());
+        assert!(env.get("session_id").is_none());
+    }
+
+    #[test]
+    fn agent_error_envelope_redacts_key_fingerprints() {
+        let sanitized = sanitize_provider_error("boom sk-abcdefgh12345678");
+        let env = agent_error_envelope(
+            AskError::ProviderError(sanitized.clone()).kind_str(),
+            &AskError::ProviderError(sanitized).message(),
+            "openrouter",
+            "openrouter/free",
+            &[],
+        );
+        let msg = env["error"]["message"].as_str().unwrap_or_default();
+        assert!(msg.contains("sk-[REDACTED]"), "{msg}");
+        assert!(!msg.contains("sk-abcdefgh12345678"), "{msg}");
+    }
+}

--- a/crates/garraia-cli/src/mcp_server.rs
+++ b/crates/garraia-cli/src/mcp_server.rs
@@ -1,20 +1,27 @@
 //! GAR-583 — MCP server exposing `garra ask` as a stdio tool.
 //!
 //! Implements the `Model Context Protocol` (MCP) `ServerHandler` trait
-//! from `rmcp 2.2` and exposes a single tool — `garra_ask` — that calls
+//! from `rmcp 2.2` and exposes `garra_ask` — LLM-only — which calls
 //! [`crate::ask::ask_oneshot`] **in-process** (no subprocess spawn, no
 //! shell). Designed for Claude Desktop, Claude Code, and any MCP host
 //! that speaks stdio JSON-RPC.
 //!
 //! Scope (locked-in MVP, user-approved 2026-05-11):
 //!   - Stdio transport only. No HTTP / Streamable HTTP in this PR.
-//!   - One tool: `garra_ask`.
+//!   - Tool: `garra_ask` (LLM-only). Optionally `garra_agent` — the
+//!     full-agent sibling from [`crate::mcp_agent`] — advertised and
+//!     dispatched ONLY when the operator starts the process with
+//!     `GARRAIA_MCP_ENABLE_TOOLS` (see `ServerPolicy`). This file stays
+//!     a pure dispatcher: it never registers runtime tools, never
+//!     spawns subprocesses and never writes to stdout outside of
+//!     `rmcp`'s JSON-RPC channel; the agent machinery (tool
+//!     constructors, shell execution) lives entirely in
+//!     `mcp_agent.rs`, which the audit tests below do NOT scan.
 //!   - Default `openrouter/free`; `openrouter/auto` only opt-in.
-//!   - Response = full `garra.ask.v1` envelope as MCP text content.
-//!   - LLM-only — `mcp_server` MUST NOT register tools, MUST NOT spawn
-//!     subprocesses, MUST NOT write to stdout outside of `rmcp`'s
-//!     JSON-RPC channel. Two audit tests enforce these invariants at
-//!     compile time by scanning the production code of this very file.
+//!   - Response = full `garra.ask.v1` / `garra.agent.v1` envelope as
+//!     MCP text content.
+//!   - Two audit tests enforce the invariants at compile time by
+//!     scanning the production code of this very file.
 
 use std::sync::Arc;
 
@@ -57,14 +64,15 @@ const MODEL_DEFAULT: &str = "openrouter/free";
 /// `garra_ask` JSON schema — which MCP hosts treat as advisory, so it must
 /// be enforced here. Provider aliases defined in the user's `config.yml`
 /// `llm:` section are additionally accepted (see `validate_policy`).
-const PROVIDER_ENUM: [&str; 4] = ["ollama", "anthropic", "openai", "openrouter"];
+pub(crate) const PROVIDER_ENUM: [&str; 4] = ["ollama", "anthropic", "openai", "openrouter"];
 
-/// Runtime limits for `garra_ask`, resolved once at server startup.
+/// Runtime limits for the MCP tools, resolved once at server startup.
 ///
-/// Both knobs are opt-in via env vars; when absent, behavior is unchanged
-/// (any model accepted, caller timeout honored up to the schema max).
-/// This is the operator-side "policy" hook for pairing GarraIA with other
-/// agents (e.g. Hermes) without handing them an unbounded spend button.
+/// All knobs are opt-in via env vars; when absent, behavior is unchanged
+/// (any model accepted, caller timeout honored up to the schema max,
+/// `garra_agent` not advertised). This is the operator-side "policy"
+/// hook for pairing GarraIA with other agents (e.g. Hermes) without
+/// handing them an unbounded spend button.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ServerPolicy {
     /// From `GARRAIA_MCP_MODEL_ALLOWLIST` (comma-separated). Empty = any
@@ -73,14 +81,40 @@ pub(crate) struct ServerPolicy {
     /// e.g. `openrouter/auto` unreachable from MCP callers.
     model_allowlist: Vec<String>,
     /// From `GARRAIA_MCP_MAX_TIMEOUT_SECS`, clamped to the schema max.
-    /// `None` = schema max (600) applies.
+    /// `None` = schema max (600 for `garra_ask`, 1800 for `garra_agent`)
+    /// applies.
     max_timeout_secs: Option<u64>,
+    /// Same raw env value, clamped to the AGENT schema range [5, 1800]
+    /// (wall clock covers the whole tool loop, so it needs headroom over
+    /// the ask cap). Stored separately because the ask clamp above would
+    /// truncate values like 9999 to 600 before the agent could clamp to
+    /// its own max.
+    agent_max_timeout_secs: Option<u64>,
+    /// From `GARRAIA_MCP_ENABLE_TOOLS` (truthy: 1/true/yes, case-
+    /// insensitive). `false` (the default) = the surface is byte-identical
+    /// to the pre-`garra_agent` server: only `garra_ask` is advertised and
+    /// any `garra_agent` call comes back as "unknown tool".
+    tools_enabled: bool,
+}
+
+/// Truthy set for `GARRAIA_MCP_ENABLE_TOOLS` — anything outside it (and
+/// outside the falsy set) keeps the flag off; the operator opts in
+/// explicitly.
+fn parse_enable_tools(raw: &str) -> bool {
+    matches!(
+        raw.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes"
+    )
 }
 
 impl ServerPolicy {
     /// Pure constructor so tests never mutate process env (module
     /// invariant: zero env-mutation in these tests).
-    pub(crate) fn from_values(allowlist: Option<&str>, max_timeout: Option<&str>) -> Self {
+    pub(crate) fn from_values(
+        allowlist: Option<&str>,
+        max_timeout: Option<&str>,
+        enable_tools: Option<&str>,
+    ) -> Self {
         let model_allowlist = allowlist
             .map(|raw| {
                 raw.split(',')
@@ -90,12 +124,23 @@ impl ServerPolicy {
                     .collect()
             })
             .unwrap_or_default();
-        let max_timeout_secs = max_timeout
-            .and_then(|raw| raw.trim().parse::<u64>().ok())
-            .map(|v| v.clamp(ARG_TIMEOUT_SECS_MIN, ARG_TIMEOUT_SECS_MAX));
+        let raw_timeout = max_timeout.and_then(|raw| raw.trim().parse::<u64>().ok());
+        let max_timeout_secs =
+            raw_timeout.map(|v| v.clamp(ARG_TIMEOUT_SECS_MIN, ARG_TIMEOUT_SECS_MAX));
+        // The same raw value caps the agent tool, clamped to the agent
+        // schema range [5, 1800].
+        let agent_max_timeout_secs = raw_timeout.map(|v| {
+            v.clamp(
+                crate::mcp_agent::AGENT_TIMEOUT_SECS_MIN,
+                crate::mcp_agent::AGENT_TIMEOUT_SECS_MAX,
+            )
+        });
+        let tools_enabled = enable_tools.is_some_and(parse_enable_tools);
         Self {
             model_allowlist,
             max_timeout_secs,
+            agent_max_timeout_secs,
+            tools_enabled,
         }
     }
 
@@ -105,7 +150,15 @@ impl ServerPolicy {
             std::env::var("GARRAIA_MCP_MAX_TIMEOUT_SECS")
                 .ok()
                 .as_deref(),
+            std::env::var("GARRAIA_MCP_ENABLE_TOOLS").ok().as_deref(),
         )
+    }
+
+    /// Whether `garra_agent` is part of the advertised surface. Off by
+    /// default — the full-agent tool exists only behind the operator
+    /// opt-in env.
+    pub(crate) fn tools_enabled(&self) -> bool {
+        self.tools_enabled
     }
 
     /// Effective timeout when the caller omits `timeout_secs`: the schema
@@ -115,6 +168,21 @@ impl ServerPolicy {
             .map_or(ARG_TIMEOUT_SECS_DEFAULT, |cap| {
                 cap.min(ARG_TIMEOUT_SECS_DEFAULT)
             })
+    }
+
+    /// Same contract for `garra_agent`: schema default (300) floored by
+    /// the operator cap when one is set.
+    pub(crate) fn agent_default_timeout_secs(&self) -> u64 {
+        self.agent_max_timeout_secs()
+            .map_or(crate::mcp_agent::AGENT_TIMEOUT_SECS_DEFAULT, |cap| {
+                cap.min(crate::mcp_agent::AGENT_TIMEOUT_SECS_DEFAULT)
+            })
+    }
+
+    /// The operator cap as it applies to `garra_agent` (schema max 1800);
+    /// `None` = no env cap, agent schema max applies.
+    fn agent_max_timeout_secs(&self) -> Option<u64> {
+        self.agent_max_timeout_secs
     }
 }
 
@@ -127,6 +195,47 @@ pub(crate) fn validate_policy(
     provider: &str,
     model: &str,
     timeout_secs: u64,
+) -> Result<(), String> {
+    validate_policy_with_cap(
+        config,
+        policy,
+        provider,
+        model,
+        timeout_secs,
+        policy.max_timeout_secs,
+    )
+}
+
+/// Same contract for `garra_agent`: identical checks, but the operator
+/// cap clamps to the agent schema range [5, 1800] instead of the ask
+/// range [1, 600]. The model allowlist applies unchanged — one env var,
+/// both tools.
+pub(crate) fn validate_agent_policy(
+    config: &AppConfig,
+    policy: &ServerPolicy,
+    provider: &str,
+    model: &str,
+    timeout_secs: u64,
+) -> Result<(), String> {
+    validate_policy_with_cap(
+        config,
+        policy,
+        provider,
+        model,
+        timeout_secs,
+        policy.agent_max_timeout_secs(),
+    )
+}
+
+/// Shared body of [`validate_policy`]/[`validate_agent_policy`]; the
+/// only difference is which timeout cap the caller passes.
+fn validate_policy_with_cap(
+    config: &AppConfig,
+    policy: &ServerPolicy,
+    provider: &str,
+    model: &str,
+    timeout_secs: u64,
+    cap: Option<u64>,
 ) -> Result<(), String> {
     // Dev/CI only: mirrors the feature-gated "echo" entry the schema enum
     // gains under `dev-echo-provider` (PR #859) — never in default builds.
@@ -146,7 +255,7 @@ pub(crate) fn validate_policy(
             "model '{model}' blocked by GARRAIA_MCP_MODEL_ALLOWLIST"
         ));
     }
-    if let Some(cap) = policy.max_timeout_secs
+    if let Some(cap) = cap
         && timeout_secs > cap
     {
         return Err(format!(
@@ -290,6 +399,18 @@ pub(crate) fn garra_ask_tool() -> Tool {
     )
 }
 
+/// The advertised tool surface, resolved from the policy: always
+/// `garra_ask`; `garra_agent` joins it only behind the operator opt-in
+/// (`GARRAIA_MCP_ENABLE_TOOLS`). Pure — mirrors what `tools/list`
+/// returns so tests can pin the surface without spinning the server.
+pub(crate) fn advertised_tools(policy: &ServerPolicy) -> Vec<Tool> {
+    let mut tools = vec![garra_ask_tool()];
+    if policy.tools_enabled() {
+        tools.push(crate::mcp_agent::garra_agent_tool());
+    }
+    tools
+}
+
 /// GAR-583 — handler held by the running MCP server. Wraps the shared
 /// `AppConfig` so each `garra_ask` invocation can resolve the provider
 /// + model through the same pipeline used by the CLI.
@@ -302,6 +423,39 @@ pub(crate) struct GarraToolHandler {
 impl GarraToolHandler {
     pub(crate) fn with_policy(config: Arc<AppConfig>, policy: ServerPolicy) -> Self {
         Self { config, policy }
+    }
+
+    /// `tools/call garra_agent` (flag on) — delegate to
+    /// [`crate::mcp_agent::handle_agent_call`] and pack the
+    /// `garra.agent.v1` envelope exactly like the `garra_ask` arm packs
+    /// `garra.ask.v1` (full envelope as text content, `is_ok` picking
+    /// success vs error result).
+    async fn call_agent_tool(
+        &self,
+        request: CallToolRequestParams,
+    ) -> Result<CallToolResult, McpError> {
+        let raw = request.arguments.unwrap_or_default();
+        let args: crate::mcp_agent::GarraAgentArgs = serde_json::from_value(JsonValue::Object(raw))
+            .map_err(|e| McpError::invalid_params(format!("invalid arguments: {e}"), None))?;
+        if let Err(e) = crate::mcp_agent::validate_agent_args(&args) {
+            return Err(McpError::invalid_params(e, None));
+        }
+        match crate::mcp_agent::handle_agent_call(&self.config, &self.policy, args).await {
+            Ok((envelope, is_ok)) => {
+                let text = serde_json::to_string(&envelope).unwrap_or_else(|_| {
+                    String::from(
+                        "{\"schema\":\"garra.agent.v1\",\"ok\":false,\"error\":{\"kind\":\"io\",\"message\":\"json serialization failed\"}}",
+                    )
+                });
+                let content = vec![ContentBlock::text(text)];
+                if is_ok {
+                    Ok(CallToolResult::success(content))
+                } else {
+                    Ok(CallToolResult::error(content))
+                }
+            }
+            Err(e) => Err(McpError::invalid_params(e, None)),
+        }
     }
 }
 
@@ -328,7 +482,7 @@ impl ServerHandler for GarraToolHandler {
         _: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
         Ok(ListToolsResult {
-            tools: vec![garra_ask_tool()],
+            tools: advertised_tools(&self.policy),
             next_cursor: None,
             meta: None,
         })
@@ -339,6 +493,12 @@ impl ServerHandler for GarraToolHandler {
         request: CallToolRequestParams,
         _: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, McpError> {
+        // `garra_agent` dispatches only behind the operator opt-in; with
+        // the flag off it falls through to the unknown-tool branch so the
+        // rejection surface is byte-identical to the pre-agent server.
+        if request.name == "garra_agent" && self.policy.tools_enabled() {
+            return self.call_agent_tool(request).await;
+        }
         if request.name != "garra_ask" {
             return Err(McpError::invalid_params(
                 format!("unknown tool: '{}'", request.name),
@@ -425,6 +585,12 @@ pub async fn run_mcp_server(config: AppConfig) -> Result<()> {
             model_allowlist = ?policy.model_allowlist,
             max_timeout_secs = ?policy.max_timeout_secs,
             "garra_ask policy: operator limits active"
+        );
+    }
+    if policy.tools_enabled() {
+        tracing::info!(
+            "garra_agent tool ENABLED (opt-in GARRAIA_MCP_ENABLE_TOOLS): full-agent surface \
+             with shell/file/git/web tools; bash is full-auto with only the safety_gate denylist"
         );
     }
     let handler = GarraToolHandler::with_policy(Arc::new(config), policy);
@@ -817,7 +983,7 @@ mod tests {
 
     #[test]
     fn policy_default_is_unrestricted_and_preserves_historic_behavior() {
-        let policy = ServerPolicy::from_values(None, None);
+        let policy = ServerPolicy::from_values(None, None, None);
         let cfg = AppConfig::default();
         // Any model — including openrouter/auto — passes without an allowlist.
         assert!(validate_policy(&cfg, &policy, "openrouter", "openrouter/auto", 600).is_ok());
@@ -826,7 +992,7 @@ mod tests {
 
     #[test]
     fn policy_parses_allowlist_trimming_and_skipping_empties() {
-        let policy = ServerPolicy::from_values(Some(" openrouter/free, ,gpt-5-mini "), None);
+        let policy = ServerPolicy::from_values(Some(" openrouter/free, ,gpt-5-mini "), None, None);
         let cfg = AppConfig::default();
         assert!(validate_policy(&cfg, &policy, "openrouter", "openrouter/free", 60).is_ok());
         assert!(validate_policy(&cfg, &policy, "openai", "gpt-5-mini", 60).is_ok());
@@ -837,7 +1003,7 @@ mod tests {
 
     #[test]
     fn policy_timeout_cap_rejects_above_and_lowers_default() {
-        let policy = ServerPolicy::from_values(None, Some("30"));
+        let policy = ServerPolicy::from_values(None, Some("30"), None);
         let cfg = AppConfig::default();
         assert!(validate_policy(&cfg, &policy, "openrouter", "openrouter/free", 30).is_ok());
         let err = validate_policy(&cfg, &policy, "openrouter", "openrouter/free", 31)
@@ -849,9 +1015,9 @@ mod tests {
 
     #[test]
     fn policy_timeout_cap_is_clamped_to_schema_range() {
-        let policy = ServerPolicy::from_values(None, Some("9999"));
+        let policy = ServerPolicy::from_values(None, Some("9999"), None);
         assert_eq!(policy.max_timeout_secs, Some(600));
-        let unparsable = ServerPolicy::from_values(None, Some("banana"));
+        let unparsable = ServerPolicy::from_values(None, Some("banana"), None);
         assert_eq!(unparsable.max_timeout_secs, None);
     }
 
@@ -878,5 +1044,91 @@ mod tests {
         let err = validate_policy(&cfg, &policy, "evil-provider", "any-model", 60)
             .expect_err("unknown provider must be rejected");
         assert!(err.contains("not accepted"), "{err}");
+    }
+
+    // ─── garra_agent opt-in (ServerPolicy.tools_enabled + agent cap) ──
+
+    #[test]
+    fn policy_tools_flag_defaults_off() {
+        let policy = ServerPolicy::from_values(None, None, None);
+        assert!(!policy.tools_enabled(), "flag off by default");
+        let advertised = advertised_tools(&policy);
+        assert_eq!(advertised.len(), 1);
+        assert_eq!(advertised[0].name.as_ref(), "garra_ask");
+    }
+
+    #[test]
+    fn policy_tools_flag_truthy_values_case_insensitive() {
+        for on in ["1", "true", "TRUE", "True", "yes", "Yes", " yes "] {
+            let policy = ServerPolicy::from_values(None, None, Some(on));
+            assert!(policy.tools_enabled(), "{on} must enable tools");
+        }
+        for off in ["0", "false", "no", "banana", "", "  ", "enabled"] {
+            let policy = ServerPolicy::from_values(None, None, Some(off));
+            assert!(!policy.tools_enabled(), "{off:?} must NOT enable tools");
+        }
+    }
+
+    #[test]
+    fn advertised_tools_includes_agent_only_with_flag() {
+        let on = ServerPolicy::from_values(None, None, Some("1"));
+        let advertised = advertised_tools(&on);
+        let names: Vec<&str> = advertised.iter().map(|t| t.name.as_ref()).collect();
+        assert_eq!(names, ["garra_ask", "garra_agent"]);
+    }
+
+    #[test]
+    fn policy_agent_timeout_cap_clamps_to_agent_range() {
+        // Raw 9999: ask cap clamps DOWN to 600 (existing test), agent cap
+        // clamps to its own schema max 1800.
+        let policy = ServerPolicy::from_values(None, Some("9999"), None);
+        let cfg = AppConfig::default();
+        assert!(
+            validate_agent_policy(&cfg, &policy, "openrouter", "openrouter/free", 1800).is_ok()
+        );
+        let err = validate_agent_policy(&cfg, &policy, "openrouter", "openrouter/free", 1801)
+            .expect_err("above agent cap must be rejected");
+        assert!(err.contains("GARRAIA_MCP_MAX_TIMEOUT_SECS=1800"), "{err}");
+        // Default stays the agent schema default 300 even with headroom.
+        assert_eq!(policy.agent_default_timeout_secs(), 300);
+
+        // Raw 30: both caps apply; agent default floors to 30.
+        let tight = ServerPolicy::from_values(None, Some("30"), None);
+        assert_eq!(tight.agent_default_timeout_secs(), 30);
+        let err = validate_agent_policy(&cfg, &tight, "openrouter", "openrouter/free", 31)
+            .expect_err("above tight cap must be rejected");
+        assert!(err.contains("GARRAIA_MCP_MAX_TIMEOUT_SECS=30"), "{err}");
+
+        // Raw below the agent minimum clamps UP to 5 (agent range [5, 1800]).
+        let tiny = ServerPolicy::from_values(None, Some("3"), None);
+        assert_eq!(tiny.agent_default_timeout_secs(), 5);
+    }
+
+    #[test]
+    fn validate_agent_policy_shares_model_allowlist_with_ask() {
+        let policy = ServerPolicy::from_values(Some("openrouter/free"), None, Some("1"));
+        let cfg = AppConfig::default();
+        assert!(validate_agent_policy(&cfg, &policy, "openrouter", "openrouter/free", 300).is_ok());
+        let err = validate_agent_policy(&cfg, &policy, "openrouter", "openrouter/auto", 300)
+            .expect_err("allowlist must bind the agent tool too");
+        assert!(err.contains("GARRAIA_MCP_MODEL_ALLOWLIST"), "{err}");
+    }
+
+    /// Audit companion: the agent dispatch lives in `mcp_agent.rs` — this
+    /// file must keep referring to it only through its facade functions
+    /// (descriptor/validate/handle), never by naming runtime tool
+    /// constructors or spawning processes (the two audit tests above pin
+    /// that with string matching).
+    #[test]
+    fn mcp_agent_descriptor_advertises_agent_bounds() {
+        let t = crate::mcp_agent::garra_agent_tool();
+        assert_eq!(t.name.as_ref(), "garra_agent");
+        let schema = (*t.input_schema).clone();
+        let ts = serde_json::Value::Object(schema)
+            .pointer("/properties/timeout_secs")
+            .cloned()
+            .expect("timeout_secs property");
+        assert_eq!(ts.get("minimum").and_then(|v| v.as_u64()), Some(5));
+        assert_eq!(ts.get("maximum").and_then(|v| v.as_u64()), Some(1800));
     }
 }

--- a/docs/cli-mcp-server.md
+++ b/docs/cli-mcp-server.md
@@ -1,8 +1,13 @@
 # `garra mcp-server` — MCP server exposing `garra ask`
 
-> GAR-583 — stdio Model Context Protocol server. Exposes a single tool
-> (`garra_ask`) that runs the same code path as
-> [`garra ask`](cli-ask.md) in-process — no subprocess, no shell, LLM-only.
+> GAR-583 — stdio Model Context Protocol server. Exposes `garra_ask`,
+> an LLM-only tool that runs the same code path as
+> [`garra ask`](cli-ask.md) in-process — no subprocess, no shell.
+> Optionally (operator opt-in via `GARRAIA_MCP_ENABLE_TOOLS=1`) it also
+> exposes `garra_agent`, a **full-agent** sibling with shell, file,
+> git and web tools — see
+> ["Full agent tool (`garra_agent`)"](#full-agent-tool-garra_agent--operator-opt-in)
+> below.
 >
 > Designed for Claude Desktop, Claude Code, and any MCP host that
 > speaks stdio JSON-RPC.
@@ -51,6 +56,22 @@ If `garra` is not on `PATH`, use the absolute path:
     "garra": {
       "command": "G:/Projetos/GarraRUST/target/release/garra.exe",
       "args": ["mcp-server"]
+    }
+  }
+}
+```
+
+To also expose the full-agent tool (opt-in — read the
+[security surface](#security-surface-read-before-enabling) first), set
+the env in the server entry:
+
+```json
+{
+  "mcpServers": {
+    "garra": {
+      "command": "garra",
+      "args": ["mcp-server"],
+      "env": { "GARRAIA_MCP_ENABLE_TOOLS": "1" }
     }
   }
 }
@@ -141,13 +162,98 @@ at startup via env vars, read once when `garra mcp-server` boots:
 
 | Env var | Effect |
 |---------|--------|
-| `GARRAIA_MCP_MODEL_ALLOWLIST` | Comma-separated model names. When set, a call whose (explicit or defaulted) `model` is not in the list is rejected with `invalid_params`. The operator's way to keep `openrouter/auto` unreachable: `GARRAIA_MCP_MODEL_ALLOWLIST=openrouter/free`. |
-| `GARRAIA_MCP_MAX_TIMEOUT_SECS` | Cap on `timeout_secs` (clamped to the schema max 600). Calls above the cap are rejected; a call omitting `timeout_secs` gets `min(60, cap)`. |
+| `GARRAIA_MCP_MODEL_ALLOWLIST` | Comma-separated model names. When set, a call whose (explicit or defaulted) `model` is not in the list is rejected with `invalid_params`. The operator's way to keep `openrouter/auto` unreachable: `GARRAIA_MCP_MODEL_ALLOWLIST=openrouter/free`. Applies to BOTH tools. |
+| `GARRAIA_MCP_MAX_TIMEOUT_SECS` | Cap on `timeout_secs` (clamped to each tool's schema max: 600 for `garra_ask`, 1800 for `garra_agent`). Calls above the cap are rejected; a call omitting `timeout_secs` gets `min(schema_default, cap)` — 60 for `garra_ask`, 300 for `garra_agent`. |
+| `GARRAIA_MCP_ENABLE_TOOLS` | Opt-in for the full-agent tool. Truthy values: `1`, `true`, `yes` (case-insensitive). When unset, `garra_agent` is not advertised in `tools/list` and calls come back as `unknown tool` — the surface is byte-identical to the pre-agent server. |
+| `GARRAIA_MCP_ALLOWED_DIRS` | Optional comma-separated directory allowlist for `garra_agent`'s file tools (`file_read`/`file_write` relative paths). Falls back to the server's CWD. **UX belt only, not a boundary** — unrestricted `bash` can read anywhere the process can. |
 
 The `provider` enum advertised in the JSON schema
 (`ollama|anthropic|openai|openrouter`) is enforced at runtime — plus any
 provider alias configured under `llm:` in `config.yml`. The active
 policy is logged to stderr at startup.
+
+## Full agent tool (`garra_agent`) — operator opt-in
+
+`garra_agent` runs the GarraIA assistant as a **complete agent** — the
+same runtime the Telegram/gateway path uses — instead of the LLM-only
+`garra_ask`. One-shot per call: fresh session (`mcp-<uuid>`), empty
+history, one turn. The tool is only advertised and dispatched when the
+server process starts with `GARRAIA_MCP_ENABLE_TOOLS` set.
+
+### Registered tools
+
+Mirrors the gateway bootstrap exactly (`garraia-gateway/src/bootstrap/`):
+
+| Tool | Notes |
+|------|-------|
+| `bash` | Full-auto (Telegram parity): only the `safety_gate` DENY_LIST blocks; no per-command confirmation. Confirmation would deadlock a stateless MCP call anyway — it needs conversation history to be approved. |
+| `file_read` / `file_write` | Relative paths resolve against `working_dir` (or the server CWD). `GARRAIA_MCP_ALLOWED_DIRS` narrows them. |
+| `web_fetch` | No blocked-domain list by default. |
+| `git_diff` | Read-only git inspection. |
+| `web_search` | Only when a Brave key exists (`config.yml llm.brave.api_key` or `BRAVE_API_KEY` env). |
+
+### Tool schema (`garra_agent`)
+
+| Field           | Type    | Required | Default            | Notes |
+|-----------------|---------|----------|--------------------|-------|
+| `message`       | string  | yes      | —                  | Max 64 KiB. The task for the agent. |
+| `provider`      | string  | no       | `openrouter`       | Same enum as `garra_ask`. |
+| `model`         | string  | no       | `openrouter/free`  | Pass `openrouter/auto` for complex tasks. |
+| `timeout_secs`  | integer | no       | `300`              | Range `[5, 1800]`. **Wall-clock cap for the ENTIRE agent loop** — every LLM round-trip plus every tool execution. |
+| `system_prompt` | string  | no       | generated          | Max 8 KiB. The default prompt names every registered tool and instructs the model to investigate instead of describing. |
+| `working_dir`   | string  | no       | —                  | Directory for file-tool relative paths. **`bash` ignores it** — it runs in the server's CWD; the default system prompt tells the model to prefix bash commands with `cd <dir> && `. Must exist and be a directory. |
+
+### Response shape (`garra.agent.v1`)
+
+Same shape as `garra.ask.v1` plus `session_id` and a `tool_calls`
+summary (each entry: `name`, `duration_ms`, `success`, `summary` —
+redacted and truncated at the source by the runtime):
+
+```json
+{
+  "schema": "garra.agent.v1",
+  "ok": true,
+  "answer": "...",
+  "provider": "openrouter",
+  "model": "z-ai/glm-5.3-flash",
+  "latency_ms": 15230,
+  "session_id": "mcp-0b6c…",
+  "tool_calls": [
+    {"name": "bash", "duration_ms": 120, "success": true, "summary": "3 files"}
+  ]
+}
+```
+
+On failure or timeout, `ok` is `false` and `error` carries
+`{kind, message}` (same stable labels as `garra.ask.v1`) — and
+`tool_calls` still travels, so the host sees what the agent executed
+before dying.
+
+### Security surface (read before enabling)
+
+- **The bash tool is full-auto** — the operator opt-in chooses Telegram
+  parity. The only hard gate is the `safety_gate` DENY_LIST
+  (substring blocklist, trivially bypassable by quoting/encoding).
+- **The child shell inherits the MCP server process environment with no
+  scrubbing.** Depending on how the server was started, that can include
+  `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, `SSH_AUTH_SOCK`,
+  `XAUTHORITY`, and any secrets `dotenvy` auto-loaded from a `.env` in
+  the CWD. A prompt-injected model can exfiltrate them (e.g. `curl` with
+  `$OPENROUTER_API_KEY`). Do not enable this flag for MCP servers
+  exposed to third-party agents; prefer per-call `working_dir` scoping
+  plus a clean env wrapper if you must.
+- **`allowed_dirs` is UX, not a boundary** — unrestricted bash reaches
+  the whole filesystem.
+- **No per-caller authentication or rate limiting** (same as
+  `garra_ask`); concurrent calls from the host run concurrently.
+- **Config write access**: the file tools can edit `~/.garraia/config.yml`
+  and anything else writable by the process user.
+
+Implementation note: the agent handler lives in
+`crates/garraia-cli/src/mcp_agent.rs`, a module the audit tests in
+`mcp_server.rs` deliberately do NOT scan (they scan only their own
+file). `mcp_server.rs` remains a pure dispatcher — it names no runtime
+tool constructor and spawns no process.
 
 ## Stdio invariants
 
@@ -168,6 +274,16 @@ tests in `crates/garraia-cli/src/mcp_server.rs::tests`:
 
 A future PR that tries to slip a tool registration or a subprocess
 spawn into `mcp_server.rs` will fail the audit at `cargo test` time.
+
+Since the `garra_agent` opt-in, the agent machinery (tool
+constructors, shell execution) lives in
+`crates/garraia-cli/src/mcp_agent.rs`, which those audits
+deliberately do NOT scan — they `include_str!` only `mcp_server.rs`
+itself. The dispatcher file stays free of runtime tool names and
+process spawning; the escape hatch is documented in the module
+docblock of `mcp_agent.rs`. `ask.rs` has its own third audit
+(`ask_module_never_registers_a_tool`, GAR-579) that also scans
+`mcp_server.rs` for spinner references — untouched.
 
 ## Troubleshooting
 
@@ -311,9 +427,11 @@ working under a fully filtered environment:
   directly. There is no subprocess spawn, no shell invocation, no
   PATH lookup. Path hijacking and shell injection are not in the
   threat model.
-- **LLM-only runtime**. No `bash`/`file_read`/`file_write`/`git_diff`
-  tools are registered on the agent runtime — the audit test prevents
-  regression.
+- **LLM-only runtime by default**. No `bash`/`file_read`/`file_write`/`git_diff`
+  tools are registered on the agent runtime unless the operator sets
+  `GARRAIA_MCP_ENABLE_TOOLS` — and even then the registration happens
+  in `mcp_agent.rs`, never in this dispatcher. The audit test prevents
+  regression in `mcp_server.rs`.
 - **Prompt size bounded**. Messages ≤ 64 KiB, system prompts ≤ 8 KiB.
 - **Output bounded**. `max_tokens: 4096` in the runtime caps the
   response.
@@ -322,22 +440,32 @@ working under a fully filtered environment:
 - **Provider errors sanitized** before reaching the response or
   stderr (regex-based redaction of `sk-…`/`sk-or-v1-…` fingerprints).
 - **Operator limits** — see "Operator limits" above for the
-  `GARRAIA_MCP_MODEL_ALLOWLIST` / `GARRAIA_MCP_MAX_TIMEOUT_SECS` knobs.
+  `GARRAIA_MCP_MODEL_ALLOWLIST` / `GARRAIA_MCP_MAX_TIMEOUT_SECS` /
+  `GARRAIA_MCP_ENABLE_TOOLS` knobs.
   There is still no per-caller authentication or rate limiting: the
   trust boundary is process-level (whoever can spawn the binary can
-  call `garra_ask` within the configured policy).
+  call the tools within the configured policy).
+- **`garra_agent` extends the threat model when enabled** — env
+  inheritance by the bash child, full filesystem via unrestricted
+  bash, config write access. Read
+  ["Security surface (read before enabling)"](#security-surface-read-before-enabling)
+  before turning the flag on.
 
 ## Out of scope (separate follow-ups)
 
 - Streamable HTTP transport (this PR is stdio-only).
-- Additional tools beyond `garra_ask` (e.g. `garra_chat`,
-  `garra_files`).
-- `--enable-tools` opt-in for `garra ask` (and MCP propagation).
+- Additional conversational tools beyond `garra_ask`/`garra_agent`
+  (e.g. `garra_chat`, `garra_files`).
+- `--enable-tools` opt-in for `garra ask` (the MCP-side opt-in
+  `GARRAIA_MCP_ENABLE_TOOLS` shipped 2026-09; the CLI `ask`
+  flag remains open).
 - Streaming partial responses via MCP.
 - `RedactingWriter` extension for provider error payloads.
 - Automatic `openrouter/free → openrouter/auto` fallback.
 - Per-user authentication / permissions.
 - MCP server telemetry / Prometheus counters.
+- Bash env allowlist for `garra_agent` (`GARRAIA_MCP_BASH_ENV_ALLOWLIST`)
+  to stop child-process env inheritance.
 
 ## See also
 

--- a/docs/hermes-integration.md
+++ b/docs/hermes-integration.md
@@ -140,9 +140,25 @@ tool-enabled gateway runtime, or if the Hermes tool you expose to
 GarraIA can itself call `garra_ask`, an unbounded ping-pong becomes
 possible, bounded only by per-call timeouts.
 
+**Conditional — `garra_agent` breaks this reasoning when enabled.** If
+the operator starts `garra mcp-server` with `GARRAIA_MCP_ENABLE_TOOLS=1`
+(see [cli-mcp-server.md](cli-mcp-server.md#full-agent-tool-garra_agent--operator-opt-in)),
+the server also exposes `garra_agent`, a full-agent tool with shell,
+file, git and web access. Handing that to Hermes hands it a shell on
+the GarraIA host with the MCP process environment inherited by the
+bash child. **Recommendation: keep the flag OFF wherever the MCP
+caller is a third-party agent (Hermes included).** The safe pairing is
+the default one — Hermes talks to `garra_ask` only. If you must enable
+it, at minimum set `GARRAIA_MCP_MODEL_ALLOWLIST` +
+`GARRAIA_MCP_MAX_TIMEOUT_SECS` and pass `working_dir` per call, and
+understand that `allowed_dirs` is UX, not a boundary (unrestricted
+`bash`).
+
 Practical rules:
 
 - Keep `garra_ask` the only tool GarraIA exposes to Hermes.
+- Do **not** set `GARRAIA_MCP_ENABLE_TOOLS` on the Hermes-spawned
+  `garra mcp-server` process.
 - In GarraIA, allowlist only Hermes tools that do **not** call back into
   GarraIA (or that answer from Hermes' own state).
 - Set explicit timeouts on both sides (`timeout` in the client config;
@@ -154,6 +170,9 @@ Practical rules:
       `garra mcp-server` (blocks `openrouter/auto` and other expensive
       models).
 - [ ] `GARRAIA_MCP_MAX_TIMEOUT_SECS` set (e.g. `120`).
+- [ ] `GARRAIA_MCP_ENABLE_TOOLS` **not** set on the Hermes-spawned
+      process — the full-agent tool must stay out of third-party reach
+      (see the loop topology section above).
 - [ ] `allowed_tools` set on the `hermes` entry in GarraIA's config —
       enforced both at tool registration and on every dispatch.
 - [ ] Timeout (`timeout`) set on the `hermes` entry.
@@ -166,5 +185,6 @@ Practical rules:
 
 - [docs/mcp.md](mcp.md) — GarraIA as MCP **client** (config reference).
 - [docs/cli-mcp-server.md](cli-mcp-server.md) — GarraIA as MCP
-  **server** (`garra_ask` contract, operator limits, stdio invariants).
+  **server** (`garra_ask` contract, `garra_agent` opt-in, operator
+  limits, stdio invariants).
 - `mcp.json.example` — bridge recipes (`mcp-remote`, `supergateway`).

--- a/mcp.json.example
+++ b/mcp.json.example
@@ -1,5 +1,13 @@
 {
   "mcpServers": {
+    "garra": {
+      "command": "garra",
+      "args": ["mcp-server"],
+      "env": {
+        "GARRAIA_MCP_ENABLE_TOOLS": "1",
+        "GARRAIA_MCP_MAX_TIMEOUT_SECS": "600"
+      }
+    },
     "filesystem": {
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]


### PR DESCRIPTION
## Resumo

Aterra em `main` a tool MCP `garra_agent` (v0.4.1) que ja roda em producao no meu host desde 2026-09-09 com `GARRAIA_MCP_ENABLE_TOOLS=1` — ate agora o modulo (`mcp_agent.rs`) existia so no working tree local, sem commit, sem branch e sem clone novo conseguir reconstruir a feature (estado verificado na #1075).

O que entra:

- **`mcp_agent.rs`** (modulo novo): agente completo em sessao nova por chamada — `bash` (full-auto, parity com Telegram; so o DENY_LIST do safety_gate), `file_read`/`file_write` com `GARRAIA_MCP_ALLOWED_DIRS`, `web_fetch`, `git_diff` e `web_search` (com chave Brave). Envelope `garra.agent.v1` com `tool_calls` (nome, duracao, sucesso, resumo redigido), inclusive em falha e timeout. Teto proprio de 1800s (default 300s); `GARRAIA_MCP_MAX_TIMEOUT_SECS` e `GARRAIA_MCP_MODEL_ALLOWLIST` passam a valer para as duas tools.
- **`mcp_server.rs`**: continua dispatcher puro (opt-in via `GARRAIA_MCP_ENABLE_TOOLS={1,true,yes}`; sem a env a superficie fica byte-identica — `garra_agent` nem anunciado). A maquina de agente mora em `mcp_agent.rs`, que os testes de auditoria do dispatcher nao escaneiam por desenho.
- **Honestidade do `answer`** (ponto 3 da #1075): o system prompt default obriga a relatar na resposta final toda ferramenta que falhar ou for bloqueada — nunca reportar sucesso sem saida real, nunca contornar silenciosamente um bloqueio. Repro real: `file_write` bloqueado por `allowed_dirs` e reexecutado como redirect bash com a falha omitida da prosa.
- **Docs + exemplo + fragmento de changelog** (`changelog.d/added/1075-mcp-garra-agent.md`), incluindo a secao "Security surface (read before enabling)" que manda manter a flag OFF para callers de terceiros.

Fora do escopo deste PR (rastreado na #1075): o re-landing do hardening R1-R3 do `BashTool`/`safety_gate` (fonte foi perdido; so existe no binario) e o `GARRAIA_MCP_BASH_ENV_ALLOWLIST`.

Nota: nao carrega bump de versao — mantenho a versao do workspace para o PR de release, como feito na #1020.

## Testes

- `cargo fmt -p garraia -- --check` ok
- `cargo test -p garraia mcp` → 66 passed (mcp_agent + suites de auditoria do mcp_server)
- `cargo test -p garraia --bins` → **467 passed, 0 failed** (1 ignored preexistente)
- `cargo clippy -p garraia --all-targets` limpo

🤖 Generated with [Claude Code](https://claude.com/claude-code)