### PR TITLE
fix(webconsole): tira o Em breve de 6 paginas e orienta o 401 (#1116)

### DIFF
--- a/changelog.d/fixed/1116-em-breve-e-401.md
+++ b/changelog.d/fixed/1116-em-breve-e-401.md
@@ -1,0 +1,12 @@
+- **Seis paginas implementadas perdem a tag "Em breve" (#1116).** Providers,
+  channels, sessions, settings, diagnostics e logs continuavam marcados como
+  por vir na sidebar mesmo com o roteador ja despachando cada um para o seu
+  loader real. As duas coisas que de fato nao existem - o sino de
+  notificacoes e as abas CLI/Schema do painel direito - mantem a marca, mas
+  o titulo agora cita a issue #1116 em vez do plan 0117a, que nao existe.
+- **Falha de carregamento passa a dizer o codigo HTTP e o que fazer (#1116).**
+  Um helper `renderFetchError` substitui os "Falha ao carregar X." espalhados
+  pelos loaders. No caso 401 - o frequente, quando `gateway.api_key` esta
+  ligada e o navegador nao tem chave salva - a mensagem aponta para o form
+  "Gateway Authentication" do painel direito e o revela, em vez de mandar
+  recarregar a pagina.

--- a/crates/garraia-gateway/src/webchat.html
+++ b/crates/garraia-gateway/src/webchat.html
@@ -924,7 +924,7 @@ aside.right-panel#right-panel .right-panel-close {
 aside.right-panel#right-panel .right-panel-close:hover { background: rgba(255, 255, 255, 0.1); }
 
 /* Toolbar tabs (Status / CLI / Schema). Only Status active for now;
- * CLI/Schema show "em breve" — covered by plan 0117a follow-up. */
+ * CLI/Schema are not implemented — see issue #1116. */
 .toolbar-tabs {
   display: flex; gap: 6px;
   padding: 8px 14px;
@@ -2496,7 +2496,7 @@ nav.sidebar#sidebar .sidebar-footer-btn .icon-svg rect {
       <svg class="icon-svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M4.5 11.5A.5.5 0 0 1 5 11h6a.5.5 0 0 1 0 1H5a.5.5 0 0 1-.5-.5zm-2-1A.5.5 0 0 1 3 10h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-7A.5.5 0 0 1 3 3h10a.5.5 0 0 1 .5.5v5a.5.5 0 0 1-.5.5H3a.5.5 0 0 1-.5-.5v-5zM3 4v4h10V4H3z"/></svg>
       <span id="gateway-url-text">http://127.0.0.1:3888</span>
     </span>
-    <button class="header-icon-btn" type="button" id="header-bell-btn" title="Notifications (em breve)" aria-disabled="true">
+    <button class="header-icon-btn" type="button" id="header-bell-btn" title="Notificações — não implementado (issue #1116)" aria-disabled="true">
       <svg class="icon-svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 16a2 2 0 0 0 2-2H6a2 2 0 0 0 2 2zM8 1.918l-.797.161A4.002 4.002 0 0 0 4 6c0 .628-.134 2.197-.459 3.742-.16.767-.376 1.566-.663 2.258h10.244c-.287-.692-.502-1.49-.663-2.258C12.134 8.197 12 6.628 12 6a4.002 4.002 0 0 0-3.203-3.92L8 1.917zM14.22 12c.223.447.481.801.78 1H1c.299-.199.557-.553.78-1C2.68 10.2 3 6.88 3 6c0-2.42 1.72-4.44 4.005-4.901a1 1 0 1 1 1.99 0A5.002 5.002 0 0 1 13 6c0 .88.32 4.2 1.22 6z"/></svg>
     </button>
     <button class="header-icon-btn" type="button" id="header-theme-toggle" title="Toggle theme (light/dark)">
@@ -2535,27 +2535,27 @@ nav.sidebar#sidebar .sidebar-footer-btn .icon-svg rect {
       </button>
       <button class="sidebar-page-btn" type="button" data-page="providers">
         <svg class="icon-svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M3 4a2 2 0 1 1 .195 1.41L1.5 8.5l1.695 3.09a2 2 0 1 1-.71.412L.71 8.5 2.485 4.58A2 2 0 0 1 3 4zm10 0a2 2 0 1 0-.195 1.41l1.695 3.09-1.695 3.09a2 2 0 1 0 .71.412l1.775-3.502L13.515 4.58A2 2 0 0 0 13 4z"/></svg>
-        Providers <span class="page-tag">Em breve</span>
+        Providers
       </button>
       <button class="sidebar-page-btn" type="button" data-page="channels">
         <svg class="icon-svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M5.5 9.511c.076.954.83 1.697 2.182 1.785V12h.6v-.709c1.4-.098 2.218-.846 2.218-1.932 0-.987-.626-1.496-1.745-1.76l-.473-.112V5.57c.6.068.982.396 1.074.85h1.052c-.076-.93-.848-1.642-2.126-1.726V4h-.6v.719c-1.195.117-2.01.836-2.01 1.853 0 .9.606 1.472 1.613 1.707l.397.098v2.034c-.615-.093-1.022-.43-1.114-.9H5.5zm2.177-2.166c-.59-.137-.91-.416-.91-.836 0-.47.345-.822.915-.925v1.76h-.005zm.692 1.193c.717.166 1.048.435 1.048.91 0 .542-.412.914-1.135.982V8.518l.087.02z"/></svg>
-        Channels <span class="page-tag">Em breve</span>
+        Channels
       </button>
       <button class="sidebar-page-btn" type="button" data-page="sessions">
         <svg class="icon-svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M14.5 3h-13a.5.5 0 0 0-.5.5v9a.5.5 0 0 0 .5.5h13a.5.5 0 0 0 .5-.5v-9a.5.5 0 0 0-.5-.5zm-13-1A1.5 1.5 0 0 0 0 3.5v9A1.5 1.5 0 0 0 1.5 14h13a1.5 1.5 0 0 0 1.5-1.5v-9A1.5 1.5 0 0 0 14.5 2h-13z"/><path d="M3.5 5a.5.5 0 0 1 0-1h9a.5.5 0 0 1 0 1h-9zm0 2.5a.5.5 0 0 1 0-1h9a.5.5 0 0 1 0 1h-9zm0 2.5a.5.5 0 0 1 0-1h9a.5.5 0 0 1 0 1h-9z"/></svg>
-        Sessions <span class="page-tag">Em breve</span>
+        Sessions
       </button>
       <button class="sidebar-page-btn" type="button" data-page="settings">
         <svg class="icon-svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M9.405 1.05c-.413-1.4-2.397-1.4-2.81 0l-.1.34a1.464 1.464 0 0 1-2.105.872l-.31-.17c-1.283-.698-2.686.705-1.987 1.987l.169.311c.446.82.023 1.841-.872 2.105l-.34.1c-1.4.413-1.4 2.397 0 2.81l.34.1a1.464 1.464 0 0 1 .872 2.105l-.17.31c-.698 1.283.705 2.686 1.987 1.987l.311-.169a1.464 1.464 0 0 1 2.105.872l.1.34c.413 1.4 2.397 1.4 2.81 0l.1-.34a1.464 1.464 0 0 1 2.105-.872l.31.17c1.283.698 2.686-.705 1.987-1.987l-.169-.311a1.464 1.464 0 0 1 .872-2.105l.34-.1c1.4-.413 1.4-2.397 0-2.81l-.34-.1a1.464 1.464 0 0 1-.872-2.105l.17-.31c.698-1.283-.705-2.686-1.987-1.987l-.311.169a1.464 1.464 0 0 1-2.105-.872l-.1-.34zM8 10.93a2.929 2.929 0 1 1 0-5.86 2.929 2.929 0 0 1 0 5.858z"/></svg>
-        Settings <span class="page-tag">Em breve</span>
+        Settings
       </button>
       <button class="sidebar-page-btn" type="button" data-page="diagnostics">
         <svg class="icon-svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 1a2 2 0 0 1 2 2v4H6V3a2 2 0 0 1 2-2zm3 6V3a3 3 0 1 0-6 0v4a5 5 0 1 0 6 0z"/></svg>
-        Diagnostics <span class="page-tag">Em breve</span>
+        Diagnostics
       </button>
       <button class="sidebar-page-btn" type="button" data-page="logs">
         <svg class="icon-svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M14 14V4.5L9.5 0H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2zM9.5 3A1.5 1.5 0 0 0 11 4.5h2V14a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h5.5v2zM4.5 12.5A.5.5 0 0 1 5 12h6a.5.5 0 0 1 0 1H5a.5.5 0 0 1-.5-.5zm0-2A.5.5 0 0 1 5 10h6a.5.5 0 0 1 0 1H5a.5.5 0 0 1-.5-.5zm.5-2.5a.5.5 0 0 0 0 1h3a.5.5 0 0 0 0-1H5z"/></svg>
-        Logs <span class="page-tag">Em breve</span>
+        Logs
       </button>
       <button class="sidebar-page-btn" type="button" data-page="skins">
         <svg class="icon-svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M15.825.12a.5.5 0 0 1 .132.584c-1.53 3.43-4.743 8.17-7.095 10.64a6.067 6.067 0 0 1-2.373 1.534c-.018.227-.06.538-.16.868-.201.659-.667 1.479-1.708 1.74a8.118 8.118 0 0 1-3.078.132 3.659 3.659 0 0 1-.562-.135 1.382 1.382 0 0 1-.466-.247.714.714 0 0 1-.204-.288.622.622 0 0 1 .004-.443c.095-.245.316-.38.461-.452.394-.197.625-.453.867-.826.095-.144.184-.297.287-.472l.117-.198c.151-.255.326-.54.546-.848.528-.739 1.201-.925 1.746-.896.126.007.243.025.348.048.062-.172.142-.38.238-.608.261-.619.658-1.419 1.187-2.069 2.176-2.67 6.18-6.206 9.117-8.104a.5.5 0 0 1 .596.04z"/></svg>
@@ -2947,8 +2947,8 @@ nav.sidebar#sidebar .sidebar-footer-btn .icon-svg rect {
     </div>
     <div class="toolbar-tabs" role="tablist" aria-label="Context view">
       <button class="tab-btn active" type="button" role="tab" aria-selected="true">Status</button>
-      <button class="tab-btn" type="button" role="tab" aria-disabled="true" title="Em breve (plan 0117a)">CLI</button>
-      <button class="tab-btn" type="button" role="tab" aria-disabled="true" title="Em breve (plan 0117a)">Schema</button>
+      <button class="tab-btn" type="button" role="tab" aria-disabled="true" title="Não implementado (issue #1116)">CLI</button>
+      <button class="tab-btn" type="button" role="tab" aria-disabled="true" title="Não implementado (issue #1116)">Schema</button>
     </div>
     <div class="context-panel-body">
     <div class="right-section">
@@ -3319,6 +3319,27 @@ function initSkinCards() {
   });
 }
 
+// ─── Erro de fetch compartilhado (#1116) ─────────────────────────────
+//
+// Cada loader escrevia o seu proprio "Falha ao carregar X." — sem codigo de
+// status e sem nenhuma saida. O 401 e o caso que mais aparece na pratica:
+// `gateway.api_key` ligada (#1045) e nenhuma chave salva neste navegador.
+// Ai a resposta util nao e "recarregue", e "informe a chave", entao o 401
+// aponta para o form que ja existe no painel direito e o revela.
+//
+// `colspan` > 0 faz a caixa nascer dentro de uma linha — a pagina de sessions
+// monta num <tbody>, onde um <div> solto seria HTML invalido.
+function renderFetchError(el, status, label, colspan) {
+  const code = Number.isInteger(status) ? status : 0;
+  const hint = code === 401
+    ? ' A chave do gateway não foi aceita. Informe-a em <strong>Gateway Authentication</strong>, no painel direito, e clique em Connect.'
+    : ' Recarregue a página; se o erro persistir, veja os detalhes em Diagnostics.';
+  if (code === 401 && authSection) authSection.style.display = 'block';
+  const box = '<div class="warning-box">Falha ao carregar ' + escapeHtml(label) +
+    ' (HTTP ' + code + ').' + hint + '</div>';
+  el.innerHTML = colspan > 0 ? '<tr><td colspan="' + colspan + '">' + box + '</td></tr>' : box;
+}
+
 // ─── Providers & Models page (plan 0119) ─────────────────────────────
 async function loadProvidersPage() {
   const grid = document.getElementById('providers-grid');
@@ -3327,7 +3348,7 @@ async function loadProvidersPage() {
   try {
     const r = await fetch('/api/providers');
     if (!r.ok) {
-      grid.innerHTML = '<div class="warning-box">Falha ao carregar providers (HTTP ' + r.status + ').</div>';
+      renderFetchError(grid, r.status, 'providers');
       return;
     }
     const j = await r.json();
@@ -3422,7 +3443,7 @@ async function loadDiagnosticsPage() {
   checks.innerHTML = '';
   try {
     const r = await fetch('/api/diagnostics');
-    if (!r.ok) { summary.innerHTML = '<div class="warning-box">Falha ao carregar diagnostics.</div>'; return; }
+    if (!r.ok) { renderFetchError(summary, r.status, 'diagnostics'); return; }
     const j = await r.json();
     _diagnosticsLastReport = j;
     const overall = j.status;
@@ -3482,6 +3503,7 @@ async function loadLogsPage() {
   pre.textContent = 'Carregando logs…';
   try {
     const r = await fetch('/api/logs');
+    if (!r.ok) { renderFetchError(pre, r.status, 'logs'); return; }
     const j = await r.json();
     _logsLastRaw = String(j.logs || '');
     renderLogs();
@@ -3548,7 +3570,8 @@ async function loadSettingsPage() {
       fetch('/api/settings/effective'),
     ]);
     if (!schemaRes.ok || !effectiveRes.ok) {
-      root.innerHTML = '<div class="warning-box">Falha ao carregar settings.</div>';
+      const failed = schemaRes.ok ? effectiveRes : schemaRes;
+      renderFetchError(root, failed.status, 'settings');
       return;
     }
     const schema = (await schemaRes.json()).settings || [];
@@ -3670,7 +3693,7 @@ async function loadChannelsPage() {
   grid.innerHTML = '<div style="color:var(--garra-muted);font-size:13px;">Carregando channels…</div>';
   try {
     const r = await fetch('/api/channels');
-    if (!r.ok) { grid.innerHTML = '<div class="warning-box">Falha ao carregar channels.</div>'; return; }
+    if (!r.ok) { renderFetchError(grid, r.status, 'channels'); return; }
     const j = await r.json();
     const items = Array.isArray(j.channels) ? j.channels : [];
     grid.innerHTML = items.map((c, i) => renderChannelCard(c, i)).join('');
@@ -3699,7 +3722,7 @@ async function loadSessionsPage() {
   body.innerHTML = '<tr><td colspan="5" style="color:var(--garra-muted);text-align:center;padding:20px;">Carregando sessions…</td></tr>';
   try {
     const r = await fetch('/api/sessions');
-    if (!r.ok) { body.innerHTML = '<tr><td colspan="5" class="warning-box">Falha ao carregar.</td></tr>'; return; }
+    if (!r.ok) { renderFetchError(body, r.status, 'sessions', 5); return; }
     const j = await r.json();
     const items = Array.isArray(j) ? j : (Array.isArray(j.sessions) ? j.sessions : []);
     if (!items.length) {

--- a/tests/playwright/webchat-redesign.spec.ts
+++ b/tests/playwright/webchat-redesign.spec.ts
@@ -214,3 +214,129 @@ test.describe('Garra Glass — multi-page router matrix', () => {
     }
   });
 });
+
+// ────────────────────────────────────────────────────────────────────────────
+// #1116 — six pages still wore an "Em breve" tag in the sidebar even though the
+// router already dispatches them to real loaders. The two placeholders that
+// genuinely are not implemented (notification bell, right-panel CLI/Schema
+// tabs) keep their marker, now citing the issue instead of a dead plan.
+// ────────────────────────────────────────────────────────────────────────────
+
+const IMPLEMENTED_PAGES = [
+  'providers',
+  'channels',
+  'sessions',
+  'settings',
+  'diagnostics',
+  'logs',
+] as const;
+
+test.describe('Garra Glass — "Em breve" tags (#1116)', () => {
+  for (const page_name of IMPLEMENTED_PAGES) {
+    test(`sidebar nav for "${page_name}" no longer shows "Em breve"`, async ({ page }) => {
+      await page.setViewportSize({ width: 1280, height: 800 });
+      await openWebchat(page);
+
+      const btn = page.locator(`.sidebar-page-btn[data-page="${page_name}"]`);
+      await expect(btn).toBeVisible();
+      await expect(btn.locator('.page-tag')).toHaveCount(0);
+      await expect(btn).not.toContainText('Em breve');
+    });
+  }
+
+  test('the pages that are still not implemented keep the marker, citing #1116', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await openWebchat(page);
+
+    const bell = page.locator('#header-bell-btn');
+    await expect(bell).toHaveAttribute('aria-disabled', 'true');
+    await expect(bell).toHaveAttribute('title', /#1116/);
+
+    const cliTab = page.locator('.toolbar-tabs .tab-btn', { hasText: 'CLI' });
+    const schemaTab = page.locator('.toolbar-tabs .tab-btn', { hasText: 'Schema' });
+    await expect(cliTab).toHaveAttribute('aria-disabled', 'true');
+    await expect(cliTab).toHaveAttribute('title', /#1116/);
+    await expect(schemaTab).toHaveAttribute('aria-disabled', 'true');
+    await expect(schemaTab).toHaveAttribute('title', /#1116/);
+  });
+
+  test('each of the six pages renders real data, not a placeholder', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+
+    for (const page_name of IMPLEMENTED_PAGES) {
+      await page.goto(`/#/${page_name}`);
+      await page.locator('body').waitFor({ state: 'visible', timeout: 10_000 });
+
+      const view = page.locator(`.page-view[data-page="${page_name}"]`);
+      await expect(view).toHaveClass(/active/);
+      // The loader must move past its "Carregando…" placeholder and must not
+      // fall into the fetch-error box.
+      await expect(view).not.toContainText('Carregando', { timeout: 15_000 });
+      await expect(view).not.toContainText('Falha ao carregar', { timeout: 15_000 });
+    }
+
+    // Positive signal: the loaders actually mounted something. A gateway with
+    // no provider configured is still a success — it renders the empty state.
+    await page.goto('/#/providers');
+    await expect
+      .poll(
+        async () =>
+          await page.evaluate(() => {
+            const el = document.getElementById('providers-grid');
+            if (!el) return 0;
+            return (
+              el.querySelectorAll('.provider-card').length +
+              (el.textContent.includes('Nenhum provider registrado') ? 1 : 0)
+            );
+          }),
+        { timeout: 15_000 },
+      )
+      .toBeGreaterThan(0);
+
+    await page.goto('/#/channels');
+    await expect
+      .poll(async () => await page.evaluate(() => document.querySelectorAll('#channels-grid .provider-card').length), { timeout: 15_000 })
+      .toBeGreaterThan(0);
+
+    await page.goto('/#/diagnostics');
+    await expect
+      .poll(async () => await page.evaluate(() => (document.getElementById('diagnostics-checks') || document.body).children.length), { timeout: 15_000 })
+      .toBeGreaterThan(0);
+
+    await page.goto('/#/settings');
+    await expect
+      .poll(async () => await page.evaluate(() => document.querySelectorAll('#settings-form input, #settings-form select').length), { timeout: 15_000 })
+      .toBeGreaterThan(0);
+
+    await page.goto('/#/sessions');
+    await expect
+      .poll(async () => await page.evaluate(() => document.querySelectorAll('#sessions-table-body tr').length), { timeout: 15_000 })
+      .toBeGreaterThan(0);
+  });
+
+  // The old messages were a bare "Falha ao carregar X." — no status code, no
+  // way forward. A 401 is the common case (gateway.api_key set, no key stored
+  // in this browser), so it now names the form that solves it and reveals it.
+  test('a 401 tells the user to fill in the gateway key and reveals the form', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    // A 401 implies the gateway requires a key, so keep `/api/auth-check`
+    // consistent with it — otherwise init would hide the form again right
+    // after the loader revealed it.
+    await page.route('**/api/auth-check*', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{"auth_required":true}' }),
+    );
+    await page.route('**/api/providers*', (route) =>
+      route.fulfill({ status: 401, contentType: 'application/json', body: '{}' }),
+    );
+
+    await page.goto('/#/providers');
+    await page.locator('body').waitFor({ state: 'visible', timeout: 10_000 });
+
+    const grid = page.locator('#providers-grid');
+    await expect(grid).toContainText('HTTP 401', { timeout: 15_000 });
+    await expect(grid).toContainText('Gateway Authentication');
+    await expect(grid).toContainText('Connect');
+    // The form lives in the right panel and is hidden by CSS until needed.
+    await expect(page.locator('#auth-section')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## 1. As tags "Em breve" que ja nao eram verdade

Seis paginas continuavam marcadas na sidebar mesmo estando implementadas e no
ar: o `switch` do roteador (`:3282-3289`) ja despacha cada uma para um loader
real - `loadProvidersPage`, `loadChannelsPage`, `loadSessionsPage`,
`loadSettingsPage`, `loadDiagnosticsPage`, `loadLogsPage`.

| Pagina | Loader |
| --- | --- |
| providers | `loadProvidersPage` |
| channels | `loadChannelsPage` |
| sessions | `loadSessionsPage` |
| settings | `loadSettingsPage` |
| diagnostics | `loadDiagnosticsPage` |
| logs | `loadLogsPage` |

As seis tags `<span class="page-tag">Em breve</span>` saem. O CSS generico de
`.page-tag` (`:1158-1166`) fica - nao ha motivo para mexer nele.

As duas coisas que **realmente** nao existem mantem a marca, porque ai ela e
informativa:

- sino de notificacoes (`:2499`)
- abas CLI/Schema do painel direito (`:2950-2951`)

So o texto muda: em vez de `Em breve (plan 0117a)` - um plano que nao existe -
o titulo cita `issue #1116`. `aria-disabled="true"` continua nos dois.

## 2. 401 sem orientacao

Os loaders escreviam um `Falha ao carregar X.` sem codigo HTTP e sem saida
nenhuma (e o de sessions nem dizia o que falhou). Agora existe um helper
compartilhado:

```js
renderFetchError(el, status, label, colspan)
```

- sempre mostra o codigo (`HTTP 401`, `HTTP 500`, ...);
- no **401** - o caso frequente, com `gateway.api_key` ligada (#1045) e nenhuma
  chave salva no navegador - aponta para o form **Gateway Authentication** do
  painel direito e o revela (ele nasce `display: none`);
- nos outros codigos, manda recarregar e procurar Diagnostics;
- `colspan` > 0 faz a caixa nascer dentro de uma `<tr>`, porque a pagina de
  sessions monta num `<tbody>` e um `<div>` solto ali seria HTML invalido.

Aplicado nos seis loaders. Nenhuma mensagem anterior foi mantida.

## Testes

`tests/playwright/webchat-redesign.spec.ts` ganha um bloco novo:

- para cada uma das seis paginas: o botao da sidebar nao tem `.page-tag` e nao
  contem "Em breve";
- sino e abas CLI/Schema continuam `aria-disabled` e citam `#1116`;
- as seis paginas saem do placeholder "Carregando…" e nao caem em
  "Falha ao carregar", com sinal positivo de que o loader montou conteudo
  (cards, checks, inputs, linhas);
- um 401 forcado em `/api/providers` mostra `HTTP 401`, cita
  "Gateway Authentication" e "Connect", e deixa `#auth-section` visivel.

Nenhuma assertiva existente foi afrouxada.

> **As assertivas Playwright nao foram executadas localmente** - este container
> nao tem browser, e `tests/playwright/` nao tem `node_modules` para nem mesmo
> um `tsc --noEmit`. O HTML/JS foi verificado com `node --check` no bloco
> `<script>` extraido do `webchat.html`; quem valida o comportamento e o CI.

## Gates

```text
python3 scripts/changelog/assemble.py --check                          OK (6 fragmentos)
cargo fmt --all -- --check                                             OK
cargo check --workspace --exclude garraia-desktop                     OK
cargo clippy --workspace --exclude garraia-desktop --all-targets \
    --all-features -- -D warnings                                      OK
```

Closes #1116

🤖 Generated with [Claude Code](https://claude.com/claude-code)
