### PR TITLE
fix(gateway): status dos canais push vem do que subiu, nao do registry (#1079)

### DIFF
--- a/changelog.d/fixed/1079-status-canais-push.md
+++ b/changelog.d/fixed/1079-status-canais-push.md
@@ -1,0 +1,8 @@
+- `GET /api/channels` parou de reportar os quatro canais push (WhatsApp,
+  Google Chat, Teams, LINE) como `offline` num gateway saudavel. Canal push
+  nao entra no `ChannelRegistry` por desenho — vira estado da rota
+  `/webhooks/*` —, entao derivar status do registry dava `offline` eterno.
+  O `KNOWN_CHANNELS` ganhou uma coluna `kind` (`Pull` | `Push`) e o status
+  dos push passa a vir das listas que de fato subiram, e nao do arquivo de
+  config: um canal configurado mas recusado no boot continua aparecendo
+  como `offline`, que e a verdade. (#1079)

--- a/crates/garraia-gateway/src/lib.rs
+++ b/crates/garraia-gateway/src/lib.rs
@@ -39,6 +39,7 @@ pub mod path_validation;
 pub mod plugins_handler;
 pub mod project_root;
 pub mod projects_handler;
+pub mod push_channels;
 pub mod rate_limiter;
 pub mod rest_v1;
 pub mod router;

--- a/crates/garraia-gateway/src/push_channels.rs
+++ b/crates/garraia-gateway/src/push_channels.rs
@@ -1,0 +1,158 @@
+//! Os quatro canais *push* e o que o gateway consegue afirmar sobre eles.
+//!
+//! Canal *pull* (Telegram, Discord, Slack, IRC, Signal, Matrix, …) abre uma
+//! conexao persistente no boot e entra no [`ChannelRegistry`]. Canal *push*
+//! (WhatsApp, Google Chat, Teams, LINE) nao abre conexao nenhuma: o
+//! `Vec<Arc<_>>` dele vira **estado da rota** `/webhooks/*`. Isso e desenho,
+//! nao omissao — esta escrito em cada `bootstrap/<canal>.rs`.
+//!
+//! A consequencia e a #1079: o `GET /api/channels` derivava status do
+//! registry, entao os quatro push davam `active == false` para sempre e,
+//! por terem `needs_secret: true`, saiam classificados como `"offline"`
+//! num gateway saudavel que estava recebendo webhook e respondendo.
+//!
+//! Este modulo e a segunda fonte que faltava. Ele guarda os mesmos
+//! `Vec<Arc<_>>` que viram estado de rota, entao a resposta do `/api/channels`
+//! sai do que **de fato subiu**, e nao do que estava escrito no arquivo de
+//! config.
+//!
+//! ## Por que nao derivar do `AppConfig`
+//!
+//! A #1079 propos derivar de "ha pelo menos um configurado e habilitado no
+//! `AppConfig`". Funciona para o sintoma, mas erra na direcao perigosa: um
+//! canal push pode estar **configurado e ainda assim nao subir**. O
+//! `build_line_channels` descarta canal com `channel_secret` invalido
+//! (#1051), o `build_teams_channels` descarta canal sem `app_id`, o
+//! `build_google_chat_channels` descarta canal sem `audience`, e desde a
+//! #1070 o `WhatsAppChannel::new` recusa canal sem `app_secret`. Em todos
+//! esses casos o config diz "configurado" e a rota tem zero canais.
+//!
+//! Status derivado de config mostraria **melhor** do que a realidade. A
+//! #1079 mostra pior, o que ja destroi a confianca na tela; mostrar melhor
+//! e o erro que faz um operador acreditar que o webhook esta protegido
+//! quando o canal sequer existe. Entao o status vem do que subiu.
+//!
+//! [`ChannelRegistry`]: garraia_channels::ChannelRegistry
+
+use garraia_channels::google_chat::webhook::GoogleChatState;
+use garraia_channels::line_channel::webhook::LineState;
+use garraia_channels::teams::webhook::TeamsState;
+use garraia_channels::whatsapp::webhook::WhatsAppState;
+
+/// Como um canal recebe mensagem. Coluna nova do `KNOWN_CHANNELS` (#1079).
+///
+/// E aqui que mora o conhecimento de "quem e push" — em **um** lugar. O
+/// [`PushChannelStates::mounted`] e conferido contra esta coluna por um teste
+/// (`todo_canal_push_da_tabela_e_conhecido_pelo_struct`), entao as duas
+/// fontes nao conseguem divergir em silencio.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChannelKind {
+    /// Abre conexao persistente no boot e entra no `ChannelRegistry`.
+    Pull,
+    /// Nao abre conexao: vira estado da rota `/webhooks/*`.
+    Push,
+}
+
+/// Os `Vec<Arc<_>>` dos quatro canais push, juntos.
+///
+/// Substitui os quatro parametros posicionais que o `build_router` recebia.
+/// Nos dois call-sites de teste eles eram quatro `Arc::new(Vec::new())`
+/// seguidos, distinguidos so por comentario — trocar dois de lugar compilava
+/// e montava o webhook do Teams com os canais do LINE.
+#[derive(Clone)]
+pub struct PushChannelStates {
+    pub whatsapp: WhatsAppState,
+    pub google_chat: GoogleChatState,
+    pub teams: TeamsState,
+    pub line: LineState,
+}
+
+impl PushChannelStates {
+    /// Nenhum canal push. Para testes de rota que nao exercitam `/webhooks/*`.
+    pub fn empty() -> Self {
+        Self {
+            whatsapp: std::sync::Arc::new(Vec::new()),
+            google_chat: std::sync::Arc::new(Vec::new()),
+            teams: std::sync::Arc::new(Vec::new()),
+            line: std::sync::Arc::new(Vec::new()),
+        }
+    }
+
+    /// Quantos canais deste `id` subiram de fato.
+    ///
+    /// `None` significa "este `id` nao e um canal push que eu conheco" — e
+    /// nao "zero". A distincao importa: `Some(0)` e um canal push que existe
+    /// no gateway e nao subiu (mostrar `"offline"` esta certo); `None` e a
+    /// tabela `KNOWN_CHANNELS` e este struct discordando sobre quem e push,
+    /// que e defeito de codigo e nao estado de runtime.
+    pub fn mounted(&self, id: &str) -> Option<usize> {
+        match id {
+            "whatsapp" => Some(self.whatsapp.len()),
+            "google_chat" => Some(self.google_chat.len()),
+            "teams" => Some(self.teams.len()),
+            "line" => Some(self.line.len()),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Debug for PushChannelStates {
+    /// So as contagens. Um canal push carrega segredo (`app_secret` da Meta,
+    /// `channel_secret` do LINE, credencial de service account do Google
+    /// Chat) e a regra 6 do `CLAUDE.md` proibe que isso apareca em log.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PushChannelStates")
+            .field("whatsapp", &self.whatsapp.len())
+            .field("google_chat", &self.google_chat.len())
+            .field("teams", &self.teams.len())
+            .field("line", &self.line.len())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vazio_conhece_os_quatro_push_e_reporta_zero() {
+        let p = PushChannelStates::empty();
+        for id in ["whatsapp", "google_chat", "teams", "line"] {
+            assert_eq!(
+                p.mounted(id),
+                Some(0),
+                "{id} e push: deve responder Some(0), nao None"
+            );
+        }
+    }
+
+    #[test]
+    fn canal_pull_nao_e_conhecido_pelo_struct() {
+        let p = PushChannelStates::empty();
+        for id in ["telegram", "discord", "slack", "irc", "signal", "matrix"] {
+            assert_eq!(
+                p.mounted(id),
+                None,
+                "{id} e pull: o status dele vem do registry, nao daqui"
+            );
+        }
+    }
+
+    #[test]
+    fn id_desconhecido_da_none_e_nao_zero() {
+        // `Some(0)` diria "canal push que nao subiu". Para um id que nao
+        // existe a resposta certa e "nao sei", para o chamador poder tratar
+        // como defeito em vez de estampar "offline" numa linha inventada.
+        assert_eq!(PushChannelStates::empty().mounted("nao-existe"), None);
+    }
+
+    #[test]
+    fn debug_nao_vaza_conteudo_dos_canais() {
+        let s = format!("{:?}", PushChannelStates::empty());
+        assert!(s.contains("whatsapp"), "esperava as contagens: {s}");
+        assert!(
+            !s.contains("secret") && !s.contains("token"),
+            "Debug nao pode carregar segredo: {s}"
+        );
+    }
+}

--- a/crates/garraia-gateway/src/router.rs
+++ b/crates/garraia-gateway/src/router.rs
@@ -17,6 +17,7 @@ use crate::mobile_chat;
 use crate::oauth;
 use crate::openai_api;
 use crate::parrot_ws;
+use crate::push_channels::ChannelKind;
 use crate::state::SharedState;
 use crate::stats_handler;
 use crate::totp;
@@ -137,13 +138,15 @@ fn build_skill_skin_routes(
 
 pub fn build_router(
     state: SharedState,
-    whatsapp_state: garraia_channels::whatsapp::webhook::WhatsAppState,
-    google_chat_state: garraia_channels::google_chat::webhook::GoogleChatState,
-    teams_state: garraia_channels::teams::webhook::TeamsState,
-    line_state: garraia_channels::line_channel::webhook::LineState,
+    push: crate::push_channels::PushChannelStates,
     admin_store: Arc<Mutex<admin::store::AdminStore>>,
     admin_encryption_key: Arc<Vec<u8>>,
 ) -> Router {
+    // Clonado antes de os campos irem para o `.with_state()` de cada rota de
+    // webhook: o `/api/channels` precisa das mesmas listas para saber quais
+    // canais push subiram (#1079). E `Arc<Vec<_>>` dos dois lados, entao o
+    // clone e um bump de refcount por canal, nao copia dos canais.
+    let push_para_o_status = push.clone();
     // Per-IP rate limit from config (default: 1 req/sec, burst 60).
     let rl = &state.config.gateway.rate_limit;
     let governor_conf = GovernorConfigBuilder::default()
@@ -194,7 +197,7 @@ pub fn build_router(
             get(garraia_channels::whatsapp::webhook::whatsapp_verify)
                 .post(garraia_channels::whatsapp::webhook::whatsapp_webhook),
         )
-        .with_state(whatsapp_state);
+        .with_state(push.whatsapp);
 
     // #1050: so POST. O `GET` do WhatsApp existe por causa do handshake
     // `hub.challenge` da Cloud API; o Google Chat valida pelo proprio POST,
@@ -204,7 +207,7 @@ pub fn build_router(
             "/webhooks/google-chat",
             post(garraia_channels::google_chat::webhook::google_chat_webhook),
         )
-        .with_state(google_chat_state);
+        .with_state(push.google_chat);
 
     // #1050: so POST, como o Google Chat.
     let teams_routes = Router::new()
@@ -212,7 +215,7 @@ pub fn build_router(
             "/webhooks/teams",
             post(garraia_channels::teams::webhook::teams_webhook),
         )
-        .with_state(teams_state);
+        .with_state(push.teams);
 
     // #1050: o LINE tambem so tem POST. O `GET` do WhatsApp existe porque a
     // Cloud API faz um handshake `hub.challenge` para validar a URL; o LINE
@@ -223,7 +226,7 @@ pub fn build_router(
             "/webhooks/line",
             post(garraia_channels::line_channel::webhook::line_webhook),
         )
-        .with_state(line_state);
+        .with_state(push.line);
 
     let router = Router::new()
         .route("/", get(web_chat))
@@ -521,6 +524,10 @@ pub fn build_router(
             api_key_gate,
             crate::gateway_auth::api_key_layer,
         ))
+        // #1079: as listas dos canais push, para o `/api/channels` derivar o
+        // status deles de quem subiu de fato. Nao e segredo — o handler so
+        // consulta `len()`, e o `Debug` do struct so mostra contagem.
+        .layer(axum::Extension(Arc::new(push_para_o_status)))
         .layer(governor_layer)
         .layer(cors_layer)
         .layer({
@@ -1239,34 +1246,82 @@ async fn test_provider(
 // ─── Channels (plan 0120 / PR-7) ───────────────────────────────────────────
 
 /// Known channels — display metadata mirrors `KNOWN_PROVIDERS`. The `id`
-/// column matches `ChannelRegistry` entries; `needs_secret` is purely
-/// informational (the Web Console renders an amber pill when true but the
-/// actual secret value never crosses the API boundary).
-const KNOWN_CHANNELS: &[(&str, &str, bool)] = &[
-    ("web", "Web Chat", false),
-    ("api", "REST API", false),
-    ("telegram", "Telegram", true),
-    ("discord", "Discord", true),
-    ("slack", "Slack", true),
-    ("whatsapp", "WhatsApp", true),
-    ("imessage", "iMessage", false),
-    ("google_chat", "Google Chat", true),
-    ("teams", "Microsoft Teams", true),
-    ("line", "LINE", true),
-    ("irc", "IRC", false),
-    ("signal", "Signal", false),
-    ("matrix", "Matrix", true),
-    ("openclaw", "OpenClaw", false),
-    ("mcp", "MCP", false),
-    ("cli", "CLI", false),
+/// column matches `ChannelRegistry` entries for pull channels; `needs_secret`
+/// is purely informational (the Web Console renders an amber pill when true
+/// but the actual secret value never crosses the API boundary).
+///
+/// A coluna `kind` entrou pela #1079 e e a **unica** fonte de "quem e push".
+/// Canal push nao entra no `ChannelRegistry` — o `Vec<Arc<_>>` dele vira
+/// estado da rota `/webhooks/*` —, entao derivar status do registry dava
+/// `"offline"` eterno para os quatro. O status deles vem do
+/// [`PushChannelStates`], e um teste confere que todo `Push` desta tabela e
+/// conhecido la, para as duas fontes nao divergirem em silencio.
+///
+/// [`PushChannelStates`]: crate::push_channels::PushChannelStates
+const KNOWN_CHANNELS: &[(&str, &str, bool, ChannelKind)] = &[
+    ("web", "Web Chat", false, ChannelKind::Pull),
+    ("api", "REST API", false, ChannelKind::Pull),
+    ("telegram", "Telegram", true, ChannelKind::Pull),
+    ("discord", "Discord", true, ChannelKind::Pull),
+    ("slack", "Slack", true, ChannelKind::Pull),
+    ("whatsapp", "WhatsApp", true, ChannelKind::Push),
+    ("imessage", "iMessage", false, ChannelKind::Pull),
+    ("google_chat", "Google Chat", true, ChannelKind::Push),
+    ("teams", "Microsoft Teams", true, ChannelKind::Push),
+    ("line", "LINE", true, ChannelKind::Push),
+    ("irc", "IRC", false, ChannelKind::Pull),
+    ("signal", "Signal", false, ChannelKind::Pull),
+    ("matrix", "Matrix", true, ChannelKind::Pull),
+    ("openclaw", "OpenClaw", false, ChannelKind::Pull),
+    ("mcp", "MCP", false, ChannelKind::Pull),
+    ("cli", "CLI", false, ChannelKind::Pull),
 ];
+
+/// Decide o `status` de uma linha do `/api/channels`.
+///
+/// Extraida do handler para poder ser exercitada sem montar router, pool nem
+/// runtime: e a regra que a #1079 errava, e um teste dela vale mais que um
+/// teste do JSON inteiro.
+///
+/// `mounted` e o que o [`PushChannelStates`] respondeu para este `id`:
+/// `None` para canal pull (a resposta vem de `live`), e para canal push
+/// significa que a tabela e o struct discordam — tratado como `"unknown"`
+/// em vez de virar `"offline"` numa linha que ninguem consegue explicar.
+///
+/// [`PushChannelStates`]: crate::push_channels::PushChannelStates
+fn channel_status(
+    kind: ChannelKind,
+    needs_secret: bool,
+    live: bool,
+    mounted: Option<usize>,
+) -> &'static str {
+    let up = match kind {
+        ChannelKind::Pull => live,
+        ChannelKind::Push => match mounted {
+            Some(n) => n > 0,
+            // A tabela diz push e o struct nao conhece o id. Defeito de
+            // codigo, nao estado de runtime — nao vale mentir "offline".
+            None => return "unknown",
+        },
+    };
+
+    if up {
+        "active"
+    } else if needs_secret {
+        "offline"
+    } else {
+        "optional"
+    }
+}
 
 #[derive(serde::Serialize)]
 struct ChannelInfo {
     id: &'static str,
     display_name: &'static str,
-    /// `"active"` (registered + live), `"configured"` (known but not registered),
-    /// `"offline"` (not registered, secret needed), `"optional"` (no secret needed).
+    /// `"active"` (canal pull registrado e vivo, ou canal push com pelo menos
+    /// um canal montado na rota), `"offline"` (nao subiu e precisa de
+    /// segredo), `"optional"` (nao subiu e nao precisa de segredo),
+    /// `"unknown"` (a tabela e o `PushChannelStates` discordam — defeito).
     status: &'static str,
     needs_secret: bool,
     /// Server-side timestamp of process boot — `last_activity` is not tracked
@@ -1278,6 +1333,7 @@ struct ChannelInfo {
 /// GET /api/channels — Web Console Channels page payload. Secret-free.
 async fn list_channels(
     axum::extract::State(state): axum::extract::State<SharedState>,
+    axum::Extension(push): axum::Extension<Arc<crate::push_channels::PushChannelStates>>,
 ) -> axum::Json<serde_json::Value> {
     let live: Vec<String> = state
         .channels
@@ -1289,15 +1345,22 @@ async fn list_channels(
         .collect();
 
     let mut channels: Vec<ChannelInfo> = Vec::with_capacity(KNOWN_CHANNELS.len());
-    for (id, display, needs_secret) in KNOWN_CHANNELS {
-        let active = live.iter().any(|name| name == *id);
-        let status = if active {
-            "active"
-        } else if *needs_secret {
-            "offline"
-        } else {
-            "optional"
+    for (id, display, needs_secret, kind) in KNOWN_CHANNELS {
+        // Canal push nunca aparece em `live` — nao entra no registry por
+        // desenho (#1079). Consultar `mounted` so quando `kind` diz push
+        // mantem o registry como fonte unica para os pull.
+        let mounted = match kind {
+            ChannelKind::Push => push.mounted(id),
+            ChannelKind::Pull => None,
         };
+        let live_aqui = live.iter().any(|name| name == *id);
+        let status = channel_status(*kind, *needs_secret, live_aqui, mounted);
+        if status == "unknown" {
+            tracing::warn!(
+                channel = id,
+                "KNOWN_CHANNELS marca este canal como push mas PushChannelStates nao o conhece"
+            );
+        }
         channels.push(ChannelInfo {
             id,
             display_name: display,
@@ -1567,5 +1630,138 @@ mod tests {
         // leaving the endpoints open.
         assert!(!super::bind_is_loopback(""));
         assert!(!super::bind_is_loopback("this is not a hostname"));
+    }
+
+    // ─── #1079: status dos canais push ────────────────────────────────────
+
+    use crate::push_channels::{ChannelKind, PushChannelStates};
+
+    /// O bug da #1079, escrito como teste: canal push que subiu nao pode
+    /// sair `"offline"`. Antes do fix, `live` era a unica fonte e os quatro
+    /// push nunca apareciam nela.
+    #[test]
+    fn canal_push_montado_fica_active_mesmo_fora_do_registry() {
+        let status = super::channel_status(
+            ChannelKind::Push,
+            true,  // needs_secret — era isto que empurrava para "offline"
+            false, // nunca aparece no ChannelRegistry: e desenho
+            Some(1),
+        );
+        assert_eq!(status, "active");
+    }
+
+    #[test]
+    fn canal_push_sem_nenhum_montado_e_offline() {
+        // Configurado errado, ou recusado no boot (LINE com channel_secret
+        // invalido, Teams sem app_id, WhatsApp sem app_secret desde a #1070).
+        assert_eq!(
+            super::channel_status(ChannelKind::Push, true, false, Some(0)),
+            "offline"
+        );
+    }
+
+    #[test]
+    fn canal_push_sem_segredo_e_opcional_e_nao_offline() {
+        assert_eq!(
+            super::channel_status(ChannelKind::Push, false, false, Some(0)),
+            "optional"
+        );
+    }
+
+    /// O `live` do registry nao pode promover um canal push. Se um dia um id
+    /// colidir com uma entrada do registry, o status ainda tem que sair do
+    /// que montou na rota.
+    #[test]
+    fn live_do_registry_nao_promove_canal_push() {
+        assert_eq!(
+            super::channel_status(ChannelKind::Push, true, true, Some(0)),
+            "offline"
+        );
+    }
+
+    #[test]
+    fn canal_pull_continua_vindo_do_registry() {
+        assert_eq!(
+            super::channel_status(ChannelKind::Pull, true, true, None),
+            "active"
+        );
+        assert_eq!(
+            super::channel_status(ChannelKind::Pull, true, false, None),
+            "offline"
+        );
+        assert_eq!(
+            super::channel_status(ChannelKind::Pull, false, false, None),
+            "optional"
+        );
+    }
+
+    /// `mounted` do canal pull e ignorado, nao consultado. Blinda contra um
+    /// refactor futuro que passe `Some(0)` para todo mundo e volte a
+    /// classificar Telegram vivo como offline.
+    #[test]
+    fn mounted_de_canal_pull_e_ignorado() {
+        assert_eq!(
+            super::channel_status(ChannelKind::Pull, true, true, Some(0)),
+            "active"
+        );
+    }
+
+    /// A tabela diz push e o struct nao conhece o id: defeito de codigo.
+    /// Sai `"unknown"` em vez de `"offline"` para nao virar uma linha
+    /// vermelha que ninguem consegue explicar.
+    #[test]
+    fn tabela_e_struct_em_desacordo_dao_unknown() {
+        assert_eq!(
+            super::channel_status(ChannelKind::Push, true, false, None),
+            "unknown"
+        );
+    }
+
+    /// O guard estrutural. A #1079 objetou que consultar as listas push
+    /// "espalha o conhecimento de quem e push por mais um lugar" — este
+    /// teste e a resposta: o `KNOWN_CHANNELS` continua sendo a fonte, e o
+    /// `PushChannelStates` e conferido contra ela. Canal push novo que
+    /// entre na tabela sem entrar no `mounted` derruba o CI.
+    #[test]
+    fn todo_canal_push_da_tabela_e_conhecido_pelo_struct() {
+        let vazio = PushChannelStates::empty();
+        for (id, _, _, kind) in super::KNOWN_CHANNELS {
+            match kind {
+                ChannelKind::Push => assert_eq!(
+                    vazio.mounted(id),
+                    Some(0),
+                    "{id} esta como Push no KNOWN_CHANNELS mas PushChannelStates::mounted \
+                     nao o conhece — adicione o braco no match"
+                ),
+                ChannelKind::Pull => assert_eq!(
+                    vazio.mounted(id),
+                    None,
+                    "{id} esta como Pull no KNOWN_CHANNELS mas PushChannelStates::mounted \
+                     responde por ele — uma das duas fontes esta errada"
+                ),
+            }
+        }
+    }
+
+    /// Os quatro push nomeados. Se um deles for reclassificado como Pull
+    /// por engano, este teste cai antes de o console voltar a mentir.
+    #[test]
+    fn os_quatro_canais_push_estao_marcados_na_tabela() {
+        let push: Vec<&str> = super::KNOWN_CHANNELS
+            .iter()
+            .filter(|(_, _, _, kind)| matches!(kind, ChannelKind::Push))
+            .map(|(id, _, _, _)| *id)
+            .collect();
+        assert_eq!(push, vec!["whatsapp", "google_chat", "teams", "line"]);
+    }
+
+    /// Nenhum id repetido na tabela: uma duplicata faria o console mostrar
+    /// duas linhas para o mesmo canal, possivelmente com status diferente.
+    #[test]
+    fn ids_da_tabela_sao_unicos() {
+        let mut vistos = std::collections::HashSet::new();
+        for (id, _, _, _) in super::KNOWN_CHANNELS {
+            assert!(vistos.insert(*id), "id duplicado no KNOWN_CHANNELS: {id}");
+        }
     }
 }

--- a/crates/garraia-gateway/src/server.rs
+++ b/crates/garraia-gateway/src/server.rs
@@ -991,10 +991,12 @@ impl GatewayServer {
         let state_for_shutdown = Arc::clone(&state);
         let app = build_router(
             state,
-            whatsapp_state,
-            google_chat_state,
-            teams_state,
-            line_state,
+            crate::push_channels::PushChannelStates {
+                whatsapp: whatsapp_state,
+                google_chat: google_chat_state,
+                teams: teams_state,
+                line: line_state,
+            },
             admin_store,
             admin_encryption_key,
         );
@@ -1135,11 +1137,6 @@ pub async fn build_router_for_test_with_storage(
     let state: crate::state::SharedState = Arc::new(state);
 
     // Minimal collaborators expected by the production router.
-    let whatsapp_state: garraia_channels::whatsapp::webhook::WhatsAppState = Arc::new(Vec::new());
-    let google_chat_state: garraia_channels::google_chat::webhook::GoogleChatState =
-        Arc::new(Vec::new());
-    let teams_state: garraia_channels::teams::webhook::TeamsState = Arc::new(Vec::new());
-    let line_state: garraia_channels::line_channel::webhook::LineState = Arc::new(Vec::new());
     let mut admin_store_owned =
         admin::store::AdminStore::in_memory().expect("in-memory admin store should work");
     let admin_encryption_key = Arc::new(admin::handlers::resolve_admin_encryption_key(
@@ -1149,10 +1146,7 @@ pub async fn build_router_for_test_with_storage(
 
     build_router(
         state,
-        whatsapp_state,
-        google_chat_state,
-        teams_state,
-        line_state,
+        crate::push_channels::PushChannelStates::empty(),
         admin_store,
         admin_encryption_key,
     )

--- a/crates/garraia-gateway/tests/api_key_gate.rs
+++ b/crates/garraia-gateway/tests/api_key_gate.rs
@@ -18,6 +18,7 @@ use garraia_agents::AgentRuntime;
 use garraia_channels::ChannelRegistry;
 use garraia_config::AppConfig;
 use garraia_gateway::admin::store::AdminStore;
+use garraia_gateway::push_channels::PushChannelStates;
 use garraia_gateway::router::build_router;
 use garraia_gateway::state::AppState;
 use tokio::sync::Mutex;
@@ -38,16 +39,10 @@ fn router_com(chave: Option<&str>) -> Router {
     ));
     build_router(
         state,
-        // whatsapp
-        Arc::new(Vec::new()),
-        // google chat (#1050) — o gate nao toca em `/webhooks/*`, entao a
-        // lista vazia basta; o que este teste exercita e o layer sobre
-        // `/api/*`.
-        Arc::new(Vec::new()),
-        // teams (#1050), idem
-        Arc::new(Vec::new()),
-        // line (#1050), idem
-        Arc::new(Vec::new()),
+        // O gate nao toca em `/webhooks/*`; o que este teste exercita e o
+        // layer sobre `/api/*`. Antes da #1079 eram quatro
+        // `Arc::new(Vec::new())` posicionais distinguidos so por comentario.
+        PushChannelStates::empty(),
         admin_store,
         Arc::new(vec![0u8; 32]),
     )

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -376,3 +376,37 @@ Messages are automatically routed to the active agent session. Users on differen
 Use session management commands to bridge channels:
 - `/session` - View current session
 - `/session bridge <user_id>` - Bridge sessions
+
+## Pull channels vs push channels (and what the console shows)
+
+A channel receives messages in one of two ways, and the difference decides how
+the Web Console reports its status.
+
+| | Pull | Push |
+|---|---|---|
+| Channels | Telegram, Discord, Slack, IRC, Signal, Matrix, iMessage, OpenClaw | WhatsApp, Google Chat, Teams, LINE |
+| How it receives | opens a persistent connection at boot and polls or listens | the provider POSTs to `/webhooks/<channel>` |
+| Registered in `ChannelRegistry` | yes | **no** — the channel list becomes route state |
+| Status source in `GET /api/channels` | the registry | the channels that actually mounted on the route |
+
+Until #1079, `GET /api/channels` derived every status from the registry. Since
+push channels never enter it, all four reported `offline` forever, even while
+receiving webhooks and replying normally. If you are on a build older than
+v0.4.1 and the console shows WhatsApp, Google Chat, Teams or LINE as offline,
+check the webhook itself before assuming the channel is down.
+
+The status of a push channel comes from what **started**, not from what is
+written in the config file. Several push channels are refused at boot when
+misconfigured — LINE with an invalid `channel_secret`, Teams without `app_id`,
+Google Chat without `audience`, WhatsApp without `app_secret` — and in every
+one of those cases the config says "configured" while the route has zero
+channels. Reporting from config would show better than reality, which is the
+dangerous direction: it would tell an operator the webhook is protected when
+the channel does not exist. So a refused channel still reads `offline`.
+
+| Status | Meaning |
+|---|---|
+| `active` | pull channel registered and live, or push channel with at least one mounted |
+| `offline` | did not start, and the channel needs a secret |
+| `optional` | did not start, and needs no secret |
+| `unknown` | internal defect: the channel table and the push state disagree. Report it |


### PR DESCRIPTION
Fecha #1079.

## O bug

`list_channels` derivava `active` do `ChannelRegistry`. Canal push nunca entra nele, por desenho: o `Vec<Arc<_>>` vira estado da rota `/webhooks/*`, como está escrito em cada `bootstrap/<canal>.rs`. Como WhatsApp, Google Chat, Teams e LINE têm `needs_secret: true`, o `else if` os classificava como `"offline"` para sempre, num gateway que estava recebendo webhook e respondendo.

## A solução, e onde ela diverge da proposta do issue

O issue propôs a opção 2: `KNOWN_CHANNELS` ganha uma coluna `kind`, e o status push vem de "há pelo menos um configurado e habilitado no `AppConfig`".

Adotei a coluna `kind`, mas **não** derivei o status do config. O motivo é concreto: um canal push pode estar configurado e não subir.

| Canal | Quando o boot descarta |
|---|---|
| LINE | `channel_secret` inválido (#1051) |
| Teams | sem `app_id` |
| Google Chat | sem `audience` |
| WhatsApp | sem `app_secret`, desde #1070 |

Nesses casos o config diz "configurado" e a rota tem zero canais. Status derivado de config mostraria **melhor** do que a realidade. O #1079 mostra pior, o que já destrói a confiança na tela; mostrar melhor é o erro que faz um operador acreditar que o webhook está protegido quando o canal sequer existe.

Então o status vem do que montou, via o novo `PushChannelStates` — as mesmas listas que viram estado de rota.

### A objeção do issue, respondida por teste

O issue rejeitou consultar as listas push porque isso "espalha o conhecimento de quem é push por mais um lugar". Justo. A resposta é o teste `todo_canal_push_da_tabela_e_conhecido_pelo_struct`: ele percorre o `KNOWN_CHANNELS` e exige que todo `Push` seja respondido pelo `PushChannelStates::mounted` e todo `Pull` **não** seja. O `KNOWN_CHANNELS` continua sendo a fonte; o struct é conferido contra ela. Canal push novo que entre na tabela sem entrar no `mounted` derruba o CI.

## O que mudou

- **`push_channels.rs`** (novo): `ChannelKind` + `PushChannelStates`, com `Debug` manual que só mostra contagens. Canal push carrega segredo, e a regra 6 do `CLAUDE.md` não abre exceção.
- **`channel_status`** extraída do handler. É a regra que o issue errava, e testá-la não exige montar router, pool nem runtime.
- **`build_router`** troca os quatro parâmetros posicionais de canal push por um `PushChannelStates`. Nos dois call-sites de teste eram quatro `Arc::new(Vec::new())` seguidos, distinguidos só por comentário: trocar dois de lugar compilava e montava o webhook do Teams com os canais do LINE.
- **`"unknown"`** quando a tabela e o struct discordam. É defeito de código, não estado de runtime, e não vale estampar `"offline"` numa linha que ninguém consegue explicar. Vai com `warn!`.

## Testes

14 novos, 10 em `router.rs` e 4 em `push_channels.rs`.

```
garraia-gateway --lib               1000 passed
garraia-gateway --test <gate>          7 passed
garraia-gateway --test router_smoke    3 passed
```

O teste `canal_push_montado_fica_active_mesmo_fora_do_registry` é o bug escrito como asserção: com `live=false` e `mounted=Some(1)` ele exige `"active"`, e a lógica antiga devolveria `"offline"` por construção.

## Docs

`docs/channels.md` ganha a seção "Pull channels vs push channels", com a tabela dos dois modos, o que cada status significa, e por que um canal recusado no boot continua lendo `offline`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVnUdw6gJJLtcmWxzxMtFz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UVnUdw6gJJLtcmWxzxMtFz)_