### PR TITLE
test(ci): roda o ciclo de vida do MCP no CI (#1089)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,21 @@ jobs:
         # `garraia` é o nome do pacote em `crates/garraia-cli/`.
         run: cargo clippy -p garraia --features mcp-http --all-targets -- -D warnings
 
+      - name: Run clippy + tests (mcp)
+        # Buraco vizinho do `mcp-http` acima: `crates/garraia-agents` declara
+        # `default = []` e `mcp = ["dep:rmcp"]`, e o unico alvo de teste que
+        # exercita o ciclo de vida real do MCP
+        # (`crates/garraia-agents/tests/mcp_lifecycle.rs`) comeca com
+        # `#![cfg(feature = "mcp")]`. Como nenhum job passava `--features mcp`
+        # — e `--all-features` nao e usado em lugar nenhum —, os tres testes
+        # (`tool_survives_reconnect`, `detects_dead_child_and_reconnects`,
+        # `disconnect_all_is_bounded_with_stubborn_child`) nunca rodavam no CI.
+        # Issue #1089. O clippy vem junto pelo mesmo motivo dos outros steps:
+        # sem ele o codigo sob a feature apodrece sem aviso.
+        run: |
+          cargo clippy -p garraia-agents --features mcp --all-targets -- -D warnings
+          cargo test -p garraia-agents --features mcp --test mcp_lifecycle
+
       - name: Run clippy + tests (signal)
         # Mesmo buraco do `mcp-http` acima, e do `auth-integration` mais
         # abaixo: `pub mod signal` e `#[cfg(feature = "signal")]` e a feature

--- a/changelog.d/changed/1089-mcp-lifecycle-no-ci.md
+++ b/changelog.d/changed/1089-mcp-lifecycle-no-ci.md
@@ -1,0 +1,7 @@
+- **#1089** o CI passa a compilar e rodar `garraia-agents` com
+  `--features mcp`. A feature e OFF por default (`default = []`) e
+  `tests/mcp_lifecycle.rs` comeca com `#![cfg(feature = "mcp")]`, entao os tres
+  testes de ciclo de vida do MCP (reconexao, deteccao de filho morto e
+  disconnect limitado) nunca executavam em nenhum job. O novo step
+  `Run clippy + tests (mcp)` segue o mesmo padrao dos steps `signal`, `line` e
+  `mcp-http`, que ja fechavam buracos identicos.


### PR DESCRIPTION
## O que muda

A feature `mcp` de `garraia-agents` e OFF por default (`default = []`) e `crates/garraia-agents/tests/mcp_lifecycle.rs` comeca com `#![cfg(feature = "mcp")]`. Nenhum job do CI passava `--features mcp` — e `--all-features` nao e usado em lugar nenhum — entao estes tres testes **nunca executaram no CI**:

- `tool_survives_reconnect`
- `detects_dead_child_and_reconnects`
- `disconnect_all_is_bounded_with_stubborn_child`

## O buraco

E o mesmo buraco que os steps `signal`, `line` e `mcp-http` ja fecham, cada um com o comentario explicando que o `--workspace` nao ve uma feature desligada. O `mcp` ficou de fora porque o step vizinho `Run clippy (mcp-http)` cobre `garraia` (o binario), nao `garraia-agents` (a lib), e nenhum deles roda testes.

## A correcao

Um step `Run clippy + tests (mcp)` no job de lint, no mesmo formato dos vizinhos:

```yaml
cargo clippy -p garraia-agents --features mcp --all-targets -- -D warnings
cargo test -p garraia-agents --features mcp --test mcp_lifecycle
```

## Evidencia

- `cargo test -p garraia-agents --features mcp --test mcp_lifecycle` → `3 passed; 0 failed` (0 filtered).
- `cargo clippy -p garraia-agents --features mcp --all-targets -- -D warnings` → exit 0, sem warnings.

Ou seja: o step entra verde, nao vermelho.

## Risco

R0. Nenhum codigo de producao muda; so o CI passa a enxergar testes que ja existem e ja passam.

Closes #1089

🤖 Generated with [Claude Code](https://claude.com/claude-code)