### PR TITLE
fix(agents): aspas na description do test-engineer corrigem o YAML (#1107)

### DIFF
--- a/.claude/agents/test-engineer.md
+++ b/.claude/agents/test-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: test-engineer
-description: Engenheiro de QA do GarraRUST. Prova independentemente que uma mudança funciona e não introduziu regressão: roda fmt/check/clippy/test, escreve teste de regressão e caça edge cases. Use após qualquer implementação. Não confia no relatório do Implementer.
+description: "Engenheiro de QA do GarraRUST. Prova independentemente que uma mudança funciona e não introduziu regressão: roda fmt/check/clippy/test, escreve teste de regressão e caça edge cases. Use após qualquer implementação. Não confia no relatório do Implementer."
 model: deepseek/deepseek-v4-flash-0731
 ---
 

--- a/changelog.d/fixed/1107-test-engineer-yaml.md
+++ b/changelog.d/fixed/1107-test-engineer-yaml.md
@@ -1,0 +1,5 @@
+- A description do agente test-engineer no frontmatter do `.claude/agents`
+  passou a virar string entre aspas. O texto contem "regressao: roda", e o
+  dois-pontos sem aspas quebrava o parse do YAML inteiro — o agente nao
+  carregava em sessao nova nenhuma, e a equipe rodava com 6 dos 7 papeis,
+  sem o Tester (#1107).


### PR DESCRIPTION
## O que estava errado

O frontmatter de `.claude/agents/test-engineer.md` não parseava: a
`description` (linha 3) estava sem aspas e contém `regressão: roda fmt/...`
— o `: ` dentro do scalar faz o YAML devolver *mapping values are not
allowed here*. Frontmatter inválido = agente que não carrega: a equipe
rodava com 6 dos 7 papéis, sem o **Tester**. Era o único arquivo quebrado
dos sete, introduzido no #1107.

## A correção

Uma linha — a `description` vira string entre aspas; o texto em si fica
idêntico. Os sete frontmatters agora parseiam com `yaml.safe_load`, e os
modelos conferem com o roster (coordinator = hy4; analyst/tester/doc =
deepseek-v4-flash; implementer = glm-5.3-flash; reviewer/security =
gpt-5.6-luna).

Nenhum arquivo de crate é tocado — sem impacto em código Rust.

## Verificação

- `yaml.safe_load` sobre os 7 `.claude/agents/*.md` → todos `OK` (rodado
  antes e depois da correção; antes, exatamente este arquivo falhava)
- `python3 scripts/changelog/assemble.py --check` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
