### PR TITLE
fix(webconsole): exibir form de gateway key quando a autenticacao e exigida

### DIFF
--- a/changelog.d/fixed/1101-webconsole-form-gateway-key.md
+++ b/changelog.d/fixed/1101-webconsole-form-gateway-key.md
@@ -1,0 +1,7 @@
+- **O form de gateway key volta a aparecer quando a autenticacao e exigida (#1100).**
+  O CSS deixa `.gateway-key-form` escondida com `display: none`, e o boot apenas
+  limpava o estilo inline (`authSection.style.display = ''`), o que nunca sobrepoe a
+  folha de estilo. Com `gateway.api_key` configurada o console avisava "Gateway API Key
+  required." sem nenhum campo visivel para digitar a chave, e o WebSocket reconectava
+  em loop com 401. Passa a usar `display: 'block'` explicito em `webchat.html` e
+  `assets/app.js`, que duplicam a mesma logica.

--- a/crates/garraia-gateway/assets/app.js
+++ b/crates/garraia-gateway/assets/app.js
@@ -40,7 +40,10 @@ async function boot() {
   }
 
   if (GarraState.authRequired) {
-    if (dom.authSection) dom.authSection.style.display = "";
+    // Issue #1100: the CSS hides .gateway-key-form with `display: none`, so
+    // clearing the inline style ("") never reveals the auth form. Use an
+    // explicit display so the "Gateway API Key required" state is actionable.
+    if (dom.authSection) dom.authSection.style.display = "block";
     if (GarraState.gatewayKey) {
       connect();
     } else {

--- a/crates/garraia-gateway/src/webchat.html
+++ b/crates/garraia-gateway/src/webchat.html
@@ -5050,7 +5050,10 @@ async function boot() {
   } catch { State.authRequired = false; }
 
   if (State.authRequired) {
-    if (authSection) authSection.style.display = '';
+    // Issue #1100: the CSS hides .gateway-key-form with `display: none`, so
+    // clearing the inline style ('') never reveals the auth form. The user
+    // was told to enter a key that no visible field could accept.
+    if (authSection) authSection.style.display = 'block';
     if (State.gatewayKey) { connect(); }
     else { appendSystemMsg('Gateway API Key required.'); }
   } else {

--- a/tests/playwright/webchat-auth-form.spec.ts
+++ b/tests/playwright/webchat-auth-form.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * #1100 (PR #1101): com a autenticacao exigida, o form de gateway key
+ * aparece para o usuario digitar a chave.
+ *
+ * O CSS esconde `.gateway-key-form` com `display: none`. Antes do fix o boot
+ * limpava o estilo inline (`display = ''`), que reverteria ao CSS escondido —
+ * o usuario via "Gateway API Key required." sem nenhum campo visivel para
+ * digitar a chave, e o WebSocket reconectava em loop com 401 (#1100).
+ *
+ * Os mocks `page.route` interceptam no browser, entao o spec funciona tanto
+ * contra o gateway real do CI quanto em verificacao local com o console
+ * servido estaticamente (o webchat.html e auto-contido, ports inline).
+ */
+import { test, expect } from '@playwright/test';
+
+test.describe('#1100 — form de gateway key', () => {
+  test('auth exigida no boot revela o form e avisa em vez de conectar', async ({ page }) => {
+    await page.route('**/api/auth-check', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ auth_required: true }),
+      }),
+    );
+
+    await page.goto('/');
+    // Sem chave guardada, o boot nao tenta conectar — ele mostra o form.
+    await expect(page.locator('#auth-section')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('#chat-messages')).toContainText('Gateway API Key required.');
+  });
+
+  test('auth nao exigida deixa o form escondido', async ({ page }) => {
+    await page.route('**/api/auth-check', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ auth_required: false }),
+      }),
+    );
+
+    await page.goto('/');
+    await expect(page.locator('#auth-section')).toBeHidden({ timeout: 10_000 });
+  });
+});


### PR DESCRIPTION
## Resumo

Corrige a Web Console que fica inutilizável quando `gateway.api_key` está configurada: o form de autenticação (`#auth-section`) existe no HTML mas o CSS o esconde com `.gateway-key-form { display: none; }`, e o boot apenas limpava o estilo inline (`authSection.style.display = ''`), o que nunca sobrepõe a folha de estilo. Resultado: "Gateway API Key required." sem nenhum campo visível para digitar a chave, e o WebSocket reconnectando em loop com 401.

Correção: `display: 'block'` explícito (2 arquivos, mesmo trecho duplicado).

## Evidência

- `.gateway-key-form { display: none; }` — `webchat.html:2234`
- `authSection.style.display = ''` — `webchat.html:5053` e `assets/app.js:43`
- Repro: v0.4.1 + `gateway.api_key` setada + aba anônima em `/` → aviso de key sem form; WS rejeitado a cada 2s (`WARN garraia_gateway::ws: WebSocket connection rejected: invalid API key`)

## Teste

- [ ] Build do gateway
- [ ] Com `gateway.api_key` setada: abrir `/` em aba anônima → form "Gateway Authentication" visível; colar a chave + Connect → WS conecta (HTTP 101) e as chamadas `/api/*` retornam 200
- [ ] Sem `gateway.api_key`: abrir `/` → form permanece oculto e o chat conecta direto (comportamento atual preservado)

Closes #1100
