### PR TITLE
fix(security): o modo ask passa a negar bash (#1104)

### DIFF
--- a/changelog.d/security/1104-ask-nega-bash.md
+++ b/changelog.d/security/1104-ask-nega-bash.md
@@ -1,0 +1,7 @@
+- **O modo `ask` passa a negar `bash` (#1104).** A negacao de `file_write`
+  era decorativa: `bash` e execucao arbitraria e o modelo escrevia o arquivo
+  pelo shell (`printf ... > arquivo`), contornando a promessa "apenas
+  perguntas" do modo padrao de Telegram/Discord/WhatsApp. Leitura (`file_read`,
+  `list_dir`, `repo_search`, `web_search`) segue livre. `run_tests` nao e
+  `bash`: executa toolchains fixas com nome de programa fixo, e continua
+  permitido.

--- a/crates/garraia-agents/src/modes.rs
+++ b/crates/garraia-agents/src/modes.rs
@@ -692,7 +692,12 @@ impl ModeProfile {
             ),
             tool_policy: ToolPolicy {
                 allowed: vec![],
-                denied: vec!["file_write".to_string()],
+                // #1104: `bash` e execucao arbitraria — com ele fora da lista,
+                // a negacao de `file_write` era decorativa: o modelo escrevia
+                // o arquivo pelo shell (`printf ... > arquivo`) e furava a
+                // promessa deste modo, que o proprio prompt declara ("Prefer
+                // providing text explanations over executing code").
+                denied: vec!["file_write".to_string(), "bash".to_string()],
                 required: vec![],
                 whitelist_mode: false,
             },
@@ -1195,6 +1200,22 @@ mod tests {
         let g = ToolGate::for_mode_name("ask");
         assert!(!g.permite("file_write"), "ask deveria negar file_write");
         assert!(g.permite("file_read"));
+    }
+
+    /// Negar `bash` no `ask` e o que faz a negacao de `file_write` valer (#1104).
+    ///
+    /// `bash` e execucao arbitraria: fora da lista, o modelo escrevia o
+    /// arquivo pelo shell e a promessa "apenas perguntas" era contornavel.
+    /// Leitura segue livre — o modo existe para responder, nao para isolar.
+    #[test]
+    fn ask_mode_denies_bash_so_the_file_write_denial_is_not_bypassable() {
+        let g = ToolGate::for_mode_name("ask");
+        assert!(!g.permite("bash"), "ask deveria negar bash (#1104)");
+        assert!(!g.permite("file_write"));
+        assert!(g.permite("file_read"));
+        assert!(g.permite("list_dir"));
+        assert!(g.permite("repo_search"));
+        assert!(g.permite("web_search"));
     }
 
     /// Modo somente-leitura barra escrita e bash.


### PR DESCRIPTION
## O que muda

O modo `ask` (padrao de Telegram/Discord/WhatsApp) declarava `denied: ["file_write"]`, mas `bash` continuava liberado. `bash` e execucao arbitraria: o modelo escrevia o arquivo pelo shell (`printf ... > arquivo`) e a negacao de `file_write` ficava decorativa, furando a promessa que o proprio prompt do modo faz ("Prefer providing text explanations over executing code").

Agora `ask` nega `file_write` **e** `bash`. Leitura segue livre: `file_read`, `list_dir`, `repo_search`, `web_search` continuam permitidos — o modo existe para responder, nao para isolar.

`run_tests` nao e `bash`: executa toolchains fixas com nome de programa fixo (nao e um shell do usuario), e continua permitido.

## Risco

R4 (auth/crypto/permissoes de tool) — o gate de tools e um controle de seguranca. Mudanca de 1 linha + teste de regressao.

## Verificacao

- `cargo fmt --check` — PASS
- `cargo clippy -p garraia-agents --all-targets` — PASS
- `cargo test -p garraia-agents` — 351 passed, 0 failed (inclui o novo `ask_mode_denies_bash_so_the_file_write_denial_is_not_bypassable`)
- Fragmento em `changelog.d/security/1104-ask-nega-bash.md`; `python3 scripts/changelog/assemble.py --check` OK

Closes #1104

🤖 Generated with [Claude Code](https://claude.com/claude-code)