### PR TITLE
feat(admin): troca de senha do proprio usuario por rota e UI

### DIFF
--- a/changelog.d/added/1120-troca-de-senha-no-admin.md
+++ b/changelog.d/added/1120-troca-de-senha-no-admin.md
@@ -1,0 +1,26 @@
+- O admin passa a ter troca de senha do proprio usuario, pela UI e por rota:
+  `POST /admin/api/change-password` recebe a senha atual e a senha nova,
+  reverifica a atual com o mesmo `verify_password` da danger zone antes de
+  mexer em qualquer coisa e so entao grava o novo hash pelo
+  `update_user_password` que ja existia (e estava morto). Antes disso a unica
+  forma de trocar a senha era SQL manual no `admin.db` (#1120).
+- A pagina Account do console traz o formulario: senha atual, senha nova e
+  confirmacao, com validacao de tamanho minimo de 8 caracteres e de igualdade
+  entre os dois campos antes de sair o pedido. E a primeira pagina de conta
+  acessivel a qualquer papel — ate hoje so havia telas de gestao de usuarios,
+  que exigem papel admin (#1120).
+- O hash continua sendo o PBKDF2-HMAC-SHA256 local do `admin/store.rs`, com
+  os mesmos 600 mil iteracoes: nada muda para as linhas ja existentes e o
+  Argon2id do `garraia-auth` segue fora do escopo do admin, que e SQLite e nao
+  o provedor de identidade do workspace (#1120).
+- Cada terminal escreve auditoria (`action` `change_password`, recurso `user`),
+  com `outcome` `success` ou `failure`, e nenhuma delas carrega senha — nem a
+  atual, nem a nova. A resposta de erro repete o formato `{"error": ...}` do
+  resto da API do admin, e a falha de gravacao devolve uma mensagem fixa, com o
+  detalhe do SQLite indo so para o log (#1120).
+- As outras sessoes do usuario sao revogadas na mesma hora — a nova
+  `delete_other_user_sessions` mantem a sessao que fez o pedido, entao o
+  console nao se desloga no meio do proprio submit enquanto um cookie roubado
+  para de valer. Segue sem rate limit dedicado na rota, como todo o resto do
+  router do admin; o custo de 600 mil iteracoes de PBKDF2 por tentativa errada
+  e o freio que existe hoje (#1120).

--- a/changelog.d/added/1120-troca-de-senha-no-admin.md
+++ b/changelog.d/added/1120-troca-de-senha-no-admin.md
@@ -1,8 +1,7 @@
 - O admin passa a ter troca de senha do proprio usuario, pela UI e por rota:
   `POST /admin/api/change-password` recebe a senha atual e a senha nova,
   reverifica a atual com o mesmo `verify_password` da danger zone antes de
-  mexer em qualquer coisa e so entao grava o novo hash pelo
-  `update_user_password` que ja existia (e estava morto). Antes disso a unica
+  mexer em qualquer coisa e so entao grava o novo hash. Antes disso a unica
   forma de trocar a senha era SQL manual no `admin.db` (#1120).
 - A pagina Account do console traz o formulario: senha atual, senha nova e
   confirmacao, com validacao de tamanho minimo de 8 caracteres e de igualdade
@@ -18,9 +17,11 @@
   atual, nem a nova. A resposta de erro repete o formato `{"error": ...}` do
   resto da API do admin, e a falha de gravacao devolve uma mensagem fixa, com o
   detalhe do SQLite indo so para o log (#1120).
-- As outras sessoes do usuario sao revogadas na mesma hora — a nova
-  `delete_other_user_sessions` mantem a sessao que fez o pedido, entao o
-  console nao se desloga no meio do proprio submit enquanto um cookie roubado
-  para de valer. Segue sem rate limit dedicado na rota, como todo o resto do
-  router do admin; o custo de 600 mil iteracoes de PBKDF2 por tentativa errada
-  e o freio que existe hoje (#1120).
+- As outras sessoes do usuario sao revogadas NA MESMA TRANSACAO do novo hash,
+  pela `rotate_password_and_revoke_sessions`: ou as duas coisas acontecem,
+  ou nenhuma — a rota nunca responde sucesso com o hash trocado e um cookie
+  roubado ainda valido. A sessao que fez o pedido e mantida, entao o console
+  nao se desloga no meio do proprio submit. Segue sem rate limit dedicado na
+  rota, como todo o resto do router do admin (so o governor per-IP global);
+  o custo de 600 mil iteracoes de PBKDF2 por tentativa errada e o freio que
+  existe hoje (#1120).

--- a/crates/garraia-gateway/src/admin.html
+++ b/crates/garraia-gateway/src/admin.html
@@ -534,6 +534,10 @@ tr:hover { background: var(--bg-hover); }
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
           <span class="nav-label">About</span>
         </div>
+        <div class="nav-item" data-page="account">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 11-7.778 7.778 5.5 5.5 0 017.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg>
+          <span class="nav-label">Account</span>
+        </div>
       </div>
     </nav>
     <div id="main-area">
@@ -698,7 +702,8 @@ var pages = {
   dashboard: pageDashboard, mcp: pageMcp, providers: pageProviders, secrets: pageSecrets,
   config: pageConfig, memory: pageMemory, tools: pageTools, channels: pageChannels,
   sessions: pageSessions, logs: pageLogs, metrics: pageMetrics, alerts: pageAlerts,
-  templates: pageTemplates, audit: pageAudit, users: pageUsers, about: pageAbout
+  templates: pageTemplates, audit: pageAudit, users: pageUsers, about: pageAbout,
+  account: pageAccount
 };
 
 function navigate(page) {
@@ -720,7 +725,8 @@ function pageTitle(page) {
     dashboard:'Dashboard', mcp:'MCP Servers', providers:'Providers', secrets:'Secrets',
     config:'Configuration', memory:'Memory', tools:'Tools', channels:'Channels',
     sessions:'Sessions', logs:'Logs', metrics:'Metrics', alerts:'Alerts',
-    templates:'Templates', audit:'Audit Log', users:'Users', about:'About'
+    templates:'Templates', audit:'Audit Log', users:'Users', about:'About',
+    account:'Account'
   };
   return titles[page] || page;
 }
@@ -1615,6 +1621,72 @@ async function pageAbout() {
     frag.appendChild(card);
     renderContent(frag);
   } catch(e) { renderContent(el('div', { className: 'card', textContent: 'Failed: ' + e.message })); }
+}
+
+// ─── Account (self-service password change, #1120) ───────────────────
+// Antes desta pagina a unica forma de trocar a senha do admin era SQL
+// manual no admin.db. O POST exige a senha atual, entao um cookie de
+// sessao roubado nao basta para trocar a senha e trancar o dono fora.
+var MIN_PASSWORD_LEN = 8;
+
+function accountField(id, placeholder, autocomplete) {
+  return el('input', {
+    type: 'password', id: id, placeholder: placeholder, autocomplete: autocomplete,
+    'data-testid': id
+  });
+}
+
+function pageAccount() {
+  var card = el('div', { className: 'card', style: 'max-width:520px' });
+  card.appendChild(el('h3', { textContent: 'Change password', style: 'margin-bottom:4px' }));
+  card.appendChild(el('p', {
+    style: 'color:var(--text-muted);font-size:12px;margin-bottom:16px',
+    textContent: currentUser
+      ? 'Rotates the password of "' + currentUser.username + '". Every other session of this user is signed out; this one stays.'
+      : 'Rotates the password of the signed-in user.'
+  }));
+
+  var currentInput = accountField('current-password', 'Current password', 'current-password');
+  var newInput = accountField('new-password', 'New password (8+ characters)', 'new-password');
+  var confirmInput = accountField('confirm-password', 'Confirm new password', 'new-password');
+  // Sem a classe `hidden`: ela e `display:none !important`, e aqui a
+  // mensagem e religada por `style.display`.
+  var errorEl = el('div', {
+    className: 'badge badge-error', 'data-testid': 'account-error',
+    style: 'display:none;margin-top:12px'
+  });
+
+  [['Current password', currentInput], ['New password', newInput], ['Confirm new password', confirmInput]]
+    .forEach(function (pair) {
+      card.appendChild(el('div', { className: 'form-group' }, [el('label', { textContent: pair[0] }), pair[1]]));
+    });
+
+  function fail(msg) { errorEl.textContent = msg; errorEl.style.display = 'block'; }
+
+  var submit = el('button', {
+    className: 'btn-primary btn-sm', textContent: 'Change password',
+    'data-testid': 'change-password-submit',
+    onClick: async function () {
+      errorEl.style.display = 'none';
+      if (!currentInput.value || !newInput.value || !confirmInput.value) { fail('All three fields are required.'); return; }
+      if (newInput.value.length < MIN_PASSWORD_LEN) { fail('New password must be at least ' + MIN_PASSWORD_LEN + ' characters.'); return; }
+      if (newInput.value !== confirmInput.value) { fail('New passwords do not match.'); return; }
+      submit.disabled = true;
+      try {
+        await apiPost('/change-password', { current_password: currentInput.value, new_password: newInput.value });
+        currentInput.value = ''; newInput.value = ''; confirmInput.value = '';
+        toast('Password changed', 'success');
+      } catch (e) {
+        fail(e.message);
+      } finally {
+        submit.disabled = false;
+      }
+    }
+  });
+
+  card.appendChild(el('div', { style: 'display:flex;gap:8px' }, [submit]));
+  card.appendChild(errorEl);
+  renderContent(card);
 }
 
 // ─── Auth Handlers ──────────────────────────────────────────────────

--- a/crates/garraia-gateway/src/admin/handlers.rs
+++ b/crates/garraia-gateway/src/admin/handlers.rs
@@ -176,8 +176,9 @@ pub async fn me(
 // Slice 9.g (GAR-474): setup, user-management, and danger-zone handlers extracted to
 // `admin::users`. Re-exported so `routes.rs` paths (`handlers::setup`, etc.) keep resolving.
 pub use super::users::{
-    CreateUserRequest, DangerZoneRequest, SetupRequest, UpdateUserRoleRequest, create_user,
-    danger_zone, delete_user, list_users, setup, setup_status, update_user_role,
+    CHANGE_PASSWORD_ACTION, ChangePasswordRequest, CreateUserRequest, DangerZoneRequest,
+    SetupRequest, UpdateUserRoleRequest, change_password, create_user, danger_zone, delete_user,
+    list_users, setup, setup_status, update_user_role,
 };
 
 // Slice 9.f (GAR-475): secrets CRUD + rotation + migration + AES-256-GCM helpers extracted to

--- a/crates/garraia-gateway/src/admin/routes.rs
+++ b/crates/garraia-gateway/src/admin/routes.rs
@@ -48,6 +48,8 @@ pub fn build_admin_router(
         .route("/api/users/{id}/role", put(handlers::update_user_role))
         .route("/api/users/{id}", delete(handlers::delete_user))
         .route("/api/danger-zone", post(handlers::danger_zone))
+        // ── #1120: self-service password rotation ──
+        .route("/api/change-password", post(handlers::change_password))
         .route("/api/audit-log", get(handlers::get_audit_log))
         // Phase 7.1: additional audit endpoint alias (canonical path)
         .route("/api/audit", get(handlers::get_audit_log))

--- a/crates/garraia-gateway/src/admin/store.rs
+++ b/crates/garraia-gateway/src/admin/store.rs
@@ -744,25 +744,48 @@ impl AdminStore {
         Ok(())
     }
 
-    /// Revoke every session of `user_id` **except** `keep_token`.
+    /// Rotate the password and revoke the user's other sessions, atomically.
     ///
-    /// #1120: used by the self-service password change. The caller keeps the
-    /// session it is authenticating with, so the console survives the
-    /// rotation, while every other session for that user — a stolen cookie
-    /// included — stops validating on the next request.
+    /// #1120: used by the self-service password change. One SQLite
+    /// transaction wraps the new hash AND the `DELETE` of the other
+    /// sessions — a failure in either one rolls the whole rotation back, so
+    /// the route can never answer success with a committed password and a
+    /// stale — possibly stolen — session still validating. The caller keeps
+    /// the session it is authenticating with, so the console survives the
+    /// rotation, while every other session for that user stops validating
+    /// on the next request.
     ///
-    /// Returns the number of rows deleted.
-    pub fn delete_other_user_sessions(
+    /// Returns the number of sessions revoked alongside the rotation.
+    pub fn rotate_password_and_revoke_sessions(
         &self,
         user_id: &str,
+        new_password: &str,
         keep_token: &str,
     ) -> Result<usize, String> {
-        self.conn
+        let (hash, salt) = hash_password(new_password)?;
+        let tx = self
+            .conn
+            .unchecked_transaction()
+            .map_err(|e| format!("failed to begin transaction: {e}"))?;
+        let affected = tx
+            .execute(
+                "UPDATE admin_users SET password_hash = ?1, password_salt = ?2, updated_at = datetime('now')
+                 WHERE id = ?3",
+                params![hash, salt, user_id],
+            )
+            .map_err(|e| format!("failed to update password: {e}"))?;
+        if affected == 0 {
+            return Err("user not found".to_string());
+        }
+        let revoked = tx
             .execute(
                 "DELETE FROM admin_sessions WHERE user_id = ?1 AND token <> ?2",
                 params![user_id, keep_token],
             )
-            .map_err(|e| format!("failed to revoke other sessions: {e}"))
+            .map_err(|e| format!("failed to revoke other sessions: {e}"))?;
+        tx.commit()
+            .map_err(|e| format!("failed to commit password rotation: {e}"))?;
+        Ok(revoked)
     }
 
     pub fn cleanup_expired_sessions(&self) -> usize {

--- a/crates/garraia-gateway/src/admin/store.rs
+++ b/crates/garraia-gateway/src/admin/store.rs
@@ -420,6 +420,27 @@ impl AdminStore {
         Ok(())
     }
 
+    /// Revoke every session of `user_id` **except** `keep_token`.
+    ///
+    /// #1120: used by the self-service password change. The caller keeps the
+    /// session it is authenticating with, so the console survives the
+    /// rotation, while every other session for that user — a stolen cookie
+    /// included — stops validating on the next request.
+    ///
+    /// Returns the number of rows deleted.
+    pub fn delete_other_user_sessions(
+        &self,
+        user_id: &str,
+        keep_token: &str,
+    ) -> Result<usize, String> {
+        self.conn
+            .execute(
+                "DELETE FROM admin_sessions WHERE user_id = ?1 AND token <> ?2",
+                params![user_id, keep_token],
+            )
+            .map_err(|e| format!("failed to revoke other sessions: {e}"))
+    }
+
     pub fn cleanup_expired_sessions(&self) -> usize {
         self.conn
             .execute(

--- a/crates/garraia-gateway/src/admin/users.rs
+++ b/crates/garraia-gateway/src/admin/users.rs
@@ -9,6 +9,14 @@ use axum::response::IntoResponse;
 use super::middleware::{AuthenticatedAdmin, build_session_cookie, extract_ip};
 use super::rbac::{Action, Resource, Role, check_permission};
 use super::shared::AdminState;
+use super::store::AdminStore;
+
+/// Minimum length for a new password. Same bound the `setup` and
+/// `create_user` handlers already enforce.
+const MIN_PASSWORD_LEN: usize = 8;
+
+/// Audit `action` written by [`change_password`].
+pub const CHANGE_PASSWORD_ACTION: &str = "change_password";
 
 // ── Setup endpoint (first-run bootstrap) ─────────────────────────────
 
@@ -34,7 +42,7 @@ pub async fn setup(
         );
     }
 
-    if body.username.len() < 3 || body.password.len() < 8 {
+    if body.username.len() < 3 || body.password.len() < MIN_PASSWORD_LEN {
         return (
             StatusCode::BAD_REQUEST,
             HeaderMap::new(),
@@ -135,7 +143,7 @@ pub async fn create_user(
         }
     };
 
-    if body.username.len() < 3 || body.password.len() < 8 {
+    if body.username.len() < 3 || body.password.len() < MIN_PASSWORD_LEN {
         return (
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({"error": "username >=3 chars, password >=8 chars"})),
@@ -379,4 +387,129 @@ pub async fn danger_zone(
             )
         }
     }
+}
+
+// ── Self-service password change (#1120) ─────────────────────────────
+
+#[derive(serde::Deserialize)]
+pub struct ChangePasswordRequest {
+    pub current_password: String,
+    pub new_password: String,
+}
+
+/// Write one audit row for a change-password attempt.
+///
+/// `details` describes the terminal for the trail and never carries a
+/// password — neither the current nor the new one.
+fn audit_change_password(
+    store: &AdminStore,
+    admin: &AuthenticatedAdmin,
+    details: &str,
+    ip: Option<&str>,
+    outcome: &str,
+) {
+    let _ = store.append_audit(
+        Some(&admin.user_id),
+        Some(&admin.username),
+        CHANGE_PASSWORD_ACTION,
+        "user",
+        Some(&admin.user_id),
+        Some(details),
+        ip,
+        outcome,
+    );
+}
+
+/// POST /admin/api/change-password — rotate the caller's own password.
+///
+/// #1120: before this route the only way to change an admin password was to
+/// run SQL against `admin.db` by hand.
+///
+/// The current password is re-verified with the same `verify_password` the
+/// danger zone uses, so a stolen session cookie alone cannot lock the real
+/// owner out; session auth and CSRF come from the router this handler is
+/// mounted in. Hashing stays the local PBKDF2-HMAC-SHA256 of `store.rs` —
+/// `garraia_auth` (Argon2id) belongs to the Postgres workspace identity
+/// provider and pulling it here would change the scheme for existing rows.
+///
+/// Every terminal writes an audit event. Responses reuse the
+/// `{"error": ...}` / `{"ok": true}` shapes of the rest of the admin API; no
+/// password is ever echoed back or logged.
+pub async fn change_password(
+    State(state): State<AdminState>,
+    headers: HeaderMap,
+    axum::Extension(admin): axum::Extension<AuthenticatedAdmin>,
+    Json(body): Json<ChangePasswordRequest>,
+) -> impl IntoResponse {
+    let ip = extract_ip(&headers, None);
+
+    // Cheapest rejection first: no KDF work, no DB write.
+    if body.new_password.len() < MIN_PASSWORD_LEN {
+        let guard = state.store.lock().await;
+        audit_change_password(
+            &guard,
+            &admin,
+            "rejected: new password shorter than the minimum",
+            ip.as_deref(),
+            "failure",
+        );
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "new password must be >=8 chars"})),
+        );
+    }
+
+    let guard = state.store.lock().await;
+
+    let verified = guard.verify_password(&admin.username, &body.current_password);
+    if verified.is_none() {
+        audit_change_password(
+            &guard,
+            &admin,
+            "rejected: current password did not verify",
+            ip.as_deref(),
+            "failure",
+        );
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({"error": "password verification failed"})),
+        );
+    }
+
+    if let Err(e) = guard.update_user_password(&admin.user_id, &body.new_password) {
+        // Log the cause, answer with a fixed string: the SQLite message is an
+        // internal detail and the admin API has been echoing it elsewhere.
+        tracing::error!("change-password: failed to persist new hash: {e}");
+        audit_change_password(
+            &guard,
+            &admin,
+            "rejected: could not persist the new hash",
+            ip.as_deref(),
+            "failure",
+        );
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "failed to update password"})),
+        );
+    }
+
+    // The hash is already committed; revocation is best effort. The session
+    // the caller authenticated with is kept so the console stays usable.
+    let revoked = match guard.delete_other_user_sessions(&admin.user_id, &admin.session_token) {
+        Ok(n) => n,
+        Err(e) => {
+            tracing::warn!("change-password: password changed but sessions not revoked: {e}");
+            0
+        }
+    };
+
+    audit_change_password(
+        &guard,
+        &admin,
+        &format!("self-service password change, {revoked} other session(s) revoked"),
+        ip.as_deref(),
+        "success",
+    );
+
+    (StatusCode::OK, Json(serde_json::json!({"ok": true})))
 }

--- a/crates/garraia-gateway/src/admin/users.rs
+++ b/crates/garraia-gateway/src/admin/users.rs
@@ -428,7 +428,9 @@ fn audit_change_password(
 /// The current password is re-verified with the same `verify_password` the
 /// danger zone uses, so a stolen session cookie alone cannot lock the real
 /// owner out; session auth and CSRF come from the router this handler is
-/// mounted in. Hashing stays the local PBKDF2-HMAC-SHA256 of `store.rs` —
+/// mounted in. The new hash and the revocation of the user's other sessions
+/// commit in one SQLite transaction — either both land or neither does.
+/// Hashing stays the local PBKDF2-HMAC-SHA256 of `store.rs` —
 /// `garraia_auth` (Argon2id) belongs to the Postgres workspace identity
 /// provider and pulling it here would change the scheme for existing rows.
 ///
@@ -476,30 +478,32 @@ pub async fn change_password(
         );
     }
 
-    if let Err(e) = guard.update_user_password(&admin.user_id, &body.new_password) {
-        // Log the cause, answer with a fixed string: the SQLite message is an
-        // internal detail and the admin API has been echoing it elsewhere.
-        tracing::error!("change-password: failed to persist new hash: {e}");
-        audit_change_password(
-            &guard,
-            &admin,
-            "rejected: could not persist the new hash",
-            ip.as_deref(),
-            "failure",
-        );
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({"error": "failed to update password"})),
-        );
-    }
-
-    // The hash is already committed; revocation is best effort. The session
-    // the caller authenticated with is kept so the console stays usable.
-    let revoked = match guard.delete_other_user_sessions(&admin.user_id, &admin.session_token) {
+    // The new hash and the revocation of the other sessions commit in ONE
+    // SQLite transaction: a failure in either one rolls the whole rotation
+    // back, so success is never announced with a stolen cookie still
+    // validating. The session the caller authenticated with is kept, so the
+    // console survives the rotation.
+    let revoked = match guard.rotate_password_and_revoke_sessions(
+        &admin.user_id,
+        &body.new_password,
+        &admin.session_token,
+    ) {
         Ok(n) => n,
         Err(e) => {
-            tracing::warn!("change-password: password changed but sessions not revoked: {e}");
-            0
+            // Log the cause, answer with a fixed string: the SQLite message is an
+            // internal detail and the admin API has been echoing it elsewhere.
+            tracing::error!("change-password: rotation failed, nothing was persisted: {e}");
+            audit_change_password(
+                &guard,
+                &admin,
+                "rejected: could not persist the rotation",
+                ip.as_deref(),
+                "failure",
+            );
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "failed to update password"})),
+            );
         }
     };
 

--- a/crates/garraia-gateway/src/admin/users.rs
+++ b/crates/garraia-gateway/src/admin/users.rs
@@ -400,7 +400,10 @@ pub struct ChangePasswordRequest {
 /// Write one audit row for a change-password attempt.
 ///
 /// `details` describes the terminal for the trail and never carries a
-/// password — neither the current nor the new one.
+/// password — neither the current nor the new one. An audit write that
+/// itself fails must not vanish: it lands in the log, so a silent hole in
+/// the trail is at least observable. The terminal still answers as usual —
+/// same fail-open behaviour as every other admin route.
 fn audit_change_password(
     store: &AdminStore,
     admin: &AuthenticatedAdmin,
@@ -408,7 +411,7 @@ fn audit_change_password(
     ip: Option<&str>,
     outcome: &str,
 ) {
-    let _ = store.append_audit(
+    if let Err(e) = store.append_audit(
         Some(&admin.user_id),
         Some(&admin.username),
         CHANGE_PASSWORD_ACTION,
@@ -417,7 +420,9 @@ fn audit_change_password(
         Some(details),
         ip,
         outcome,
-    );
+    ) {
+        tracing::warn!("change-password: failed to write audit event: {e}");
+    }
 }
 
 /// POST /admin/api/change-password — rotate the caller's own password.

--- a/crates/garraia-gateway/tests/admin_change_password.rs
+++ b/crates/garraia-gateway/tests/admin_change_password.rs
@@ -1,0 +1,341 @@
+//! #1120: troca de senha do proprio admin, por HTTP, contra o router real.
+//!
+//! Os testes de unidade do `admin` provam pecas isoladas; o que este arquivo
+//! prova e a **montagem mais o efeito**:
+//!
+//! * a rota existe dentro do grupo autenticado, entao herda sessao e CSRF;
+//! * a senha muda de verdade — conferido com `verify_password` no store, nao
+//!   apenas com o status da resposta;
+//! * a senha atual errada (e a senha nova curta) nao mudam nada;
+//! * cada terminal escreve auditoria, com o outcome certo;
+//! * as outras sessoes do usuario sao revogadas, e a que fez o pedido nao.
+
+use std::sync::Arc;
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{HeaderMap, Request, StatusCode, header};
+use garraia_agents::AgentRuntime;
+use garraia_channels::ChannelRegistry;
+use garraia_config::AppConfig;
+use garraia_gateway::admin::store::{AdminStore, AuditEntry};
+use garraia_gateway::admin::users::CHANGE_PASSWORD_ACTION;
+use garraia_gateway::push_channels::PushChannelStates;
+use garraia_gateway::router::build_router;
+use garraia_gateway::state::AppState;
+use serde_json::json;
+use tokio::sync::Mutex;
+use tower::ServiceExt;
+
+const USUARIO: &str = "root";
+const SENHA_INICIAL: &str = "senha-inicial-do-admin";
+const SENHA_NOVA: &str = "senha-nova-do-admin";
+const SENHA_CURTA: &str = "curta";
+
+const CAMINHO: &str = "/admin/api/change-password";
+
+/// Cookie de sessao + token de CSRF que o console usaria.
+struct Sessao {
+    token: String,
+    csrf: String,
+}
+
+/// Router de verdade, com um `AdminStore` em memoria que o teste continua
+/// enxergando depois do pedido — e assim que ele confere o efeito colateral.
+fn router_com_store() -> (Router, Arc<Mutex<AdminStore>>) {
+    let config = AppConfig::default();
+    let state = Arc::new(AppState::new(
+        config,
+        Arc::new(AgentRuntime::new()),
+        ChannelRegistry::new(),
+    ));
+    let store = Arc::new(Mutex::new(
+        AdminStore::in_memory().expect("store em memoria"),
+    ));
+    let router = build_router(
+        state,
+        PushChannelStates::empty(),
+        Arc::clone(&store),
+        Arc::new(vec![0u8; 32]),
+    );
+    (router, store)
+}
+
+async fn post_admin(
+    router: &Router,
+    caminho: &str,
+    sessao: Option<&Sessao>,
+    csrf: Option<&str>,
+    corpo: serde_json::Value,
+) -> (StatusCode, serde_json::Value, HeaderMap) {
+    let mut req = Request::builder()
+        .method("POST")
+        .uri(caminho)
+        .header(header::CONTENT_TYPE, "application/json");
+    if let Some(s) = sessao {
+        req = req.header(header::COOKIE, format!("garraia_admin_session={}", s.token));
+    }
+    if let Some(t) = csrf {
+        req = req.header("x-csrf-token", t);
+    }
+
+    let mut req = req
+        .body(Body::from(serde_json::to_vec(&corpo).expect("json")))
+        .expect("request");
+    // O governor le o IP de `ConnectInfo`, que em producao vem do
+    // `into_make_service_with_connect_info`. Sem ele o pedido morre em 500
+    // antes de chegar na rota.
+    req.extensions_mut()
+        .insert(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+            [127, 0, 0, 1],
+            41120,
+        ))));
+
+    let resp = router
+        .clone()
+        .oneshot(req)
+        .await
+        .expect("o router respondeu");
+    let status = resp.status();
+    let headers = resp.headers().clone();
+    let bytes = axum::body::to_bytes(resp.into_body(), 256 * 1024)
+        .await
+        .expect("corpo");
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+    (status, json, headers)
+}
+
+/// Cria o primeiro admin via `/setup`, que ja devolve sessao e CSRF.
+async fn criar_admin(router: &Router) -> Sessao {
+    let (status, corpo, headers) = post_admin(
+        router,
+        "/admin/api/setup",
+        None,
+        None,
+        json!({ "username": USUARIO, "password": SENHA_INICIAL }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{corpo}");
+
+    let csrf = corpo["csrf_token"]
+        .as_str()
+        .expect("csrf_token")
+        .to_string();
+    let cookie = headers
+        .get(header::SET_COOKIE)
+        .and_then(|v| v.to_str().ok())
+        .expect("set-cookie")
+        .to_string();
+    let token = cookie
+        .split(';')
+        .next()
+        .and_then(|parte| parte.trim().strip_prefix("garraia_admin_session="))
+        .expect("token da sessao")
+        .to_string();
+
+    Sessao { token, csrf }
+}
+
+/// Uma segunda sessao do mesmo usuario, como a de outro navegador.
+async fn abrir_outra_sessao(router: &Router) -> Sessao {
+    let (status, corpo, headers) = post_admin(
+        router,
+        "/admin/api/login",
+        None,
+        None,
+        json!({ "username": USUARIO, "password": SENHA_INICIAL }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{corpo}");
+
+    let csrf = corpo["csrf_token"]
+        .as_str()
+        .expect("csrf_token")
+        .to_string();
+    let cookie = headers
+        .get(header::SET_COOKIE)
+        .and_then(|v| v.to_str().ok())
+        .expect("set-cookie")
+        .to_string();
+    let token = cookie
+        .split(';')
+        .next()
+        .and_then(|parte| parte.trim().strip_prefix("garraia_admin_session="))
+        .expect("token da sessao")
+        .to_string();
+
+    Sessao { token, csrf }
+}
+
+async fn senha_confere(store: &Arc<Mutex<AdminStore>>, senha: &str) -> bool {
+    let guard = store.lock().await;
+    guard.verify_password(USUARIO, senha).is_some()
+}
+
+async fn sessao_valida(store: &Arc<Mutex<AdminStore>>, token: &str) -> bool {
+    let guard = store.lock().await;
+    guard.validate_session(token).is_some()
+}
+
+/// A trilha de auditoria da propria rota, filtrada por acao e recurso.
+async fn trilha(store: &Arc<Mutex<AdminStore>>) -> Vec<AuditEntry> {
+    let guard = store.lock().await;
+    guard.list_audit_log(50, 0, Some("user"), Some(CHANGE_PASSWORD_ACTION))
+}
+
+#[tokio::test]
+async fn troca_a_senha_do_proprio_usuario_e_audita() {
+    let (router, store) = router_com_store();
+    let sessao = criar_admin(&router).await;
+
+    let (status, corpo, _) = post_admin(
+        &router,
+        CAMINHO,
+        Some(&sessao),
+        Some(&sessao.csrf),
+        json!({ "current_password": SENHA_INICIAL, "new_password": SENHA_NOVA }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{corpo}");
+    assert_eq!(corpo["ok"], serde_json::Value::Bool(true), "{corpo}");
+
+    // A prova que importa: a senha nova abre e a antiga nao abre mais.
+    assert!(senha_confere(&store, SENHA_NOVA).await, "a senha nao mudou");
+    assert!(
+        !senha_confere(&store, SENHA_INICIAL).await,
+        "a senha antiga continua valendo"
+    );
+
+    let trilha = trilha(&store).await;
+    assert_eq!(trilha.len(), 1, "exatamente um evento: {trilha:?}");
+    assert_eq!(trilha[0].outcome, "success");
+    assert_eq!(trilha[0].username.as_deref(), Some(USUARIO));
+}
+
+#[tokio::test]
+async fn senha_atual_errada_nao_troca_nada() {
+    let (router, store) = router_com_store();
+    let sessao = criar_admin(&router).await;
+
+    let (status, corpo, _) = post_admin(
+        &router,
+        CAMINHO,
+        Some(&sessao),
+        Some(&sessao.csrf),
+        json!({ "current_password": "nao-e-a-senha", "new_password": SENHA_NOVA }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::UNAUTHORIZED, "{corpo}");
+    assert_eq!(
+        corpo["error"],
+        serde_json::Value::String("password verification failed".to_string())
+    );
+
+    assert!(
+        senha_confere(&store, SENHA_INICIAL).await,
+        "a senha nao pode mudar com a atual errada"
+    );
+    assert!(!senha_confere(&store, SENHA_NOVA).await);
+
+    let trilha = trilha(&store).await;
+    assert_eq!(trilha.len(), 1, "{trilha:?}");
+    assert_eq!(trilha[0].outcome, "failure");
+}
+
+#[tokio::test]
+async fn senha_nova_curta_e_rejeitada_sem_tocar_no_hash() {
+    let (router, store) = router_com_store();
+    let sessao = criar_admin(&router).await;
+
+    let (status, corpo, _) = post_admin(
+        &router,
+        CAMINHO,
+        Some(&sessao),
+        Some(&sessao.csrf),
+        json!({ "current_password": SENHA_INICIAL, "new_password": SENHA_CURTA }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{corpo}");
+    assert!(
+        senha_confere(&store, SENHA_INICIAL).await,
+        "a senha antiga tem de continuar valendo"
+    );
+    assert!(!senha_confere(&store, SENHA_CURTA).await);
+
+    let trilha = trilha(&store).await;
+    assert_eq!(trilha.len(), 1, "{trilha:?}");
+    assert_eq!(trilha[0].outcome, "failure");
+}
+
+#[tokio::test]
+async fn sem_sessao_o_pedido_nem_chega_no_handler() {
+    let (router, store) = router_com_store();
+    let sessao = criar_admin(&router).await;
+
+    let (status, _, _) = post_admin(
+        &router,
+        CAMINHO,
+        None,
+        Some(&sessao.csrf),
+        json!({ "current_password": SENHA_INICIAL, "new_password": SENHA_NOVA }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert!(senha_confere(&store, SENHA_INICIAL).await);
+    assert!(
+        trilha(&store).await.is_empty(),
+        "sem auditoria de quem nao entrou"
+    );
+}
+
+#[tokio::test]
+async fn sem_csrf_o_pedido_e_barrado() {
+    let (router, store) = router_com_store();
+    let sessao = criar_admin(&router).await;
+
+    let (status, _, _) = post_admin(
+        &router,
+        CAMINHO,
+        Some(&sessao),
+        None,
+        json!({ "current_password": SENHA_INICIAL, "new_password": SENHA_NOVA }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert!(senha_confere(&store, SENHA_INICIAL).await);
+    assert!(trilha(&store).await.is_empty());
+}
+
+/// Depois da troca, as outras sessoes do usuario caem; a que fez o pedido
+/// continua de pe, senao o console se desloga no meio do proprio submit.
+#[tokio::test]
+async fn revoga_as_outras_sessoes_e_mantem_a_atual() {
+    let (router, store) = router_com_store();
+    let primeira = criar_admin(&router).await;
+    let segunda = abrir_outra_sessao(&router).await;
+    assert_ne!(primeira.token, segunda.token);
+
+    let (status, corpo, _) = post_admin(
+        &router,
+        CAMINHO,
+        Some(&segunda),
+        Some(&segunda.csrf),
+        json!({ "current_password": SENHA_INICIAL, "new_password": SENHA_NOVA }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{corpo}");
+
+    assert!(
+        sessao_valida(&store, &segunda.token).await,
+        "a sessao que pediu a troca tem de sobreviver"
+    );
+    assert!(
+        !sessao_valida(&store, &primeira.token).await,
+        "a outra sessao tem de ser revogada"
+    );
+}


### PR DESCRIPTION
## O que e

O admin nao tinha troca de senha do proprio usuario: nem rota, nem UI. A unica
forma de trocar a senha de um admin era abrir o `admin.db` e rodar SQL na mao —
e, como o hash e PBKDF2 com salt, nao tem como fazer isso de cabeca, entao na
pratica a senha ficava a que o setup gerou. Este PR fecha #1120 com a rota, o
formulario no console e auditoria nos dois caminhos.

## O que muda

**Rota** — `POST /admin/api/change-password`, montada no grupo `auth_routes` de
`admin/routes.rs`, entao herda `require_admin_auth` + `require_csrf` sem
nenhum layer novo:

1. rejeita senha nova com menos de 8 caracteres (400) antes de qualquer KDF;
2. reverifica a senha atual com o mesmo `verify_password` da `danger_zone`
   (401, `{"error": "password verification failed"}` — a string e a forma que
   a API do admin ja usa);
3. grava o novo hash e revoga as outras sessoes do usuario em UMA transacao
   SQLite (`rotate_password_and_revoke_sessions`): ou as duas coisas acontecem,
   ou nenhuma — a rota nunca responde sucesso com o hash trocado e um cookie
   roubado ainda validando. Falha na transacao vira 500 com mensagem fixa;
4. escreve auditoria em todo terminal — inclusive o de validacao; se a propria
   gravacao de auditoria falhar, o erro vai para `tracing::warn!` (nao fica
   mudo).

**UI** — pagina Account no console (sidebar, secao System), com senha atual,
senha nova e confirmacao. Valida tamanho minimo e igualdade dos campos antes
de sair o pedido. Nenhum CSS novo, nenhum CDN: `card` / `form-group` /
`btn-primary` do design language existente, e `data-testid` nos campos, que e
a convencao que o plan 0052 fixou para os specs de Playwright do admin. E a
primeira pagina de conta acessivel a qualquer papel — as telas que existiam
eram de gestao de usuarios, e essas exigem admin.

**Store** — `rotate_password_and_revoke_sessions(user_id, new_password,
keep_token)`, transacao unica (`unchecked_transaction`, mesmo padrao dos
metodos TOTP audited do mesmo arquivo). A sessao que fez o pedido e preservada
— revogar *todas* as sessoes deslogaria o proprio console no meio do submit —
e as outras caem junto com o hash novo, ou nada cai.

## O que NAO muda

- **O esquema de hash.** Segue o PBKDF2-HMAC-SHA256 local de
  `admin/store.rs`, 600 mil iteracoes, `ring::pbkdf2`. `garraia_auth`
  (Argon2id) nao foi puxado para ca de proposito: ele e o provedor de
  identidade do workspace em Postgres, e importa-lo mudaria o esquema de
  linhas que ja existem no `admin.db` de todo mundo.
- Nenhuma migration.
- Nenhum formato de resposta novo: `{"ok": true}` / `{"error": ...}`, como o
  resto da API do admin.

## Riscos para revisao

1. **Sem rate limit dedicado.** O sub-router do admin nao tem rate limit
   proprio; o freio e o `GovernorLayer` per-IP do gateway inteiro
   (`rate_limit` da config, default 1 req/s burst 60), que tambem cobre esta
   rota, mais o custo de 600 mil iteracoes de PBKDF2 por tentativa com a
   senha atual errada — o mesmo custo e a mesma superficie da `danger_zone`
   pre-existente. Lockout por usuario e o #1140, fora do escopo.
2. **`verify_password` tambem atualiza `last_login`.** E o efeito colateral do
   helper existente (ele faz o `UPDATE ... last_login` no caminho de sucesso).
   Mantive: reescrever so para esta rota abriria uma segunda copia da
   verificacao, que e justamente o tipo de coisa que este PR esta tirando do
   caminho. Trocar senha vai aparecer como login na coluna `last_login`.
3. **A falha de gravacao devolve mensagem fixa** (`"failed to update password"`)
   com o detalhe do SQLite indo so para `tracing::error!`. Outras rotas do
   admin devolvem o texto do erro; aqui preferi nao ecoar mensagem de banco
   numa resposta de auth.

## Verificacao

- 6 testes de integracao novos em
  `crates/garraia-gateway/tests/admin_change_password.rs`, contra o
  `build_router` de verdade (nao um router de mentira): caminho feliz com
  prova de que a senha mudou (`verify_password` no store, nao so o status),
  senha atual errada, senha nova curta, sem sessao (401), sem CSRF (403) e
  revogacao das outras sessoes com a atual preservada. Cada teste de falha
  tambem confere que a senha antiga continua valendo e que a auditoria saiu
  com o `outcome` certo.

## Trilha de auditoria da esteira (gates independentes)

- security-auditor (gpt-5.6-luna): FAIL no primeiro head (revogacao
  best-effort pos-commit, HIGH) → transacao atomica no 6f429d4 → PASS
  (6f429d4) → PASS (85c00a7).
- code-reviewer (gpt-5.6-luna): FAIL no 6f429d4 (auditoria descartando erro
  com `let _ =`) → log explicito no 85c00a7 → PASS (85c00a7).
- test-engineer (deepseek-v4-flash): PASS / MERGE_READY no 85c00a7, com dois
  gaps anotados como nao-bloqueantes (sem spec Playwright da pagina Account —
  a logica critica ja esta coberta por integracao HTTP; falha de I/O dentro
  da transacao e falha de gravacao de auditoria nao sao forcaveis por HTTP).
  Evidencia local: 6/6 nos tres heads (4.15s / 4.03s / 3.98s), fmt limpo; CI
  26/26 nos tres SOs no head final.

Closes #1120

🤖 Generated with [Claude Code](https://claude.com/claude-code)
