### PR TITLE
feat(mobile): chat mostra a resposta enquanto ela acontece (#1081)

### DIFF
--- a/apps/garraia-mobile/lib/providers/chat_provider.dart
+++ b/apps/garraia-mobile/lib/providers/chat_provider.dart
@@ -1,10 +1,22 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../runtime/chat_event.dart';
 import '../runtime/models.dart';
 import '../runtime/runtime_config.dart';
 import '../runtime/runtime_providers.dart';
+import 'streaming_reply_provider.dart';
 
 part 'chat_provider.g.dart';
+
+/// The runtime reported a failed turn (an `error` frame, or a transport that
+/// died after the message was already submitted).
+class ChatTurnFailed implements Exception {
+  final String message;
+  const ChatTurnFailed(this.message);
+
+  @override
+  String toString() => message;
+}
 
 /// In-memory list of chat messages for the current session (loaded from
 /// history, appended on send). Runtime-agnostic: every call goes through
@@ -19,8 +31,14 @@ class ChatMessages extends _$ChatMessages {
     return conn.history(sessionId);
   }
 
+  /// Runs one turn, showing it as it arrives.
+  ///
+  /// The reply is streamed into [StreamingReplyState] rather than into this
+  /// list: appending here per token would rebuild every bubble on screen. Only
+  /// when the turn ends does the finished text become a real message.
   Future<void> send(String text) async {
     final conn = requireConnection(ref);
+    final streaming = ref.read(streamingReplyStateProvider.notifier);
 
     // Optimistically add user message
     final current = state.value ?? const [];
@@ -34,27 +52,63 @@ class ChatMessages extends _$ChatMessages {
     ]);
 
     ref.read(mascotStateProvider.notifier).set(MascotState.thinking);
+    streaming.start();
 
     try {
       final sessionId = conn.mode == RuntimeMode.cloud
           ? null
           : await ref.read(currentSessionProvider.notifier).ensure();
-      final reply = await conn.sendMessage(text, sessionId: sessionId);
 
-      final updated = state.value ?? const [];
-      state = AsyncData([
-        ...updated,
-        ChatMessage(
-          role: 'assistant',
-          content: reply,
-          timestamp: DateTime.now().toIso8601String(),
-        ),
-      ]);
+      var reply = '';
+      String? failure;
+
+      await for (final event in conn.sendMessageStreaming(
+        text,
+        sessionId: sessionId,
+      )) {
+        switch (event) {
+          case ChatDelta(:final content):
+            streaming.appendDelta(content);
+          case ChatToolStarted(:final name):
+            streaming.toolStarted(name);
+          case ChatToolFinished():
+            streaming.toolFinished();
+          case ChatCompleted(:final content):
+            reply = content;
+          case ChatStopped():
+            // A cancelled turn is never persisted by the gateway, so the text
+            // the user already read exists only here. Keeping it is the whole
+            // difference between "stopped" and "lost".
+            reply = ref.read(streamingReplyStateProvider).text;
+          case ChatFailed(:final message):
+            failure = message;
+          case ChatSessionChanged(sessionId: final rotated):
+            // The resume did not take and the gateway opened a fresh session.
+            // Follow it, or the next history load reads the wrong one.
+            ref.read(currentSessionProvider.notifier).select(rotated);
+        }
+      }
+
+      if (failure != null) throw ChatTurnFailed(failure);
+
+      if (reply.isNotEmpty) {
+        final updated = state.value ?? const [];
+        state = AsyncData([
+          ...updated,
+          ChatMessage(
+            role: 'assistant',
+            content: reply,
+            timestamp: DateTime.now().toIso8601String(),
+          ),
+        ]);
+      }
+      streaming.finish();
 
       ref.read(mascotStateProvider.notifier).set(MascotState.talking);
       await Future<void>.delayed(const Duration(seconds: 2));
       ref.read(mascotStateProvider.notifier).set(MascotState.idle);
     } catch (e) {
+      streaming.finish();
       final withoutOptimistic = (state.value ?? const [])
           .where((m) => m.content != text || m.role != 'user')
           .toList();
@@ -63,6 +117,10 @@ class ChatMessages extends _$ChatMessages {
       rethrow;
     }
   }
+
+  /// Asks the runtime to cancel the turn in flight. What is on screen stays:
+  /// the `stopped` frame ends the stream and [send] commits the partial text.
+  Future<void> stop() => requireConnection(ref).stopStreaming();
 }
 
 /// Mascot animation state machine.

--- a/apps/garraia-mobile/lib/providers/streaming_reply_provider.dart
+++ b/apps/garraia-mobile/lib/providers/streaming_reply_provider.dart
@@ -1,0 +1,58 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'streaming_reply_provider.g.dart';
+
+/// The reply currently being streamed, and the tool it is waiting on.
+///
+/// It lives in its own provider for one reason: a delta arrives per token, and
+/// if the growing text sat in `ChatMessages` every token would rebuild the
+/// whole message list. Here only the widget watching this provider rebuilds,
+/// and the list above it stays untouched until the turn ends.
+class StreamingReply {
+  /// Whether a turn is in flight. The chat screen watches this alone, so it
+  /// rebuilds twice per turn rather than once per token.
+  final bool active;
+
+  /// Text accumulated from `delta` frames so far.
+  final String text;
+
+  /// Tool running right now, `null` between calls.
+  final String? tool;
+
+  const StreamingReply({this.active = false, this.text = '', this.tool});
+
+  static const idle = StreamingReply();
+
+  StreamingReply copyWith({bool? active, String? text, String? tool}) =>
+      StreamingReply(
+        active: active ?? this.active,
+        text: text ?? this.text,
+        // `copyWith(tool: null)` has to be able to clear it, which the usual
+        // `??` idiom cannot express — so clearing goes through [clearTool].
+        tool: tool ?? this.tool,
+      );
+
+  StreamingReply clearTool() =>
+      StreamingReply(active: active, text: text, tool: null);
+}
+
+/// Generated provider name: `streamingReplyStateProvider`.
+@riverpod
+class StreamingReplyState extends _$StreamingReplyState {
+  @override
+  StreamingReply build() => StreamingReply.idle;
+
+  /// Marks a turn as started, dropping anything left from the previous one.
+  void start() => state = const StreamingReply(active: true);
+
+  void appendDelta(String chunk) =>
+      state = state.copyWith(active: true, text: state.text + chunk);
+
+  void toolStarted(String name) => state = state.copyWith(tool: name);
+
+  void toolFinished() => state = state.clearTool();
+
+  /// Ends the turn. The text is dropped because by now the caller has either
+  /// committed it as a real message or decided not to.
+  void finish() => state = StreamingReply.idle;
+}

--- a/apps/garraia-mobile/lib/runtime/chat_event.dart
+++ b/apps/garraia-mobile/lib/runtime/chat_event.dart
@@ -1,0 +1,128 @@
+import 'dart:convert';
+
+/// One event of an assistant turn, as it happens.
+///
+/// The gateway streams a turn frame by frame over `/ws`
+/// (`crates/garraia-gateway/src/ws.rs`): `delta` for each chunk of text,
+/// `tool_started` / `tool_finished` around a tool call, then exactly one
+/// terminator — `message` when the turn completed, `stopped` when it was
+/// cancelled, `error` when the agent failed.
+///
+/// The hierarchy is sealed so a `switch` over it is exhaustive at compile
+/// time: a frame type added here cannot be forgotten at a consumer.
+sealed class ChatEvent {
+  const ChatEvent();
+
+  /// Parses one server frame, or returns `null` for anything this client does
+  /// not understand.
+  ///
+  /// Returning `null` rather than throwing is the point: the gateway may grow
+  /// a frame type before the app ships support for it, and a stranger on the
+  /// wire must never take the turn down. Handshake frames (`connected`,
+  /// `resumed`) are consumed by the transport and are unknown here too.
+  static ChatEvent? tryParse(String raw) {
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(raw);
+    } on FormatException {
+      return null;
+    }
+    if (decoded is! Map<String, dynamic>) return null;
+
+    switch (_string(decoded['type'])) {
+      case 'delta':
+        final content = _string(decoded['content']);
+        return content == null ? null : ChatDelta(content);
+
+      case 'tool_started':
+        final name = _string(decoded['name']);
+        return name == null
+            ? null
+            : ChatToolStarted(name: name, detail: _string(decoded['detail']));
+
+      case 'tool_finished':
+        final name = _string(decoded['name']);
+        return name == null
+            ? null
+            : ChatToolFinished(
+                name: name,
+                success: decoded['success'] == true,
+                summary: _string(decoded['summary']),
+              );
+
+      case 'message':
+        final content = _string(decoded['content']);
+        return content == null ? null : ChatCompleted(content);
+
+      case 'stopped':
+        return const ChatStopped();
+
+      case 'error':
+        return ChatFailed(
+          _string(decoded['message']) ?? 'the runtime reported an error',
+        );
+
+      default:
+        return null;
+    }
+  }
+
+  /// `null` unless the value really is a string. A frame carrying a number
+  /// where a string belongs is a malformed frame, not a cast to force.
+  static String? _string(Object? value) => value is String ? value : null;
+}
+
+/// A chunk of assistant text. Chunks concatenate in arrival order.
+final class ChatDelta extends ChatEvent {
+  final String content;
+  const ChatDelta(this.content);
+}
+
+/// A tool call started. [detail] is a short human-readable argument summary.
+final class ChatToolStarted extends ChatEvent {
+  final String name;
+  final String? detail;
+  const ChatToolStarted({required this.name, this.detail});
+}
+
+/// A tool call finished. The tool's full output is deliberately not on the
+/// wire — the frame says it ended, it does not carry the result.
+final class ChatToolFinished extends ChatEvent {
+  final String name;
+  final bool success;
+  final String? summary;
+  const ChatToolFinished({
+    required this.name,
+    required this.success,
+    this.summary,
+  });
+}
+
+/// The turn completed. [content] is the whole reply, authoritative over the
+/// concatenated deltas.
+final class ChatCompleted extends ChatEvent {
+  final String content;
+  const ChatCompleted(this.content);
+}
+
+/// The turn was cancelled. Whatever arrived before this is what the user saw,
+/// and it is kept — the server does not persist a cancelled turn, so dropping
+/// it here would erase text the user already read.
+final class ChatStopped extends ChatEvent {
+  const ChatStopped();
+}
+
+/// The runtime failed mid-turn, or the transport did.
+final class ChatFailed extends ChatEvent {
+  final String message;
+  const ChatFailed(this.message);
+}
+
+/// The gateway answered the handshake with a different session than the one
+/// asked for — it does that when a resume fails, creating a fresh session
+/// instead. The app has to follow, otherwise the next history load reads a
+/// session the reply never went to.
+final class ChatSessionChanged extends ChatEvent {
+  final String sessionId;
+  const ChatSessionChanged(this.sessionId);
+}

--- a/apps/garraia-mobile/lib/runtime/chat_socket.dart
+++ b/apps/garraia-mobile/lib/runtime/chat_socket.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+/// The slice of a WebSocket that streaming chat actually needs.
+///
+/// Narrow on purpose: a test can implement it with a `StreamController` and no
+/// socket at all, which is the only way `flutter test` can exercise the turn
+/// protocol — deltas, an unknown frame, a cancel — without a running gateway.
+abstract interface class ChatSocket {
+  /// Text frames from the server, in arrival order.
+  Stream<String> get incoming;
+
+  /// Completes when the connection is usable, throws when it never opened.
+  Future<void> get ready;
+
+  /// Sends one text frame.
+  void send(String frame);
+
+  Future<void> close();
+}
+
+/// Builds a socket for [uri]. Injected so tests can swap the transport.
+typedef ChatSocketFactory = ChatSocket Function(Uri uri);
+
+/// [ChatSocket] over a real `WebSocketChannel`.
+class WebSocketChatSocket implements ChatSocket {
+  final WebSocketChannel _channel;
+
+  WebSocketChatSocket(this._channel);
+
+  factory WebSocketChatSocket.connect(Uri uri) =>
+      WebSocketChatSocket(WebSocketChannel.connect(uri));
+
+  @override
+  Stream<String> get incoming => _channel.stream.map((frame) {
+    if (frame is String) return frame;
+    if (frame is List<int>) return utf8.decode(frame, allowMalformed: true);
+    return '';
+  });
+
+  @override
+  Future<void> get ready => _channel.ready;
+
+  @override
+  void send(String frame) => _channel.sink.add(frame);
+
+  @override
+  Future<void> close() => _channel.sink.close();
+}
+
+/// Default factory: a real WebSocket.
+ChatSocket connectWebSocket(Uri uri) => WebSocketChatSocket.connect(uri);
+
+/// Turns an `http(s)://host/base` into the `ws(s)://host/base/ws` the gateway
+/// serves, carrying the gateway key as `?token=` when there is one.
+///
+/// The key travels in the query because `WebSocketChannel.connect` cannot set
+/// headers on the web target; `ws_handler` accepts either
+/// (`crates/garraia-gateway/src/ws.rs`).
+Uri chatSocketUri(String baseUrl, {String? apiKey}) {
+  final base = Uri.parse(baseUrl);
+  final scheme = base.scheme == 'https' ? 'wss' : 'ws';
+  final basePath = base.path.endsWith('/')
+      ? base.path.substring(0, base.path.length - 1)
+      : base.path;
+  final query = <String, String>{
+    ...base.queryParameters,
+    if (apiKey != null && apiKey.isNotEmpty) 'token': apiKey,
+  };
+  // A `null` here keeps the base query (which is empty whenever the map is),
+  // where an empty map would append a bare `?`.
+  return base.replace(
+    scheme: scheme,
+    path: '$basePath/ws',
+    queryParameters: query.isEmpty ? null : query,
+  );
+}

--- a/apps/garraia-mobile/lib/runtime/cloud_connection.dart
+++ b/apps/garraia-mobile/lib/runtime/cloud_connection.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 
 import '../services/api_service.dart';
+import 'chat_event.dart';
 import 'gateway_connection.dart';
 import 'models.dart';
 import 'runtime_config.dart';
@@ -53,6 +54,25 @@ class CloudConnection extends GatewayConnection {
   @override
   Future<String> sendMessage(String text, {String? sessionId}) =>
       _api.sendMessage(text);
+
+  /// Cloud Alpha answers on `POST /chat` behind a JWT, and `/ws` speaks the
+  /// gateway's session protocol instead — resuming a session Cloud never
+  /// creates. So the whole reply arrives as one event.
+  ///
+  /// Overriding matters: without it this class would inherit the gateway's
+  /// implementation and open a socket against the cloud host with the
+  /// synthetic `'cloud'` session id.
+  @override
+  Stream<ChatEvent> sendMessageStreaming(
+    String text, {
+    String? sessionId,
+  }) async* {
+    yield ChatCompleted(await _api.sendMessage(text));
+  }
+
+  /// Nothing to cancel: the reply is already on its way over HTTP.
+  @override
+  Future<void> stopStreaming() async {}
 }
 
 class _JwtInterceptor extends Interceptor {

--- a/apps/garraia-mobile/lib/runtime/garra_connection.dart
+++ b/apps/garraia-mobile/lib/runtime/garra_connection.dart
@@ -1,3 +1,4 @@
+import 'chat_event.dart';
 import 'models.dart';
 import 'runtime_config.dart';
 
@@ -19,7 +20,24 @@ abstract interface class GarraConnection {
   Future<List<ChatMessage>> history(String? sessionId);
 
   /// Returns the assistant reply. [sessionId] is null only in cloud mode.
+  ///
+  /// Still the fallback path: [sendMessageStreaming] drops to it whenever the
+  /// stream cannot be opened.
   Future<String> sendMessage(String text, {String? sessionId});
+
+  /// Runs one turn and reports it as it happens.
+  ///
+  /// The stream always terminates with exactly one of [ChatCompleted],
+  /// [ChatStopped] or [ChatFailed]. A runtime with no streaming endpoint is
+  /// not an error: the implementation falls back to [sendMessage] and emits
+  /// the whole reply as a single [ChatCompleted], so a caller never has to ask
+  /// which mode it is talking to.
+  Stream<ChatEvent> sendMessageStreaming(String text, {String? sessionId});
+
+  /// Cancels the turn in flight, if there is one and the transport can carry
+  /// the request. A no-op otherwise — a reply already on its way over HTTP
+  /// cannot be recalled.
+  Future<void> stopStreaming();
 
   // Memory
   Future<List<MemoryEntry>> recentMemory({int limit = 50});

--- a/apps/garraia-mobile/lib/runtime/gateway_connection.dart
+++ b/apps/garraia-mobile/lib/runtime/gateway_connection.dart
@@ -1,5 +1,10 @@
+import 'dart:async';
+import 'dart:convert';
+
 import 'package:dio/dio.dart';
 
+import 'chat_event.dart';
+import 'chat_socket.dart';
 import 'garra_connection.dart';
 import 'models.dart';
 import 'runtime_config.dart';
@@ -25,13 +30,31 @@ class GatewayConnection implements GarraConnection {
   final Dio _dio;
   String? _sessionCookie;
 
+  /// Kept for the WebSocket URL: `WebSocketChannel.connect` cannot set headers
+  /// on the web target, so the gateway key rides in the query string.
+  final String? _apiKey;
+
+  /// How the streaming transport is built. Swapped in tests.
+  final ChatSocketFactory _socketFactory;
+
+  /// The socket carrying the current turn, if any. `stopStreaming` needs it,
+  /// and it is the only mutable handle the class keeps.
+  ChatSocket? _activeSocket;
+
+  /// Session the gateway acknowledged for the current turn — not necessarily
+  /// the one we asked for, since a failed resume rotates it.
+  String? _activeSessionId;
+
   GatewayConnection({
     required this.mode,
     required this.baseUrl,
     String? apiKey,
     Dio? dio,
     bool replaySessionCookie = true,
-  }) : _dio =
+    ChatSocketFactory socketFactory = connectWebSocket,
+  }) : _apiKey = apiKey,
+       _socketFactory = socketFactory,
+       _dio =
            dio ??
            Dio(
              BaseOptions(
@@ -131,6 +154,136 @@ class GatewayConnection implements GarraConnection {
       );
     }
     return content;
+  }
+
+  /// Opening budget for the socket. Short on purpose: when there is no `/ws`
+  /// to talk to, the POST fallback still has to feel immediate.
+  static const _openTimeout = Duration(seconds: 6);
+
+  /// Longest silence tolerated inside a turn. Every frame resets it, so it
+  /// only fires when the runtime stops talking altogether. Same order as the
+  /// Dio `receiveTimeout` the POST path already uses.
+  static const _silenceTimeout = Duration(seconds: 120);
+
+  @override
+  Stream<ChatEvent> sendMessageStreaming(
+    String text, {
+    String? sessionId,
+  }) async* {
+    if (sessionId == null || sessionId.isEmpty) {
+      throw ArgumentError('sessionId is required for gateway chat');
+    }
+
+    // The socket never opening is the ordinary case on an older gateway, a
+    // proxy that refuses the upgrade, or a LAN that dropped. Nothing was
+    // submitted yet, so the POST path can still run the turn and the user sees
+    // a reply rather than an error. This is the *only* safe place to fall
+    // back: once the content frame goes out, retrying over HTTP would send the
+    // same message twice.
+    final ChatSocket socket;
+    try {
+      socket = _socketFactory(chatSocketUri(baseUrl, apiKey: _apiKey));
+    } catch (_) {
+      yield* _sendOverPost(text, sessionId);
+      return;
+    }
+    try {
+      await socket.ready.timeout(_openTimeout);
+    } catch (_) {
+      unawaited(socket.close());
+      yield* _sendOverPost(text, sessionId);
+      return;
+    }
+
+    _activeSocket = socket;
+    _activeSessionId = sessionId;
+    var submitted = false;
+
+    try {
+      // Resume the session the app already has, so the turn lands in the same
+      // history the HTTP path reads. A resume the gateway cannot honour is not
+      // refused: it answers `connected` with a *different* session.
+      socket.send(jsonEncode({'type': 'resume', 'session_id': sessionId}));
+
+      await for (final raw in socket.incoming.timeout(_silenceTimeout)) {
+        if (!submitted) {
+          final acked = _handshakeSessionId(raw, requested: sessionId);
+          if (acked == null) {
+            // An error during the handshake means no turn ever started, so the
+            // POST fallback is still safe. Anything else: keep waiting.
+            if (ChatEvent.tryParse(raw) is ChatFailed) break;
+            continue;
+          }
+          if (acked != sessionId) {
+            _activeSessionId = acked;
+            yield ChatSessionChanged(acked);
+          }
+          socket.send(jsonEncode({'content': text}));
+          submitted = true;
+          continue;
+        }
+
+        final event = ChatEvent.tryParse(raw);
+        // An unknown frame is skipped, never fatal: the gateway may grow a
+        // frame type before the app learns it.
+        if (event == null) continue;
+        yield event;
+        if (event is ChatCompleted ||
+            event is ChatStopped ||
+            event is ChatFailed) {
+          return;
+        }
+      }
+
+      // The stream ended without a terminator.
+      if (!submitted) {
+        yield* _sendOverPost(text, sessionId);
+      } else {
+        yield const ChatFailed('a conexao caiu antes de a resposta terminar');
+      }
+    } catch (e) {
+      if (!submitted) {
+        yield* _sendOverPost(text, sessionId);
+      } else {
+        yield ChatFailed('$e');
+      }
+    } finally {
+      _activeSocket = null;
+      _activeSessionId = null;
+      unawaited(socket.close());
+    }
+  }
+
+  @override
+  Future<void> stopStreaming() async {
+    final socket = _activeSocket;
+    final sessionId = _activeSessionId;
+    if (socket == null || sessionId == null) return;
+    // Always addressed: an unaddressed stop cancels whatever turn the socket
+    // happens to be running, and the acknowledged id is the only one the
+    // gateway matches against (`ws.rs`).
+    socket.send(jsonEncode({'type': 'stop', 'session_id': sessionId}));
+  }
+
+  /// The session id a handshake frame acknowledges, or `null` when [raw] is
+  /// not a handshake frame.
+  static String? _handshakeSessionId(String raw, {required String requested}) {
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(raw);
+    } on FormatException {
+      return null;
+    }
+    if (decoded is! Map<String, dynamic>) return null;
+    final type = decoded['type'];
+    if (type != 'connected' && type != 'resumed') return null;
+    final acked = decoded['session_id'];
+    return acked is String && acked.isNotEmpty ? acked : requested;
+  }
+
+  /// One turn over `POST /api/sessions/{id}/messages`, shaped like a stream.
+  Stream<ChatEvent> _sendOverPost(String text, String sessionId) async* {
+    yield ChatCompleted(await sendMessage(text, sessionId: sessionId));
   }
 
   // ── Memory ───────────────────────────────────────────────────────────────

--- a/apps/garraia-mobile/lib/screens/chat_screen.dart
+++ b/apps/garraia-mobile/lib/screens/chat_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../providers/auth_provider.dart';
 import '../providers/chat_provider.dart';
+import '../providers/streaming_reply_provider.dart';
 import '../runtime/runtime_config.dart';
 import '../runtime/runtime_providers.dart';
 import '../services/offline_queue.dart';
@@ -12,6 +13,7 @@ import '../widgets/mascot_widget.dart';
 import '../widgets/queue_status_indicator.dart';
 import '../widgets/scroll_to_bottom_button.dart';
 import '../widgets/slash_suggestions.dart';
+import '../widgets/streaming_bubble.dart';
 import '../widgets/typing_indicator.dart';
 import '../widgets/voice_input_widget.dart';
 
@@ -97,6 +99,10 @@ class _ChatScreenState extends ConsumerState<ChatScreen>
     }
   }
 
+  Future<void> _stop() async {
+    await ref.read(chatMessagesProvider.notifier).stop();
+  }
+
   Future<void> _send() async {
     final text = _inputCtrl.text.trim();
     if (text.isEmpty || _sending) return;
@@ -158,6 +164,12 @@ class _ChatScreenState extends ConsumerState<ChatScreen>
     final messages = ref.watch(chatMessagesProvider);
     final mascotState = ref.watch(mascotStateProvider);
     final isThinking = mascotState == MascotState.thinking;
+    // Deliberately `select`ed down to the boolean: watching the whole
+    // streaming state here would rebuild the screen — and the message list
+    // with it — on every token.
+    final streaming = ref.watch(
+      streamingReplyStateProvider.select((s) => s.active),
+    );
     final isCloud =
         ref.watch(runtimeConfigStateProvider).value?.mode == RuntimeMode.cloud;
 
@@ -239,7 +251,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen>
                   ),
                 ),
               ),
-              data: (msgs) => msgs.isEmpty && !isThinking
+              data: (msgs) => msgs.isEmpty && !isThinking && !streaming
                   ? _EmptyChat(
                       onPrompt: (p) {
                         _inputCtrl.text = p;
@@ -254,10 +266,18 @@ class _ChatScreenState extends ConsumerState<ChatScreen>
                             horizontal: 12,
                             vertical: 8,
                           ),
-                          itemCount: msgs.length + (isThinking ? 1 : 0),
+                          // One trailing slot for the turn in flight: the
+                          // streaming bubble when the socket is carrying it,
+                          // the old typing dots when the reply comes over
+                          // POST (cloud, or the fallback).
+                          itemCount:
+                              msgs.length +
+                              (streaming || isThinking ? 1 : 0),
                           itemBuilder: (_, i) {
-                            if (i == msgs.length && isThinking) {
-                              return const TypingIndicator();
+                            if (i == msgs.length) {
+                              return streaming
+                                  ? const StreamingBubble()
+                                  : const TypingIndicator();
                             }
                             return ChatBubble(message: msgs[i]);
                           },
@@ -273,7 +293,9 @@ class _ChatScreenState extends ConsumerState<ChatScreen>
           _InputBar(
             controller: _inputCtrl,
             sending: _sending,
+            streaming: streaming,
             onSend: _send,
+            onStop: _stop,
             showVoiceInput: _showVoiceInput,
             onToggleVoice: () {
               setState(() => _showVoiceInput = !_showVoiceInput);
@@ -293,7 +315,11 @@ class _ChatScreenState extends ConsumerState<ChatScreen>
 class _InputBar extends StatelessWidget {
   final TextEditingController controller;
   final bool sending;
+
+  /// A turn is in flight over the socket, so the send button becomes Stop.
+  final bool streaming;
   final VoidCallback onSend;
+  final VoidCallback onStop;
   final bool showVoiceInput;
   final VoidCallback onToggleVoice;
   final Future<String> Function(String) onAudioRecorded;
@@ -302,7 +328,9 @@ class _InputBar extends StatelessWidget {
   const _InputBar({
     required this.controller,
     required this.sending,
+    required this.streaming,
     required this.onSend,
+    required this.onStop,
     required this.showVoiceInput,
     required this.onToggleVoice,
     required this.onAudioRecorded,
@@ -350,7 +378,9 @@ class _InputBar extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(width: 8),
-                _SendButton(sending: sending, onSend: onSend),
+                streaming
+                    ? _StopButton(onStop: onStop)
+                    : _SendButton(sending: sending, onSend: onSend),
               ],
             ),
           ),
@@ -387,6 +417,32 @@ class _SendButton extends StatelessWidget {
                   ),
                 )
               : const Icon(Icons.send_rounded, color: Colors.white, size: 22),
+        ),
+      ),
+    );
+  }
+}
+
+/// Replaces the send button while a turn streams. Only reachable then, which
+/// is why it has no disabled state.
+class _StopButton extends StatelessWidget {
+  final VoidCallback onStop;
+
+  const _StopButton({required this.onStop});
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Material(
+      color: cs.errorContainer,
+      borderRadius: BorderRadius.circular(14),
+      child: InkWell(
+        key: const ValueKey('stop-turn'),
+        onTap: onStop,
+        borderRadius: BorderRadius.circular(14),
+        child: Padding(
+          padding: const EdgeInsets.all(14),
+          child: Icon(Icons.stop_rounded, color: cs.onErrorContainer, size: 22),
         ),
       ),
     );

--- a/apps/garraia-mobile/lib/widgets/streaming_bubble.dart
+++ b/apps/garraia-mobile/lib/widgets/streaming_bubble.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../providers/streaming_reply_provider.dart';
+import 'brand/wolf_mark.dart';
+import 'typing_indicator.dart';
+
+/// The assistant bubble while the reply is still arriving.
+///
+/// It watches [streamingReplyStateProvider] itself instead of taking the text
+/// as a parameter. That is the point: the chat screen only watches whether a
+/// turn is active, so a delta rebuilds this widget and nothing else — the
+/// message list above stays put, token after token.
+///
+/// The text renders as plain text, not markdown, on purpose. Half-written
+/// markdown reflows on every token (an unclosed fence turns the rest of the
+/// reply into a code block until it closes), and parsing per token is work
+/// thrown away. The finished message becomes a real ChatBubble with markdown
+/// once the turn ends.
+class StreamingBubble extends ConsumerWidget {
+  const StreamingBubble({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final reply = ref.watch(streamingReplyStateProvider);
+    final cs = Theme.of(context).colorScheme;
+    final maxWidth = MediaQuery.of(context).size.width * 0.78;
+
+    // Nothing has arrived yet: the runtime is thinking, or a tool is running.
+    if (reply.text.isEmpty && reply.tool == null) {
+      return const TypingIndicator();
+    }
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          const SizedBox(
+            width: 32,
+            height: 32,
+            child: WolfMark(size: 32, glow: 0.4),
+          ),
+          const SizedBox(width: 8),
+          Flexible(
+            child: ConstrainedBox(
+              constraints: BoxConstraints(maxWidth: maxWidth),
+              child: Container(
+                key: const ValueKey('streaming-bubble'),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 14,
+                  vertical: 10,
+                ),
+                decoration: BoxDecoration(
+                  color: cs.surfaceContainerHighest,
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (reply.tool != null)
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 6),
+                        child: _ToolChip(name: reply.tool!),
+                      ),
+                    if (reply.text.isNotEmpty)
+                      Text(reply.text, style: TextStyle(color: cs.onSurface)),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// "rodando <tool>" while a tool call is open.
+class _ToolChip extends StatelessWidget {
+  final String name;
+
+  const _ToolChip({required this.name});
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SizedBox(
+          width: 12,
+          height: 12,
+          child: CircularProgressIndicator(strokeWidth: 2, color: cs.primary),
+        ),
+        const SizedBox(width: 8),
+        Text(
+          'rodando $name',
+          key: const ValueKey('streaming-tool'),
+          style: TextStyle(
+            fontSize: 12,
+            color: cs.onSurfaceVariant,
+            fontStyle: FontStyle.italic,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/garraia-mobile/test/chat_streaming_test.dart
+++ b/apps/garraia-mobile/test/chat_streaming_test.dart
@@ -1,0 +1,329 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:garraia_mobile/runtime/chat_event.dart';
+import 'package:garraia_mobile/runtime/chat_socket.dart';
+import 'package:garraia_mobile/runtime/gateway_connection.dart';
+import 'package:garraia_mobile/runtime/runtime_config.dart';
+
+/// A socket with no socket in it: frames go in and out of a controller, so the
+/// turn protocol can be exercised without a gateway.
+class _FakeSocket implements ChatSocket {
+  final _incoming = StreamController<String>();
+
+  /// Every frame the client sent, in order.
+  final sent = <String>[];
+
+  final bool failToOpen;
+  bool closed = false;
+
+  _FakeSocket({this.failToOpen = false});
+
+  @override
+  Stream<String> get incoming => _incoming.stream;
+
+  @override
+  Future<void> get ready =>
+      failToOpen ? Future.error(StateError('upgrade recusado')) : Future.value();
+
+  @override
+  void send(String frame) => sent.add(frame);
+
+  @override
+  Future<void> close() async {
+    closed = true;
+    if (!_incoming.isClosed) await _incoming.close();
+  }
+
+  void emit(String frame) => _incoming.add(frame);
+
+  /// The server hanging up without finishing the turn.
+  Future<void> hangUp() => _incoming.close();
+
+  Map<String, dynamic> sentFrame(int index) =>
+      jsonDecode(sent[index]) as Map<String, dynamic>;
+}
+
+/// A gateway whose POST path is a counter, so the fallback is observable
+/// without an HTTP server.
+class _TestGateway extends GatewayConnection {
+  int posts = 0;
+  String? lastPostSession;
+
+  _TestGateway(ChatSocketFactory factory)
+    : super(
+        mode: RuntimeMode.local,
+        baseUrl: 'http://127.0.0.1:3888',
+        socketFactory: factory,
+      );
+
+  @override
+  Future<String> sendMessage(String text, {String? sessionId}) async {
+    posts++;
+    lastPostSession = sessionId;
+    return 'resposta via POST';
+  }
+}
+
+/// Lets the turn generator advance: it awaits between frames, so a single
+/// microtask hop is not enough. Local on purpose — one less framework API to
+/// be wrong about.
+Future<void> settle() async {
+  for (var i = 0; i < 10; i++) {
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
+void main() {
+  group('ChatEvent.tryParse', () {
+    test('reads every frame the gateway documents', () {
+      expect(
+        (ChatEvent.tryParse('{"type":"delta","content":"oi"}') as ChatDelta)
+            .content,
+        'oi',
+      );
+      expect(
+        (ChatEvent.tryParse('{"type":"tool_started","name":"bash"}')
+                as ChatToolStarted)
+            .name,
+        'bash',
+      );
+      expect(
+        ChatEvent.tryParse(
+          '{"type":"tool_finished","name":"bash","success":true}',
+        ),
+        isA<ChatToolFinished>(),
+      );
+      expect(
+        (ChatEvent.tryParse('{"type":"message","content":"pronto"}')
+                as ChatCompleted)
+            .content,
+        'pronto',
+      );
+      expect(ChatEvent.tryParse('{"type":"stopped"}'), isA<ChatStopped>());
+      expect(
+        ChatEvent.tryParse('{"type":"error","message":"deu ruim"}'),
+        isA<ChatFailed>(),
+      );
+    });
+
+    test('an unknown frame is null, not an exception', () {
+      // The gateway may grow a frame type before the app learns it.
+      expect(ChatEvent.tryParse('{"type":"telemetry","v":1}'), isNull);
+      expect(ChatEvent.tryParse('{"type":"connected","session_id":"s1"}'),
+          isNull);
+      expect(ChatEvent.tryParse('nao e json'), isNull);
+      expect(ChatEvent.tryParse('[1,2,3]'), isNull);
+      expect(ChatEvent.tryParse('{"sem":"tipo"}'), isNull);
+      // A number where a string belongs is malformed, not a cast to force.
+      expect(ChatEvent.tryParse('{"type":"delta","content":7}'), isNull);
+    });
+  });
+
+  group('chatSocketUri', () {
+    test('http becomes ws and https becomes wss', () {
+      expect(
+        chatSocketUri('http://127.0.0.1:3888').toString(),
+        'ws://127.0.0.1:3888/ws',
+      );
+      expect(
+        chatSocketUri('https://garra.example.com').toString(),
+        'wss://garra.example.com/ws',
+      );
+    });
+
+    test('carries the gateway key, which cannot go in a header on web', () {
+      expect(
+        chatSocketUri('http://127.0.0.1:3888', apiKey: 'k1').toString(),
+        'ws://127.0.0.1:3888/ws?token=k1',
+      );
+    });
+
+    test('a trailing slash does not produce //ws', () {
+      expect(
+        chatSocketUri('http://127.0.0.1:3888/').toString(),
+        'ws://127.0.0.1:3888/ws',
+      );
+    });
+  });
+
+  group('sendMessageStreaming', () {
+    test('resumes the session, submits, and streams the turn', () async {
+      final socket = _FakeSocket();
+      final conn = _TestGateway((_) => socket);
+
+      final events = <ChatEvent>[];
+      final done = conn
+          .sendMessageStreaming('oi', sessionId: 's1')
+          .listen(events.add)
+          .asFuture<void>();
+
+      await settle();
+      // First frame is the resume for the session the app already has, so the
+      // turn lands in the same history the HTTP path reads.
+      expect(socket.sentFrame(0)['type'], 'resume');
+      expect(socket.sentFrame(0)['session_id'], 's1');
+      expect(socket.sent.length, 1, reason: 'nothing submitted before the ack');
+
+      socket.emit('{"type":"resumed","session_id":"s1"}');
+      await settle();
+      expect(socket.sentFrame(1)['content'], 'oi');
+
+      socket.emit('{"type":"delta","content":"oi "}');
+      socket.emit('{"type":"telemetry","ignore":true}');
+      socket.emit('{"type":"delta","content":"mundo"}');
+      socket.emit('{"type":"message","content":"oi mundo"}');
+      await done;
+
+      expect(events.whereType<ChatDelta>().map((e) => e.content).toList(), [
+        'oi ',
+        'mundo',
+      ]);
+      expect((events.last as ChatCompleted).content, 'oi mundo');
+      expect(conn.posts, 0, reason: 'the socket carried it, not POST');
+      expect(socket.closed, isTrue);
+    });
+
+    test('an unknown frame does not take the stream down', () async {
+      final socket = _FakeSocket();
+      final conn = _TestGateway((_) => socket);
+      final events = <ChatEvent>[];
+      final done = conn
+          .sendMessageStreaming('oi', sessionId: 's1')
+          .listen(events.add)
+          .asFuture<void>();
+
+      await settle();
+      socket.emit('{"type":"resumed","session_id":"s1"}');
+      await settle();
+
+      socket.emit('{"type":"quem_sabe_o_que","x":1}');
+      socket.emit('{"type":"delta","content":"segue"}');
+      socket.emit('{"type":"message","content":"segue"}');
+      await done;
+
+      expect(events.length, 2, reason: 'the stranger was skipped: $events');
+      expect(events.first, isA<ChatDelta>());
+    });
+
+    test('a cancelled turn ends with stopped, keeping what arrived', () async {
+      final socket = _FakeSocket();
+      final conn = _TestGateway((_) => socket);
+      final events = <ChatEvent>[];
+      final done = conn
+          .sendMessageStreaming('oi', sessionId: 's1')
+          .listen(events.add)
+          .asFuture<void>();
+
+      await settle();
+      socket.emit('{"type":"resumed","session_id":"s1"}');
+      await settle();
+      socket.emit('{"type":"delta","content":"metade"}');
+      await settle();
+
+      await conn.stopStreaming();
+      // Always addressed: an unaddressed stop would cancel whatever turn the
+      // socket happens to be running.
+      final stop = socket.sentFrame(2);
+      expect(stop['type'], 'stop');
+      expect(stop['session_id'], 's1');
+
+      socket.emit('{"type":"stopped","session_id":"s1"}');
+      await done;
+
+      expect(events.first, isA<ChatDelta>());
+      expect(events.last, isA<ChatStopped>());
+    });
+
+    test('a rotated session is reported so the app can follow', () async {
+      // A resume the gateway cannot honour is not refused: it answers
+      // `connected` with a different session.
+      final socket = _FakeSocket();
+      final conn = _TestGateway((_) => socket);
+      final events = <ChatEvent>[];
+      final done = conn
+          .sendMessageStreaming('oi', sessionId: 'expirada')
+          .listen(events.add)
+          .asFuture<void>();
+
+      await settle();
+      socket.emit(
+        '{"type":"connected","session_id":"nova","note":"previous session expired"}',
+      );
+      await settle();
+      socket.emit('{"type":"message","content":"pronto"}');
+      await done;
+
+      expect((events.first as ChatSessionChanged).sessionId, 'nova');
+      expect(socket.sentFrame(1)['content'], 'oi');
+    });
+
+    test('falls back to POST when the socket never opens', () async {
+      // An older gateway with no /ws, a proxy refusing the upgrade, the LAN
+      // dropping: the user gets a reply, not an error.
+      final socket = _FakeSocket(failToOpen: true);
+      final conn = _TestGateway((_) => socket);
+
+      final events = await conn
+          .sendMessageStreaming('oi', sessionId: 's1')
+          .toList();
+
+      expect(conn.posts, 1);
+      expect(conn.lastPostSession, 's1');
+      expect((events.single as ChatCompleted).content, 'resposta via POST');
+    });
+
+    test('falls back when the socket dies before the turn is submitted',
+        () async {
+      final socket = _FakeSocket();
+      final conn = _TestGateway((_) => socket);
+
+      final pending = conn.sendMessageStreaming('oi', sessionId: 's1').toList();
+      await settle();
+      await socket.hangUp(); // hung up during the handshake
+
+      final events = await pending;
+      expect(conn.posts, 1, reason: 'nothing was submitted, so POST is safe');
+      expect((events.single as ChatCompleted).content, 'resposta via POST');
+    });
+
+    test('does not resend over POST once the turn was submitted', () async {
+      // The message is already with the runtime; retrying would send it twice.
+      final socket = _FakeSocket();
+      final conn = _TestGateway((_) => socket);
+      final events = <ChatEvent>[];
+      final done = conn
+          .sendMessageStreaming('oi', sessionId: 's1')
+          .listen(events.add)
+          .asFuture<void>();
+
+      await settle();
+      socket.emit('{"type":"resumed","session_id":"s1"}');
+      await settle();
+      socket.emit('{"type":"delta","content":"metade"}');
+      await settle();
+      await socket.hangUp();
+      await done;
+
+      expect(conn.posts, 0);
+      expect(events.last, isA<ChatFailed>());
+    });
+
+    test('stopStreaming is a no-op with no turn in flight', () async {
+      final socket = _FakeSocket();
+      final conn = _TestGateway((_) => socket);
+      await conn.stopStreaming();
+      expect(socket.sent, isEmpty);
+    });
+
+    test('a session id is required in gateway mode', () async {
+      final conn = _TestGateway((_) => _FakeSocket());
+      // `async*` reports it when the stream is listened to, not at the call.
+      await expectLater(
+        conn.sendMessageStreaming('oi').toList(),
+        throwsArgumentError,
+      );
+    });
+  });
+}

--- a/changelog.d/added/1081-streaming-no-app.md
+++ b/changelog.d/added/1081-streaming-no-app.md
@@ -1,0 +1,15 @@
+- O chat do Garra Mobile passa a mostrar a resposta enquanto ela acontece, em
+  vez de esperar o turno inteiro. O app abre o `/ws` do gateway, retoma a
+  sessao que ja tinha e vai concatenando os `delta` numa bolha que cresce;
+  `tool_started` / `tool_finished` viram um indicador de qual ferramenta esta
+  rodando. Um botao Parar aparece durante o turno e manda `{"type":"stop"}`
+  **sempre com o `session_id`** — um stop sem endereco cancelaria qualquer
+  turno que o socket estivesse carregando. O texto parcial que chegou antes do
+  `stopped` vira a mensagem final: o gateway nao persiste turno cancelado,
+  entao descartar aqui apagaria o que o usuario ja tinha lido (#1081).
+- Quando o socket nao abre — gateway antigo sem `/ws`, proxy que recusa o
+  upgrade, LAN que caiu — o app volta sozinho para o `POST` de sempre, sem
+  mostrar erro. O fallback so vale antes de o turno ser submetido; depois
+  disso, repetir por HTTP mandaria a mesma mensagem duas vezes (#1081).
+- Um frame que o app nao conhece e ignorado em vez de derrubar o turno: o
+  gateway pode ganhar um tipo novo antes de o app aprender (#1081).


### PR DESCRIPTION
Metade Flutter do #1047, separada em #1081. A metade servidor ja estava em `main` (#1063): `/ws` emite `delta`, `tool_started`, `tool_finished` e `stopped`, e aceita `{"type":"stop"}`.

## O que muda

| Peca | Por que |
|---|---|
| `ChatEvent` (selado) | `switch` exaustivo em tempo de compilacao; frame desconhecido vira `null` e e pulado, nunca derruba o turno |
| `ChatSocket` + `ChatSocketFactory` | fatia estreita do WebSocket, injetavel — e o unico jeito de o `flutter test` exercitar o protocolo sem gateway rodando |
| `sendMessageStreaming` (3 modos) | gateway usa o socket; cloud entrega um evento so |
| `StreamingReplyState` (provider proprio) | a tela observa so `active` via `select`, entao um token reconstroi a bolha e **nada mais** |
| `StreamingBubble` + `_StopButton` | bolha que cresce, chip da tool em execucao, Parar durante o turno |

## Decisoes que valem revisao

**O fallback so acontece antes da submissao.** Se o socket nao abre (gateway antigo sem `/ws`, proxy recusando o upgrade, LAN caindo), o app cai para o `POST` de sempre e o usuario ve uma resposta, nao um erro. Depois que o frame de conteudo sai, repetir por HTTP mandaria a mesma mensagem duas vezes — entao ai o erro aparece. Ha um teste para cada lado dessa linha.

**Cloud precisa do override.** `CloudConnection extends GatewayConnection`; sem sobrescrever, herdaria o socket e abriria `/ws` contra o host do cloud com a sessao sintetica `'cloud'`. Cloud Alpha responde em `POST /chat` com JWT, que nao fala o protocolo de sessao do `/ws`.

**Sessao rotacionada.** Um resume que o gateway nao honra nao e recusado: ele responde `connected` com uma sessao **diferente** (`ws.rs:193`). O app segue a nova via `ChatSessionChanged`, senao o proximo carregamento de historico le a sessao que nunca recebeu a resposta.

**Parar manda sempre o `session_id`.** Um stop sem endereco cancela qualquer turno que o socket esteja carregando, e `ws.rs:1318` so casa pelo id reconhecido.

**Markdown nao e renderizado no texto em voo**, de proposito: markdown pela metade reflui a cada token (uma cerca aberta transforma o resto da resposta em bloco de codigo ate fechar) e o parse por token e trabalho jogado fora. A mensagem final vira `ChatBubble` com markdown normal.

**Limitacao conhecida:** `_activeSocket` e estado de instancia, entao dois turnos simultaneos na mesma conexao se atropelariam. A tela serializa (`_sending`), e nao inventei trava para um caso que a UI ja impede.

## Verificacao

**Nao ha toolchain Dart neste container** (`which flutter dart` vem vazio; o Android SDK esta bloqueado). Escrevi 13 testes e o `mobile.yml` e quem executa `flutter analyze` + `flutter test` + build do APK. Evitei de proposito APIs de teste de cujo caminho de export eu nao teria certeza (`pumpEventQueue` virou um helper local) e conferi um a um: import ocioso, referencia de doc pendurada, `switch` exaustivo sobre o selado, `const` onde o lint exige.

Se o CI acusar algo, corrijo la — e o primeiro lugar onde este codigo compila.

Closes #1081

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAuuALoRsxJHEEe7kqYmCD