### PR TITLE
fix(security): scanner e redactor cobrem ghs_ stateless do GitHub

### DIFF
--- a/changelog.d/security/1159-ghs-stateless-scanner.md
+++ b/changelog.d/security/1159-ghs-stateless-scanner.md
@@ -1,0 +1,8 @@
+- A varredura de segredos e o redactor de logs passam a cobrir o formato
+  stateless dos installation tokens do GitHub (`ghs_` com pontos no corpo,
+  ~520 chars; rollout 2026). `varredura-segredos.py` nao tinha padrao `ghs_`
+  nenhum — token vazado passava batido; o redactor cobria `ghs_`, mas a classe
+  de caracteres parava no primeiro ponto e vazava o restante para o log.
+  Padroes na forma recomendada pelo GitHub (`ghs_` seguido de
+  `[A-Za-z0-9.\-_]{36,}` no scanner), cobrindo stateful (40 chars) e
+  stateless; tokens seguem tratados como opacos.

--- a/crates/garraia-security/src/redaction.rs
+++ b/crates/garraia-security/src/redaction.rs
@@ -95,7 +95,7 @@ pub fn redact_secrets(input: &str) -> String {
 
             # --- credenciais de terceiro que entram por comando de ferramenta (#937) ---
             | github_pat_[A-Za-z0-9_]{22,}          # GitHub fine-grained PAT
-            | gh[pousr]_[A-Za-z0-9]{20,}            # GitHub PAT/OAuth/user/server/refresh
+            | gh[pousr]_[A-Za-z0-9.\-_]{20,}        # GitHub PAT/OAuth/user/server/refresh (ghs_ stateless incluso)
             | eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}  # JWT
             | (?:AKIA|ASIA)[A-Z0-9]{16}             # AWS access key id (fixa e temporaria)
             | [0-9]{8,10}:AA[A-Za-z0-9_\-]{32,}    # Telegram bot token
@@ -123,6 +123,19 @@ mod tests {
             assert!(!saida.contains(token.as_str()), "vazou: {saida}");
             assert!(saida.contains("[REDACTED]"), "{saida}");
         }
+    }
+
+    /// Formato stateless dos installation tokens do GitHub (`ghs_`, ~520
+    /// chars): o corpo tem pontos. A classe do padrao precisa engolir o token
+    /// inteiro — se ela nao cobre `.`/`-`/`_`, o redactor para no primeiro
+    /// ponto e o restante segue cru para o log.
+    #[test]
+    fn redacts_stateless_installation_token() {
+        let token = format!("ghs_{}.{}.{}", "a".repeat(20), "b".repeat(20), "c".repeat(20));
+        let saida = redact_secrets(&format!("curl -H 'Authorization: Bearer {token}'"));
+        // assert_eq de proposito: se so o pedaco antes do primeiro ponto for
+        // redigido, o `.bbb...ccc...` restante aparece na saida e o teste falha.
+        assert_eq!(saida, "curl -H 'Authorization: Bearer [REDACTED]'");
     }
 
     #[test]

--- a/crates/garraia-security/src/redaction.rs
+++ b/crates/garraia-security/src/redaction.rs
@@ -131,7 +131,12 @@ mod tests {
     /// ponto e o restante segue cru para o log.
     #[test]
     fn redacts_stateless_installation_token() {
-        let token = format!("ghs_{}.{}.{}", "a".repeat(20), "b".repeat(20), "c".repeat(20));
+        let token = format!(
+            "ghs_{}.{}.{}",
+            "a".repeat(20),
+            "b".repeat(20),
+            "c".repeat(20)
+        );
         let saida = redact_secrets(&format!("curl -H 'Authorization: Bearer {token}'"));
         // assert_eq de proposito: se so o pedaco antes do primeiro ponto for
         // redigido, o `.bbb...ccc...` restante aparece na saida e o teste falha.

--- a/scripts/security/varredura-segredos.py
+++ b/scripts/security/varredura-segredos.py
@@ -12,6 +12,7 @@ PATTERNS = [
     (r"(?i)aws_secret_access_key\s*=\s*['\"][A-Za-z0-9/+=]{40}['\"]", "AWS Secret Key"),
     (r"(?i)ghp_[A-Za-z0-9]{36}", "GitHub Personal Access Token"),
     (r"(?i)gho_[A-Za-z0-9]{36}", "GitHub OAuth Token"),
+    (r"(?i)ghs_[A-Za-z0-9.\-_]{36,}", "GitHub App Installation Token"),
     (r"(?i)\bsk-[A-Za-z0-9]{32,}\b", "Generic API Key (sk-...)"),
     (r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----", "Private Key Header"),
 ]


### PR DESCRIPTION
## Contexto
Aviso do GitHub na UI do repo: installation tokens de GitHub Apps (`ghs_`) estao migrando para formato stateless (~520 chars, dois pontos no corpo; rollout desde 2026-04-27; inclui o `GITHUB_TOKEN` do Actions). Nada no repo quebra em operacao — nao usamos GitHub App e os workflows tratam o token como opaco — mas a auditoria achou duas lacunas na direcao inversa: um segredo vazado no formato novo nao seria detectado nem redigido.

## Mudancas
- `scripts/security/varredura-segredos.py`: padrao novo `ghs_[A-Za-z0-9.\-_]{36,}` — antes so `ghp_`/`gho_` com `{36}` exato, sem padrao `ghs_` nenhum
- `crates/garraia-security/src/redaction.rs`: classe alargada para `[A-Za-z0-9.\-_]` — antes o redactor parava no primeiro ponto do token e vazava o restante para o log
- Teste de regressao `redacts_stateless_installation_token` com `assert_eq` (prova que o corpo depois dos pontos sai redigido; token montado por partes, sem literal)
- Fragmento `changelog.d/security/1159-ghs-stateless-scanner.md`

## Provas
- Sonda sintetica: 3/3 capturados (ghs_ stateful, ghs_ stateless, ghp_ classico)
- Varredura completa do repo: limpa, sem falso positivo do padrao novo
- `cargo test -p garraia-security`: 38 passed, 0 failed
- `cargo clippy -p garraia-security`: limpo
- `cargo check --workspace`: so a falha ambiental conhecida do `garraia-desktop` (webkit2gtk ausente no container)

## Refs
- https://github.blog/changelog/2026-05-15-github-app-installation-tokens-per-request-override-header/
- https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/

🤖 Generated with [Claude Code](https://claude.com/claude-code)