### PR TITLE
fix(webconsole): hamburger colapsa a sidebar no desktop (#1123)

### DIFF
--- a/changelog.d/fixed/1123-hamburger-no-desktop.md
+++ b/changelog.d/fixed/1123-hamburger-no-desktop.md
@@ -1,0 +1,9 @@
+- **Hamburger do header volta a fazer algo no desktop (#1123).** O botao e
+  renderizado em todas as larguras, mas o handler abria o drawer mobile sem
+  checar o viewport: no desktop o unico efeito era o overlay que escurece a
+  tela, porque a sidebar ja estava visivel pelo layout flex. Agora o clique
+  ramifica por `matchMedia('(max-width: 768px)')` - no mobile continua abrindo
+  o drawer, no desktop alterna `collapsed` na sidebar (CSS que ja existia e nao
+  era usado por JS). `aria-expanded` acompanha o estado, e um listener de
+  `resize` limpa `mobile-open` e o overlay ao cruzar o breakpoint, para a gaveta
+  nao ficar presa numa janela que cresceu.

--- a/changelog.d/fixed/1123-hamburger-no-desktop.md
+++ b/changelog.d/fixed/1123-hamburger-no-desktop.md
@@ -4,6 +4,9 @@
   tela, porque a sidebar ja estava visivel pelo layout flex. Agora o clique
   ramifica por `matchMedia('(max-width: 768px)')` - no mobile continua abrindo
   o drawer, no desktop alterna `collapsed` na sidebar (CSS que ja existia e nao
-  era usado por JS). `aria-expanded` acompanha o estado, e um listener de
+  era usado por JS). `aria-expanded` acompanha o estado - a sincronizacao mora dentro de
+  `openSidebarMobile`/`closeSidebarMobile`, entao fechamentos por caminhos
+  pre-existentes (botoes de pagina, itens de sessao, settings) atualizam o
+  atributo sem tocar no hamburger - e um listener de
   `resize` limpa `mobile-open` e o overlay ao cruzar o breakpoint, para a gaveta
   nao ficar presa numa janela que cresceu.

--- a/crates/garraia-gateway/src/webchat.html
+++ b/crates/garraia-gateway/src/webchat.html
@@ -2476,7 +2476,7 @@ nav.sidebar#sidebar .sidebar-footer-btn .icon-svg rect {
 <body>
 <!-- APP HEADER (plan 0116 T3) -->
 <header class="app-header" data-testid="garra-app-header" role="banner">
-  <button class="hamburger-btn" id="hamburger-btn" title="Toggle sidebar" aria-label="Toggle sidebar" aria-expanded="true">
+  <button class="hamburger-btn" id="hamburger-btn" title="Toggle sidebar" aria-label="Toggle sidebar" aria-expanded="true" aria-controls="sidebar">
     <svg class="icon-svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z"/></svg>
   </button>
   <span class="header-brand">
@@ -4498,8 +4498,11 @@ document.addEventListener('click', () => {
 });
 
 // ─── Sidebar Mobile ──────────────────────────────────────────────────
-function openSidebarMobile() { sidebar.classList.add('mobile-open'); sidebarOverlay.classList.add('show'); }
-function closeSidebarMobile() { sidebar.classList.remove('mobile-open'); sidebarOverlay.classList.remove('show'); }
+// Both openers sync the hamburger's aria-expanded from inside, so every
+// close path added before or after this point (page buttons, session items,
+// settings, new chat) stays in sync without remembering to call it.
+function openSidebarMobile() { sidebar.classList.add('mobile-open'); sidebarOverlay.classList.add('show'); syncHamburgerState(); }
+function closeSidebarMobile() { sidebar.classList.remove('mobile-open'); sidebarOverlay.classList.remove('show'); syncHamburgerState(); }
 
 // ─── Sidebar toggle (mobile drawer vs desktop collapse) ───────────────
 // Below the 768px breakpoint the hamburger opens the overlay drawer; above it
@@ -4569,7 +4572,7 @@ $('hamburger-btn').addEventListener('click', () => {
   }
   syncHamburgerState();
 });
-sidebarOverlay.addEventListener('click', () => { closeSidebarMobile(); syncHamburgerState(); });
+sidebarOverlay.addEventListener('click', closeSidebarMobile);
 
 $('right-panel-toggle').addEventListener('click', () => { rightPanel.classList.toggle('collapsed'); rightPanel.classList.toggle('expanded'); });
 $('right-panel-close').addEventListener('click', () => { rightPanel.classList.add('collapsed'); rightPanel.classList.remove('expanded'); });

--- a/crates/garraia-gateway/src/webchat.html
+++ b/crates/garraia-gateway/src/webchat.html
@@ -2476,7 +2476,7 @@ nav.sidebar#sidebar .sidebar-footer-btn .icon-svg rect {
 <body>
 <!-- APP HEADER (plan 0116 T3) -->
 <header class="app-header" data-testid="garra-app-header" role="banner">
-  <button class="hamburger-btn" id="hamburger-btn" title="Toggle sidebar" aria-label="Toggle sidebar">
+  <button class="hamburger-btn" id="hamburger-btn" title="Toggle sidebar" aria-label="Toggle sidebar" aria-expanded="true">
     <svg class="icon-svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z"/></svg>
   </button>
   <span class="header-brand">
@@ -4471,6 +4471,35 @@ document.addEventListener('click', () => {
 function openSidebarMobile() { sidebar.classList.add('mobile-open'); sidebarOverlay.classList.add('show'); }
 function closeSidebarMobile() { sidebar.classList.remove('mobile-open'); sidebarOverlay.classList.remove('show'); }
 
+// ─── Sidebar toggle (mobile drawer vs desktop collapse) ───────────────
+// Below the 768px breakpoint the hamburger opens the overlay drawer; above it
+// the sidebar is already on screen, so the same button collapses it instead
+// (`.sidebar.collapsed` is pre-existing CSS, previously unused by JS).
+const MOBILE_QUERY = '(max-width: 768px)';
+const isMobileViewport = () => window.matchMedia(MOBILE_QUERY).matches;
+
+function syncHamburgerState() {
+  const expanded = isMobileViewport()
+    ? sidebar.classList.contains('mobile-open')
+    : !sidebar.classList.contains('collapsed');
+  $('hamburger-btn').setAttribute('aria-expanded', String(expanded));
+}
+
+function resetSidebarState() {
+  closeSidebarMobile();
+  sidebar.classList.remove('collapsed');
+  syncHamburgerState();
+}
+
+let wasMobileViewport = isMobileViewport();
+window.addEventListener('resize', () => {
+  const nowMobile = isMobileViewport();
+  if (nowMobile === wasMobileViewport) return;
+  wasMobileViewport = nowMobile;
+  resetSidebarState();
+});
+syncHamburgerState();
+
 // ─── Modals ──────────────────────────────────────────────────────────
 function openModal(id) { $(id).classList.add('show'); }
 function closeModal(id) { $(id).classList.remove('show'); }
@@ -4502,8 +4531,15 @@ $('new-chat-btn').addEventListener('click', () => {
   closeSidebarMobile();
 });
 
-$('hamburger-btn').addEventListener('click', openSidebarMobile);
-sidebarOverlay.addEventListener('click', closeSidebarMobile);
+$('hamburger-btn').addEventListener('click', () => {
+  if (isMobileViewport()) {
+    if (sidebar.classList.contains('mobile-open')) { closeSidebarMobile(); } else { openSidebarMobile(); }
+  } else {
+    sidebar.classList.toggle('collapsed');
+  }
+  syncHamburgerState();
+});
+sidebarOverlay.addEventListener('click', () => { closeSidebarMobile(); syncHamburgerState(); });
 
 $('right-panel-toggle').addEventListener('click', () => { rightPanel.classList.toggle('collapsed'); rightPanel.classList.toggle('expanded'); });
 $('right-panel-close').addEventListener('click', () => { rightPanel.classList.add('collapsed'); rightPanel.classList.remove('expanded'); });

--- a/tests/playwright/webchat-redesign.spec.ts
+++ b/tests/playwright/webchat-redesign.spec.ts
@@ -110,6 +110,75 @@ test.describe('Garra Glass — webchat redesign', () => {
     // We just assert the hamburger button is reachable — it's the door back.
     await expect(page.locator('#hamburger-btn')).toBeVisible();
   });
+
+  // #1123 — the hamburger is rendered at every width, but the old handler
+  // unconditionally opened the *mobile* drawer. On desktop that only produced
+  // the dimming overlay: the sidebar was already on screen, so nothing moved.
+  test('desktop viewport: hamburger collapses the sidebar without the mobile overlay', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 633 });
+    await openWebchat(page);
+
+    const hamburger = page.locator('#hamburger-btn');
+    const sidebarEl = page.locator('#sidebar');
+    const overlay = page.locator('#sidebar-overlay');
+
+    await expect(hamburger).toBeVisible();
+    await expect(sidebarEl).not.toHaveClass(/collapsed/);
+    await expect(hamburger).toHaveAttribute('aria-expanded', 'true');
+
+    await hamburger.click();
+
+    await expect(sidebarEl).toHaveClass(/collapsed/);
+    await expect(hamburger).toHaveAttribute('aria-expanded', 'false');
+    // The regression itself: no dimming overlay may be left behind on desktop.
+    await expect(overlay).not.toHaveClass(/show/);
+    await expect(sidebarEl).not.toHaveClass(/mobile-open/);
+
+    await hamburger.click();
+
+    await expect(sidebarEl).not.toHaveClass(/collapsed/);
+    await expect(hamburger).toHaveAttribute('aria-expanded', 'true');
+    await expect(overlay).not.toHaveClass(/show/);
+  });
+
+  test('mobile viewport: hamburger still opens the sidebar drawer with its overlay', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await openWebchat(page);
+
+    const hamburger = page.locator('#hamburger-btn');
+    const sidebarEl = page.locator('#sidebar');
+    const overlay = page.locator('#sidebar-overlay');
+
+    await expect(sidebarEl).not.toHaveClass(/mobile-open/);
+    await expect(hamburger).toHaveAttribute('aria-expanded', 'false');
+
+    await hamburger.click();
+
+    await expect(sidebarEl).toHaveClass(/mobile-open/);
+    await expect(overlay).toHaveClass(/show/);
+    await expect(hamburger).toHaveAttribute('aria-expanded', 'true');
+
+    await hamburger.click();
+
+    await expect(sidebarEl).not.toHaveClass(/mobile-open/);
+    await expect(overlay).not.toHaveClass(/show/);
+    await expect(hamburger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('resizing from mobile to desktop clears a stale mobile-open sidebar', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await openWebchat(page);
+
+    await page.locator('#hamburger-btn').click();
+    await expect(page.locator('#sidebar')).toHaveClass(/mobile-open/);
+    await expect(page.locator('#sidebar-overlay')).toHaveClass(/show/);
+
+    await page.setViewportSize({ width: 1280, height: 633 });
+
+    await expect(page.locator('#sidebar')).not.toHaveClass(/mobile-open/);
+    await expect(page.locator('#sidebar-overlay')).not.toHaveClass(/show/);
+    await expect(page.locator('#sidebar')).not.toHaveClass(/collapsed/);
+  });
 });
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/tests/playwright/webchat-redesign.spec.ts
+++ b/tests/playwright/webchat-redesign.spec.ts
@@ -165,6 +165,30 @@ test.describe('Garra Glass — webchat redesign', () => {
     await expect(hamburger).toHaveAttribute('aria-expanded', 'false');
   });
 
+  // #1132 CR follow-up: the drawer has pre-existing close paths that never
+  // touch the hamburger (page-router buttons, session items, settings). The
+  // sync lives inside closeSidebarMobile(), so aria-expanded must follow even
+  // when the button itself is not the trigger.
+  test('mobile viewport: closing the drawer via a sidebar page button syncs aria-expanded', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await openWebchat(page);
+
+    const hamburger = page.locator('#hamburger-btn');
+    const sidebarEl = page.locator('#sidebar');
+    const overlay = page.locator('#sidebar-overlay');
+
+    await hamburger.click();
+    await expect(sidebarEl).toHaveClass(/mobile-open/);
+    await expect(hamburger).toHaveAttribute('aria-expanded', 'true');
+
+    // A pre-existing close path: a nav button inside the drawer.
+    await page.locator('.sidebar-page-btn[data-page="dashboard"]').click();
+
+    await expect(sidebarEl).not.toHaveClass(/mobile-open/);
+    await expect(overlay).not.toHaveClass(/show/);
+    await expect(hamburger).toHaveAttribute('aria-expanded', 'false');
+  });
+
   test('resizing from mobile to desktop clears a stale mobile-open sidebar', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 667 });
     await openWebchat(page);


### PR DESCRIPTION
## O que era

O `.app-header button.hamburger-btn` recebe `display: grid` fora de qualquer
media query (`:615`), entao o botao aparece em **todas** as larguras. Mas o
comportamento dele so existia no mobile:

- `.sidebar.mobile-open { transform: translateX(0) }` e
  `.hamburger-btn { display: flex }` vivem **apenas** dentro de
  `@media (max-width: 768px)` (`:2390-2400`).
- `openSidebarMobile()` / `closeSidebarMobile()` (`:4471-4472`) alternavam
  `.mobile-open` + `.sidebar-overlay.show` **sem checar o viewport**.
- O listener do clique nao tinha nenhum branch.

Resultado no desktop: a sidebar ja esta visivel pelo layout flex, entao a unica
coisa que o clique produzia era o `.sidebar-overlay` escurecendo a tela. O
botao parecia "nao fazer nada" - a nao ser pelo apagao.

## O que muda

O handler passa a ramificar por `matchMedia('(max-width: 768px)')`:

- **mobile** - o clique vira um toggle de verdade: abre o drawer se fechado,
  fecha se aberto (antes so abria).
- **desktop** - alterna `.sidebar.collapsed` no lugar. Essa regra **ja existe**
  em `:367` (`width: 0; overflow: hidden; border: none`) e nao era usada por
  JS nenhum: o CSS morto vira o comportamento que faltava.

Alem disso:

- `aria-expanded` no botao acompanha o estado (mobile: `.mobile-open`;
  desktop: `!collapsed`), e passa a existir tambem no markup inicial, junto com
  `aria-controls="sidebar"`. A sincronizacao mora **dentro** de
  `openSidebarMobile()` / `closeSidebarMobile()` (achado da revisao): os
  caminhos pre-existentes que fecham o drawer sem tocar no hamburger (botoes
  de pagina do router, itens de sessao, new-chat, settings, skin-editor)
  atualizam o atributo do mesmo jeito.
- Um listener de `resize` limpa `mobile-open`, o overlay e `collapsed` **so
  quando o viewport cruza o breakpoint** - sem isso, uma gaveta aberta no
  mobile ficava presa numa janela que cresceu.

Nada mais foi repintado: nenhuma cor, espacamento ou token mudou.

## Testes

`tests/playwright/webchat-redesign.spec.ts` ganha quatro casos:

1. `1280x633` - clicar colapsa e expande a sidebar, `aria-expanded` acompanha,
   e **`.sidebar-overlay` nunca fica com `.show`** (a regressao em si).
2. `375x667` - o drawer mobile abre com overlay e fecha no segundo clique,
   com `aria-expanded` coerente nos dois estados.
3. `375x667` - abre o drawer pelo hamburger e fecha pelo **botao de pagina**
   dentro do drawer: `aria-expanded` tem que acompanhar esse caminho
   pre-existente sem que o hamburger seja tocado (caso da revisao).
4. resize `375 -> 1280` - estado `mobile-open` velho e limpo.

Nenhuma assertiva existente foi afrouxada.

**Verificacao local executada**: chromium real contra um gateway servindo a
pagina desta branch (worktree), spec completo - 32/33 verdes na primeira
passada e o unico vermelho foi um timeout frio de `page.goto` (cold start),
que passou em 584ms no re-run quente. Zero falhas de assercao. As falhas
aparentes das primeiras rodadas (15F, depois 13F, com conjuntos diferentes por
run) foram diagnosticadas como 429 do governor per-IP do gateway local
(default 1 req/s, burst 60 - o error-context mostrava "Too Many Requests!" no
lugar da pagina); com o mesmo `rate_limit` que o job Playwright do `ci.yml`
usa (1000/5000), tudo verde. O veredito autoritativo segue sendo o CI.

## Gates

```text
python3 scripts/changelog/assemble.py --check                          OK (6 fragmentos)
cargo fmt --all -- --check                                             OK
cargo check --workspace --exclude garraia-desktop                     OK
cargo clippy --workspace --exclude garraia-desktop --all-targets \
    --all-features -- -D warnings                                      OK
```

Closes #1123

🤖 Generated with [Claude Code](https://claude.com/claude-code)
