### PR TITLE
feat(chat): --persist e --resume salvam a conversa do garra chat (#1088)

### DIFF
--- a/changelog.d/added/1088-chat-persist.md
+++ b/changelog.d/added/1088-chat-persist.md
@@ -10,4 +10,8 @@
   retoma-la. Com `--resume`, o historico gravado e carregado antes do primeiro
   turno, a tela diz quantos turnos voltaram e a sessao continua gravando dali
   em diante — as duas flags sao independentes, mas qualquer uma basta para
-  abrir o store. Falha de gravacao avisa e a conversa segue.
+  abrir o store. Falha de gravacao avisa e a conversa segue; e se a contagem
+  de mensagens fora da janela falha, o aviso tambem acontece em vez de
+  anunciar zero no silencio. Turnos voltados sao contados pelas perguntas
+  (`user`), nao por divisao da lista — turno incompleto deixado pela
+  hidratacao do gateway nao mente no placar.

--- a/changelog.d/added/1088-chat-persist.md
+++ b/changelog.d/added/1088-chat-persist.md
@@ -1,0 +1,13 @@
+- **`garra chat` ganha `--persist` e `--resume <SESSION_ID>` para nao perder a
+  conversa quando o processo acaba (#1088).** O REPL guardava o historico so
+  na memoria, entao a conversa morria com ele; o que decidia isso era um
+  comentario em `chat.rs`, sem flag nem doc. Agora e opt-in explicito: sem
+  nenhuma das duas flags **nenhum** banco e aberto e nada vai para o disco —
+  exatamente o comportamento anterior, e ha teste que prende isso.
+- Com `--persist`, cada turno vai para `<data_dir>/sessions.db` (o mesmo
+  `sessions.db` do gateway) por `upsert_session` + `append_message`, sem
+  mudanca de schema; o id da sessao aparece na abertura ja com o comando para
+  retoma-la. Com `--resume`, o historico gravado e carregado antes do primeiro
+  turno, a tela diz quantos turnos voltaram e a sessao continua gravando dali
+  em diante — as duas flags sao independentes, mas qualquer uma basta para
+  abrir o store. Falha de gravacao avisa e a conversa segue.

--- a/crates/garraia-cli/src/chat.rs
+++ b/crates/garraia-cli/src/chat.rs
@@ -16,6 +16,7 @@ use garraia_agents::{
     normalize_ollama_tag, tools::git_diff_tool::GitDiffTool,
 };
 use garraia_config::AppConfig;
+use garraia_db::SessionStore;
 use tokio::sync::mpsc;
 
 use crate::ui::error_card::ErrorCard;
@@ -144,6 +145,13 @@ fn get_api_key(config: &AppConfig, provider_name: &str, env_var: &str) -> Option
 /// gateway does. `schedule_heartbeat` / `schedule_recurring` need a
 /// `SessionStore` the chat does not open — they stay gateway-only, on
 /// purpose and said here rather than silently.
+///
+/// #1088 mudou **metade** dessa frase: com `--persist`/`--resume` o chat
+/// passa a abrir um `SessionStore`, entao "o chat nao abre store" deixou de
+/// ser verdade no modo persistente. O registro das duas tools continua
+/// gateway-only mesmo assim — a loja existe so quando a pessoa pediu, e
+/// registrar a tool condicionalmente daria ao agente um conjunto de
+/// ferramentas que depende de uma flag. Fica para um slice proprio.
 fn register_cli_tools(
     runtime: &AgentRuntime,
     review: Option<(Arc<dyn LlmProvider>, String)>,
@@ -164,6 +172,97 @@ fn register_cli_tools(
     if let Some(key) = brave_key {
         runtime.register_tool(Box::new(WebSearchTool::new(key)));
     }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Persistencia do `garra chat` (#1088)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Quantas mensagens o `--resume` traz de volta.
+///
+/// E o mesmo numero da hidratacao do gateway (`state.rs`), e pela mesma
+/// razao: acima disso o historico inteiro da sessao iria para o prompt de
+/// cada turno, e um prompt gigante custa mais caro do que as mensagens
+/// antigas valem.
+const RESUME_LIMIT: usize = 100;
+
+/// Nome do arquivo do `SessionStore` dentro do diretorio de dados.
+///
+/// O mesmo `sessions.db` que o gateway abre (`server.rs`): quem retoma no
+/// chat uma conversa que comecou num canal encontra as mensagens no lugar
+/// onde elas ja estavam.
+const SESSIONS_DB: &str = "sessions.db";
+
+/// Abre o `SessionStore` **apenas** quando a sessao vai usa-lo.
+///
+/// `None` — o padrao, sem `--persist` nem `--resume` — significa nenhum
+/// arquivo criado e nada gravado em disco, que e exatamente o que o chat
+/// sempre fez. A decisao de nao gravar era implicita num comentario; agora
+/// ela e uma flag, e este `None` e a prova de que o caminho antigo continua
+/// intacto (ha teste).
+fn open_chat_store(
+    config: &AppConfig,
+    persist: bool,
+    resume: Option<&str>,
+) -> Result<Option<SessionStore>> {
+    if !persist && resume.is_none() {
+        return Ok(None);
+    }
+    let data_dir = config.resolved_data_dir();
+    std::fs::create_dir_all(&data_dir)
+        .with_context(|| format!("nao foi possivel criar {}", data_dir.display()))?;
+    let path = data_dir.join(SESSIONS_DB);
+    let store = SessionStore::open(&path)
+        .with_context(|| format!("nao foi possivel abrir {}", path.display()))?;
+    Ok(Some(store))
+}
+
+/// Grava um turno (pergunta + resposta) no store.
+///
+/// `direction` segue o vocabulario que o gateway ja usa em `persist_turn` —
+/// `"user"` e `"assistant"` —, porque e o que `load_history` e a hidratacao
+/// do gateway leem de volta. Nada de schema novo: sao as duas mesmas
+/// chamadas, so que feitas pelo CLI.
+fn append_turn(
+    store: &SessionStore,
+    session_id: &str,
+    user_text: &str,
+    assistant_text: &str,
+) -> Result<()> {
+    store.upsert_session(
+        session_id,
+        "cli",
+        "local",
+        &serde_json::json!({ "origem": "garra chat" }),
+    )?;
+    let meta = serde_json::json!({ "channel_id": "cli", "user_id": "local" });
+    let agora = chrono::Utc::now();
+    store.append_message(session_id, "user", user_text, agora, &meta)?;
+    store.append_message(session_id, "assistant", assistant_text, agora, &meta)?;
+    Ok(())
+}
+
+/// Le o historico gravado de uma sessao, em ordem cronologica.
+///
+/// Direcoes que nao sao `"user"` nem `"assistant"` (resumo de sistema, lixo
+/// de uma versao antiga) sao descartadas em vez de virarem mensagem com
+/// papel inventado.
+fn load_history(store: &SessionStore, session_id: &str, limit: usize) -> Result<Vec<ChatMessage>> {
+    let gravadas = store.load_recent_messages(session_id, limit)?;
+    Ok(gravadas
+        .into_iter()
+        .filter_map(|m| {
+            let role = match m.direction.as_str() {
+                "user" => ChatRole::User,
+                "assistant" => ChatRole::Assistant,
+                _ => return None,
+            };
+            Some(ChatMessage {
+                role,
+                content: MessagePart::Text(m.content),
+            })
+        })
+        .collect())
 }
 
 /// One line of the system prompt per registered tool.
@@ -1009,6 +1108,8 @@ pub async fn run_chat(
     url_override: Option<String>,
     timeout_secs: u64,
     assume_yes: bool,
+    persist: bool,
+    resume: Option<String>,
 ) -> Result<()> {
     // An explicit `--provider` short-circuits detection entirely; otherwise
     // `detect_provider` owns both the provider *and* the model, so the two can
@@ -1114,7 +1215,20 @@ pub async fn run_chat(
     runtime.set_system_prompt(system_prompt);
     runtime.set_max_tokens(4096);
 
-    let session_id = format!("cli-{}", uuid::Uuid::new_v4());
+    // #1088: o store so existe quando a pessoa pediu. Sem `--persist` nem
+    // `--resume` fica `None` — nenhum banco aberto, nenhum arquivo criado —
+    // e o chat segue vivendo apenas na memoria, como sempre viveu.
+    let store = open_chat_store(&config, persist, resume.as_deref())?;
+    // Retomar e adotar o id que veio da linha de comando; comecar do zero e
+    // sortear um. Nos dois casos o id aparece na tela (abaixo) justamente
+    // para poder ser digitado de volta no `--resume`.
+    let session_id = match resume.as_deref() {
+        Some(id) => id.to_string(),
+        None => format!("cli-{}", uuid::Uuid::new_v4()),
+    };
+    // Ja vem cheio quando ha `--resume`; a carga acontece abaixo, depois do
+    // renderer existir, para a contagem sair pela mesma moldura das outras
+    // mensagens da sessao.
     let mut history: Vec<ChatMessage> = Vec::new();
     // A saida completa das ferramentas do turno, para o `/tool` (#938).
     // Limitada em entradas e em bytes — ver `ui::tool_log`.
@@ -1126,6 +1240,58 @@ pub async fn run_chat(
     // daquele turno (#942). O rotulo `Garra` e a ordem de escrita passam a ser
     // responsabilidade dele — ver ADR 0017.
     let mut renderer = TerminalRenderer::new(caps, None);
+
+    // Aviso e carga da persistencia (#1088). Fica aqui, e nao junto da
+    // abertura do store, porque a contagem de turnos recuperados sai pela
+    // mesma moldura das outras mensagens da sessao — e nao por `println!`,
+    // que ignoraria `NO_COLOR` e pipe.
+    if let Some(ref store) = store {
+        let db = config.resolved_data_dir().join(SESSIONS_DB);
+        if resume.is_some() {
+            let carregadas = load_history(store, &session_id, RESUME_LIMIT)?;
+            // Duas mensagens por turno: a pergunta e a resposta.
+            let turnos = carregadas.len() / 2;
+            // A janela nao e a sessao inteira. Dizer quantas mensagens
+            // ficaram de fora e a diferenca entre "retomei a conversa" e
+            // "retomei metade achando que era tudo" — que e justamente a
+            // queixa que abriu esta issue.
+            let antigas = (store.get_message_count(&session_id).unwrap_or(0) as usize)
+                .saturating_sub(carregadas.len());
+            let sufixo = if antigas > 0 {
+                format!("; {antigas} mensagens mais antigas ficaram fora da janela")
+            } else {
+                String::new()
+            };
+            history = carregadas;
+            // O `/status` conta turnos daqui, e nao do zero: retomar na
+            // quinta pergunta e continuar na quinta, nao na primeira.
+            turn_index = turnos;
+            if turnos == 0 {
+                renderer.handle(
+                    UiEvent::Warning(&format!(
+                        "A sessao {session_id} nao tem historico em {}. Comece uma conversa nova.",
+                        db.display()
+                    )),
+                    &mut io::stdout(),
+                );
+            } else {
+                renderer.handle(
+                    UiEvent::Hint(&format!(
+                        "Retomando {session_id}: {turnos} turno(s) recuperado(s){sufixo}."
+                    )),
+                    &mut io::stdout(),
+                );
+            }
+        } else {
+            renderer.handle(
+                UiEvent::Hint(&format!(
+                    "Sessao {session_id} — gravando em {}. Retome com: garraia chat --resume {session_id}",
+                    db.display()
+                )),
+                &mut io::stdout(),
+            );
+        }
+    }
 
     // Dono único do SIGINT.
     //
@@ -1200,6 +1366,10 @@ pub async fn run_chat(
                 break;
             }
             "/clear" | "/limpar" => {
+                // So a memoria. O que ja foi gravado com `--persist` continua
+                // no banco e voltaria num `--resume` — apagar o historico do
+                // disco junto e outro slice, e precisa de confirmacao porque
+                // e a unica copia (#1088).
                 history.clear();
                 renderer.handle(UiEvent::Hint("Historico limpo."), &mut io::stdout());
                 continue;
@@ -1672,6 +1842,19 @@ pub async fn run_chat(
             TurnOutcome::Done(Ok(full_response)) => {
                 // Deltas were already printed live during streaming
                 println!();
+
+                // #1088: gravar e opcional e nao pode derrubar a conversa —
+                // disco cheio ou banco travado avisa e segue. Tambem nao e
+                // o caso de `save_session_summary`: sem um resumidor no CLI
+                // (ele mora no gateway) nao ha resumo honesto para gravar.
+                if let Some(ref store) = store
+                    && let Err(e) = append_turn(store, &session_id, &input, &full_response)
+                {
+                    renderer.handle(
+                        UiEvent::Warning(&format!("Turno nao gravado: {e}")),
+                        &mut stdout,
+                    );
+                }
 
                 history.push(ChatMessage {
                     role: ChatRole::User,
@@ -2774,5 +2957,105 @@ mod cli_tools_tests {
         }
         assert!(!doc.contains("web_search"));
         assert_eq!(doc.matches("- **").count(), names.len());
+    }
+}
+
+#[cfg(test)]
+mod persist_tests {
+    //! #1088 — o `garra chat` so toca o disco quando `--persist`/`--resume`
+    //! pede. Nenhum teste aqui fala com LLM: o store e `in_memory()`, ou um
+    //! diretorio temporario quando o que esta em jogo e o arquivo em si.
+
+    use super::*;
+
+    fn config_no_dir(dir: &std::path::Path) -> AppConfig {
+        AppConfig {
+            data_dir: Some(dir.to_path_buf()),
+            ..AppConfig::default()
+        }
+    }
+
+    fn papel(m: &ChatMessage) -> &'static str {
+        match m.role {
+            ChatRole::User => "user",
+            ChatRole::Assistant => "assistant",
+            _ => "outro",
+        }
+    }
+
+    fn textos(h: &[ChatMessage]) -> Vec<&str> {
+        h.iter()
+            .filter_map(|m| match &m.content {
+                MessagePart::Text(t) => Some(t.as_str()),
+                MessagePart::Parts(_) => None,
+            })
+            .collect()
+    }
+
+    /// O padrao, preso por teste: nenhum store e nenhum arquivo. E o que o
+    /// chat sempre fez, e o motivo de a persistencia ser opt-in em vez de
+    /// ligada para todo mundo.
+    #[test]
+    fn sem_flag_nao_abre_store_nem_cria_arquivo() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = open_chat_store(&config_no_dir(dir.path()), false, None).expect("sem erro");
+        assert!(store.is_none(), "sem flag nao ha store");
+        assert!(
+            !dir.path().join(SESSIONS_DB).exists(),
+            "nenhum banco deveria ter sido criado"
+        );
+        assert!(
+            dir.path().read_dir().expect("le o dir").next().is_none(),
+            "o diretorio de dados nao deveria ganhar nada"
+        );
+    }
+
+    /// Cada flag basta sozinha: `--persist` e `--resume` abrem o store, e o
+    /// `--persist` cria o banco no diretorio de dados do config.
+    #[test]
+    fn persist_ou_resume_abrem_o_store() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert!(
+            open_chat_store(&config_no_dir(dir.path()), true, None)
+                .expect("sem erro")
+                .is_some(),
+            "--persist abre o store"
+        );
+        assert!(
+            dir.path().join(SESSIONS_DB).exists(),
+            "--persist cria o banco"
+        );
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert!(
+            open_chat_store(&config_no_dir(dir.path()), false, Some("cli-x"))
+                .expect("sem erro")
+                .is_some(),
+            "--resume abre o store mesmo sem --persist"
+        );
+    }
+
+    /// Ida e volta: dois turnos gravados voltam em ordem cronologica, cada
+    /// mensagem com o papel com que foi gravada.
+    #[test]
+    fn dois_turnos_voltam_em_ordem() {
+        let store = SessionStore::in_memory().expect("store em memoria");
+        append_turn(&store, "cli-teste", "oi", "ola").expect("turno 1");
+        append_turn(&store, "cli-teste", "tudo bem?", "tudo").expect("turno 2");
+
+        let historico = load_history(&store, "cli-teste", RESUME_LIMIT).expect("carrega");
+        assert_eq!(historico.len(), 4, "dois turnos sao quatro mensagens");
+        let papeis: Vec<&str> = historico.iter().map(papel).collect();
+        assert_eq!(papeis, vec!["user", "assistant", "user", "assistant"]);
+        assert_eq!(textos(&historico), vec!["oi", "ola", "tudo bem?", "tudo"]);
+    }
+
+    /// Um id que nao existe devolve historico vazio em vez de erro: e o que
+    /// um `--resume` digitado errado encontra, e a sessao comeca do zero.
+    #[test]
+    fn retomar_id_inexistente_devolve_vazio() {
+        let store = SessionStore::in_memory().expect("store em memoria");
+        let historico = load_history(&store, "cli-nao-existe", RESUME_LIMIT).expect("sem erro");
+        assert!(historico.is_empty());
     }
 }

--- a/crates/garraia-cli/src/chat.rs
+++ b/crates/garraia-cli/src/chat.rs
@@ -1249,14 +1249,34 @@ pub async fn run_chat(
         let db = config.resolved_data_dir().join(SESSIONS_DB);
         if resume.is_some() {
             let carregadas = load_history(store, &session_id, RESUME_LIMIT)?;
-            // Duas mensagens por turno: a pergunta e a resposta.
-            let turnos = carregadas.len() / 2;
+            // Cada turno comeca com uma pergunta. Contar `user` e mais
+            // honesto que `len / 2` quando a hidratacao do gateway deixou
+            // um turno pela metade na mesma sessao.
+            let turnos = carregadas
+                .iter()
+                .filter(|m| matches!(m.role, ChatRole::User))
+                .count();
             // A janela nao e a sessao inteira. Dizer quantas mensagens
             // ficaram de fora e a diferenca entre "retomei a conversa" e
             // "retomei metade achando que era tudo" — que e justamente a
             // queixa que abriu esta issue.
-            let antigas = (store.get_message_count(&session_id).unwrap_or(0) as usize)
-                .saturating_sub(carregadas.len());
+            let antigas = match store.get_message_count(&session_id) {
+                Ok(total) => (total as usize).saturating_sub(carregadas.len()),
+                Err(e) => {
+                    // A conversa nao cai por causa de uma contagem — mas
+                    // engolir o erro anunciaria "nada ficou fora da
+                    // janela" sem ninguem saber. Avisa e segue: o mesmo
+                    // fail-open da gravacao de turno.
+                    renderer.handle(
+                        UiEvent::Warning(&format!(
+                            "Nao consegui contar o historico de {session_id} ({e}); \
+                             mensagens mais antigas podem ter ficado fora da janela."
+                        )),
+                        &mut io::stdout(),
+                    );
+                    0
+                }
+            };
             let sufixo = if antigas > 0 {
                 format!("; {antigas} mensagens mais antigas ficaram fora da janela")
             } else {
@@ -3057,5 +3077,41 @@ mod persist_tests {
         let store = SessionStore::in_memory().expect("store em memoria");
         let historico = load_history(&store, "cli-nao-existe", RESUME_LIMIT).expect("sem erro");
         assert!(historico.is_empty());
+    }
+
+    /// `append_turn` grava pergunta e resposta com o MESMO `Utc::now()`.
+    /// A ordem entre elas nao pode depender do timestamp: `load_recent_messages`
+    /// ordena por `rowid` (ordem de insercao), e e isso que mantem o turno
+    /// deterministico. Aqui o teste força o pior caso — todas as mensagens
+    /// da sessao com timestamp identico — e prende a ordem de insercao.
+    #[test]
+    fn timestamps_iguais_mantem_ordem_de_insercao() {
+        let store = SessionStore::in_memory().expect("store em memoria");
+        // A FK de messages exige a sessao antes do primeiro append — o
+        // mesmo passo que o `append_turn` da vida real da.
+        store
+            .upsert_session("cli-iguais", "cli", "local", &serde_json::json!({}))
+            .expect("upsert da sessao");
+        let t = chrono::Utc::now();
+        let meta = serde_json::json!({ "channel_id": "cli", "user_id": "local" });
+        store
+            .append_message("cli-iguais", "user", "primeiro", t, &meta)
+            .expect("append 1");
+        store
+            .append_message("cli-iguais", "assistant", "segundo", t, &meta)
+            .expect("append 2");
+        store
+            .append_message("cli-iguais", "user", "terceiro", t, &meta)
+            .expect("append 3");
+
+        let msgs = store
+            .load_recent_messages("cli-iguais", 10)
+            .expect("carrega");
+        let conteudos: Vec<&str> = msgs.iter().map(|m| m.content.as_str()).collect();
+        assert_eq!(
+            conteudos,
+            vec!["primeiro", "segundo", "terceiro"],
+            "timestamp identico nao pode reordenar a sessao"
+        );
     }
 }

--- a/crates/garraia-cli/src/cli_args.rs
+++ b/crates/garraia-cli/src/cli_args.rs
@@ -99,6 +99,8 @@ mod tests {
         "--log-level",
         "--model",
         "--provider",
+        // #1088: `--resume` leva o id da sessao, entao tambem come o proximo.
+        "--resume",
         "--timeout-secs",
         "--url",
         "-m",

--- a/crates/garraia-cli/src/main.rs
+++ b/crates/garraia-cli/src/main.rs
@@ -230,6 +230,20 @@ enum Commands {
         /// Pull a missing Ollama model without asking first.
         #[arg(long, short = 'y')]
         yes: bool,
+
+        /// Keep the conversation on disk. Every turn goes to
+        /// `<data_dir>/sessions.db` and the session id is printed on start,
+        /// so `--resume` can pick the conversation up later. Off by
+        /// default: without it nothing is written, and no database is even
+        /// opened (#1088).
+        #[arg(long)]
+        persist: bool,
+
+        /// Reopen a persisted session, loading its history before the first
+        /// turn. Implies persistence for the turns that follow, so the
+        /// resumed conversation keeps growing in the same session (#1088).
+        #[arg(long, value_name = "SESSION_ID")]
+        resume: Option<String>,
     },
 
     /// Non-interactive AI query — single message in, single answer out
@@ -1987,13 +2001,25 @@ async fn async_main(
             url,
             timeout_secs,
             yes,
+            persist,
+            resume,
         } => {
             // Without a tracing subscriber, --debug/RUST_LOG silently produce
             // nothing in chat mode. Since #933 the file gets everything while
             // stderr stays WARN+ unless --verbose/--debug asks for more — the
             // interactive console no longer competes with INFO records.
             init_tracing(&effective_level);
-            chat::run_chat(config, provider, model, url, timeout_secs, yes).await?;
+            chat::run_chat(
+                config,
+                provider,
+                model,
+                url,
+                timeout_secs,
+                yes,
+                persist,
+                resume,
+            )
+            .await?;
         }
         Commands::Ask {
             message,
@@ -2372,6 +2398,8 @@ mod tests {
                 "--log-level",
                 "--model",
                 "--provider",
+                // #1088: `--resume <SESSION_ID>` tambem come o proximo argv.
+                "--resume",
                 "--timeout-secs",
                 "--url",
                 "-m",


### PR DESCRIPTION
## O problema (#1088)

O REPL do `garra chat` guardava o histórico **só na memória**: a conversa
morria com o processo. O que decidiu isso foi um comentário em `chat.rs` ("o
chat não abre store"), sem flag e sem doc — ou seja, uma limitação que ninguém
escolheu e que não estava em lugar nenhum visível.

## O que entra

Duas flags, ambas opt-in:

- `--persist` — cada turno vai para `<data_dir>/sessions.db` (o **mesmo**
  arquivo que o gateway abre) via `upsert_session` + `append_message`, sem
  mudança de schema. O id da sessão aparece na abertura já com o comando para
  retomá-la.
- `--resume <SESSION_ID>` — carrega o histórico gravado antes do primeiro
  turno, diz na tela quantos turnos voltaram e continua gravando dali em
  diante. As flags são independentes, mas qualquer uma basta para abrir o
  store.

Sem nenhuma das duas: **`None` store, nenhum banco aberto, nenhum arquivo
criado.** É exatamente o comportamento anterior, e há teste que prende isso —
a decisão de não gravar deixa de ser um comentário e passa a ser uma flag com
prova.

Dois detalhes que a issue não pediu e que evitam a próxima queixa:

- Quando a janela de 100 mensagens corta o histórico, a tela **diz quantas
  mensagens ficaram de fora**. "Retomei a conversa" e "retomei metade achando
  que era tudo" são experiências diferentes.
- Falha de gravação avisa e a conversa segue: perder o log não pode derrubar o
  turno.

O vocabulário é o do gateway (`"user"`/`"assistant"`, `channel_id: "cli"`),
então o histórico gravado pelo CLI é legível pela hidratação do gateway e vice
versa — nada de schema novo.

## O que a revisão acrescentou (698f470)

A revisão independente pediu duas correções, ambas no commit `698f470`:

- **Contagem honesta no `--resume`** — `get_message_count` não tem mais
  `unwrap_or(0)`: se a contagem falha, a tela avisa ("não consegui contar o
  histórico; mensagens mais antigas podem ter ficado fora da janela") e a
  conversa segue, em vez de anunciar zero no silêncio. E os turnos
  recuperados passam a ser contados pelas perguntas (`user`), não por
  `len / 2` — turno incompleto deixado pela hidratação do gateway não mente
  no placar.
- **Teste do pior caso de timestamp** — os dois appends de um turno
  compartilham um `Utc::now()`, e a ordem vem do `ORDER BY rowid` da query
  (já existente em `load_recent_messages`). Agora há teste prendendo isso:
  três mensagens gravadas **no mesmo instante** voltam na ordem exata de
  inserção.

## O que não entra

`save_session_summary`, tools `schedule_*` e o sumarizador de contexto: não
existe sumarizador no CLI, e inventar um resumo seria falso. `/clear` continua
limpando só a memória (registrado em comentário).

## Verificação

- `cargo fmt --all -- --check` — limpo
- `cargo clippy -p garraia -p garraia-db --all-targets -- -D warnings` — limpo
- `cargo test -p garraia --bins` — **472 passed** (5 novos em `chat::persist_tests`)

Os 5 testes provam: sem flag ⇒ sem store **e** sem `sessions.db`, diretório de
dados vazio; qualquer flag abre (e `--persist` cria) o banco; dois turnos
voltam como 4 mensagens na ordem exata com os papéis certos; id inexistente
devolve vazio, não erro; timestamps idênticos preservam a ordem de inserção. O
teste de round-trip foi confirmado não-vacuo: trocando a ordem do append, ele
fica vermelho.

## Riscos para revisão

Metadado usa `user_id: "local"` / `channel: "cli"`; os dois appends de um turno
compartilham um `Utc::now()` (a ordem é por rowid — agora preso por teste);
`--resume` trunca acima de 100 mensagens — agora isso é dito na tela, mas
ainda não é condensado, o que é o slice do sumarizador.

Closes #1088

🤖 Generated with [Claude Code](https://claude.com/claude-code)
