### PR TITLE
chore(deps): rmcp 2.2 → 3.3 portado do privado (#163)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -147,7 +147,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1285,7 +1285,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes 3.0.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1302,7 +1302,7 @@ dependencies = [
  "maybe-owned",
  "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
  "winx",
 ]
 
@@ -1584,7 +1584,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2143,6 +2143,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
+dependencies = [
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2170,6 +2180,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2189,6 +2212,17 @@ dependencies = [
  "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
+dependencies = [
+ "darling_core 0.24.1",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2463,7 +2497,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2807,7 +2841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3832,8 +3866,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -5527,7 +5561,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5683,7 +5717,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6235,7 +6269,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6843,9 +6877,9 @@ dependencies = [
 
 [[package]]
 name = "process-wrap"
-version = "9.1.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+checksum = "0e3f4237d0e4741eb50bc5584db701f1299c85fa31ff0274dd6445e79dc42d12"
 dependencies = [
  "futures",
  "indexmap 2.14.0",
@@ -7464,15 +7498,16 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+checksum = "b88db56b8ae316560e9e868b6b978ea940f27cb883323fc90e07435e44158f5c"
 dependencies = [
- "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
+ "bytes",
  "chrono",
  "futures",
  "http 1.4.1",
+ "indexmap 2.14.0",
  "pastey",
  "pin-project-lite",
  "process-wrap",
@@ -7487,19 +7522,20 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "rmcp-macros"
-version = "2.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
+checksum = "873b730df6f0a9b74b13eb514e0dca4c2db0d8b68b74af98a2e9bf3f9d436585"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.1",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7614,7 +7650,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7683,7 +7719,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8359,7 +8395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8665,7 +8701,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9425,7 +9461,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10118,7 +10154,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10232,7 +10268,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11278,7 +11314,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,9 +138,13 @@ tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
 # 2.2 alinha os tipos de modelo à spec MCP 2025-11-25 (upstream rust-sdk#927):
 # `Annotated<RawContent>`/`RawContent`/`Content` viraram o enum achatado
 # `ContentBlock`, e `PromptMessageRole`/`PromptMessageContent` viraram
-# `Role`/`ContentBlock`. Migração em plans/0358. O salto para 3.x segue
-# adiado (tracker interno #163).
-rmcp = { version = "2.2" }
+# `Role`/`ContentBlock`. Migração em plans/0358.
+# 3.x (tracker interno #163): o cliente usa `Peer::call_tool_once` (o
+# `RunningService::call_tool` virou o helper MRTR SEP-2322 que dirige
+# rodadas de input) e o trait `ServerHandler` passou a devolver o enum
+# `CallToolResponse`; `ListToolsResult`/irmãos paginados ganham
+# `result_type`/`ttl_ms`/`cache_scope` (SEP-2322/2549).
+rmcp = { version = "3.1" }
 
 # System / OS interop
 libc = "0.2"

--- a/changelog.d/changed/163-rmcp-3-port.md
+++ b/changelog.d/changed/163-rmcp-3-port.md
@@ -1,0 +1,12 @@
+- **rmcp 2.2.0 → 3.3.0 (portado do repo privado, tracker GarraIA/GarraIA#163).**
+  O SDK MCP salta um major com a API pós-2.2 preservada: no cliente, a
+  ponte de tools usa `Peer::call_tool_once` — o enum MRTR-aware
+  `CallToolResponse` (`Complete`/`InputRequired`/`Task`) — com os braços
+  `InputRequired` (SEP-2322) e `Task` (SEP-2663) **fail-closed**: o bridge
+  não dirige rodadas interativas nem polling de `tasks/get`, e o LLM vê o
+  motivo. No servidor (`garra mcp-server`), o trait `ServerHandler` passa a
+  devolver `CallToolResponse` (só `Complete`, via `From<CallToolResult>`) e
+  `ListToolsResult` usa o construtor `with_all_items` com os campos novos
+  SEP-2322/2549 (`result_type`/`ttl_ms`/`cache_scope`). O supervisor
+  `get_info_advertises_only_tools_capability` acompanha: `tasks` saiu do
+  `ServerCapabilities` e agora viaja como extensão em `extensions`.

--- a/crates/garraia-agents/src/mcp/tool_bridge.rs
+++ b/crates/garraia-agents/src/mcp/tool_bridge.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use garraia_common::{Error, Result};
-use rmcp::model::{CallToolRequestParams, ContentBlock};
+use rmcp::model::{CallToolRequestParams, CallToolResponse, ContentBlock};
 use serde_json::Value;
 use tracing::info;
 
@@ -121,8 +121,15 @@ impl Tool for McpTool {
                 ))
             })?;
 
-        // Executa com timeout
-        let resultado = tokio::time::timeout(self.timeout, peer.call_tool(params))
+        // Executa com timeout.
+        //
+        // rmcp 3.x: `Peer::call_tool_once` manda UM `tools/call` e devolve o
+        // enum MRTR-aware `CallToolResponse`. Os braços `InputRequired`
+        // (SEP-2322: o servidor pede input do usuário antes de completar) e
+        // `Task` (SEP-2663: o servidor materializou uma task e quer polling
+        // em `tasks/get`) são fail-closed — este bridge não dirige rounds
+        // interativos nem ciclos de task; o LLM vê o motivo e decide.
+        let resultado = tokio::time::timeout(self.timeout, peer.call_tool_once(params))
             .await
             .map_err(|_| {
                 Error::Mcp(format!(
@@ -136,6 +143,33 @@ impl Tool for McpTool {
                     self.nome_original, self.nome_servidor
                 ))
             })?;
+
+        let resultado = match resultado {
+            CallToolResponse::Complete(resultado) => resultado,
+            CallToolResponse::InputRequired(_) => {
+                return Err(Error::Mcp(format!(
+                    "servidor MCP '{}' pediu input do usuário (SEP-2322 input_required) para '{}'; \
+                     este runtime não conduz rodadas interativas — chame a ferramenta com \
+                     argumentos completos ou negocie fora do MCP",
+                    self.nome_servidor, self.nome_original
+                )));
+            }
+            CallToolResponse::Task(_) => {
+                return Err(Error::Mcp(format!(
+                    "servidor MCP '{}' materializou a chamada como task (SEP-2663) para '{}'; \
+                     polling de tasks/get não é suportado neste runtime",
+                    self.nome_servidor, self.nome_original
+                )));
+            }
+            // `CallToolResponse` é `#[non_exhaustive]` (o mesmo contrato do
+            // `ContentBlock`): variantes novas da spec caem aqui, fail-closed.
+            _ => {
+                return Err(Error::Mcp(format!(
+                    "resposta desconhecida do servidor MCP '{}' para '{}'; fail-closed",
+                    self.nome_servidor, self.nome_original
+                )));
+            }
+        };
 
         // Converte conteúdos retornados pelo MCP em texto único.
         //

--- a/crates/garraia-cli/src/mcp_server.rs
+++ b/crates/garraia-cli/src/mcp_server.rs
@@ -1,7 +1,7 @@
 //! GAR-583 — MCP server exposing `garra ask` as a stdio tool.
 //!
 //! Implements the `Model Context Protocol` (MCP) `ServerHandler` trait
-//! from `rmcp 2.2` and exposes `garra_ask` — LLM-only — which calls
+//! from `rmcp 3.x` and exposes `garra_ask` — LLM-only — which calls
 //! [`crate::ask::ask_oneshot`] **in-process** (no subprocess spawn, no
 //! shell). Designed for Claude Desktop, Claude Code, and any MCP host
 //! that speaks stdio JSON-RPC.
@@ -29,8 +29,8 @@ use anyhow::Result;
 use garraia_config::AppConfig;
 use rmcp::ErrorData as McpError;
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, ContentBlock, ListToolsResult, PaginatedRequestParams,
-    ServerCapabilities, ServerInfo, Tool,
+    CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ListToolsResult,
+    PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
 };
 use rmcp::service::RequestContext;
 use rmcp::{RoleServer, ServerHandler, ServiceExt};
@@ -433,7 +433,7 @@ impl GarraToolHandler {
     async fn call_agent_tool(
         &self,
         request: CallToolRequestParams,
-    ) -> Result<CallToolResult, McpError> {
+    ) -> Result<CallToolResponse, McpError> {
         let raw = request.arguments.unwrap_or_default();
         let args: crate::mcp_agent::GarraAgentArgs = serde_json::from_value(JsonValue::Object(raw))
             .map_err(|e| McpError::invalid_params(format!("invalid arguments: {e}"), None))?;
@@ -449,9 +449,9 @@ impl GarraToolHandler {
                 });
                 let content = vec![ContentBlock::text(text)];
                 if is_ok {
-                    Ok(CallToolResult::success(content))
+                    Ok(CallToolResult::success(content).into())
                 } else {
-                    Ok(CallToolResult::error(content))
+                    Ok(CallToolResult::error(content).into())
                 }
             }
             Err(e) => Err(McpError::invalid_params(e, None)),
@@ -481,18 +481,22 @@ impl ServerHandler for GarraToolHandler {
         _: Option<PaginatedRequestParams>,
         _: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
-        Ok(ListToolsResult {
-            tools: advertised_tools(&self.policy),
-            next_cursor: None,
-            meta: None,
-        })
+        // rmcp 3.x: `ListToolsResult` ganhou os campos SEP-2322 (`result_type`) e
+        // SEP-2549 (`ttl_ms`/`cache_scope`); o construtor `with_all_items`
+        // preenche o padrão da spec (`result_type = COMPLETE`, resto `None`).
+        Ok(ListToolsResult::with_all_items(advertised_tools(
+            &self.policy,
+        )))
     }
 
+    // rmcp 3.x: o retorno passou a ser o enum MRTR-aware `CallToolResponse`;
+    // este handler só produz respostas finais (`Complete`, via
+    // `From<CallToolResult>` — nunca `InputRequired`/`Task`).
     async fn call_tool(
         &self,
         request: CallToolRequestParams,
         _: RequestContext<RoleServer>,
-    ) -> Result<CallToolResult, McpError> {
+    ) -> Result<CallToolResponse, McpError> {
         // `garra_agent` dispatches only behind the operator opt-in; with
         // the flag off it falls through to the unknown-tool branch so the
         // rejection surface is byte-identical to the pre-agent server.
@@ -559,9 +563,9 @@ impl ServerHandler for GarraToolHandler {
         // success`/`error` recebem como `Vec<ContentBlock>`.
         let content = vec![ContentBlock::text(text)];
         if outcome.is_ok() {
-            Ok(CallToolResult::success(content))
+            Ok(CallToolResult::success(content).into())
         } else {
-            Ok(CallToolResult::error(content))
+            Ok(CallToolResult::error(content).into())
         }
     }
 }
@@ -936,7 +940,9 @@ mod tests {
         assert!(caps.completions.is_none(), "completions must stay off");
         assert!(caps.prompts.is_none(), "prompts must stay off");
         assert!(caps.resources.is_none(), "resources must stay off");
-        assert!(caps.tasks.is_none(), "tasks must stay off");
+        // rmcp 3.x: `tasks` (SEP-2663) saiu do struct `ServerCapabilities` e
+        // virou uma extensão (SEP-1724) em `extensions` — o assert acima de
+        // `extensions.is_none()` já garante "tasks must stay off".
     }
 
     /// GAR-583 §4 invariant #2 — production code MUST NOT register


### PR DESCRIPTION
## O que esta PR entrega

Fecha o último item vivo do tracker interno GarraIA/GarraIA#163 — a migração deliberada do SDK MCP que atravessa o major 2→3, **portada por conteúdo do repo privado** (a main privada já roda `rmcp 3.2.0` verde desde a PR consolidada #172; os dois repos não compartilham SHAs, então a porta foi por comparação de API, não de diff).

O lock resolve para **3.3.0** (latest do range `3.1` — semver-compatível, mesmo contrato de API que o 3.2.0 do privado).

## Mudanças de fonte (todas na fronteira com o SDK)

**Cliente** (`crates/garraia-agents/src/mcp/tool_bridge.rs`):
- `Peer::call_tool` → `Peer::call_tool_once`: no 3.x, `RunningService::call_tool` virou o helper de alto nível que **dirige rodadas** `input_required` (MRTR, SEP-2322) via o `ClientHandler` local — comportamento que este runtime não quer por baixo da ponte de tools.
- O retorno agora é o enum MRTR-aware `CallToolResponse`:
  - `Complete(CallToolResult)` → fluxo de sempre (filtro de `ContentBlock` + `is_error`);
  - `InputRequired(_)` (SEP-2322) → **fail-closed**: erro explicando que o runtime não conduz rodadas interativas;
  - `Task(_)` (SEP-2663) → **fail-closed**: polling de `tasks/get` não é suportado;
  - braço curinga obrigatório (`#[non_exhaustive]`, mesmo contrato do `ContentBlock`) → fail-closed "resposta desconhecida".

**Servidor** (`crates/garraia-cli/src/mcp_server.rs`, `garra mcp-server`):
- `ServerHandler::call_tool` (e o helper interno `call_agent_tool`) devolvem `Result<CallToolResponse, McpError>`; o handler só produz respostas finais via `From<CallToolResult>` — nunca `InputRequired`/`Task`.
- `ListToolsResult` passa pelo construtor `with_all_items`: o struct paginado ganhou os campos SEP-2322 (`result_type`) e SEP-2549 (`ttl_ms`/`cache_scope`).
- O supervisor `get_info_advertises_only_tools_capability` acompanha a API: o campo `tasks` saiu do `ServerCapabilities` e agora viaja como extensão (SEP-1724) em `extensions` — o assert de `extensions.is_none()` já cobre "tasks must stay off".

**Cargo.toml**: `rmcp "2.2" → "3.1"` + comentário documentando o contrato 3.x no lugar de onde o 2.2 era explicado.

## Verificação local

- `cargo check -p garraia-agents --features mcp -p garraia` (e com `mcp-http`) → limpo
- `cargo test -p garraia-agents --features mcp` → 379 passed
- `cargo test -p garraia --bin garra` → 476 passed
- `cargo clippy` + `cargo fmt` nos crates tocados → limpos

## O que não mudou (de propósito)

- `manager.rs` intacto: `read_resource`/`list_prompts`/transports (`TokioChildProcess`, `StreamableHttpClientTransport`) e os tipos `Role`/`ContentBlock` da era 2.2 continuam idênticos no 3.x — o lado privado compila o mesmo código contra 3.2.0 sem mudança de fonte neles.
- Nenhum comportamento novo: a ponte continua manda-UM-pedido-resposta, fail-closed nos modos que ela não sabe dirigir.

Parte de GarraIA/GarraIA#163 (upgrades de dependência adiados no repo público).

🤖 Generated with [Claude Code](https://claude.com/claude-code)