### PR TITLE
fix(admin): lockout de TOTP duravel e segredo cifrado (#1140, #1141)

### DIFF
--- a/changelog.d/security/1140-lockout-totp-duravel.md
+++ b/changelog.d/security/1140-lockout-totp-duravel.md
@@ -1,0 +1,12 @@
+- **O lockout de TOTP do painel admin virou duravel (#1140).** A contagem de
+  codigos errados (5 em 15 minutos) vivia num `HashMap` dentro do processo:
+  reiniciar o gateway, atingir outra instancia ou usar processos
+  independentes zerava o contador e devolvia o brute force de um codigo de 6
+  digitos a quem ja tinha a senha. Agora ela mora na tabela `totp_attempts`
+  do `admin.db`, com limpeza da janela expirada na mesma transacao em que
+  conta — duas instancias sobre o mesmo banco compartilham um so orcamento
+  de tentativas. Contagem ilegivel virou recusa fechada (500) em vez de "nao
+  esgotou", e uma tentativa avaliada que nao consegue ser registrada tambem
+  recusa: um chute de graca era o mesmo buraco por outro caminho. O custo
+  aceito e o inverso do anterior: o dono espera a janela de 15 minutos, sem
+  atalho por restart.

--- a/changelog.d/security/1141-totp-secret-cifrado.md
+++ b/changelog.d/security/1141-totp-secret-cifrado.md
@@ -1,0 +1,11 @@
+- **O segredo TOTP do painel admin passa a ser cifrado no `admin.db`
+  (#1141).** Ele ficava em claro (base32) na coluna `admin_users.totp_secret`
+  e agora e gravado em `totp_secret_enc`/`totp_secret_nonce` com AES-256-GCM
+  sob a chave mestra do painel — a mesma que `admin/secrets.rs` ja usa para
+  as chaves de provider no mesmo arquivo. Isso tira o comprometimento
+  **duravel** do 2FA: o segredo em claro sobrevivia a expiracao da sessao e a
+  troca de senha. Banco existente migra sozinho na primeira leitura (lazy
+  upgrade forward-only, que zera a coluna antiga) — nao ha passo de operador.
+  Decifrar falhando e indisponibilidade, nao "2FA desligado": trocar a chave
+  mestra sem re-cifrar recusa o login em vez de abrir o painel so com a
+  senha.

--- a/changelog.d/security/1141-totp-secret-cifrado.md
+++ b/changelog.d/security/1141-totp-secret-cifrado.md
@@ -9,3 +9,13 @@
   Decifrar falhando e indisponibilidade, nao "2FA desligado": trocar a chave
   mestra sem re-cifrar recusa o login em vez de abrir o painel so com a
   senha.
+- **O re-key da chave mestra do painel passa a levar o segredo do 2FA junto
+  (#1141).** Cifrar o segredo criou uma dependencia da chave mestra que a
+  rotacao de parametros KDF nao conhecia: ela re-cifrava `secrets` e
+  `secret_versions` e deixava `admin_users.totp_secret_enc` sob a chave
+  antiga, o que virava HTTP 500 permanente no login de todo admin com 2FA
+  ligado. As colunas do 2FA entram na mesma transacao do re-key, e um
+  segredo que nao decifra com a chave legada aborta o re-key inteiro em vez
+  de gravar parametros que nao abrem nada. Um `master.key` ilegivel tambem
+  deixou de ser substituido em silencio: ele e preservado como
+  `master.key.unreadable` com aviso no log.

--- a/crates/garraia-gateway/src/admin/handlers.rs
+++ b/crates/garraia-gateway/src/admin/handlers.rs
@@ -67,7 +67,7 @@ pub async fn login(
     Json(body): Json<LoginRequest>,
 ) -> impl IntoResponse {
     let ip = extract_ip(&headers, None);
-    let mut guard = state.store.lock().await;
+    let guard = state.store.lock().await;
 
     let user = match guard.verify_password(&body.username, &body.password) {
         Some(u) => u,
@@ -143,24 +143,47 @@ pub async fn login(
             }
         };
 
-        if guard.totp_attempts_exhausted(&user.id) {
-            log_auth_failure(
-                &guard,
-                Some(&user.id),
-                Some(&user.username),
-                "login",
-                "too many totp attempts",
-                ip.as_deref(),
-            );
-            drop(guard);
-            return (
-                StatusCode::TOO_MANY_REQUESTS,
-                HeaderMap::new(),
-                Json(serde_json::json!({
-                    "error": "too many totp attempts",
-                    "totp_required": true,
-                })),
-            );
+        // Contagem ilegivel recusa fechado, como o gate de estado acima:
+        // tratar "nao consegui contar" como "ainda pode tentar" devolveria o
+        // brute force do segundo fator a quem derruba a leitura (#1140).
+        match guard.totp_attempts_exhausted(&user.id) {
+            Ok(false) => {}
+            Ok(true) => {
+                log_auth_failure(
+                    &guard,
+                    Some(&user.id),
+                    Some(&user.username),
+                    "login",
+                    "too many totp attempts",
+                    ip.as_deref(),
+                );
+                drop(guard);
+                return (
+                    StatusCode::TOO_MANY_REQUESTS,
+                    HeaderMap::new(),
+                    Json(serde_json::json!({
+                        "error": "too many totp attempts",
+                        "totp_required": true,
+                    })),
+                );
+            }
+            Err(e) => {
+                tracing::warn!("admin login: totp attempt counter unreadable: {e}");
+                log_auth_failure(
+                    &guard,
+                    Some(&user.id),
+                    Some(&user.username),
+                    "login",
+                    "totp attempt counter unreadable",
+                    ip.as_deref(),
+                );
+                drop(guard);
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    HeaderMap::new(),
+                    Json(serde_json::json!({"error": "internal error"})),
+                );
+            }
         }
 
         // Segredo ausente, vazio ou ilegivel com 2FA ligado: `disable_totp`
@@ -169,7 +192,7 @@ pub async fn login(
         // resposta honesta e a mesma do gate de estado acima: recusa sem
         // abrir sessao. Erro de leitura nao pode virar "codigo invalido"
         // (#1121, pass-3).
-        let secret = match guard.get_totp_secret(&user.id) {
+        let secret = match guard.get_totp_secret(&user.id, &state.encryption_key) {
             Ok(Some(s)) if !s.is_empty() => s,
             Ok(_) => {
                 tracing::warn!("admin login: 2FA enabled but secret missing");
@@ -207,7 +230,26 @@ pub async fn login(
             }
         };
         let ok = crate::totp::verify_totp(&secret, code);
-        guard.record_totp_attempt(&user.id, ok);
+        // Registrar antes de responder, e recusar se nao der: um codigo
+        // avaliado que nao entra na contagem e uma tentativa de graca — nem
+        // a certa, que abriria sessao sem zerar o contador (#1140).
+        if let Err(e) = guard.record_totp_attempt(&user.id, ok) {
+            tracing::warn!("admin login: failed to record totp attempt: {e}");
+            log_auth_failure(
+                &guard,
+                Some(&user.id),
+                Some(&user.username),
+                "login",
+                "totp attempt not recorded",
+                ip.as_deref(),
+            );
+            drop(guard);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                HeaderMap::new(),
+                Json(serde_json::json!({"error": "internal error"})),
+            );
+        }
 
         if !ok {
             log_auth_failure(

--- a/crates/garraia-gateway/src/admin/shared.rs
+++ b/crates/garraia-gateway/src/admin/shared.rs
@@ -256,6 +256,27 @@ fn master_key_file_keys() -> AdminKeys {
         };
     }
 
+    // Chegar aqui com o arquivo EXISTINDO significa que ele esta ilegivel ou
+    // com tamanho errado, e a chave nova logo abaixo vai substitui-lo. Antes
+    // do #1141 isso custava as chaves de provider; agora custa tambem o
+    // segredo do 2FA de todo admin que tem 2FA ligado — o login passa a
+    // responder 500 e o dono so volta pelo break-glass de `docs/security.md`.
+    // Guardar o arquivo antigo em vez de sobrescrever nao recupera a chave
+    // (32 bytes truncados nao voltam), mas tira o "silenciosamente": o
+    // operador ve o aviso e encontra o arquivo preservado ao lado.
+    if key_path.exists() {
+        let preservado = key_path.with_extension("key.unreadable");
+        let movido = std::fs::rename(&key_path, &preservado).is_ok();
+        warn!(
+            preserved = movido,
+            "admin master.key exists but is unreadable or has the wrong length; \
+             generating a new one. Every secret encrypted under the old key — \
+             provider keys AND admin 2FA secrets — becomes unreadable. Admins \
+             with 2FA will get HTTP 500 on login until the second factor is \
+             cleared; see docs/security.md"
+        );
+    }
+
     // The `.expect` predates this change: the function returns `AdminKeys`,
     // not `Result`, so propagating would mean changing the signature and its
     // callers. Without entropy there is no key to hand back either way.
@@ -327,6 +348,11 @@ pub fn resolve_admin_encryption_key(store: &mut AdminStore) -> Vec<u8> {
 /// Re-encrypt every stored admin secret under `keys.current`, then persist the
 /// new KDF parameters.
 ///
+/// "Every stored secret" includes the panel's TOTP secrets
+/// (`admin_users.totp_secret_enc`) since #1141 — they are under the same
+/// master key, and a row left behind by a re-key is an owner locked out of
+/// the console, not just an unreadable credential.
+///
 /// Forward-only and fail-closed:
 ///
 /// * every ciphertext is decrypted with the legacy key and re-encrypted with
@@ -347,6 +373,7 @@ fn migrate_admin_secrets_kdf(store: &mut AdminStore, keys: &AdminKeys) -> Result
 
     let secrets = store.secret_ciphertexts()?;
     let versions = store.secret_version_ciphertexts()?;
+    let totp_secrets = store.totp_secret_ciphertexts()?;
 
     let mut new_secrets = Vec::with_capacity(secrets.len());
     for (id, encrypted, nonce) in &secrets {
@@ -367,6 +394,21 @@ fn migrate_admin_secrets_kdf(store: &mut AdminStore, keys: &AdminKeys) -> Result
         new_versions.push((*id, re_encrypted, new_nonce));
     }
 
+    // The panel's 2FA secret is encrypted under this same master key since
+    // #1141, so it re-keys with everything else. Leaving it behind would not
+    // lose a provider credential — it would lock the owner out of the console:
+    // `get_totp_secret` would return `Err` under the new key and the login
+    // would answer 500 forever, with no recovery code to fall back on.
+    let mut new_totp = Vec::with_capacity(totp_secrets.len());
+    for (user_id, encrypted, nonce) in &totp_secrets {
+        let plaintext = super::secrets::decrypt_value(encrypted, nonce, legacy).map_err(|e| {
+            format!("totp secret for user {user_id} does not decrypt with the legacy key: {e}")
+        })?;
+        let (re_encrypted, new_nonce) = super::secrets::encrypt_value(&plaintext, &keys.current)
+            .map_err(|e| format!("failed to re-encrypt totp secret for user {user_id}: {e}"))?;
+        new_totp.push((user_id.clone(), re_encrypted, new_nonce));
+    }
+
     // Ciphertexts and the parameters that describe them land together or not at
     // all. An earlier revision committed the SQL and then wrote a `kdf.json`;
     // a crash or a failed write in between left the data under a key nothing
@@ -374,6 +416,7 @@ fn migrate_admin_secrets_kdf(store: &mut AdminStore, keys: &AdminKeys) -> Result
     let rekeyed = store.apply_secret_rekey(
         &new_secrets,
         &new_versions,
+        &new_totp,
         &(params.version, params.salt.clone(), params.iterations.get()),
     )?;
 
@@ -497,6 +540,83 @@ mod tests {
         let next_boot = derive_with_passphrase(Some(recorded), PASS);
         assert_eq!(next_boot.current, keys.current);
         assert!(!next_boot.migration_pending());
+    }
+
+    // ── #1141: o segredo do 2FA entra no re-key da chave mestra ──────────
+
+    /// O buraco que a revisao deste PR pegou: cifrar o segredo do 2FA criou
+    /// uma dependencia da chave mestra que a rotacao de KDF nao conhecia. Se
+    /// o re-key re-cifrasse so `secrets`/`secret_versions`, o segredo do
+    /// segundo fator ficaria sob a chave antiga enquanto o processo passa a
+    /// usar a nova — `get_totp_secret` viraria `Err` e o login do dono
+    /// responderia 500 para sempre, sem recovery code para sair.
+    #[test]
+    fn migration_reencrypts_the_admin_totp_secret_too() {
+        let mut store = AdminStore::in_memory().expect("in-memory store");
+        let keys = pending_keys(PASS);
+        let legacy = keys.legacy.clone().expect("legacy key");
+        let user = store
+            .create_user("dono", "senha", super::super::rbac::Role::Admin)
+            .expect("usuario");
+
+        // Estado de uma instalacao legada: o segredo do 2FA cifrado sob a
+        // chave derivada do salt compartilhado.
+        store
+            .set_pending_totp_secret(&user.id, "JBSWY3DPEHPK3PXP", &legacy)
+            .expect("segredo sob a chave legada");
+        store.enable_totp(&user.id).expect("2fa ligado");
+
+        migrate_admin_secrets_kdf(&mut store, &keys).expect("migration");
+
+        // Depois do re-key o segredo tem que abrir com a chave NOVA — que e a
+        // que o processo passa a usar a partir daqui.
+        assert_eq!(
+            store
+                .get_totp_secret(&user.id, &keys.current)
+                .expect("segredo legivel sob a chave nova")
+                .as_deref(),
+            Some("JBSWY3DPEHPK3PXP"),
+            "o re-key tem que levar o segredo do 2FA junto, senao o dono fica \
+             trancado fora do painel"
+        );
+        assert!(
+            store.get_totp_secret(&user.id, &legacy).is_err(),
+            "a chave legada nao pode mais abrir o segredo"
+        );
+    }
+
+    /// Fail-closed tambem no lado do 2FA: um segredo TOTP que nao abre com a
+    /// chave legada aborta o re-key inteiro, sem gravar `kdf_params`. Gravar
+    /// parametros de uma chave que nao abre esse segredo transformaria uma
+    /// inconsistencia recuperavel (ainda da para rodar na legada) em perda
+    /// definitiva.
+    #[test]
+    fn a_totp_secret_that_does_not_decrypt_aborts_the_rekey() {
+        let mut store = AdminStore::in_memory().expect("in-memory store");
+        let keys = pending_keys(PASS);
+        let user = store
+            .create_user("dono", "senha", super::super::rbac::Role::Admin)
+            .expect("usuario");
+
+        let unrelated = vec![5u8; MASTER_KEY_LEN];
+        store
+            .set_pending_totp_secret(&user.id, "JBSWY3DPEHPK3PXP", &unrelated)
+            .expect("segredo sob uma chave alheia");
+
+        let err = migrate_admin_secrets_kdf(&mut store, &keys).expect_err("must refuse");
+        assert!(err.contains("totp secret"), "{err}");
+        assert!(
+            store.kdf_params().is_none(),
+            "params nao podem ser gravados quando o re-key falhou"
+        );
+        assert_eq!(
+            store
+                .get_totp_secret(&user.id, &unrelated)
+                .expect("segredo intacto")
+                .as_deref(),
+            Some("JBSWY3DPEHPK3PXP"),
+            "o ciphertext tem que ficar byte-identico"
+        );
     }
 
     #[test]

--- a/crates/garraia-gateway/src/admin/store.rs
+++ b/crates/garraia-gateway/src/admin/store.rs
@@ -2,10 +2,8 @@ use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use ring::pbkdf2;
 use rusqlite::{Connection, params};
-use std::collections::HashMap;
 use std::num::NonZeroU32;
 use std::path::Path;
-use std::time::{Duration, Instant};
 use subtle::ConstantTimeEq;
 use tracing::info;
 
@@ -26,12 +24,19 @@ const RECOVERY_CODE_LEN: usize = 32;
 /// de +-1 janela aceita 3 de cada 1e6 chutes, e `verify_totp` custa
 /// microssegundos — ao contrario da senha, que passa por 600k iteracoes de
 /// PBKDF2 e portanto ja e cara de forcar.
-const TOTP_MAX_ATTEMPTS: usize = 5;
-/// Janela da contagem acima. Reiniciar o gateway limpa a contagem junto com o
-/// travamento: e estado de processo, nao de banco, de proposito — persisti-lo
-/// deixaria um atacante capaz de travar o dono por mais tempo do que o restart
-/// resolve.
-const TOTP_ATTEMPT_WINDOW: Duration = Duration::from_secs(15 * 60);
+const TOTP_MAX_ATTEMPTS: i64 = 5;
+/// Janela da contagem acima, em segundos.
+///
+/// A contagem vive no `admin.db` (tabela `totp_attempts`), nao em memoria de
+/// processo (#1140). O comentario anterior defendia o `HashMap`: persistir
+/// deixaria um atacante travar o dono por mais tempo do que um restart
+/// resolve. A auditoria do #1137 classificou a troca como ALTO na direcao
+/// oposta e ela vale: quem restarta o gateway ja e quem opera a maquina, e
+/// **atingir outra instancia** nao exige nem isso — com a senha na mao, o
+/// segundo fator de 6 digitos voltava a ser forcavel a cada restart, o que
+/// anula o lockout inteiro. O custo aceito e o inverso: o dono espera a
+/// janela de 15 minutos, sem atalho por restart.
+const TOTP_ATTEMPT_WINDOW_SECS: i64 = 15 * 60;
 
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct AdminUser {
@@ -80,8 +85,6 @@ pub type SecretVersionCiphertext = (i64, Vec<u8>, Vec<u8>);
 
 pub struct AdminStore {
     conn: Connection,
-    /// Tentativas erradas de TOTP por usuario — ver `TOTP_MAX_ATTEMPTS`.
-    totp_attempts: HashMap<String, Vec<Instant>>,
 }
 
 impl AdminStore {
@@ -98,10 +101,7 @@ impl AdminStore {
         )
         .map_err(|e| format!("failed to set pragmas: {e}"))?;
 
-        let store = Self {
-            conn,
-            totp_attempts: HashMap::new(),
-        };
+        let store = Self { conn };
         store.run_migrations()?;
         Ok(store)
     }
@@ -113,10 +113,7 @@ impl AdminStore {
         conn.execute_batch("PRAGMA foreign_keys=ON;")
             .map_err(|e| format!("failed to set pragmas: {e}"))?;
 
-        let store = Self {
-            conn,
-            totp_attempts: HashMap::new(),
-        };
+        let store = Self { conn };
         store.run_migrations()?;
         Ok(store)
     }
@@ -228,7 +225,22 @@ impl AdminStore {
                 );
 
                 CREATE INDEX IF NOT EXISTS idx_admin_recovery_tokens_user
-                    ON admin_recovery_tokens(user_id);",
+                    ON admin_recovery_tokens(user_id);
+
+                -- #1140: lockout de TOTP duravel. Uma linha por codigo
+                -- errado; `record_totp_attempt` apaga as do usuario no
+                -- acerto e `totp_attempts_exhausted` apaga as expiradas na
+                -- mesma transacao em que conta, entao a tabela nao cresce
+                -- sem limite. Nao guarda o codigo tentado: contar basta, e
+                -- o codigo errado de hoje e vizinho do certo de amanha.
+                CREATE TABLE IF NOT EXISTS totp_attempts (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id TEXT NOT NULL,
+                    attempted_at TEXT NOT NULL DEFAULT (datetime('now'))
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_totp_attempts_user
+                    ON totp_attempts(user_id, attempted_at);",
             )
             .map_err(|e| format!("admin db migration failed: {e}"))?;
 
@@ -263,6 +275,18 @@ impl AdminStore {
             (
                 "totp_enabled",
                 "ALTER TABLE admin_users ADD COLUMN totp_enabled INTEGER NOT NULL DEFAULT 0",
+            ),
+            // #1141: o segredo cifrado (AES-256-GCM sob a chave mestra do
+            // painel) e o nonce dele. A coluna `totp_secret` em claro
+            // continua existindo so para o lazy upgrade em
+            // `get_totp_secret`: ela e zerada assim que o valor migra.
+            (
+                "totp_secret_enc",
+                "ALTER TABLE admin_users ADD COLUMN totp_secret_enc BLOB",
+            ),
+            (
+                "totp_secret_nonce",
+                "ALTER TABLE admin_users ADD COLUMN totp_secret_nonce BLOB",
             ),
         ] {
             if self.has_admin_user_column(column)? {
@@ -593,55 +617,124 @@ impl AdminStore {
     /// Segredo TOTP do usuario — tanto o pendente de confirmacao quanto o
     /// ativo. `None` tambem significa "coluna existe, valor e NULL".
     ///
-    /// O segredo fica **em claro** no `admin.db` (base32, sem cifrar). Isso e
-    /// paridade com o fluxo mobile: la o segredo tambem fica em claro
-    /// (`mobile_users.totp_secret`, TEXT, base32 sem cifrar — ver o
-    /// comentario "Estado real do segredo" em
-    /// crates/garraia-gateway/src/totp.rs). O que diferencia este lado e
-    /// que a chave existe em runtime (`AdminState::encryption_key`) e o
-    /// `admin/secrets.rs` ja cifra as chaves de provider no mesmo arquivo:
-    /// cifrar custa uma chamada e nenhuma decisao nova, e e a issue #1141.
+    /// O segredo fica **cifrado** no `admin.db` (AES-256-GCM sob a chave
+    /// mestra do painel, a mesma que `admin/secrets.rs` usa para as chaves de
+    /// provider no mesmo arquivo) — #1141. Ate o #1137 ele ficava em claro, em
+    /// paridade com o fluxo mobile (`mobile_users.totp_secret`, base32 sem
+    /// cifrar, ainda em claro hoje).
     ///
-    /// O que torna o risco aceitavel por enquanto nao e essa comparacao: e o
-    /// proprio `admin.db` ja guardar `admin_sessions.token` em texto puro, ou
-    /// seja, quem le o arquivo ja leva uma sessao de admin viva sem precisar
-    /// do segundo fator. O segredo em claro adiciona comprometimento duravel
-    /// do 2FA (sobrevive a expiracao da sessao e a troca de senha), nao uma
-    /// porta nova.
-    pub fn get_totp_secret(&self, user_id: &str) -> Result<Option<String>, String> {
-        match self.conn.query_row(
-            "SELECT totp_secret FROM admin_users WHERE id = ?1",
+    /// Isso nao troca o modelo de ameaca de lugar: quem le o arquivo continua
+    /// levando `admin_sessions.token` em texto puro, ou seja, uma sessao de
+    /// admin viva sem passar pelo segundo fator. O que a cifra tira e o
+    /// comprometimento **duravel** do 2FA — o segredo em claro sobrevivia a
+    /// expiracao da sessao e a troca de senha. Vale enquanto a chave mestra
+    /// nao estiver no mesmo lugar que o banco; ver `docs/security.md`.
+    ///
+    /// **Lazy upgrade forward-only:** um banco que vem do #1137 tem o segredo
+    /// em claro em `totp_secret`. A primeira leitura cifra o valor nas colunas
+    /// novas e zera a antiga, na mesma transacao. Falha ao migrar nao derruba
+    /// a leitura: o segredo em claro ja esta na mao e recusar o login por
+    /// causa da migracao seria trocar um risco de confidencialidade por uma
+    /// indisponibilidade — a proxima leitura tenta de novo.
+    pub fn get_totp_secret(&self, user_id: &str, key: &[u8]) -> Result<Option<String>, String> {
+        let row = match self.conn.query_row(
+            "SELECT totp_secret, totp_secret_enc, totp_secret_nonce
+             FROM admin_users WHERE id = ?1",
             params![user_id],
-            |row| row.get::<_, Option<String>>(0),
+            |row| {
+                Ok((
+                    row.get::<_, Option<String>>(0)?,
+                    row.get::<_, Option<Vec<u8>>>(1)?,
+                    row.get::<_, Option<Vec<u8>>>(2)?,
+                ))
+            },
         ) {
-            Ok(v) => Ok(v),
+            Ok(v) => v,
             // Sem linha de usuario nao e erro de leitura: e ausencia legitima
             // de segredo (pendente nunca confirmado, ou desligado). Erro real
             // de SQLite (I/O, lock, schema) e outro estado e tem que chegar
             // como `Err` no caller — quem decide o que recusar e o handler,
             // engolir aqui esconderia indisponibilidade (#1121, pass-3).
-            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
-            Err(e) => Err(format!("failed to read totp_secret for user: {e}")),
+            Err(rusqlite::Error::QueryReturnedNoRows) => return Ok(None),
+            Err(e) => return Err(format!("failed to read totp_secret for user: {e}")),
+        };
+
+        match row {
+            // Caminho normal: segredo cifrado. Decifrar falhando e erro, nao
+            // "sem segredo" — trocar a chave mestra sem re-cifrar tem que
+            // aparecer como indisponibilidade, nao como 2FA desligado.
+            (_, Some(enc), Some(nonce)) => {
+                let plain = super::secrets::decrypt_value(&enc, &nonce, key)
+                    .map_err(|e| format!("failed to decrypt totp_secret: {e}"))?;
+                let secret = String::from_utf8(plain)
+                    .map_err(|_| "totp_secret is not valid utf-8".to_string())?;
+                Ok(Some(secret))
+            }
+            // Banco anterior ao #1141: valor em claro, migra agora.
+            (Some(plaintext), _, _) if !plaintext.is_empty() => {
+                if let Err(e) = self.migrate_totp_secret_to_encrypted(user_id, &plaintext, key) {
+                    tracing::warn!("admin 2fa: lazy upgrade of totp_secret failed: {e}");
+                }
+                Ok(Some(plaintext))
+            }
+            // Cifra pela metade (`enc` sem `nonce` ou vice-versa) e estado
+            // que nenhuma escrita daqui produz — as duas colunas sempre vao
+            // juntas na mesma transacao. Devolver `None` faria o handler
+            // dizer "2FA nao configurado" para um usuario com 2FA ligado.
+            (_, Some(_), None) | (_, None, Some(_)) => {
+                Err("totp_secret ciphertext is missing its nonce".to_string())
+            }
+            _ => Ok(None),
         }
+    }
+
+    /// Cifra um segredo herdado em claro e zera a coluna antiga — as duas
+    /// coisas na mesma transacao, para nunca existir um instante com o
+    /// segredo apagado e sem substituto.
+    fn migrate_totp_secret_to_encrypted(
+        &self,
+        user_id: &str,
+        plaintext: &str,
+        key: &[u8],
+    ) -> Result<(), String> {
+        let tx = self
+            .conn
+            .unchecked_transaction()
+            .map_err(|e| format!("failed to begin transaction: {e}"))?;
+        Self::write_totp_secret_on(&tx, user_id, plaintext, key)?;
+        tx.commit()
+            .map_err(|e| format!("failed to commit totp_secret upgrade: {e}"))
     }
 
     /// Guarda o segredo como **pendente**: `totp_enabled` so vira 1 em
     /// `enable_totp`, depois de um codigo validar. Quem chama setup e nao
     /// confirma fica com um segredo inerte, nao com 2FA pela metade.
-    pub fn set_pending_totp_secret(&self, user_id: &str, secret: &str) -> Result<(), String> {
-        Self::set_pending_totp_secret_on(&self.conn, user_id, secret)
+    pub fn set_pending_totp_secret(
+        &self,
+        user_id: &str,
+        secret: &str,
+        key: &[u8],
+    ) -> Result<(), String> {
+        Self::write_totp_secret_on(&self.conn, user_id, secret, key)
     }
 
-    fn set_pending_totp_secret_on(
+    /// Escrita unica do segredo: cifra, grava `totp_secret_enc` +
+    /// `totp_secret_nonce` e **zera `totp_secret`** no mesmo UPDATE. Nenhum
+    /// caminho de escrita deixa o valor em claro para tras.
+    fn write_totp_secret_on(
         conn: &rusqlite::Connection,
         user_id: &str,
         secret: &str,
+        key: &[u8],
     ) -> Result<(), String> {
+        let (encrypted, nonce) = super::secrets::encrypt_value(secret.as_bytes(), key)
+            .map_err(|e| format!("failed to encrypt totp secret: {e}"))?;
         let affected = conn
             .execute(
-                "UPDATE admin_users SET totp_secret = ?1, updated_at = datetime('now')
-                 WHERE id = ?2",
-                params![secret, user_id],
+                "UPDATE admin_users SET totp_secret = NULL, totp_secret_enc = ?1,
+                 totp_secret_nonce = ?2, updated_at = datetime('now')
+                 WHERE id = ?3",
+                params![encrypted, nonce, user_id],
             )
             .map_err(|e| format!("failed to store totp secret: {e}"))?;
         if affected == 0 {
@@ -658,6 +751,7 @@ impl AdminStore {
         &self,
         user_id: &str,
         secret: &str,
+        key: &[u8],
         username: &str,
         ip: Option<&str>,
     ) -> Result<(), String> {
@@ -665,7 +759,7 @@ impl AdminStore {
             .conn
             .unchecked_transaction()
             .map_err(|e| format!("failed to begin transaction: {e}"))?;
-        Self::set_pending_totp_secret_on(&tx, user_id, secret)?;
+        Self::write_totp_secret_on(&tx, user_id, secret, key)?;
         Self::append_audit_on(
             &tx,
             Some(user_id),
@@ -737,7 +831,8 @@ impl AdminStore {
     fn disable_totp_on(conn: &rusqlite::Connection, user_id: &str) -> Result<(), String> {
         let affected = conn
             .execute(
-                "UPDATE admin_users SET totp_secret = NULL, totp_enabled = 0,
+                "UPDATE admin_users SET totp_secret = NULL, totp_secret_enc = NULL,
+                 totp_secret_nonce = NULL, totp_enabled = 0,
                  updated_at = datetime('now')
                  WHERE id = ?1",
                 params![user_id],
@@ -798,26 +893,61 @@ impl AdminStore {
     }
 
     /// `true` quando o usuario ja errou `TOTP_MAX_ATTEMPTS` codigos dentro da
-    /// janela. Efeito colateral: descarta as tentativas que ja expiraram, para
-    /// a contagem nao crescer sem limite.
-    pub fn totp_attempts_exhausted(&mut self, user_id: &str) -> bool {
-        let attempts = self.totp_attempts.entry(user_id.to_string()).or_default();
-        let now = Instant::now();
-        attempts.retain(|t| now.duration_since(*t) < TOTP_ATTEMPT_WINDOW);
-        attempts.len() >= TOTP_MAX_ATTEMPTS
+    /// janela. Efeito colateral: apaga as tentativas que ja expiraram, para a
+    /// tabela nao crescer sem limite.
+    ///
+    /// A assinatura e `Result` pelo mesmo motivo de `is_totp_enabled`: quem
+    /// decide autenticacao nao pode tratar "nao consegui contar" como "nao
+    /// esgotou". Todo chamador recusa fechado quando a contagem nao le.
+    ///
+    /// A limpeza e a contagem rodam na mesma transacao, entao duas instancias
+    /// contando ao mesmo tempo nao veem uma janela pela metade (#1140).
+    pub fn totp_attempts_exhausted(&self, user_id: &str) -> Result<bool, String> {
+        let tx = self
+            .conn
+            .unchecked_transaction()
+            .map_err(|e| format!("failed to begin transaction: {e}"))?;
+        tx.execute(
+            "DELETE FROM totp_attempts
+             WHERE attempted_at <= datetime('now', ?1)",
+            params![format!("-{TOTP_ATTEMPT_WINDOW_SECS} seconds")],
+        )
+        .map_err(|e| format!("failed to prune totp attempts: {e}"))?;
+        let count: i64 = tx
+            .query_row(
+                "SELECT COUNT(*) FROM totp_attempts WHERE user_id = ?1",
+                params![user_id],
+                |row| row.get(0),
+            )
+            .map_err(|e| format!("failed to count totp attempts: {e}"))?;
+        tx.commit()
+            .map_err(|e| format!("failed to commit totp attempt count: {e}"))?;
+        Ok(count >= TOTP_MAX_ATTEMPTS)
     }
 
     /// Conta uma tentativa. Sucesso zera a contagem — travar o dono que acabou
     /// de acertar o codigo seria pior que nao travar.
-    pub fn record_totp_attempt(&mut self, user_id: &str, success: bool) {
+    ///
+    /// `Result` tambem aqui: uma escrita que falha em silencio devolve o
+    /// brute force de graca (erra, o INSERT falha, a contagem nao anda). Os
+    /// chamadores recusam fechado quando nao conseguem registrar.
+    pub fn record_totp_attempt(&self, user_id: &str, success: bool) -> Result<(), String> {
         if success {
-            self.totp_attempts.remove(user_id);
-            return;
+            self.conn
+                .execute(
+                    "DELETE FROM totp_attempts WHERE user_id = ?1",
+                    params![user_id],
+                )
+                .map_err(|e| format!("failed to clear totp attempts: {e}"))?;
+            return Ok(());
         }
-        self.totp_attempts
-            .entry(user_id.to_string())
-            .or_default()
-            .push(Instant::now());
+        self.conn
+            .execute(
+                "INSERT INTO totp_attempts (user_id) VALUES (?1)",
+                params![user_id],
+            )
+            .map_err(|e| format!("failed to record totp attempt: {e}"))?;
+        Ok(())
     }
 
     // ── Session management ───────────────────────────────────────────
@@ -1701,18 +1831,24 @@ mod tests {
         store.create_user("cofre", "senha", Role::Admin).unwrap().id
     }
 
+    /// Chave AES-256 dos testes. Nao e credencial: um padrao fixo basta para
+    /// exercitar cifra e decifra — mesma escolha de `secrets.rs`.
+    fn chave_de_teste() -> [u8; 32] {
+        [7u8; 32]
+    }
+
     #[test]
     fn segredo_pendente_nao_liga_o_segundo_fator() {
         let store = test_store();
         let id = usuario_totp(&store);
 
         store
-            .set_pending_totp_secret(&id, "JBSWY3DPEHPK3PXP")
+            .set_pending_totp_secret(&id, "JBSWY3DPEHPK3PXP", &chave_de_teste())
             .unwrap();
 
         assert_eq!(
             store
-                .get_totp_secret(&id)
+                .get_totp_secret(&id, &chave_de_teste())
                 .expect("segredo legivel")
                 .as_deref(),
             Some("JBSWY3DPEHPK3PXP")
@@ -1729,7 +1865,7 @@ mod tests {
         let id = usuario_totp(&store);
 
         store
-            .set_pending_totp_secret(&id, "JBSWY3DPEHPK3PXP")
+            .set_pending_totp_secret(&id, "JBSWY3DPEHPK3PXP", &chave_de_teste())
             .unwrap();
         store.enable_totp(&id).unwrap();
         assert!(store.is_totp_enabled(&id).expect("estado 2fa legivel"));
@@ -1738,7 +1874,9 @@ mod tests {
 
         assert!(!store.is_totp_enabled(&id).expect("estado 2fa legivel"));
         assert_eq!(
-            store.get_totp_secret(&id).expect("segredo legivel"),
+            store
+                .get_totp_secret(&id, &chave_de_teste())
+                .expect("segredo legivel"),
             None,
             "segredo sobrevivente seria uma reativacao sem novo enrollment"
         );
@@ -1754,7 +1892,7 @@ mod tests {
         let store = test_store();
         let id = usuario_totp(&store);
         store
-            .set_pending_totp_secret(&id, "JBSWY3DPEHPK3PXP")
+            .set_pending_totp_secret(&id, "JBSWY3DPEHPK3PXP", &chave_de_teste())
             .unwrap();
         store.enable_totp(&id).unwrap();
 
@@ -1785,7 +1923,12 @@ mod tests {
                 .is_totp_enabled(&id)
                 .expect("usuario novo tem estado legivel")
         );
-        assert_eq!(store.get_totp_secret(&id).expect("segredo legivel"), None);
+        assert_eq!(
+            store
+                .get_totp_secret(&id, &chave_de_teste())
+                .expect("segredo legivel"),
+            None
+        );
     }
 
     /// #1121 (pass-3): erro de leitura do segredo nao e "segredo ausente" —
@@ -1797,58 +1940,305 @@ mod tests {
         let id = usuario_totp(&store);
 
         assert_eq!(
-            store.get_totp_secret(&id).expect("usuario novo e legivel"),
+            store
+                .get_totp_secret(&id, &chave_de_teste())
+                .expect("usuario novo e legivel"),
             None,
             "sem segredo guardado e um estado legitimo, nao erro"
         );
 
         store
             .conn
-            .execute("ALTER TABLE admin_users DROP COLUMN totp_secret", [])
+            .execute("ALTER TABLE admin_users DROP COLUMN totp_secret_enc", [])
             .expect("derrubar a coluna do segredo");
 
         assert!(
-            store.get_totp_secret(&id).is_err(),
+            store.get_totp_secret(&id, &chave_de_teste()).is_err(),
             "coluna sumida e erro de leitura e tem que chegar como Err"
         );
     }
 
     #[test]
     fn errar_muito_trava_e_um_acerto_zera_a_contagem() {
-        let mut store = test_store();
+        let store = test_store();
         let id = usuario_totp(&store);
 
         for _ in 0..TOTP_MAX_ATTEMPTS - 1 {
-            store.record_totp_attempt(&id, false);
+            store.record_totp_attempt(&id, false).unwrap();
         }
         assert!(
-            !store.totp_attempts_exhausted(&id),
+            !store
+                .totp_attempts_exhausted(&id)
+                .expect("contagem legivel"),
             "travar antes da ultima tentativa valida"
         );
 
-        store.record_totp_attempt(&id, false);
-        assert!(store.totp_attempts_exhausted(&id));
+        store.record_totp_attempt(&id, false).unwrap();
+        assert!(
+            store
+                .totp_attempts_exhausted(&id)
+                .expect("contagem legivel")
+        );
 
         // Acertar nao pode deixar o dono travado.
-        store.record_totp_attempt(&id, true);
-        assert!(!store.totp_attempts_exhausted(&id));
+        store.record_totp_attempt(&id, true).unwrap();
+        assert!(
+            !store
+                .totp_attempts_exhausted(&id)
+                .expect("contagem legivel")
+        );
     }
 
     #[test]
     fn a_contagem_e_por_usuario() {
-        let mut store = test_store();
+        let store = test_store();
         let a = usuario_totp(&store);
         let b = store.create_user("outro", "senha", Role::Admin).unwrap().id;
 
         for _ in 0..TOTP_MAX_ATTEMPTS {
-            store.record_totp_attempt(&a, false);
+            store.record_totp_attempt(&a, false).unwrap();
         }
 
-        assert!(store.totp_attempts_exhausted(&a));
+        assert!(store.totp_attempts_exhausted(&a).expect("contagem legivel"));
         assert!(
-            !store.totp_attempts_exhausted(&b),
+            !store.totp_attempts_exhausted(&b).expect("contagem legivel"),
             "um usuario errando nao pode travar os outros"
         );
+    }
+
+    // ── #1140: o lockout sobrevive ao processo ───────────────────────
+
+    /// O motivo da issue: com a contagem em `HashMap` de processo, quem tinha
+    /// a senha reiniciava o gateway e voltava a forcar o codigo de 6 digitos.
+    /// Reabrir o mesmo arquivo e o que um restart faz.
+    #[test]
+    fn o_lockout_sobrevive_a_reabertura_do_banco() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("admin.db");
+
+        let id = {
+            let store = AdminStore::open(&path).expect("abrir banco");
+            let id = usuario_totp(&store);
+            for _ in 0..TOTP_MAX_ATTEMPTS {
+                store.record_totp_attempt(&id, false).unwrap();
+            }
+            assert!(
+                store
+                    .totp_attempts_exhausted(&id)
+                    .expect("contagem legivel")
+            );
+            id
+        };
+
+        let reaberto = AdminStore::open(&path).expect("reabrir banco");
+        assert!(
+            reaberto
+                .totp_attempts_exhausted(&id)
+                .expect("contagem legivel"),
+            "restart nao pode zerar o lockout do segundo fator (#1140)"
+        );
+    }
+
+    /// Duas conexoes sobre o mesmo arquivo sao a aproximacao de duas
+    /// instancias do gateway: a contagem e compartilhada, entao distribuir as
+    /// tentativas entre instancias nao multiplica o orcamento de chutes.
+    #[test]
+    fn duas_instancias_compartilham_a_contagem() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("admin.db");
+
+        let uma = AdminStore::open(&path).expect("abrir banco");
+        let outra = AdminStore::open(&path).expect("abrir o mesmo banco");
+        let id = usuario_totp(&uma);
+
+        for _ in 0..TOTP_MAX_ATTEMPTS - 1 {
+            uma.record_totp_attempt(&id, false).unwrap();
+        }
+        outra.record_totp_attempt(&id, false).unwrap();
+
+        assert!(
+            uma.totp_attempts_exhausted(&id).expect("contagem legivel"),
+            "tentativa feita na outra instancia tem que contar aqui (#1140)"
+        );
+    }
+
+    /// A tabela nao pode crescer sem limite: tentativa fora da janela sai na
+    /// mesma transacao que conta.
+    #[test]
+    fn tentativa_expirada_e_apagada_e_nao_conta() {
+        let store = test_store();
+        let id = usuario_totp(&store);
+
+        for _ in 0..TOTP_MAX_ATTEMPTS {
+            store.record_totp_attempt(&id, false).unwrap();
+        }
+        assert!(
+            store
+                .totp_attempts_exhausted(&id)
+                .expect("contagem legivel")
+        );
+
+        // Envelhece as tentativas para fora da janela de 15 minutos.
+        store
+            .conn
+            .execute(
+                "UPDATE totp_attempts SET attempted_at = datetime('now', '-1 hour')",
+                [],
+            )
+            .expect("envelhecer as tentativas");
+
+        assert!(
+            !store
+                .totp_attempts_exhausted(&id)
+                .expect("contagem legivel"),
+            "tentativa fora da janela nao pode travar"
+        );
+        let restantes: i64 = store
+            .conn
+            .query_row("SELECT COUNT(*) FROM totp_attempts", [], |r| r.get(0))
+            .expect("contar linhas");
+        assert_eq!(restantes, 0, "a contagem tambem faz a limpeza");
+    }
+
+    /// Contagem ilegivel tem que chegar como `Err` — o chamador recusa
+    /// fechado. Tratar como "nao esgotou" devolveria o brute force de graca.
+    #[test]
+    fn contagem_ilegivel_e_erro_nao_zero() {
+        let store = test_store();
+        let id = usuario_totp(&store);
+
+        store
+            .conn
+            .execute("DROP TABLE totp_attempts", [])
+            .expect("derrubar a tabela de tentativas");
+
+        assert!(store.totp_attempts_exhausted(&id).is_err());
+        assert!(store.record_totp_attempt(&id, false).is_err());
+    }
+
+    // ── #1141: o segredo nao fica em claro no arquivo ────────────────
+
+    /// O nucleo da issue: quem le o `admin.db` nao pode achar o base32 do
+    /// segundo fator la dentro.
+    #[test]
+    fn o_segredo_nao_fica_em_claro_na_coluna() {
+        let store = test_store();
+        let id = usuario_totp(&store);
+        store
+            .set_pending_totp_secret(&id, "JBSWY3DPEHPK3PXP", &chave_de_teste())
+            .unwrap();
+
+        let (claro, cifrado, nonce): (Option<String>, Option<Vec<u8>>, Option<Vec<u8>>) = store
+            .conn
+            .query_row(
+                "SELECT totp_secret, totp_secret_enc, totp_secret_nonce
+                 FROM admin_users WHERE id = ?1",
+                params![id],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .expect("ler as colunas cruas");
+
+        assert_eq!(claro, None, "a coluna em claro tem que ficar vazia (#1141)");
+        let cifrado = cifrado.expect("segredo cifrado presente");
+        assert!(nonce.is_some(), "nonce gravado junto com o ciphertext");
+        assert!(
+            !cifrado.windows(16).any(|w| w == b"JBSWY3DPEHPK3PXP"),
+            "o base32 nao pode aparecer dentro do ciphertext"
+        );
+
+        // E ainda assim o segredo volta legivel para quem tem a chave.
+        assert_eq!(
+            store
+                .get_totp_secret(&id, &chave_de_teste())
+                .expect("segredo legivel")
+                .as_deref(),
+            Some("JBSWY3DPEHPK3PXP")
+        );
+    }
+
+    /// Chave errada e indisponibilidade, nao "2FA desligado": decifrar
+    /// falhando tem que chegar como `Err`, senao trocar a chave mestra sem
+    /// re-cifrar abriria o painel so com a senha.
+    #[test]
+    fn chave_errada_nao_vira_segredo_ausente() {
+        let store = test_store();
+        let id = usuario_totp(&store);
+        store
+            .set_pending_totp_secret(&id, "JBSWY3DPEHPK3PXP", &chave_de_teste())
+            .unwrap();
+
+        assert!(store.get_totp_secret(&id, &[9u8; 32]).is_err());
+    }
+
+    /// Lazy upgrade forward-only: banco vindo do #1137 tem o segredo em claro.
+    /// A primeira leitura devolve o valor **e** migra para as colunas
+    /// cifradas, zerando a antiga.
+    #[test]
+    fn segredo_herdado_em_claro_migra_na_primeira_leitura() {
+        let store = test_store();
+        let id = usuario_totp(&store);
+
+        // Estado de um banco anterior ao #1141, escrito na mao.
+        store
+            .conn
+            .execute(
+                "UPDATE admin_users SET totp_secret = ?1 WHERE id = ?2",
+                params!["JBSWY3DPEHPK3PXP", id],
+            )
+            .expect("plantar o segredo em claro");
+
+        assert_eq!(
+            store
+                .get_totp_secret(&id, &chave_de_teste())
+                .expect("segredo legivel")
+                .as_deref(),
+            Some("JBSWY3DPEHPK3PXP"),
+            "a migracao nao pode quebrar o login de quem ja tinha 2FA"
+        );
+
+        let claro: Option<String> = store
+            .conn
+            .query_row(
+                "SELECT totp_secret FROM admin_users WHERE id = ?1",
+                params![id],
+                |r| r.get(0),
+            )
+            .expect("ler a coluna em claro");
+        assert_eq!(claro, None, "a leitura tem que zerar a coluna em claro");
+
+        // E segue legivel depois da migracao, agora pelo caminho cifrado.
+        assert_eq!(
+            store
+                .get_totp_secret(&id, &chave_de_teste())
+                .expect("segredo legivel")
+                .as_deref(),
+            Some("JBSWY3DPEHPK3PXP")
+        );
+    }
+
+    /// Desligar apaga o ciphertext e o nonce junto — um dos dois sobrevivendo
+    /// seria segredo reaproveitavel depois do desligamento.
+    #[test]
+    fn desligar_apaga_ciphertext_e_nonce() {
+        let store = test_store();
+        let id = usuario_totp(&store);
+        store
+            .set_pending_totp_secret(&id, "JBSWY3DPEHPK3PXP", &chave_de_teste())
+            .unwrap();
+        store.enable_totp(&id).unwrap();
+
+        store.disable_totp(&id).unwrap();
+
+        let (enc, nonce): (Option<Vec<u8>>, Option<Vec<u8>>) = store
+            .conn
+            .query_row(
+                "SELECT totp_secret_enc, totp_secret_nonce FROM admin_users WHERE id = ?1",
+                params![id],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .expect("ler as colunas cruas");
+        assert_eq!(enc, None);
+        assert_eq!(nonce, None);
     }
 
     /// `admin_users` criada **antes** do #1121, sem as colunas de 2FA. E o
@@ -1890,11 +2280,11 @@ mod tests {
             "usuario antigo nasce com 2FA desligado"
         );
         store
-            .set_pending_totp_secret("u1", "JBSWY3DPEHPK3PXP")
+            .set_pending_totp_secret("u1", "JBSWY3DPEHPK3PXP", &chave_de_teste())
             .expect("escrever segredo");
         assert_eq!(
             store
-                .get_totp_secret("u1")
+                .get_totp_secret("u1", &chave_de_teste())
                 .expect("segredo legivel")
                 .as_deref(),
             Some("JBSWY3DPEHPK3PXP")

--- a/crates/garraia-gateway/src/admin/store.rs
+++ b/crates/garraia-gateway/src/admin/store.rs
@@ -83,6 +83,11 @@ pub type SecretCiphertext = (String, Vec<u8>, Vec<u8>);
 /// autoincrement integer rather than a uuid, hence the separate alias.
 pub type SecretVersionCiphertext = (i64, Vec<u8>, Vec<u8>);
 
+/// One encrypted admin TOTP secret for the master-key re-key:
+/// `(admin_users.id, totp_secret_enc, totp_secret_nonce)` (#1141). Shaped like
+/// `SecretCiphertext` but keyed by user, so the aliases stay separate.
+pub type TotpSecretCiphertext = (String, Vec<u8>, Vec<u8>);
+
 pub struct AdminStore {
     conn: Connection,
 }
@@ -235,7 +240,8 @@ impl AdminStore {
                 -- o codigo errado de hoje e vizinho do certo de amanha.
                 CREATE TABLE IF NOT EXISTS totp_attempts (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    user_id TEXT NOT NULL,
+                    user_id TEXT NOT NULL
+                        REFERENCES admin_users(id) ON DELETE CASCADE,
                     attempted_at TEXT NOT NULL DEFAULT (datetime('now'))
                 );
 
@@ -1226,6 +1232,35 @@ impl AdminStore {
             .map_err(|e| format!("failed to read secrets row: {e}"))
     }
 
+    /// Segredos TOTP cifrados, como `(admin_users.id, enc, nonce)` — a
+    /// entrada do 2FA do painel no re-key da chave mestra (#1141).
+    ///
+    /// Sem isto o re-key deixaria o segredo do segundo fator sob a chave
+    /// antiga enquanto o processo passa a usar a nova, e `get_totp_secret`
+    /// devolveria `Err` para sempre: login em 500 permanente, o dono trancado
+    /// fora do proprio painel. So linhas com as duas colunas preenchidas
+    /// entram — `NULL` e ausencia legitima de segredo, nao ciphertext.
+    pub fn totp_secret_ciphertexts(&self) -> Result<Vec<TotpSecretCiphertext>, String> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, totp_secret_enc, totp_secret_nonce FROM admin_users
+                 WHERE totp_secret_enc IS NOT NULL AND totp_secret_nonce IS NOT NULL",
+            )
+            .map_err(|e| format!("failed to prepare totp secrets scan: {e}"))?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Vec<u8>>(1)?,
+                    row.get::<_, Vec<u8>>(2)?,
+                ))
+            })
+            .map_err(|e| format!("failed to scan totp secrets: {e}"))?;
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("failed to read totp secret row: {e}"))
+    }
+
     /// Archived ciphertexts, as `(secret_versions.id, encrypted_value, nonce)`.
     pub fn secret_version_ciphertexts(&self) -> Result<Vec<SecretVersionCiphertext>, String> {
         let mut stmt = self
@@ -1288,6 +1323,7 @@ impl AdminStore {
         &mut self,
         secrets: &[SecretCiphertext],
         versions: &[SecretVersionCiphertext],
+        totp_secrets: &[TotpSecretCiphertext],
         kdf: &StoredKdfParams,
     ) -> Result<usize, String> {
         let (version, salt, iterations) = kdf;
@@ -1312,6 +1348,20 @@ impl AdminStore {
                     params![encrypted, nonce, id],
                 )
                 .map_err(|e| format!("failed to rekey secret version {id}: {e}"))?;
+        }
+
+        // O segredo do 2FA do painel entra na MESMA transacao (#1141): se ele
+        // ficasse sob a chave antiga enquanto `kdf_params` anuncia a nova, o
+        // login do dono viraria 500 permanente na proxima vez que ele abrisse
+        // o painel.
+        for (user_id, encrypted, nonce) in totp_secrets {
+            changed += tx
+                .execute(
+                    "UPDATE admin_users SET totp_secret_enc = ?1, totp_secret_nonce = ?2
+                     WHERE id = ?3",
+                    params![encrypted, nonce, user_id],
+                )
+                .map_err(|e| format!("failed to rekey totp secret for user {user_id}: {e}"))?;
         }
 
         tx.execute(

--- a/crates/garraia-gateway/src/admin/totp.rs
+++ b/crates/garraia-gateway/src/admin/totp.rs
@@ -24,12 +24,16 @@
 //! `GET /2fa/status` nao gera evento, como qualquer outra rota de leitura
 //! do painel.
 //!
-//! O segredo fica **em claro** no `admin.db` (base32, sem cifrar) — paridade
-//! com o fluxo mobile, que tambem armazena em claro
+//! O segredo fica **cifrado** no `admin.db` (AES-256-GCM sob a chave mestra
+//! do painel, #1141) — o fluxo mobile ainda armazena em claro
 //! (`mobile_users.totp_secret`, base32 sem cifrar; ver totp.rs, "Estado real
-//! do segredo"). A justificativa real e o proprio `admin.db` ja guardar token
-//! de sessao em texto puro; cifrar o lado admin e a issue #1141. Ver o aviso
-//! completo em `store::AdminStore::get_totp_secret`.
+//! do segredo"). O que a cifra tira e o comprometimento duravel do 2FA, nao a
+//! leitura do arquivo em si: `admin_sessions.token` continua em texto puro.
+//! Ver o aviso completo em `store::AdminStore::get_totp_secret`.
+//!
+//! O lockout de codigo errado (5 em 15 minutos) vive no banco, nao no
+//! processo (#1140): reiniciar o gateway ou atingir outra instancia nao zera
+//! mais a contagem.
 
 use axum::Json;
 use axum::extract::State;
@@ -64,16 +68,18 @@ fn unauthorized(error: &str) -> (StatusCode, Json<serde_json::Value>) {
 /// em que os caminhos divergem antes da mutacao final, que fica no handler.
 /// Toda recusa devolve a resposta HTTP pronta com a trilha best-effort ja
 /// gravada (#1121).
+#[allow(clippy::too_many_arguments)]
 fn exigir_codigo_valido(
-    guard: &mut AdminStore,
+    guard: &AdminStore,
     user_id: &str,
     username: &str,
     acao: &str,
     ausencia: &str,
     code: &str,
+    key: &[u8],
     ip: Option<&str>,
 ) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
-    let secret = match guard.get_totp_secret(user_id) {
+    let secret = match guard.get_totp_secret(user_id, key) {
         Ok(Some(s)) if !s.is_empty() => s,
         Ok(None) => {
             // Recusa tambem e evento de auditoria — operacao fora de ordem
@@ -122,23 +128,59 @@ fn exigir_codigo_valido(
         }
     };
 
-    if guard.totp_attempts_exhausted(user_id) {
+    // Contagem ilegivel nao vira "ainda pode tentar": seria devolver o brute
+    // force de graca a quem consegue derrubar a leitura (#1140).
+    match guard.totp_attempts_exhausted(user_id) {
+        Ok(false) => {}
+        Ok(true) => {
+            log_auth_failure(
+                guard,
+                Some(user_id),
+                Some(username),
+                acao,
+                "too many attempts",
+                ip,
+            );
+            return Err((
+                StatusCode::TOO_MANY_REQUESTS,
+                Json(serde_json::json!({"error": "too many attempts"})),
+            ));
+        }
+        Err(e) => {
+            tracing::warn!("admin {acao}: attempt counter unreadable: {e}");
+            log_auth_failure(
+                guard,
+                Some(user_id),
+                Some(username),
+                acao,
+                "totp attempt counter unreadable",
+                ip,
+            );
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "internal error"})),
+            ));
+        }
+    }
+
+    let ok = crate::totp::verify_totp(&secret, code);
+    // Registrar antes de responder, e recusar se nao der: um codigo avaliado
+    // que nao entra na contagem e uma tentativa de graca (#1140).
+    if let Err(e) = guard.record_totp_attempt(user_id, ok) {
+        tracing::warn!("admin {acao}: failed to record attempt: {e}");
         log_auth_failure(
             guard,
             Some(user_id),
             Some(username),
             acao,
-            "too many attempts",
+            "totp attempt not recorded",
             ip,
         );
         return Err((
-            StatusCode::TOO_MANY_REQUESTS,
-            Json(serde_json::json!({"error": "too many attempts"})),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "internal error"})),
         ));
     }
-
-    let ok = crate::totp::verify_totp(&secret, code);
-    guard.record_totp_attempt(user_id, ok);
 
     if !ok {
         log_auth_failure(
@@ -267,6 +309,7 @@ pub async fn totp_setup(
     if let Err(e) = guard.set_pending_totp_secret_audited(
         &admin.user_id,
         &secret,
+        &state.encryption_key,
         &admin.username,
         ip.as_deref(),
     ) {
@@ -303,15 +346,16 @@ pub async fn totp_verify(
     Json(req): Json<TotpCodeRequest>,
 ) -> impl IntoResponse {
     let ip = extract_ip(&headers, None);
-    let mut guard = state.store.lock().await;
+    let guard = state.store.lock().await;
 
     if let Err(resp) = exigir_codigo_valido(
-        &mut guard,
+        &guard,
         &admin.user_id,
         &admin.username,
         "2fa.verify",
         "2fa not set up",
         &req.code,
+        &state.encryption_key,
         ip.as_deref(),
     ) {
         drop(guard);
@@ -349,15 +393,16 @@ pub async fn totp_disable(
     Json(req): Json<TotpCodeRequest>,
 ) -> impl IntoResponse {
     let ip = extract_ip(&headers, None);
-    let mut guard = state.store.lock().await;
+    let guard = state.store.lock().await;
 
     if let Err(resp) = exigir_codigo_valido(
-        &mut guard,
+        &guard,
         &admin.user_id,
         &admin.username,
         "2fa.disable",
         "2fa not enabled",
         &req.code,
+        &state.encryption_key,
         ip.as_deref(),
     ) {
         drop(guard);

--- a/crates/garraia-gateway/tests/admin_totp_login.rs
+++ b/crates/garraia-gateway/tests/admin_totp_login.rs
@@ -30,6 +30,10 @@ use tokio::sync::Mutex;
 use tower::ServiceExt;
 
 const USUARIO: &str = "dono";
+/// A mesma chave mestra que `cenario`/`cenario_arquivo` passam ao router: o
+/// segredo do 2FA e cifrado com ela desde o #1141, entao ligar o 2FA "por
+/// dentro" tem que usar a chave que os handlers vao usar para ler.
+const CHAVE: [u8; 32] = [0u8; 32];
 const SENHA: &str = "senha-do-painel-de-teste";
 
 /// `(status, corpo, valor do cookie de sessao, se vier)`
@@ -135,7 +139,7 @@ async fn ligar_2fa(store: &Arc<Mutex<AdminStore>>) -> String {
         .expect("usuario de teste existe");
     let secret = garraia_gateway::totp::generate_totp_secret().expect("segredo");
     guard
-        .set_pending_totp_secret(&user.id, &secret)
+        .set_pending_totp_secret(&user.id, &secret, &CHAVE)
         .expect("segredo pendente");
     guard.enable_totp(&user.id).expect("2fa ligado");
     drop(guard);
@@ -214,6 +218,64 @@ async fn tantas_tentativas_erradas_travam_o_segundo_fator() {
         StatusCode::TOO_MANY_REQUESTS,
         "sem travamento, o segundo fator e forcavel por forca bruta"
     );
+}
+
+/// #1140: o travamento sobrevive ao restart do gateway.
+///
+/// Este e o teste que o lockout em `HashMap` de processo nao passava: quem
+/// tinha a senha derrubava o gateway, subia de novo e voltava a ter as cinco
+/// tentativas de um codigo de 6 digitos. Aqui o "restart" e montar um router
+/// novo sobre uma `AdminStore` nova aberta no MESMO arquivo — a contagem
+/// continua sendo a mesma porque mora no `admin.db`.
+///
+/// O mesmo caminho cobre a outra metade do finding: duas instancias sobre o
+/// mesmo banco compartilham a contagem, entao distribuir as tentativas entre
+/// elas nao multiplica o orcamento de chutes.
+#[tokio::test]
+async fn o_travamento_sobrevive_ao_restart_do_gateway() {
+    let dir = tempfile::tempdir().expect("diretorio temporario");
+    let (router, store, path) = cenario_arquivo(&dir);
+    let secret = ligar_2fa(&store).await;
+
+    for _ in 0..6 {
+        let (_, _, _) = login(
+            &router,
+            json!({"username": USUARIO, "password": SENHA, "totp_code": "000000"}),
+        )
+        .await;
+    }
+    drop(router);
+    drop(store);
+
+    // O restart: processo novo, store nova, mesmo arquivo.
+    let reaberta = AdminStore::open(&path).expect("reabrir o admin.db");
+    let config = AppConfig::default();
+    let state = Arc::new(AppState::new(
+        config,
+        Arc::new(AgentRuntime::new()),
+        ChannelRegistry::new(),
+    ));
+    let novo_router = build_router(
+        state,
+        PushChannelStates::empty(),
+        Arc::new(Mutex::new(reaberta)),
+        Arc::new(CHAVE.to_vec()),
+    );
+
+    // Codigo CERTO depois do restart: se o travamento tivesse zerado, isto
+    // abriria sessao — e era assim que o brute force voltava a ser barato.
+    let code = garraia_gateway::totp::current_code(&secret).expect("codigo atual");
+    let (status, json, sessao) = login(
+        &novo_router,
+        json!({"username": USUARIO, "password": SENHA, "totp_code": code}),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::TOO_MANY_REQUESTS,
+        "restart nao pode zerar o lockout do segundo fator (#1140): {json}"
+    );
+    assert!(sessao.is_none(), "travado nao abre sessao");
 }
 
 /// O enrollment por HTTP: setup devolve um segredo pendente, e ele so passa a
@@ -379,7 +441,7 @@ async fn segredo_ilegivel_recusa_sem_mentir_sobre_o_estado() {
     let secret = ligar_2fa(&store).await;
 
     let conn = rusqlite::Connection::open(&path).expect("segunda conexao");
-    conn.execute("ALTER TABLE admin_users DROP COLUMN totp_secret", [])
+    conn.execute("ALTER TABLE admin_users DROP COLUMN totp_secret_enc", [])
         .expect("derrubar a coluna do segredo");
     drop(conn);
 
@@ -425,7 +487,7 @@ async fn segredo_ilegivel_nos_endpoints_de_enrollment_e_500_nao_400() {
     );
 
     let conn = rusqlite::Connection::open(&path).expect("segunda conexao");
-    conn.execute("ALTER TABLE admin_users DROP COLUMN totp_secret", [])
+    conn.execute("ALTER TABLE admin_users DROP COLUMN totp_secret_enc", [])
         .expect("derrubar a coluna do segredo");
     drop(conn);
 
@@ -461,13 +523,16 @@ async fn segredo_ilegivel_nos_endpoints_de_enrollment_e_500_nao_400() {
     assert_eq!(json["enabled"], false);
 }
 
-/// #1121 (pass-4): segredo VAZIO com 2FA ligado e estado inconsistente —
-/// corrupcao manual, migration defeituosa. Nenhum dos dois caminhos pode
-/// mentir o motivo: o login nao pode virar "codigo invalido" com sessao
-/// destravada na contagem de lockout, e o disable nao pode deixar o 2FA
-/// ligado irrecuperavel respondendo 401 para sempre. Os dois recusam 500.
+/// #1121 (pass-4), atualizado pelo #1141: segredo ILEGIVEL com 2FA ligado e
+/// estado inconsistente — corrupcao manual, migration defeituosa, chave
+/// mestra trocada sem re-cifrar. Depois do #1141 o jeito de chegar nesse
+/// estado e o ciphertext nao decifrar, nao mais a coluna em claro vazia.
+/// Nenhum dos dois caminhos pode mentir o motivo: o login nao pode virar
+/// "codigo invalido" com sessao destravada na contagem de lockout, e o
+/// disable nao pode deixar o 2FA ligado irrecuperavel respondendo 401 para
+/// sempre. Os dois recusam 500.
 #[tokio::test]
-async fn segredo_vazio_recusa_login_e_disable_com_estado_inconsistente() {
+async fn segredo_ilegivel_recusa_login_e_disable_com_estado_inconsistente() {
     let dir = tempfile::tempdir().expect("diretorio temporario");
     let (router, store, path) = cenario_arquivo(&dir);
     // Sessao primeiro: depois que o 2FA liga, o login exigiria codigo.
@@ -476,13 +541,16 @@ async fn segredo_vazio_recusa_login_e_disable_com_estado_inconsistente() {
     let code = garraia_gateway::totp::current_code(&secret).expect("codigo atual");
 
     let conn = rusqlite::Connection::open(&path).expect("segunda conexao");
+    // Ciphertext que nao decifra sob a chave mestra (nonce valido, corpo
+    // lixo): o estado inconsistente possivel depois do #1141.
     conn.execute(
-        "UPDATE admin_users SET totp_secret = '' WHERE username = ?1",
+        "UPDATE admin_users SET totp_secret_enc = X'00000000000000000000000000000000',
+         totp_secret_nonce = X'000000000000000000000000' WHERE username = ?1",
         [USUARIO],
     )
-    .expect("esvaziar o segredo");
+    .expect("corromper o segredo cifrado");
 
-    // Login: senha certa E codigo certo — mas o segredo guardado e vazio,
+    // Login: senha certa E codigo certo — mas o segredo guardado nao le,
     // e avaliar o codigo contra ele seria decidir no escuro.
     let (status, json, sessao) = login(
         &router,
@@ -492,7 +560,7 @@ async fn segredo_vazio_recusa_login_e_disable_com_estado_inconsistente() {
     assert_eq!(
         status,
         StatusCode::INTERNAL_SERVER_ERROR,
-        "segredo vazio no login tem que virar 500: {json}"
+        "segredo ilegivel no login tem que virar 500: {json}"
     );
     assert!(sessao.is_none(), "estado inconsistente nao abre sessao");
 
@@ -510,16 +578,16 @@ async fn segredo_vazio_recusa_login_e_disable_com_estado_inconsistente() {
     assert_eq!(
         status,
         StatusCode::INTERNAL_SERVER_ERROR,
-        "segredo vazio no disable tem que virar 500, nao 'codigo invalido': {json}"
+        "segredo ilegivel no disable tem que virar 500, nao 'codigo invalido': {json}"
     );
 }
 
-/// #1121 (pass-4): o mesmo estado inconsistente no `verify`, onde o segredo
-/// e PENDENTE (2FA ainda nao ligado): a recusa e 500, nao o 400 de "2FA nao
-/// configurado" nem o 401 de codigo errado — o codigo certo estava la, o que
-/// falta e o segredo contra o qual avalia-lo.
+/// #1121 (pass-4), atualizado pelo #1141: o mesmo estado inconsistente no
+/// `verify`, onde o segredo e PENDENTE (2FA ainda nao ligado): a recusa e
+/// 500, nao o 400 de "2FA nao configurado" nem o 401 de codigo errado — o
+/// codigo certo estava la, o que falta e o segredo contra o qual avalia-lo.
 #[tokio::test]
-async fn segredo_vazio_no_verify_e_estado_inconsistente() {
+async fn segredo_ilegivel_no_verify_e_estado_inconsistente() {
     let dir = tempfile::tempdir().expect("diretorio temporario");
     let (router, _store, path) = cenario_arquivo(&dir);
     let (cookie, csrf) = entrar(&router).await;
@@ -539,11 +607,14 @@ async fn segredo_vazio_no_verify_e_estado_inconsistente() {
         .to_string();
 
     let conn = rusqlite::Connection::open(&path).expect("segunda conexao");
+    // Ciphertext que nao decifra sob a chave mestra (nonce valido, corpo
+    // lixo): o estado inconsistente possivel depois do #1141.
     conn.execute(
-        "UPDATE admin_users SET totp_secret = '' WHERE username = ?1",
+        "UPDATE admin_users SET totp_secret_enc = X'00000000000000000000000000000000',
+         totp_secret_nonce = X'000000000000000000000000' WHERE username = ?1",
         [USUARIO],
     )
-    .expect("esvaziar o segredo");
+    .expect("corromper o segredo cifrado");
 
     let code = garraia_gateway::totp::current_code(&secret).expect("codigo atual");
     let (status, json, _) = chama(
@@ -558,7 +629,7 @@ async fn segredo_vazio_no_verify_e_estado_inconsistente() {
     assert_eq!(
         status,
         StatusCode::INTERNAL_SERVER_ERROR,
-        "segredo vazio no verify e 500, nao 'nao configurado' nem 'codigo invalido': {json}"
+        "segredo ilegivel no verify e 500, nao 'nao configurado' nem 'codigo invalido': {json}"
     );
 }
 

--- a/crates/garraia-gateway/tests/admin_totp_login.rs
+++ b/crates/garraia-gateway/tests/admin_totp_login.rs
@@ -278,6 +278,38 @@ async fn o_travamento_sobrevive_ao_restart_do_gateway() {
     assert!(sessao.is_none(), "travado nao abre sessao");
 }
 
+/// #1140: a contagem que nao pode ser lida recusa o login, sem sessao.
+///
+/// O valor de seguranca da mudanca esta exatamente aqui: o caminho antigo
+/// (`HashMap`) nunca falhava, entao "nao consegui contar" e um estado novo.
+/// Tratado como "ainda pode tentar", ele devolveria o brute force do segundo
+/// fator a quem conseguisse derrubar a tabela. A recusa e 500 mesmo com a
+/// senha certa E o codigo certo.
+#[tokio::test]
+async fn contagem_de_tentativas_ilegivel_recusa_o_login_sem_abrir_sessao() {
+    let dir = tempfile::tempdir().expect("diretorio temporario");
+    let (router, store, path) = cenario_arquivo(&dir);
+    let secret = ligar_2fa(&store).await;
+
+    let conn = rusqlite::Connection::open(&path).expect("segunda conexao");
+    conn.execute("DROP TABLE totp_attempts", [])
+        .expect("derrubar a tabela de tentativas");
+    drop(conn);
+
+    let code = garraia_gateway::totp::current_code(&secret).expect("codigo atual");
+    let (status, json, sessao) = login(
+        &router,
+        json!({"username": USUARIO, "password": SENHA, "totp_code": code}),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "contagem ilegivel tem que virar 500, nao login liberado: {json}"
+    );
+    assert!(sessao.is_none(), "sem contagem legivel, sem sessao");
+}
+
 /// O enrollment por HTTP: setup devolve um segredo pendente, e ele so passa a
 /// valer depois que um codigo confirma.
 #[tokio::test]

--- a/docs/security.md
+++ b/docs/security.md
@@ -93,6 +93,24 @@ Both limits of the first version are now closed:
   value until the next read, which encrypts it and clears the old column;
   the upgrade is forward-only and needs no operator step.
 
+Encrypting the secret also creates a dependency that did not exist before, so
+two operational notes come with it:
+
+- **The secret now lives and dies with the admin master key.** A master-key
+  rotation carries it along automatically — the re-key re-encrypts
+  `admin_users.totp_secret_enc` in the same transaction as everything else — but
+  *losing* the key is different. If `<config_dir>/admin/master.key` is deleted,
+  truncated, or the vault passphrase changes, the secret stops decrypting and
+  the console answers **HTTP 500 on login**, not "2FA disabled". That is
+  deliberate (an unreadable second factor must never degrade into no second
+  factor), and the way out is the same break-glass `UPDATE` documented above:
+  clear the second factor in the database and enroll again. A `master.key` that
+  exists but cannot be used is preserved as `master.key.unreadable` and logged
+  loudly rather than silently replaced.
+- **Locked out by the 15-minute window and do not want to disable 2FA?** Clear
+  just the counter, with the gateway stopped:
+  `sqlite3 "$HOME/.garraia/data/admin.db" "DELETE FROM totp_attempts;"`
+
 Two things this does **not** change, worth being explicit about:
 
 - `admin_sessions.token` is still stored in cleartext, so whoever reads
@@ -104,6 +122,13 @@ Two things this does **not** change, worth being explicit about:
 - The **mobile** flow still stores its secret in cleartext
   (`mobile_users.totp_secret`, base32, unencrypted). Only the console side
   is encrypted today.
+- There is still **no global rate limit on `POST /admin/api/login`**. The
+  durable counter above bounds guesses at the *second* factor, per user, after
+  a valid password; it does nothing about guessing the password itself, which
+  remains unbounded (each attempt costs 600k PBKDF2 iterations, so it is also a
+  cheap way to burn CPU). `/admin/api/recovery/*` already sits behind a rate
+  limiter; the login route does not. This is the one piece of #1140 that the
+  durable counter did **not** deliver.
 
 ### Input Validation
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -63,7 +63,9 @@ valid code:
 # Stop the gateway first: the store holds the session map in memory.
 # Default path below; if `data_dir` is set in the config, use that instead.
 sqlite3 "$HOME/.garraia/data/admin.db" \
-  "UPDATE admin_users SET totp_enabled = 0, totp_secret = NULL WHERE username = 'YOUR_USERNAME';"
+  "UPDATE admin_users SET totp_enabled = 0, totp_secret = NULL,
+     totp_secret_enc = NULL, totp_secret_nonce = NULL
+   WHERE username = 'YOUR_USERNAME';"
 ```
 
 Then start the gateway again and sign in with your password.
@@ -76,18 +78,32 @@ Two things worth knowing before you turn it on:
   valid code first — replacing the secret underneath you would leave your
   authenticator app pointing at the old one.
 
-Known limits of this first version, both tracked:
+Both limits of the first version are now closed:
 
-- The wrong-code lockout (5 codes in 15 minutes) lives **in memory**: it is
-  per-process and a gateway restart clears it. A durable counter in
-  `admin.db` — which would also give the console a global login rate limit —
-  is tracked in #1140.
-- The TOTP secret is stored **in cleartext** (base32, unencrypted) in
-  `admin.db`; the mobile flow does the same (`mobile_users.totp_secret`,
-  base32 without encryption). The mitigation is the one every other secret
-  in `admin.db` already relies on: protect the database file — and it applies
-  to both flows. Encrypting the admin-side secret with the admin master key
-  is tracked in #1141.
+- The wrong-code lockout (5 codes in 15 minutes) is **durable**: it lives in
+  the `totp_attempts` table of `admin.db`, not in process memory, so a
+  gateway restart no longer clears it and two instances over the same
+  database share one count (#1140). The trade is deliberate and it is the
+  cheaper half: after five wrong codes you wait out the 15-minute window —
+  restarting the gateway is no longer a shortcut, for you or for someone who
+  has your password.
+- The TOTP secret is stored **encrypted** (AES-256-GCM under the admin master
+  key, the same key `admin/secrets.rs` uses for provider keys in the same
+  file) — #1141. A database written before this change keeps the cleartext
+  value until the next read, which encrypts it and clears the old column;
+  the upgrade is forward-only and needs no operator step.
+
+Two things this does **not** change, worth being explicit about:
+
+- `admin_sessions.token` is still stored in cleartext, so whoever reads
+  `admin.db` still walks away with a live admin session without passing the
+  second factor. What encryption removes is the *durable* compromise: the
+  cleartext secret used to outlive session expiry and a password change.
+  Protecting the database file is still the mitigation that matters — and
+  the master key must not sit next to it.
+- The **mobile** flow still stores its secret in cleartext
+  (`mobile_users.totp_secret`, base32, unencrypted). Only the console side
+  is encrypted today.
 
 ### Input Validation
 


### PR DESCRIPTION
## Descrição

Fecha os **dois follow-ups obrigatórios** que a auditoria de segurança do #1137 (2FA no login do painel, #1121) deixou em aberto. Eles são o mesmo arquivo, o mesmo fluxo e a mesma superfície de teste — separá-los em dois PRs duplicaria a migração de schema de `admin_users` e obrigaria um merge de resolução entre eles.

**#1140 — o lockout de código errado virou durável.** A contagem de 5 códigos errados em 15 minutos vivia num `HashMap<String, Vec<Instant>>` dentro do processo. Quem já tinha a senha reiniciava o gateway, atingia outra instância ou usava processos independentes e zerava o contador — o segundo fator de 6 dígitos voltava a ser forçável por força bruta, que é exatamente o que o lockout existia para impedir. A contagem passa para a tabela `totp_attempts` do `admin.db`, com a limpeza da janela expirada na **mesma transação** em que conta, então a tabela não cresce sem limite e duas instâncias sobre o mesmo banco compartilham um só orçamento de tentativas.

`totp_attempts_exhausted` e `record_totp_attempt` passam a devolver `Result`, pelo mesmo motivo que `is_totp_enabled` já devolvia: contagem ilegível não pode virar "ainda pode tentar", e um código avaliado que não entra na contagem é uma tentativa de graça. Os três chamadores (login, verify, disable) recusam fechado com 500.

**#1141 — o segredo TOTP passa a ser cifrado.** Ele ficava em claro (base32) em `admin_users.totp_secret`. Agora é gravado em `totp_secret_enc`/`totp_secret_nonce` com AES-256-GCM sob a chave mestra do painel — a mesma que `admin/secrets.rs` já usa para as chaves de provider no mesmo arquivo, então não há decisão criptográfica nova aqui. Banco existente migra sozinho na primeira leitura (lazy upgrade forward-only, que zera a coluna antiga na mesma transação), sem passo de operador. Decifrar falhando é indisponibilidade, não "2FA desligado".

### O achado da revisão R4 (commit 2 — o mais importante deste PR)

`code-reviewer` e `security-auditor` chegaram **independentemente** ao mesmo ponto, e ele é real: cifrar o segredo criou uma dependência da chave mestra que a **rotação de parâmetros KDF não conhecia**. `migrate_admin_secrets_kdf` re-cifrava `secrets` e `secret_versions` e gravava `kdf_params` na mesma transação, mas não tocava nas colunas novas.

O caminho não é hipotético, porque o código trata falha de re-key como condição esperada e repetível e `resolve_admin_encryption_key` devolve a chave **legada** nesse caso: (1) um boot falha o re-key → a sessão roda na legada; (2) um enrollment ou o lazy upgrade grava o segredo sob a legada; (3) o boot seguinte re-keya com sucesso → `kdf_params` anuncia a chave nova e o segredo fica órfão; (4) `get_totp_secret` devolve `Err` → **login em 500 permanente**, sem recovery code, com o dono trancado fora do painel.

O detalhe que torna isso pior: antes deste PR o segredo era em claro e portanto **imune** ao ciclo de vida da chave. O lazy upgrade transformava um valor indestrutível num valor dependente da chave.

Corrigido: as colunas do 2FA entram no scan e no UPDATE do re-key, **na mesma transação** que grava `kdf_params` — o invariante que a doc de `apply_secret_rekey` já prometia. Um segredo TOTP que não decifra com a chave legada aborta o re-key inteiro, como já acontecia com os secrets de provider. E um `master.key` ilegível deixou de ser substituído em silêncio: é preservado como `master.key.unreadable` com aviso que nomeia a consequência.

**O que este PR não muda, e está dito assim em `docs/security.md`:** `admin_sessions.token` continua em texto puro, então quem lê o arquivo ainda leva uma sessão de admin viva sem passar pelo segundo fator. O que a cifra tira é o comprometimento **durável** do 2FA. O fluxo **mobile** (`mobile_users.totp_secret`) segue em claro. E **não há rate limit global em `POST /admin/api/login`** — a contagem compartilhada cobre só o *segundo* fator, depois de uma senha válida; o gap está registrado no doc em vez de deixar #1140 parecendo entregue por inteiro.

Closes #1140
Closes #1141

## Tipo de mudança

- [x] `sec`: Correção ou hardening de segurança

## Classe de Risco

- [x] **Classe C (Alto Risco)**: autenticação e criptografia (segundo fator do painel admin, chave mestra, migration de schema do `admin.db`).

## Checklist de Segurança e Qualidade

### Obrigatório antes de abrir o PR

- [x] `cargo fmt --check` executado e limpo
- [x] `cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings` sem erros (exit 0), e `-p garraia-gateway --all-targets` sem warnings
- [x] `cargo test -p garraia-gateway` passando localmente: **1071 unit + toda a suíte de integração (14 no suite de 2FA)**, 0 falhas
- [x] Nenhum `unwrap()` adicionado em código de produção (os novos estão só em `#[cfg(test)]`)
- [x] Nenhum segredo, API key, token ou credencial commitada
- [x] Nenhuma migração destrutiva: as colunas novas entram por `ALTER TABLE ... ADD COLUMN` condicional (o mecanismo idempotente que o #1121 já usa) e a coluna em claro só é zerada linha a linha, depois de o valor cifrado estar gravado na mesma transação

### Para alterações de Alto Risco (Classe C)

- [x] Revisão por `code-reviewer` + `security-auditor` conforme o `CLAUDE.md` — achado bloqueante corrigido em `b7ed92a`, veredito e follow-ups documentados no comentário do PR
- [x] Testes de regressão de autenticação adicionados — **11 novos**, listados abaixo
- [ ] Verificação de políticas RLS `USING` e `WITH CHECK` — não se aplica: `admin.db` é SQLite single-file, fora do Postgres multi-tenant
- [x] Auditoria de eventos sem PII: as recusas novas gravam motivo (`"totp attempt counter unreadable"`, `"totp attempt not recorded"`), nunca o código tentado nem o segredo

## Mudanças na API pública e Schema

- **Schema (`admin.db`, SQLite):** tabela nova `totp_attempts (id, user_id, attempted_at)` com FK `ON DELETE CASCADE` + índice `idx_totp_attempts_user`; colunas novas `admin_users.totp_secret_enc` e `admin_users.totp_secret_nonce` (BLOB, nullable). `admin_users.totp_secret` permanece, só para o lazy upgrade lê-la e zerá-la.
- **API Rust (interna ao crate):** `get_totp_secret` e `set_pending_totp_secret`/`_audited` recebem a chave mestra; `totp_attempts_exhausted` e `record_totp_attempt` devolvem `Result` e não pedem mais `&mut self`; `apply_secret_rekey` recebe os ciphertexts de TOTP; `totp_secret_ciphertexts()` é novo.
- **Nenhuma mudança em rota REST, contrato HTTP ou config.** Os status codes dos endpoints de 2FA continuam os mesmos; o que muda é que estados que antes não existiam (contagem ilegível, segredo que não decifra) recusam com 500 em vez de passarem batidos.

## Como testar

1. `cargo test -p garraia-gateway` — a suíte inteira. Os testes de regressão novos:
   - `o_travamento_sobrevive_ao_restart_do_gateway` (integração, HTTP): trava o 2FA com 6 códigos errados, monta um **router novo sobre uma `AdminStore` nova aberta no mesmo arquivo** (o "restart") e tenta o login com o código **certo** — tem que vir 429, sem sessão. É o teste que a implementação antiga não passava.
   - `contagem_de_tentativas_ilegivel_recusa_o_login_sem_abrir_sessao` (integração): tabela ausente ⇒ 500 mesmo com senha **e** código certos.
   - `migration_reencrypts_the_admin_totp_secret_too` e `a_totp_secret_that_does_not_decrypt_aborts_the_rekey`: o achado da revisão, nas duas direções.
   - `o_lockout_sobrevive_a_reabertura_do_banco`, `duas_instancias_compartilham_a_contagem`, `tentativa_expirada_e_apagada_e_nao_conta`, `contagem_ilegivel_e_erro_nao_zero`.
   - `o_segredo_nao_fica_em_claro_na_coluna` (lê as colunas cruas: exige `totp_secret IS NULL` e o base32 ausente de dentro do ciphertext), `segredo_herdado_em_claro_migra_na_primeira_leitura`, `chave_errada_nao_vira_segredo_ausente`, `desligar_apaga_ciphertext_e_nonce`.
2. Upgrade real, para ver o lazy upgrade de ponta a ponta: com um `admin.db` que já tinha 2FA ligado antes desta mudança, subir o gateway e fazer login com o código do app — funciona igual, e depois `sqlite3 admin.db "SELECT totp_secret, totp_secret_enc FROM admin_users;"` mostra a coluna em claro vazia e o ciphertext preenchido.
3. `python3 scripts/changelog/assemble.py --check` para os fragmentos em `changelog.d/security/`.

## Plano de Rollback

`git revert` dos dois commits. O código volta a ler `admin_users.totp_secret`, que é a coluna que a versão anterior usa, e as colunas novas ficam órfãs sem atrapalhar (nada as lê). A ressalva honesta: **quem tiver feito enrollment ou login com a versão nova terá o segredo só na forma cifrada**, porque o lazy upgrade zera a coluna em claro. Para esses usuários o caminho de volta é o mesmo já documentado em `docs/security.md` para perda do autenticador — limpar o 2FA no banco e refazer o enrollment:

```sql
UPDATE admin_users SET totp_enabled = 0, totp_secret = NULL,
  totp_secret_enc = NULL, totp_secret_nonce = NULL WHERE username = 'SEU_USUARIO';
```

O lockout persistido é descartável sem cerimônia: `DELETE FROM totp_attempts;` destrava qualquer usuário, e a tabela órfã não afeta a versão antiga.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USBMcveus6pNDRn37jp3gj