### PR TITLE
fix(webchat): o 401 reexibe o painel direito escondido pelo router

### DIFF
--- a/changelog.d/fixed/1116-em-breve-e-401.md
+++ b/changelog.d/fixed/1116-em-breve-e-401.md
@@ -9,4 +9,6 @@
   pelos loaders. No caso 401 - o frequente, quando `gateway.api_key` esta
   ligada e o navegador nao tem chave salva - a mensagem aponta para o form
   "Gateway Authentication" do painel direito e o revela, em vez de mandar
-  recarregar a pagina.
+  recarregar a pagina. Como o roteador esconde o painel direito nas paginas
+  nao-chat, o reveal do 401 traz o painel de volta junto - exibir so o form
+  nao valia nada com o ancestral escondido.

--- a/crates/garraia-gateway/src/webchat.html
+++ b/crates/garraia-gateway/src/webchat.html
@@ -3334,7 +3334,14 @@ function renderFetchError(el, status, label, colspan) {
   const hint = code === 401
     ? ' A chave do gateway não foi aceita. Informe-a em <strong>Gateway Authentication</strong>, no painel direito, e clique em Connect.'
     : ' Recarregue a página; se o erro persistir, veja os detalhes em Diagnostics.';
-  if (code === 401 && authSection) authSection.style.display = 'block';
+  if (code === 401 && authSection) {
+    authSection.style.display = 'block';
+    // O router esconde o painel direito nas páginas não-chat (setPage) para
+    // cortar ruído visual — mas o 401 é exatamente o caso em que ele precisa
+    // voltar: o form de gateway key que resolve o erro vive dentro dele.
+    const rp = document.getElementById('right-panel');
+    if (rp) rp.style.display = '';
+  }
   const box = '<div class="warning-box">Falha ao carregar ' + escapeHtml(label) +
     ' (HTTP ' + code + ').' + hint + '</div>';
   el.innerHTML = colspan > 0 ? '<tr><td colspan="' + colspan + '">' + box + '</td></tr>' : box;


### PR DESCRIPTION
## Contexto

O #1134 entrou no main (5ff9b57) com o job Playwright vermelho: 1 teste falhando, `webchat-redesign.spec.ts:320` ("a 401 tells the user to fill in the gateway key and reveals the form"), `toBeVisible` no `#auth-section` — `hidden` com o locator resolvendo 14×. Follow-up do #1116 (fechado pelo merge do #1134).

## Causa raiz

O roteador (`setPage` no `webchat.html`) esconde o painel direito inteiro em toda página não-chat:

```js
if (name === 'chat') { rp.style.display = ''; }
else { rp.style.display = 'none'; }
```

O `#auth-section` vive **dentro** de `#right-panel`. O reveal do 401 (`renderFetchError`) só setava `display='block'` no filho — com o ancestral escondido, o form nunca fica visível e o usuário vê o erro "HTTP 401 ... Informe-a em Gateway Authentication" apontando para um painel que não está lá. O teste pegou um bug de UX real, não um problema de teste.

## Fix

O reveal do 401 também limpa o `display` do painel (`webchat.html:3337`), trazendo o painel de volta junto com o form. Fragmento `changelog.d/fixed/1116-em-breve-e-401.md` atualizado para descrever o comportamento.

## Evidência (red-green local, gateway real)

Reproduzido localmente contra um gateway real servindo a página do branch (o `web_chat()` lê o HTML do disco relativo ao cwd — verificar marcadores na página servida antes de confiar):

- **RED** (head 77352eb, pré-fix): mesma assinatura do CI — `1 failed`, `toBeVisible` hidden, 14× locator resolved, linha 340.
- **GREEN** (com este fix): `1 passed` em 590ms; a suite Playwright local fica com **39 passed** e as únicas quedas são os 9 do `mcp-manager.spec.ts`, que dependem do Postgres do CI (`GARRAIA_LOGIN_DATABASE_URL`, serviço `postgres:16.8-alpine` no `ci.yml:1019-1044`) — no CI do 77352eb eles passaram (47/48, a única falha era exatamente este teste; job 102832849017).

⚠️ Enquanto este PR não entra, **todo PR que fizer update-branch do main carrega este teste quebrado** no job Playwright — é o bloqueador crítico da fila.

## Gates

- [ ] CI verde (head 40151c5)
- [ ] security-auditor
- [ ] test-engineer
- [ ] code-reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)
