### PR TITLE
feat(hardware): adapter MQTT do garraia-hardware (#1126)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,6 +388,16 @@ jobs:
             echo "::endgroup::"
           done
 
+          # Mesmo buraco (#1089) para a feature `mqtt` do garraia-hardware
+          # (#1126): OFF por default, entao o `--workspace` de cima nao
+          # compilava uma linha dela. O adapter e o que fala com o broker —
+          # quebrar no escuro significaria descoberta, leitura e execucao
+          # de dispositivo morrendo no deploy sem nenhum gate ver.
+          echo "::group::garraia-hardware --features mqtt"
+          cargo clippy -p garraia-hardware --features mqtt --all-targets -- -D warnings
+          cargo test -p garraia-hardware --features mqtt --lib
+          echo "::endgroup::"
+
   # Supply-chain gate: license allow-list + crate bans + registry source bans
   # + RustSec advisories. Uses deny.toml at the repo root. Runs in parallel
   # with clippy. Now invokes the `cargo-deny-action` default `command: check`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,7 +721,7 @@ dependencies = [
  "aws-smithy-types",
  "h2",
  "http 1.4.1",
- "hyper",
+ "hyper 1.11.1",
  "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
@@ -882,11 +888,45 @@ dependencies = [
 
 [[package]]
 name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.11.1",
+ "hyper-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "axum-core",
+ "axum-core 0.5.6",
  "base64 0.22.1",
  "bytes",
  "form_urlencoded",
@@ -894,10 +934,10 @@ dependencies = [
  "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.11.1",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "multer",
@@ -912,6 +952,27 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.29.0",
  "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.4.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -948,7 +1009,7 @@ dependencies = [
  "fs-err",
  "http 1.4.1",
  "http-body 1.0.1",
- "hyper",
+ "hyper 1.11.1",
  "hyper-util",
  "pin-project-lite",
  "rustls",
@@ -1104,7 +1165,7 @@ dependencies = [
  "home",
  "http 1.4.1",
  "http-body-util",
- "hyper",
+ "hyper 1.11.1",
  "hyper-named-pipe",
  "hyper-rustls",
  "hyper-util",
@@ -1625,6 +1686,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "config"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68578f196d2a33ff61b27fae256c3164f65e36382648e30666dde05b8cc9dfdf"
+dependencies = [
+ "async-trait",
+ "convert_case",
+ "json5",
+ "nom 7.1.3",
+ "pathdiff",
+ "ron",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "toml 0.8.2",
+ "yaml-rust2",
+]
+
+[[package]]
 name = "console"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1647,6 +1727,35 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "cookie"
@@ -2558,6 +2667,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
+]
+
+[[package]]
 name = "docker_credential"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2981,6 +3099,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2989,6 +3113,17 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
  "zlib-rs",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -3295,7 +3430,7 @@ name = "garraia-agents"
 version = "0.4.1"
 dependencies = [
  "async-trait",
- "axum",
+ "axum 0.8.9",
  "bytes",
  "chrono",
  "futures",
@@ -3306,8 +3441,8 @@ dependencies = [
  "getrandom 0.4.3",
  "hmac 0.12.1",
  "libc",
- "metrics",
- "metrics-util",
+ "metrics 0.24.6",
+ "metrics-util 0.20.4",
  "reqwest 0.12.28",
  "rmcp",
  "serde",
@@ -3328,7 +3463,7 @@ dependencies = [
  "anyhow",
  "argon2",
  "async-trait",
- "axum",
+ "axum 0.8.9",
  "base64 0.23.1",
  "chrono",
  "garraia-workspace",
@@ -3359,7 +3494,7 @@ name = "garraia-channels"
 version = "0.4.1"
 dependencies = [
  "async-trait",
- "axum",
+ "axum 0.8.9",
  "base64 0.23.1",
  "chrono",
  "dirs 6.0.0",
@@ -3394,7 +3529,7 @@ dependencies = [
  "futures",
  "garraia-common",
  "libc",
- "metrics",
+ "metrics 0.24.6",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -3486,7 +3621,7 @@ dependencies = [
  "argon2",
  "async-trait",
  "aws-credential-types",
- "axum",
+ "axum 0.8.9",
  "axum-server",
  "base64 0.23.1",
  "bytes",
@@ -3518,8 +3653,8 @@ dependencies = [
  "http-body-util",
  "ipnet",
  "jsonwebtoken",
- "metrics",
- "metrics-exporter-prometheus",
+ "metrics 0.24.6",
+ "metrics-exporter-prometheus 0.18.3",
  "reqwest 0.12.28",
  "ring",
  "rusqlite",
@@ -3571,6 +3706,8 @@ name = "garraia-hardware"
 version = "0.4.1"
 dependencies = [
  "async-trait",
+ "rumqttc",
+ "rumqttd",
  "rusqlite",
  "serde",
  "serde_json",
@@ -3704,9 +3841,9 @@ name = "garraia-telemetry"
 version = "0.4.1"
 dependencies = [
  "anyhow",
- "axum",
- "metrics",
- "metrics-exporter-prometheus",
+ "axum 0.8.9",
+ "metrics 0.24.6",
+ "metrics-exporter-prometheus 0.18.3",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -4219,6 +4356,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -4243,6 +4381,15 @@ dependencies = [
  "foldhash",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -4426,6 +4573,29 @@ dependencies = [
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
@@ -4453,7 +4623,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
 dependencies = [
  "hex",
- "hyper",
+ "hyper 1.11.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -4468,7 +4638,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.1",
- "hyper",
+ "hyper 1.11.1",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
@@ -4484,7 +4654,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.11.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -4499,7 +4669,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.11.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -4519,12 +4689,12 @@ dependencies = [
  "futures-util",
  "http 1.4.1",
  "http-body 1.0.1",
- "hyper",
+ "hyper 1.11.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4540,7 +4710,7 @@ checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
 dependencies = [
  "hex",
  "http-body-util",
- "hyper",
+ "hyper 1.11.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -5099,6 +5269,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "jsonptr"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5327,7 +5508,7 @@ dependencies = [
  "jiff",
  "log",
  "md-5",
- "nom",
+ "nom 8.0.0",
  "rand 0.10.1",
  "rangemap",
  "rayon",
@@ -5392,6 +5573,12 @@ dependencies = [
 
 [[package]]
 name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -5438,12 +5625,39 @@ dependencies = [
 
 [[package]]
 name = "metrics"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d05972e8cbac2671e85aa9d04d9160d193f8bebd1a5c1a2f4542c62e65d1d0"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics"
 version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
  "portable-atomic",
  "rapidhash",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bf4e7146e30ad172c42c39b3246864bd2d3c6396780711a1baf749cfe423e21"
+dependencies = [
+ "base64 0.21.7",
+ "hyper 0.14.32",
+ "indexmap 2.14.0",
+ "ipnet",
+ "metrics 0.22.4",
+ "metrics-util 0.16.3",
+ "quanta",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]
@@ -5455,18 +5669,33 @@ dependencies = [
  "base64 0.22.1",
  "evmap",
  "http-body-util",
- "hyper",
+ "hyper 1.11.1",
  "hyper-rustls",
  "hyper-util",
  "indexmap 2.14.0",
  "ipnet",
- "metrics",
- "metrics-util",
+ "metrics 0.24.6",
+ "metrics-util 0.20.4",
  "quanta",
  "rustls",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b07a5eb561b8cbc16be2d216faf7757f9baf3bfb94dbb0fae3df8387a5bb47f"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "metrics 0.22.4",
+ "num_cpus",
+ "quanta",
+ "sketches-ddsketch 0.2.2",
 ]
 
 [[package]]
@@ -5480,14 +5709,14 @@ dependencies = [
  "crossbeam-utils",
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
- "metrics",
+ "metrics 0.24.6",
  "ordered-float",
  "quanta",
  "radix_trie",
  "rand 0.9.4",
  "rand_xoshiro",
  "rapidhash",
- "sketches-ddsketch",
+ "sketches-ddsketch 0.3.1",
 ]
 
 [[package]]
@@ -5520,6 +5749,12 @@ dependencies = [
  "tagptr",
  "triomphe",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "minisign-verify"
@@ -5663,6 +5898,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -6269,6 +6514,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6471,12 +6726,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d45aeb61b4bf818e12d4205f2466f8c4748f85f4fce0146d1c03d69d753f0ad"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89cc5a242e25ed4e7704d0be240f2cfbe20a8c27e7e252d94835be93d92dc39f"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abf21475cc3820fe4b2ca2dc2142902f67a02189f3b5b3a229f4febc01a43e5"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adba4db388f687393c18c51348d44a41d870ca9df71a2c98172ea3035dc6936e"
+dependencies = [
+ "pest",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.4.2",
  "indexmap 2.14.0",
 ]
 
@@ -7030,7 +7327,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.4",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -7068,7 +7365,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7382,7 +7679,7 @@ dependencies = [
  "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.11.1",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -7425,7 +7722,7 @@ dependencies = [
  "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.11.1",
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
@@ -7555,6 +7852,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ron"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+dependencies = [
+ "base64 0.21.7",
+ "bitflags 2.13.1",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "rrule"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7585,6 +7894,53 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rumqttc"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0feff8d882bff0b2fddaf99355a10336d43dd3ed44204f85ece28cf9626ab519"
+dependencies = [
+ "bytes",
+ "fixedbitset 0.5.7",
+ "flume 0.11.1",
+ "futures-util",
+ "log",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-webpki 0.102.8",
+ "thiserror 2.0.20",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
+]
+
+[[package]]
+name = "rumqttd"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32399b9dee6e96350790223dd7356bf7f8f15009d7e58e20f4093f1137213e16"
+dependencies = [
+ "axum 0.7.9",
+ "bytes",
+ "clap",
+ "config",
+ "flume 0.11.1",
+ "metrics 0.22.4",
+ "metrics-exporter-prometheus 0.13.1",
+ "parking_lot",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "slab",
+ "subtle",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -7633,6 +7989,16 @@ checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
  "sha2 0.10.9",
  "walkdir",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0698206bcb8882bf2a9ecb4c1e7785db57ff052297085a6efd4fe42302068a"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -7690,7 +8056,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -7705,6 +8071,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -7731,7 +8106,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -7743,6 +8118,17 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -8385,6 +8771,12 @@ dependencies = [
 
 [[package]]
 name = "sketches-ddsketch"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
+
+[[package]]
+name = "sketches-ddsketch"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
@@ -8402,6 +8794,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8670,7 +9072,7 @@ checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
 dependencies = [
  "atoi",
  "chrono",
- "flume",
+ "flume 0.12.0",
  "form_urlencoded",
  "futures-channel",
  "futures-core",
@@ -9620,6 +10022,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9666,7 +10077,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -9883,19 +10294,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
- "axum",
+ "axum 0.8.9",
  "base64 0.22.1",
  "bytes",
  "h2",
  "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.11.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2",
+ "socket2 0.6.4",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
@@ -10015,7 +10426,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44de9b94d849d3c46e06a883d72d408c2de6403367b39df2b1c9d9e7b6736fe6"
 dependencies = [
- "axum",
+ "axum 0.8.9",
  "forwarded-header-value",
  "governor",
  "http 1.4.1",
@@ -10277,6 +10688,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "uds_windows"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10504,7 +10921,7 @@ version = "9.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
 dependencies = [
- "axum",
+ "axum 0.8.9",
  "base64 0.22.1",
  "mime_guess",
  "regex",
@@ -10525,6 +10942,7 @@ checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
+ "rand 0.10.1",
  "serde_core",
  "wasm-bindgen",
 ]
@@ -11869,7 +12287,7 @@ dependencies = [
  "futures",
  "http 1.4.1",
  "http-body-util",
- "hyper",
+ "hyper 1.11.1",
  "hyper-util",
  "log",
  "once_cell",
@@ -12045,6 +12463,17 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "yaml-rust2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8902160c4e6f2fb145dbe9d6760a75e3c9522d8bf796ed7047c85919ac7115f8"
+dependencies = [
+ "arraydeque",
+ "encoding_rs",
+ "hashlink 0.8.4",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7907,12 +7907,8 @@ dependencies = [
  "flume 0.11.1",
  "futures-util",
  "log",
- "rustls-native-certs",
- "rustls-pemfile",
- "rustls-webpki 0.102.8",
  "thiserror 2.0.20",
  "tokio",
- "tokio-rustls",
  "tokio-stream",
  "tokio-util",
 ]
@@ -8056,7 +8052,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -8071,15 +8067,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -8106,7 +8093,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -8118,17 +8105,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
-]
 
 [[package]]
 name = "rustls-webpki"

--- a/changelog.d/added/1126-adapter-mqtt.md
+++ b/changelog.d/added/1126-adapter-mqtt.md
@@ -1,0 +1,22 @@
+- O gateway fala com dispositivos fisicos via MQTT (#1126, epic #1124). Com a
+  secao `hardware.mqtt` no config (broker `host:porta`, `username` e
+  `password_env` — o **nome** da env que guarda a senha, nunca a senha), o
+  boot sobe o adapter rumqttc: descobre dispositivos pelo manifesto que cada
+  um publica retained em `garra/devices/{id}/capabilities`, marca presenca
+  pelos status/LWT em `garra/devices/{id}/status` e guarda o estado em
+  `<data_dir>/hardware.db` (mesma resolucao de `memory.db`, via
+  `AppConfig::hardware_db_path`).
+- A leitura correlaciona `request_id`: publica em `garra/devices/{id}/get/{cap}`
+  e espera a resposta em `state/{cap}` pelo id — sem resposta no timeout
+  (5s), erro claro para o modelo. A execucao publica `set/{cap}` com os
+  args validados contra o schema truncado do manifesto (tipos primitivos,
+  `required`) e confirma **o que o broker aceitou** — nao o que o
+  dispositivo aplicou; conferir o efeito e uma leitura depois.
+- Fail-closed nos dois sentidos: manifesto que viola as invariantes
+  (`validar()` de Capability, id que nao bate com o topico, segmentos
+  perigosos) recusa o dispositivo inteiro, e classe de risco vem do
+  manifesto declarado — nunca inferida de payload em tempo de execucao.
+- `garra chat` sobe o mesmo transporte pela mesma funcao do gateway, entao
+  o registry e o store de presenca (`hardware.db`) sao os mesmos nos dois.
+- Sem `hardware.mqtt` no config, nada muda: registry vazio e
+  `device_list` sem dispositivos, como antes.

--- a/crates/garraia-cli/src/chat.rs
+++ b/crates/garraia-cli/src/chat.rs
@@ -18,6 +18,7 @@ use garraia_agents::{
 };
 use garraia_config::AppConfig;
 use garraia_db::SessionStore;
+use garraia_gateway::bootstrap::spawn_mqtt_adapter;
 use garraia_hardware::DeviceRegistry;
 use tokio::sync::mpsc;
 
@@ -144,7 +145,10 @@ fn get_api_key(config: &AppConfig, provider_name: &str, env_var: &str) -> Option
 /// `review` is the provider + model `code_review` runs its second LLM call
 /// on; `None` skips it, which is what the tests do because building a real
 /// provider needs a backend. `brave_key` gates `web_search` exactly like the
-/// gateway does. `schedule_heartbeat` / `schedule_recurring` need a
+/// gateway does. `config` feeds `spawn_mqtt_adapter`: com `hardware.mqtt`
+/// configurado o CLI abre o mesmo transporte e o mesmo store de presenca do
+/// gateway (`AppConfig::hardware_db_path`). `schedule_heartbeat` /
+/// `schedule_recurring` need a
 /// `SessionStore` the chat does not open — they stay gateway-only, on
 /// purpose and said here rather than silently.
 ///
@@ -156,6 +160,7 @@ fn get_api_key(config: &AppConfig, provider_name: &str, env_var: &str) -> Option
 /// ferramentas que depende de uma flag. Fica para um slice proprio.
 fn register_cli_tools(
     runtime: &AgentRuntime,
+    config: &AppConfig,
     review: Option<(Arc<dyn LlmProvider>, String)>,
     brave_key: Option<String>,
     bash_allowlist: Vec<String>,
@@ -173,11 +178,16 @@ fn register_cli_tools(
     runtime.register_tool(Box::new(WebFetchTool::new(None)));
     // ADR 0020 / epic #1124: tools de hardware. O CLI é interativo — sempre
     // com canal de confirmação (R3/R4 pedem "sim" na própria conversa). O
-    // registry nasce vazio: sem adapter, `device_list` lista nada (#1128
-    // liga o boot de adapters via config).
-    let device_config = std::sync::Arc::new(DeviceToolsConfig::new(std::sync::Arc::new(
-        DeviceRegistry::new(),
-    )));
+    // registry nasce vazio; com `hardware.mqtt` configurado, o adapter sobe
+    // pela MESMA função do gateway (fonte única do wiring — resolução de
+    // senha, client id e store de presença idênticos, inclusive os warns).
+    // Sem adapter, `device_list` lista nada (#1128 liga o boot via config).
+    let device_registry = Arc::new(DeviceRegistry::new());
+    let device_state = spawn_mqtt_adapter(config, device_registry.clone());
+    let device_config = Arc::new(match device_state {
+        Some(state) => DeviceToolsConfig::new(device_registry).com_estado(state),
+        None => DeviceToolsConfig::new(device_registry),
+    });
     runtime.register_tool(Box::new(DeviceListTool::new(device_config.clone())));
     runtime.register_tool(Box::new(DeviceReadTool::new(device_config.clone())));
     runtime.register_tool(Box::new(DeviceExecuteTool::new(device_config)));
@@ -1213,6 +1223,7 @@ pub async fn run_chat(
     runtime.register_provider(provider);
     register_cli_tools(
         &runtime,
+        &config,
         Some(review),
         get_api_key(&config, "brave", "BRAVE_API_KEY"),
         config.agent.bash_allowlist.clone(),
@@ -2958,7 +2969,7 @@ mod cli_tools_tests {
     #[test]
     fn registers_the_gateway_tool_set_plus_git_diff() {
         let runtime = AgentRuntime::new();
-        register_cli_tools(&runtime, None, None, vec![]);
+        register_cli_tools(&runtime, &AppConfig::default(), None, None, vec![]);
         let names = runtime.tool_names();
         for expected in [
             "file_read",
@@ -2988,7 +2999,13 @@ mod cli_tools_tests {
     #[test]
     fn brave_key_turns_web_search_on() {
         let runtime = AgentRuntime::new();
-        register_cli_tools(&runtime, None, Some("k".into()), vec![]);
+        register_cli_tools(
+            &runtime,
+            &AppConfig::default(),
+            None,
+            Some("k".into()),
+            vec![],
+        );
         assert!(runtime.tool_names().iter().any(|n| n == "web_search"));
     }
 
@@ -2997,7 +3014,7 @@ mod cli_tools_tests {
     #[test]
     fn prompt_lists_every_registered_tool_and_nothing_else() {
         let runtime = AgentRuntime::new();
-        register_cli_tools(&runtime, None, None, vec![]);
+        register_cli_tools(&runtime, &AppConfig::default(), None, None, vec![]);
         let names = runtime.tool_names();
         let doc = tool_docs(&names);
         for n in &names {

--- a/crates/garraia-config/src/check.rs
+++ b/crates/garraia-config/src/check.rs
@@ -665,6 +665,9 @@ fn validate(config: &AppConfig) -> Vec<Finding> {
     // storage (plan 0044): validate the object storage backend config.
     validate_storage(&config.storage, &mut findings, &push_err, &push_warn);
 
+    // hardware (ADR 0020 / #1126): validate the MQTT transport config.
+    validate_hardware(&config.hardware, &mut findings, &push_err);
+
     // auth (plan 0046 §5.5): validate the non-secret JWT/refresh/metrics
     // knobs. Secret env vars remain enforced at AuthConfig::from_env.
     validate_auth(&config.auth, &mut findings, &push_err, &push_warn);
@@ -1583,6 +1586,70 @@ fn validate_storage(
     }
 }
 
+/// hardware (ADR 0020 / #1126): validate the MQTT transport config.
+///
+/// O broker precisa ser um `host:port` válido — o adapter conecta no boot
+/// e um endereço mal-formado viraria um crash/silêncio tarde demais. O
+/// `password_env` é presence-only: nunca ecoamos o valor (ele nem passa
+/// por aqui — config carrega só o nome da env var).
+fn validate_hardware(
+    hardware: &crate::model::HardwareConfig,
+    findings: &mut Vec<Finding>,
+    push_err: &impl Fn(&mut Vec<Finding>, &str, String),
+) {
+    let Some(mqtt) = &hardware.mqtt else {
+        return;
+    };
+
+    let (host, port) = match mqtt.broker.rsplit_once(':') {
+        Some((host, port)) => (host, port),
+        None => {
+            push_err(
+                findings,
+                "hardware.mqtt.broker",
+                format!(
+                    "hardware.mqtt.broker ({:?}) must be `host:port` (e.g. \"127.0.0.1:1883\")",
+                    mqtt.broker
+                ),
+            );
+            return;
+        }
+    };
+    if host.trim().is_empty() {
+        push_err(
+            findings,
+            "hardware.mqtt.broker",
+            format!("hardware.mqtt.broker ({:?}) has an empty host", mqtt.broker),
+        );
+    }
+    match port.trim().parse::<u16>() {
+        Ok(0) => push_err(
+            findings,
+            "hardware.mqtt.broker",
+            format!(
+                "hardware.mqtt.broker ({:?}) port 0 is not connectable",
+                mqtt.broker
+            ),
+        ),
+        Err(_) => push_err(
+            findings,
+            "hardware.mqtt.broker",
+            format!(
+                "hardware.mqtt.broker ({:?}) port {:?} is not a number in [1, 65535]",
+                mqtt.broker, port
+            ),
+        ),
+        Ok(_) => {}
+    }
+    if mqtt.client_id_prefix.trim().is_empty() {
+        push_err(
+            findings,
+            "hardware.mqtt.client_id_prefix",
+            "hardware.mqtt.client_id_prefix must be non-empty".to_string(),
+        );
+    }
+}
+
 /// Pure validation of the config directory path. Separated from the
 /// loader/env read so it can be unit-tested without touching process state.
 ///
@@ -2359,6 +2426,88 @@ mod tests {
             findings.iter().all(|f| !f.field.starts_with("storage")),
             "default storage config produced findings: {findings:?}"
         );
+    }
+
+    #[test]
+    fn hardware_default_is_clean() {
+        // ADR 0020 / #1126: default AppConfig must not introduce new
+        // validation errors for the hardware section.
+        let cfg = AppConfig::default();
+        let findings = validate(&cfg);
+        assert!(
+            findings.iter().all(|f| !f.field.starts_with("hardware")),
+            "default hardware config produced findings: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn mqtt_broker_malformed_is_error() {
+        use crate::model::{HardwareConfig, MqttConfig};
+        let cfg = AppConfig {
+            hardware: HardwareConfig {
+                mqtt: Some(MqttConfig {
+                    broker: "127.0.0.1".to_string(), // sem :port
+                    username: None,
+                    password_env: None,
+                    client_id_prefix: "garra".to_string(),
+                }),
+            },
+            ..AppConfig::default()
+        };
+        let findings = validate(&cfg);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.severity == Severity::Error && f.field == "hardware.mqtt.broker"),
+            "expected error on broker without port: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn mqtt_broker_non_numeric_port_is_error() {
+        use crate::model::{HardwareConfig, MqttConfig};
+        let cfg = AppConfig {
+            hardware: HardwareConfig {
+                mqtt: Some(MqttConfig {
+                    broker: "127.0.0.1:mqtt".to_string(),
+                    username: None,
+                    password_env: None,
+                    client_id_prefix: "garra".to_string(),
+                }),
+            },
+            ..AppConfig::default()
+        };
+        let findings = validate(&cfg);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.severity == Severity::Error && f.field == "hardware.mqtt.broker"),
+            "expected error on non-numeric port: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn mqtt_valid_config_is_clean() {
+        use crate::model::{HardwareConfig, MqttConfig};
+        let cfg = AppConfig {
+            hardware: HardwareConfig {
+                mqtt: Some(MqttConfig {
+                    broker: "127.0.0.1:1883".to_string(),
+                    username: Some("garra".to_string()),
+                    password_env: Some("GARRA_MQTT_PASS".to_string()),
+                    client_id_prefix: "garra".to_string(),
+                }),
+            },
+            ..AppConfig::default()
+        };
+        let findings = validate(&cfg);
+        assert!(
+            findings.iter().all(|f| !f.field.starts_with("hardware")),
+            "valid mqtt config produced findings: {findings:?}"
+        );
+        // Presence-only: nenhum finding carrega o nome da env var como valor
+        // (o nome é público de propósito, mas a disciplina de não ecoar
+        // segredo vale por princípio — aqui não há segredo para ecoar).
     }
 
     #[test]

--- a/crates/garraia-config/src/model.rs
+++ b/crates/garraia-config/src/model.rs
@@ -65,6 +65,12 @@ pub struct AppConfig {
     /// (plan 0046 §5.1) — see [`crate::AuthConfig`] for the env contract.
     #[serde(default)]
     pub auth: AuthSection,
+
+    /// ADR 0020 / #1126 — transporte de hardware (adapter MQTT). `None`
+    /// (o default) = nenhum transporte compilado/configurado; o registry
+    /// de dispositivos segue vazio (fail-closed).
+    #[serde(default)]
+    pub hardware: HardwareConfig,
 }
 
 impl Default for AppConfig {
@@ -86,8 +92,45 @@ impl Default for AppConfig {
             mobile: MobileConfig::default(),
             storage: StorageConfig::default(),
             auth: AuthSection::default(),
+            hardware: HardwareConfig::default(),
         }
     }
+}
+
+/// ADR 0020 / #1126 — configuração do transporte de hardware.
+///
+/// Hoje só o adapter MQTT; adapters futuros (#1127 Home Assistant,
+/// #1130 Serial/GPIO) entram como campos aditivos desta seção.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HardwareConfig {
+    /// Adapter MQTT (rumqttc). `None` = sem MQTT — o gateway não sobe o
+    /// loop de descoberta e o registry fica vazio (fail-closed).
+    #[serde(default)]
+    pub mqtt: Option<MqttConfig>,
+}
+
+/// Conexão com o broker MQTT (#1126). Credencial de senha é **write-only**:
+/// config carrega o nome da env var, nunca o valor — mesma disciplina do
+/// settings registry ("secrets are write-only — value never echoed back").
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MqttConfig {
+    /// Endereço do broker, `host:port` (ex.: `"127.0.0.1:1883"`).
+    pub broker: String,
+    /// Usuário do broker, quando o broker exige autenticação.
+    #[serde(default)]
+    pub username: Option<String>,
+    /// Nome da env var que guarda a senha. `None` = conexão anônima
+    /// (aceitável em brokers locais sem ACL).
+    #[serde(default)]
+    pub password_env: Option<String>,
+    /// Prefixo do client id MQTT (o pid completa a unicidade). Default
+    /// `"garra"`.
+    #[serde(default = "default_mqtt_client_prefix")]
+    pub client_id_prefix: String,
+}
+
+fn default_mqtt_client_prefix() -> String {
+    "garra".to_string()
 }
 
 /// Non-secret auth knobs (plan 0046 / GAR-379 slice 3).
@@ -435,6 +478,17 @@ impl AppConfig {
     /// relatando uma memoria vazia enquanto o agente conversa com outra.
     pub fn memory_db_path(&self) -> std::path::PathBuf {
         self.resolved_data_dir().join("memory.db")
+    }
+
+    /// Caminho do banco de estado de hardware (presenca online/offline dos
+    /// dispositivos, #1126).
+    ///
+    /// Fonte **unica**, mesmo contrato do `memory_db_path`: gateway e CLI
+    /// precisam abrir o mesmo arquivo, senao a CLI listaria offline um
+    /// dispositivo que o gateway acabou de ver online — e cada processo
+    /// reconectado do adapter reescreveria so a sua copia.
+    pub fn hardware_db_path(&self) -> std::path::PathBuf {
+        self.resolved_data_dir().join("hardware.db")
     }
 }
 
@@ -1031,6 +1085,26 @@ mod tests {
         assert!(config.embeddings.is_empty());
     }
 
+    /// #1126: os dois bancos de estado vivem sob o mesmo data_dir resolvido,
+    /// e cada um tem o nome que a doc declara — `memory.db` para a memoria
+    /// semantica, `hardware.db` para a presenca dos dispositivos. A CLI e o
+    /// gateway leem destes metodos, nunca montam o caminho na mao.
+    #[test]
+    fn db_paths_live_under_the_resolved_data_dir() {
+        let config = AppConfig::default();
+        let dir = config.resolved_data_dir();
+        assert_eq!(config.memory_db_path(), dir.join("memory.db"));
+        assert_eq!(config.hardware_db_path(), dir.join("hardware.db"));
+
+        // E o data_dir explicito vence — a resolucao e a mesma para os dois.
+        let mut custom = AppConfig::default();
+        custom.data_dir = Some(std::path::PathBuf::from("/tmp/garra-data"));
+        assert_eq!(
+            custom.hardware_db_path(),
+            std::path::PathBuf::from("/tmp/garra-data/hardware.db")
+        );
+    }
+
     #[test]
     fn agent_persona_defaults_to_friendly() {
         // Plan 0250 (GAR-771): the warm persona is the default; persona_lang
@@ -1090,5 +1164,41 @@ embeddings:
         assert_eq!(cohere.provider, "cohere");
         assert_eq!(cohere.model.as_deref(), Some("embed-english-v3.0"));
         assert_eq!(cohere.dimensions, Some(1024));
+    }
+
+    // ── ADR 0020 / #1126: seção `hardware:` (transporte MQTT) ──
+
+    #[test]
+    fn hardware_mqtt_parses_broker_username_and_password_env() {
+        let raw = r#"
+hardware:
+  mqtt:
+    broker: "127.0.0.1:1883"
+    username: garra
+    password_env: GARRA_MQTT_PASS
+"#;
+        let config: AppConfig = serde_yaml::from_str(raw).expect("yaml should parse");
+        let mqtt = config.hardware.mqtt.expect("hardware.mqtt should be Some");
+        assert_eq!(mqtt.broker, "127.0.0.1:1883");
+        assert_eq!(mqtt.username.as_deref(), Some("garra"));
+        assert_eq!(mqtt.password_env.as_deref(), Some("GARRA_MQTT_PASS"));
+        assert_eq!(mqtt.client_id_prefix, "garra");
+    }
+
+    #[test]
+    fn hardware_default_has_no_mqtt() {
+        let config = AppConfig::default();
+        assert!(config.hardware.mqtt.is_none(), "sem seção, sem transporte");
+    }
+
+    #[test]
+    fn hardware_mqtt_write_only_password_never_carries_value() {
+        // Disciplina write-only do settings registry: config carrega o NOME
+        // da env var; o valor só existe no ambiente.
+        let raw = "hardware:\n  mqtt:\n    broker: '127.0.0.1:1883'\n";
+        let config: AppConfig = serde_yaml::from_str(raw).expect("yaml should parse");
+        let mqtt = config.hardware.mqtt.expect("mqtt");
+        assert!(mqtt.password_env.is_none());
+        assert!(mqtt.username.is_none());
     }
 }

--- a/crates/garraia-config/src/model.rs
+++ b/crates/garraia-config/src/model.rs
@@ -1097,8 +1097,10 @@ mod tests {
         assert_eq!(config.hardware_db_path(), dir.join("hardware.db"));
 
         // E o data_dir explicito vence — a resolucao e a mesma para os dois.
-        let mut custom = AppConfig::default();
-        custom.data_dir = Some(std::path::PathBuf::from("/tmp/garra-data"));
+        let custom = AppConfig {
+            data_dir: Some(std::path::PathBuf::from("/tmp/garra-data")),
+            ..AppConfig::default()
+        };
         assert_eq!(
             custom.hardware_db_path(),
             std::path::PathBuf::from("/tmp/garra-data/hardware.db")

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -13,8 +13,11 @@ garraia-channels = { workspace = true, features = ["discord", "telegram", "slack
 garraia-agents = { workspace = true, features = ["mcp"] }
 # ADR 0020 (epic #1124): o registry de dispositivos que alimenta as tools
 # device_list/read/execute. Sem adapter registrado, fica vazio (#1128 liga
-# o boot de adapters via config).
-garraia-hardware = { workspace = true }
+# o boot de adapters via config). A feature `mqtt` fica ligada aqui
+# incondicionalmente: o gateway e o host de hardware, o boot decide pelo
+# config se o transporte sobe (`hardware.mqtt`) — rumqttc e cliente Rust
+# puro, sem runtime C.
+garraia-hardware = { workspace = true, features = ["mqtt"] }
 garraia-runtime = { workspace = true }
 garraia-db = { workspace = true }
 garraia-security = { workspace = true }

--- a/crates/garraia-gateway/src/bootstrap/mod.rs
+++ b/crates/garraia-gateway/src/bootstrap/mod.rs
@@ -10,7 +10,7 @@ use garraia_agents::{
 };
 use garraia_config::{AppConfig, provider_key_env};
 use garraia_db::MemoryStore;
-use garraia_hardware::DeviceRegistry;
+use garraia_hardware::{DeviceRegistry, DeviceStateStore, MqttAdapterConfig, MqttAdapterManager};
 use tracing::{info, warn};
 
 mod channels;
@@ -629,7 +629,15 @@ pub fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
     // `device_execute` honra `tool_confirmation_enabled` (mesma chave do
     // bash): sem canal, R3/R4/R5 são fail-closed BLOCKED dentro da tool.
     let device_registry = Arc::new(DeviceRegistry::new());
-    let device_config = Arc::new(DeviceToolsConfig::new(device_registry));
+    // #1126: com `hardware.mqtt` configurado, o adapter sobe aqui — event
+    // loop que descobre dispositivos pelos manifestos retained, marca
+    // presenca no store e roteia as respostas de leitura. Sem a secao, o
+    // registry segue vazio: fail-closed, o estado default do deploy.
+    let device_state = spawn_mqtt_adapter(config, device_registry.clone());
+    let device_config = Arc::new(match device_state {
+        Some(state) => DeviceToolsConfig::new(device_registry).com_estado(state),
+        None => DeviceToolsConfig::new(device_registry),
+    });
     runtime.register_tool(Box::new(DeviceListTool::new(device_config.clone())));
     runtime.register_tool(Box::new(DeviceReadTool::new(device_config.clone())));
     let device_execute = if config.agent.tool_confirmation_enabled {
@@ -1064,6 +1072,107 @@ pub fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
     }
 
     runtime
+}
+
+/// Sobe o adapter MQTT (#1126) quando `hardware.mqtt` esta configurado.
+///
+/// Chamado pelo gateway **e** pela CLI (`garra chat`) — e a fonte unica do
+/// wiring: resolucao de senha, client id e caminho do store de presenca
+/// moram aqui, nao em duas copias que divergem. A CLI chama via
+/// `garraia_gateway::bootstrap::spawn_mqtt_adapter`.
+///
+/// Fail-soft no boot: qualquer problema (broker malformado, `password_env`
+/// apontando para env vazia ou inexistente, store de presenca nao abre) nao
+/// derruba o processo — o registry de dispositivos simplesmente segue vazio
+/// e cada warn diz o que faltou. `garra config check` mostra os mesmos
+/// erros de config antes do boot.
+///
+/// Devolve o store de presenca aberto, para as tools de device mostrarem
+/// online/offline — `None` quando nao ha config ou o adapter nao subiu.
+///
+/// Precisa de runtime tokio (spawn do event loop) — gateway e CLI chamam
+/// de dentro de `run()` async. Sem secao `hardware.mqtt`, retorna antes de
+/// tocar tokio, seguro para testes.
+pub fn spawn_mqtt_adapter(
+    config: &AppConfig,
+    registry: Arc<DeviceRegistry>,
+) -> Option<Arc<DeviceStateStore>> {
+    let mqtt = config.hardware.mqtt.as_ref()?;
+
+    // A senha vem do env apontado por `password_env` e nunca e logada — o
+    // warn cita so o NOME da env, que nao e segredo. Configurada e vazia/
+    // ausente e falha de deploy, nao motivo para conectar anonimo: o broker
+    // recusaria depois, com reconnect em loop e sem mensagem clara.
+    let password = match &mqtt.password_env {
+        Some(env_name) => match std::env::var(env_name) {
+            Ok(value) if !value.is_empty() => Some(value),
+            _ => {
+                warn!(
+                    env = env_name,
+                    "hardware.mqtt: password_env aponta para env vazia ou inexistente; \
+                     adapter MQTT nao sobe e o registry de dispositivos fica vazio"
+                );
+                return None;
+            }
+        },
+        None => None,
+    };
+
+    let adapter_config = match MqttAdapterConfig::new(&mqtt.broker, mqtt.username.clone(), password)
+    {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            warn!(
+                "hardware.mqtt: {e}; adapter MQTT nao sobe e o registry de dispositivos fica vazio (veja `garra config check`)"
+            );
+            return None;
+        }
+    };
+
+    // Client id unico por processo: gateway e `garra chat` no mesmo host
+    // conectam ao mesmo broker, e dois clientes com o mesmo id se des
+    // conectam em loop — o pid completa a unicidade do prefixo.
+    let adapter_config =
+        adapter_config.com_client_id(format!("{}-{}", mqtt.client_id_prefix, std::process::id()));
+
+    // Presenca no mesmo padrao do memory.db: fonte unica da resolucao em
+    // `AppConfig::hardware_db_path`, porque gateway e CLI abrem o mesmo
+    // arquivo. O diretório precisa existir antes de abrir o SQLite — o boot
+    // da memoria cria o dele, mas o hardware pode rodar sem memoria ligada.
+    let state_path = config.hardware_db_path();
+    if let Some(parent) = state_path.parent()
+        && let Err(e) = std::fs::create_dir_all(parent)
+    {
+        warn!(
+            "hardware.mqtt: nao consegui criar {} ({e}); adapter MQTT nao sobe",
+            parent.display()
+        );
+        return None;
+    }
+    let state = match DeviceStateStore::abrir_em(&state_path) {
+        Ok(store) => Arc::new(store),
+        Err(e) => {
+            warn!(
+                "hardware.mqtt: nao abri o store de presenca em {} ({e}); adapter MQTT nao sobe",
+                state_path.display()
+            );
+            return None;
+        }
+    };
+
+    // O handle do manager fica solto de proposito: o event loop vive pela
+    // vida do processo (reconnect do rumqttc e interno), e o reload de
+    // config que o pararia e trabalho da #1128.
+    if let Err(e) = MqttAdapterManager::spawn(adapter_config, registry, Some(state.clone())) {
+        warn!("hardware.mqtt: {e}; adapter MQTT nao sobe e o registry de dispositivos fica vazio");
+        return None;
+    }
+
+    info!(
+        broker = %mqtt.broker,
+        "hardware.mqtt no ar — descoberta via manifestos retained, presenca no store"
+    );
+    Some(state)
 }
 
 /// Build MCP tools from merged config (config.yml + mcp.json).

--- a/crates/garraia-hardware/Cargo.toml
+++ b/crates/garraia-hardware/Cargo.toml
@@ -12,6 +12,9 @@ description = "Hardware — trait Device, Capability com risco R0-R5, registry e
 # `--all-features`. Builds de produção que usarem `default-features = false`
 # continuam com toda a superfície do trait — só perdem o mock.
 mock-device = []
+# Adapter MQTT (#1126, rumqttc): OFF por default — quem não usa transporte
+# de rede não paga a árvore de deps. Mesmo padrão do `storage-s3`.
+mqtt = ["dep:rumqttc"]
 default = ["mock-device"]
 
 [dependencies]
@@ -24,3 +27,11 @@ rusqlite = { workspace = true }
 # `tokio::sync::Mutex` no DeviceStateStore (padrão SessionStore); os testes
 # usam o mesmo rt para `#[tokio::test]`.
 tokio = { workspace = true }
+# Feature `mqtt` (#1126): cliente MQTT async puro (sem runtime C). O event
+# loop do rumqttc roda como task tokio própria do manager.
+rumqttc = { version = "0.25", optional = true }
+
+[dev-dependencies]
+# Broker MQTT embutido para os testes de integração da feature `mqtt`
+# (#1126): mesmo time do rumqttc, roda in-process (sem docker).
+rumqttd = { version = "0.20", default-features = false }

--- a/crates/garraia-hardware/Cargo.toml
+++ b/crates/garraia-hardware/Cargo.toml
@@ -29,7 +29,15 @@ rusqlite = { workspace = true }
 tokio = { workspace = true }
 # Feature `mqtt` (#1126): cliente MQTT async puro (sem runtime C). O event
 # loop do rumqttc roda como task tokio própria do manager.
-rumqttc = { version = "0.25", optional = true }
+#
+# `default-features = false` a propósito: o default (`use-rustls`) arrasta
+# `rustls-webpki 0.102.8` + `rustls-pemfile` — exatamente a cadeia que o
+# GAR-455 / health/20260517 eliminou do lock por advisory (RUSTSEC-2026-0049,
+# -0098, -0099, -0104 e RUSTSEC-2025-0134). O adapter fala TCP puro com o
+# broker local/LAN (`Transport::Tcp` é o default), então a superfície TLS do
+# rumqttc é código morto aqui; e rumqttd (dev-dep) aceita `tls: None`.
+# TLS MQTT voltar como slice próprio, com avaliação de supply-chain própria.
+rumqttc = { version = "0.25", optional = true, default-features = false }
 
 [dev-dependencies]
 # Broker MQTT embutido para os testes de integração da feature `mqtt`

--- a/crates/garraia-hardware/src/adapter_mqtt.rs
+++ b/crates/garraia-hardware/src/adapter_mqtt.rs
@@ -1,0 +1,1306 @@
+//! Adapter MQTT (#1126) — o primeiro transporte real do `garraia-hardware`.
+//!
+//! `rumqttc` (async puro, sem runtime C) atrás da feature `mqtt`. Este
+//! módulo implementa a convenção de tópicos `garra/devices/...` e faz a
+//! ponte entre o mundo MQTT e o [`crate::DeviceRegistry`]:
+//!
+//! | Tópico | Direção | Payload |
+//! |---|---|---|
+//! | `{p}/devices/{id}/capabilities` | device → gateway | [`DeviceManifest`] (retained) |
+//! | `{p}/devices/{id}/status` | device → gateway | `"online"`/`"offline"` (LWT) |
+//! | `{p}/devices/{id}/get/{cap}` | gateway → device | `{"request_id": ...}` |
+//! | `{p}/devices/{id}/state/{cap}` | device → gateway | `{"request_id": ..., "value": ...}` |
+//! | `{p}/devices/{id}/set/{cap}` | gateway → device | `{"request_id": ..., "args": ...}` |
+//!
+//! # Contratos
+//!
+//! - **Manifesto**: o dispositivo publica `{"id", "capabilities": [Capability]}` em
+//!   `capabilities` **retained**, logo que conecta. Retained resolve a corrida
+//!   clássica de descoberta — o manifesto sobrevive a reinícios do gateway e
+//!   chega assinando. O risk class vem do **manifesto**, nunca inferido de
+//!   payload em runtime; o parse valida a invariante leitura↔R0 na fronteira
+//!   (`Capability::validar`) e recusa o dispositivo inteiro se violada.
+//! - **Leitura**: publish em `get/{cap}` com `request_id` + espera da resposta
+//!   correlacionada em `state/{cap}` até [`MqttAdapterConfig::timeout`]. Sem
+//!   resposta → erro (nada de valor velho apresentado como atual).
+//! - **Execução**: publish em `set/{cap}` com args mini-validados contra o
+//!   subset truncado do `args_schema` (`type`/`properties`/`required`, tipos
+//!   primitivos). O retorno `{"published": true}` é honesto: confirma que o
+//!   **broker** aceitou a entrega, não que o dispositivo aplicou — para o
+//!   estado aplicado, `read` na sequência. O gate (R0–R5) continua na camada
+//!   de tools; o adapter não duplica a decisão.
+//! - **Presença**: `status` (ou LWT do dispositivo no mesmo tópico) marca
+//!   online/offline no [`DeviceStateStore`]. Recomendado retained, para o
+//!   próximo subscriber já nascer sabendo.
+//! - **Segurança**: a senha chega aqui já **resolvida do env** pelo chamador
+//!   (`password_env` no config); nunca é serializada nem aparece no `Debug`
+//!   (write-only, disciplina do settings registry).
+
+use crate::Result;
+use crate::capability::Capability;
+use crate::device::Device;
+use crate::error::HardwareError;
+use crate::registry::DeviceRegistry;
+use crate::state::DeviceStateStore;
+use async_trait::async_trait;
+use rumqttc::{AsyncClient, Event, EventLoop, Incoming, MqttOptions, Publish, QoS};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+use tokio::sync::{Mutex, oneshot};
+
+/// Prefixo de tópico padrão — a convenção `garra/devices/...` da issue.
+pub const TOPIC_PREFIX_DEFAULT: &str = "garra";
+
+/// Timeout padrão de leitura (correlação `get` → `state`).
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Capacidade do canal de requisições do cliente MQTT.
+const CLIENT_CHANNEL_CAPACITY: usize = 64;
+
+/// Mapa de leituras em voo: `request_id` → canal de resposta. Compartilhado
+/// entre o `MqttDevice` (que registra) e o event loop do manager (que roteia).
+type Pendentes = Mutex<HashMap<String, oneshot::Sender<Value>>>;
+
+static SEQUENCIA: AtomicU64 = AtomicU64::new(0);
+
+/// Novo `request_id` para correlação get/set → state. Contador do processo:
+/// colisão só ocorre se duas leituras em voo partilharem id — impossível
+/// dentro de um processo com contador monotônico.
+fn novo_request_id() -> String {
+    format!("req-{}", SEQUENCIA.fetch_add(1, Ordering::Relaxed))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Config do adapter — o que o gateway/CLI converte do `garraia-config`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Config de transporte do adapter MQTT.
+///
+/// `garraia-hardware` **não** depende de `garraia-config` — o gateway recebe
+/// `hardware.mqtt` do config (`MqttConfig`), resolve `password_env` e monta
+/// esta struct. O parse de `host:porta` vive aqui para ser testável no crate.
+pub struct MqttAdapterConfig {
+    /// Host ou IP do broker (sem porta).
+    pub broker_host: String,
+    /// Porta do broker (1–65535).
+    pub broker_port: u16,
+    /// Username MQTT, se o broker exigir.
+    pub username: Option<String>,
+    /// A senha JÁ RESOLVIDA do env — value-only, nunca logada (o `Debug`
+    /// desta struct redige) e nunca serializada.
+    pub password: Option<String>,
+    /// Client id do gateway no broker.
+    pub client_id: String,
+    /// Prefixo de tópico (default [`TOPIC_PREFIX_DEFAULT`]).
+    pub topic_prefix: String,
+    /// Quanto tempo uma leitura espera a resposta correlacionada.
+    pub timeout: Duration,
+}
+
+impl MqttAdapterConfig {
+    /// Config a partir de `broker` na forma `host:porta`.
+    ///
+    /// Literais IPv6 (`[::1]:1883`) não são suportados neste slice — os
+    /// brokers domésticos rodando no mesmo host usam `127.0.0.1`.
+    pub fn new(broker: &str, username: Option<String>, password: Option<String>) -> Result<Self> {
+        let mut partes = broker.rsplitn(2, ':');
+        // rsplitn(2, ':') devolve [porta, host] — o host vem por último.
+        let (port_str, host) = (
+            partes.next().unwrap_or_default(),
+            partes.next().unwrap_or_default(),
+        );
+        if host.is_empty() || port_str.is_empty() {
+            return Err(HardwareError::Mqtt(format!(
+                "broker '{broker}' malformado: esperado host:porta"
+            )));
+        }
+        let broker_port: u16 = port_str
+            .parse()
+            .map_err(|_| HardwareError::Mqtt(format!("broker '{broker}': porta não é número")))?;
+        if broker_port == 0 {
+            return Err(HardwareError::Mqtt(format!(
+                "broker '{broker}': porta 0 é inválida"
+            )));
+        }
+        Ok(Self {
+            broker_host: host.to_string(),
+            broker_port,
+            username,
+            password,
+            client_id: "garra-hardware".to_string(),
+            topic_prefix: TOPIC_PREFIX_DEFAULT.to_string(),
+            timeout: DEFAULT_TIMEOUT,
+        })
+    }
+
+    /// Seta o client id (único por conexão — dois clientes com o mesmo id
+    /// se des conectam em loop no broker).
+    #[must_use]
+    pub fn com_client_id(mut self, client_id: String) -> Self {
+        self.client_id = client_id;
+        self
+    }
+
+    /// Seta o prefixo de tópico.
+    #[must_use]
+    pub fn com_prefixo(mut self, topic_prefix: String) -> Self {
+        self.topic_prefix = topic_prefix;
+        self
+    }
+
+    /// Seta o timeout de leitura.
+    #[must_use]
+    pub fn com_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+}
+
+impl fmt::Debug for MqttAdapterConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MqttAdapterConfig")
+            .field("broker_host", &self.broker_host)
+            .field("broker_port", &self.broker_port)
+            .field("username", &self.username)
+            .field("password", &"<redacted>")
+            .field("client_id", &self.client_id)
+            .field("topic_prefix", &self.topic_prefix)
+            .field("timeout", &self.timeout)
+            .finish()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tópicos — a convenção é o contrato; funções nomeadas, ninguém remonta
+// string de tópico à mão.
+// ─────────────────────────────────────────────────────────────────────────────
+
+fn topico_get(prefixo: &str, id: &str, cap: &str) -> String {
+    format!("{prefixo}/devices/{id}/get/{cap}")
+}
+
+fn topico_set(prefixo: &str, id: &str, cap: &str) -> String {
+    format!("{prefixo}/devices/{id}/set/{cap}")
+}
+
+/// Os três filtros que o manager assina. `+` cobre o id do dispositivo.
+fn filtros_assinatura(prefixo: &str) -> [String; 3] {
+    [
+        format!("{prefixo}/devices/+/capabilities"),
+        format!("{prefixo}/devices/+/status"),
+        format!("{prefixo}/devices/+/state/+"),
+    ]
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Manifesto de descoberta — parse + validação na fronteira.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// O que um dispositivo publica (retained) em `{p}/devices/{id}/capabilities`.
+///
+/// O risk class de cada capability vem **aqui** — o manifesto do dispositivo
+/// é a declaração de risco; payload em runtime nunca reclassifica (#1126,
+/// §Segurança).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeviceManifest {
+    /// Id do dispositivo — tem que bater com o `{id}` do tópico.
+    pub id: String,
+    /// As capabilities expostas, cada uma com o risco declarado.
+    pub capabilities: Vec<Capability>,
+}
+
+/// Parseia (e valida) um manifesto vindo do broker.
+///
+/// Falha fechada: qualquer violação — risco incoerente com read_only, nome
+/// com caractere de tópico, id malformado — recusa o dispositivo inteiro.
+fn parse_manifesto(payload: &[u8]) -> Result<DeviceManifest> {
+    let manifesto: DeviceManifest = serde_json::from_slice(payload)
+        .map_err(|e| HardwareError::Mqtt(format!("manifesto não é JSON válido: {e}")))?;
+    if manifesto.id.is_empty() {
+        return Err(HardwareError::Mqtt(
+            "manifesto sem id de dispositivo".to_string(),
+        ));
+    }
+    valida_segmento_topico(&manifesto.id)?;
+    for cap in &manifesto.capabilities {
+        if cap.name.is_empty() {
+            return Err(HardwareError::Mqtt(format!(
+                "manifesto do dispositivo '{}' tem capability sem nome",
+                manifesto.id
+            )));
+        }
+        valida_segmento_topico(&cap.name).map_err(|e| {
+            HardwareError::Mqtt(format!(
+                "capability '{}' do dispositivo '{}': {e}",
+                cap.name, manifesto.id
+            ))
+        })?;
+        cap.validar().map_err(|e| {
+            HardwareError::Mqtt(format!("manifesto do dispositivo '{}': {e}", manifesto.id))
+        })?;
+    }
+    Ok(manifesto)
+}
+
+/// Nada de `/`, `+` ou `#` em segmentos de tópico — id e capability viajam
+/// dentro de tópicos, e um desses caracteres quebraria a convenção.
+fn valida_segmento_topico(segmento: &str) -> Result<()> {
+    if segmento.is_empty()
+        || segmento.contains('/')
+        || segmento.contains('+')
+        || segmento.contains('#')
+    {
+        return Err(HardwareError::Mqtt(format!(
+            "segmento '{segmento}' inválido: não pode ser vazio nem conter '/', '+' ou '#'"
+        )));
+    }
+    Ok(())
+}
+
+/// O mini-validador de argumentos (#1126): o subset truncado do JSON Schema
+/// que o `args_schema` de [`Capability`] garante — `type` (object),
+/// `properties` (tipos primitivos) e `required`. Chaves extras nos args são
+/// permitidas (semântica JSON Schema); tipo declarado que o validador não
+/// conhece **recusa** (fail-closed — não dá para provar, não passa).
+fn validar_args(
+    args: &Value,
+    schema: Option<&Value>,
+    dispositivo: &str,
+    capability: &str,
+) -> Result<()> {
+    let recusa = |fonte: String| {
+        Err(HardwareError::Adapter {
+            dispositivo: dispositivo.to_string(),
+            fonte,
+        })
+    };
+    let Some(schema) = schema else {
+        // Sem schema, o dispositivo declarou que não recebe argumentos.
+        return if args.as_object().is_some_and(|obj| obj.is_empty()) || args.is_null() {
+            Ok(())
+        } else {
+            recusa(format!(
+                "capability '{capability}' não declara argumentos; recebi {args}"
+            ))
+        };
+    };
+    let Some(obj_schema) = schema.as_object() else {
+        return recusa(format!("args_schema não é um objeto JSON: {schema}"));
+    };
+    if let Some(tipo) = obj_schema.get("type")
+        && tipo != "object"
+    {
+        return recusa(format!(
+            "args_schema suporta apenas type=object neste slice; recebi {tipo}"
+        ));
+    }
+    let Some(obj_args) = args.as_object() else {
+        return recusa(format!(
+            "argumentos precisam ser um objeto JSON; recebi {args}"
+        ));
+    };
+    if let Some(obrigatorios) = obj_schema.get("required").and_then(Value::as_array) {
+        for nome in obrigatorios {
+            let Some(nome) = nome.as_str() else {
+                return recusa(format!(
+                    "args_schema.required contém item não-texto: {nome}"
+                ));
+            };
+            if !obj_args.contains_key(nome) {
+                return recusa(format!("argumento obrigatório '{nome}' ausente"));
+            }
+        }
+    }
+    let Some(propriedades) = obj_schema.get("properties").and_then(Value::as_object) else {
+        return Ok(());
+    };
+    for (nome, spec) in propriedades {
+        let Some(valor) = obj_args.get(nome) else {
+            continue;
+        };
+        let Some(tipo) = spec.get("type").and_then(Value::as_str) else {
+            return recusa(format!(
+                "argumento '{nome}': schema não declara o tipo — o validador truncado só conhece type/properties/required"
+            ));
+        };
+        let ok = match tipo {
+            "string" => valor.is_string(),
+            "boolean" => valor.is_boolean(),
+            "number" => valor.is_number(),
+            "integer" => valor.as_i64().is_some(),
+            "array" => valor.is_array(),
+            "object" => valor.is_object(),
+            "null" => valor.is_null(),
+            _ => {
+                return recusa(format!(
+                    "argumento '{nome}': tipo '{tipo}' não suportado pelo validador (fail-closed)"
+                ));
+            }
+        };
+        if !ok {
+            return recusa(format!(
+                "argumento '{nome}': esperado {tipo}, recebi {valor}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MqttDevice — o Device que fala MQTT.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Um dispositivo descoberto via MQTT. Clona o cliente (barato — canal
+/// interno) e publica `get`/`set`; a resposta do `get` chega pelo event loop
+/// do manager, que roteia pelo `request_id`.
+pub struct MqttDevice {
+    id: String,
+    caps: Vec<Capability>,
+    client: AsyncClient,
+    prefixo: String,
+    pendentes: Arc<Pendentes>,
+    timeout: Duration,
+}
+
+impl MqttDevice {
+    fn new(
+        id: String,
+        caps: Vec<Capability>,
+        client: AsyncClient,
+        prefixo: String,
+        pendentes: Arc<Pendentes>,
+        timeout: Duration,
+    ) -> Self {
+        Self {
+            id,
+            caps,
+            client,
+            prefixo,
+            pendentes,
+            timeout,
+        }
+    }
+
+    fn capability(&self, name: &str) -> Result<&Capability> {
+        self.caps.iter().find(|c| c.name == name).ok_or_else(|| {
+            HardwareError::CapabilityDesconhecida {
+                dispositivo: self.id.clone(),
+                capability: name.to_string(),
+            }
+        })
+    }
+
+    fn erro_adapter(&self, fonte: String) -> HardwareError {
+        HardwareError::Adapter {
+            dispositivo: self.id.clone(),
+            fonte,
+        }
+    }
+}
+
+#[async_trait]
+impl Device for MqttDevice {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn capabilities(&self) -> Vec<Capability> {
+        self.caps.clone()
+    }
+
+    async fn read(&self, capability: &str) -> Result<Value> {
+        self.capability(capability)?;
+        let rid = novo_request_id();
+        let (tx, rx) = oneshot::channel();
+        self.pendentes.lock().await.insert(rid.clone(), tx);
+
+        let topico = topico_get(&self.prefixo, &self.id, capability);
+        let publicar = self
+            .client
+            .publish(
+                &topico,
+                QoS::AtLeastOnce,
+                false,
+                json!({ "request_id": rid }).to_string(),
+            )
+            .await;
+        if let Err(e) = publicar {
+            self.pendentes.lock().await.remove(&rid);
+            return Err(self.erro_adapter(format!("falha ao publicar '{topico}': {e}")));
+        }
+        match tokio::time::timeout(self.timeout, rx).await {
+            Ok(Ok(valor)) => Ok(valor),
+            Ok(Err(_)) => {
+                Err(self
+                    .erro_adapter("resposta descartada pelo manager (canal fechado)".to_string()))
+            }
+            Err(_) => {
+                self.pendentes.lock().await.remove(&rid);
+                Err(self.erro_adapter(format!(
+                    "sem resposta em {:?} (correlação get→state em '{topico}')",
+                    self.timeout
+                )))
+            }
+        }
+    }
+
+    async fn execute(&self, capability: &str, args: Value) -> Result<Value> {
+        let cap = self.capability(capability)?;
+        validar_args(&args, cap.args_schema.as_ref(), &self.id, capability)?;
+        let rid = novo_request_id();
+        let topico = topico_set(&self.prefixo, &self.id, capability);
+        self.client
+            .publish(
+                &topico,
+                QoS::AtLeastOnce,
+                false,
+                json!({ "request_id": rid, "args": args }).to_string(),
+            )
+            .await
+            .map_err(|e| self.erro_adapter(format!("falha ao publicar '{topico}': {e}")))?;
+        // Honestidade do transporte: só o broker confirmou a entrega. O
+        // estado aplicado é o que `read` devolver depois.
+        Ok(json!({
+            "device": self.id,
+            "capability": capability,
+            "published": true,
+            "request_id": rid,
+        }))
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// O manager — event loop único para o gateway inteiro.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Boot e event loop do adapter MQTT. Um [`MqttAdapterManager`] por
+/// processo: uma conexão, três assinaturas, N dispositivos.
+pub struct MqttAdapterManager {
+    client: AsyncClient,
+    tarefa: tokio::task::JoinHandle<()>,
+}
+
+impl MqttAdapterManager {
+    /// Sobe a conexão e o event loop em uma task tokio.
+    ///
+    /// Chamar **dentro de um runtime tokio** (gateway e CLI já são).
+    /// As assinaturas são (re)emitidas a cada `ConnAck` — reconnect do
+    /// rumqttc não re-assina sozinho com `clean_session: true`.
+    pub fn spawn(
+        config: MqttAdapterConfig,
+        registry: Arc<DeviceRegistry>,
+        state: Option<Arc<DeviceStateStore>>,
+    ) -> Result<Self> {
+        let mut opts = MqttOptions::new(
+            config.client_id.clone(),
+            config.broker_host.clone(),
+            config.broker_port,
+        );
+        if let Some(username) = &config.username {
+            // Senha sem username não forma par de credenciais MQTT — entra
+            // como anônimo. O `config check` avisa quando só há password_env.
+            opts.set_credentials(username, config.password.clone().unwrap_or_default());
+        }
+        let (client, eventloop) = AsyncClient::new(opts, CLIENT_CHANNEL_CAPACITY);
+        let pendentes: Arc<Pendentes> = Arc::default();
+        let tarefa = tokio::spawn(rodar(
+            config,
+            eventloop,
+            client.clone(),
+            registry,
+            state,
+            pendentes,
+        ));
+        Ok(Self { client, tarefa })
+    }
+
+    /// O cliente MQTT — para publicações fora do ciclo device (automações,
+    /// #1128) que queiram falar a mesma convenção de tópicos.
+    pub fn client(&self) -> &AsyncClient {
+        &self.client
+    }
+
+    /// Para o event loop (reload de config, shutdown de teste).
+    pub async fn encerrar(self) {
+        self.tarefa.abort();
+        let _ = self.tarefa.await;
+    }
+}
+
+async fn rodar(
+    config: MqttAdapterConfig,
+    mut eventloop: EventLoop,
+    client: AsyncClient,
+    registry: Arc<DeviceRegistry>,
+    state: Option<Arc<DeviceStateStore>>,
+    pendentes: Arc<Pendentes>,
+) {
+    let prefixo = config.topic_prefix.clone();
+    let filtros = filtros_assinatura(&prefixo);
+    loop {
+        match eventloop.poll().await {
+            Ok(Event::Incoming(Incoming::ConnAck(_))) => {
+                for filtro in &filtros {
+                    if let Err(e) = client.subscribe(filtro.clone(), QoS::AtLeastOnce).await {
+                        tracing::warn!("mqtt: falha ao assinar '{filtro}': {e}");
+                    }
+                }
+            }
+            Ok(Event::Incoming(Incoming::Publish(p))) => {
+                processa_publish(
+                    &prefixo,
+                    &p,
+                    &client,
+                    &registry,
+                    state.as_ref(),
+                    &pendentes,
+                    config.timeout,
+                )
+                .await;
+            }
+            Ok(_) => {}
+            Err(e) => {
+                // rumqttc reconecta no próximo poll (backoff próprio); as
+                // assinaturas voltam no ConnAck — por isso o handler acima.
+                tracing::warn!(error = %e, "mqtt: event loop com erro; reconectando");
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+        }
+    }
+}
+
+async fn processa_publish(
+    prefixo: &str,
+    p: &Publish,
+    client: &AsyncClient,
+    registry: &DeviceRegistry,
+    state: Option<&Arc<DeviceStateStore>>,
+    pendentes: &Arc<Pendentes>,
+    timeout: Duration,
+) {
+    let Some(resto) = p
+        .topic
+        .strip_prefix(&format!("{prefixo}/devices/"))
+        .map(str::to_owned)
+    else {
+        return;
+    };
+    let segmentos: Vec<&str> = resto.split('/').collect();
+    match segmentos.as_slice() {
+        [id, "capabilities"] => {
+            registrar_dispositivo(
+                id,
+                &p.payload,
+                client,
+                prefixo,
+                registry,
+                state,
+                pendentes.clone(),
+                timeout,
+            )
+            .await;
+        }
+        [id, "status"] => {
+            if let Some(store) = state {
+                aplicar_status(id, &p.payload, store).await;
+            }
+        }
+        [id, "state", cap] => {
+            // A resposta de leitura não depende de quem publicou — correlação
+            // por request_id, não por tópico. O {id} serve só para o log.
+            rotear_estado(id, cap, &p.payload, pendentes).await;
+        }
+        _ => {
+            // `get`/`set` são outbound; tópicos fora do contrato, ignorados.
+            tracing::debug!(topic = %p.topic, "mqtt: mensagem fora do contrato, ignorada");
+        }
+    }
+}
+
+async fn registrar_dispositivo(
+    id_topico: &str,
+    payload: &[u8],
+    client: &AsyncClient,
+    prefixo: &str,
+    registry: &DeviceRegistry,
+    state: Option<&Arc<DeviceStateStore>>,
+    pendentes: Arc<Pendentes>,
+    timeout: Duration,
+) {
+    let manifesto = match parse_manifesto(payload) {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!(topico = %id_topico, error = %e, "mqtt: manifesto inválido — dispositivo ignorado");
+            return;
+        }
+    };
+    if manifesto.id != id_topico {
+        tracing::warn!(
+            topico = %id_topico,
+            id_payload = %manifesto.id,
+            "mqtt: id do manifesto difere do tópico — dispositivo ignorado (fail-closed)"
+        );
+        return;
+    }
+    let device = MqttDevice::new(
+        manifesto.id.clone(),
+        manifesto.capabilities,
+        client.clone(),
+        prefixo.to_string(),
+        pendentes,
+        timeout,
+    );
+    registry.register(Arc::new(device));
+    if let Some(store) = state
+        && let Err(e) = store.marcar(id_topico, true).await
+    {
+        tracing::warn!(dispositivo = %id_topico, error = %e, "mqtt: falha ao marcar presença");
+    }
+    tracing::info!(dispositivo = %id_topico, "mqtt: dispositivo descoberto e registrado");
+}
+
+async fn aplicar_status(id: &str, payload: &[u8], store: &Arc<DeviceStateStore>) {
+    let texto = String::from_utf8_lossy(payload).trim().to_ascii_lowercase();
+    let online = match texto.as_str() {
+        "online" => true,
+        "offline" => false,
+        _ => {
+            tracing::warn!(dispositivo = %id, "mqtt: status desconhecido '{texto}' — ignorado");
+            return;
+        }
+    };
+    if let Err(e) = store.marcar(id, online).await {
+        tracing::warn!(dispositivo = %id, error = %e, "mqtt: falha ao marcar presença");
+    }
+}
+
+/// A resposta de leitura: `{"request_id": ..., "value": ...}` roteada para
+/// o canal do `read` que está esperando. Sem pending para o id, é estado
+/// não solicitado — log de debug e segue.
+async fn rotear_estado(id: &str, cap: &str, payload: &[u8], pendentes: &Arc<Pendentes>) {
+    #[derive(Deserialize)]
+    struct RespostaEstado {
+        request_id: String,
+        #[serde(default)]
+        value: Value,
+    }
+    let Ok(mensagem) = serde_json::from_slice::<RespostaEstado>(payload) else {
+        tracing::debug!(dispositivo = %id, capability = %cap, "mqtt: state sem request_id legível — ignorado");
+        return;
+    };
+    if let Some(tx) = pendentes.lock().await.remove(&mensagem.request_id) {
+        let _ = tx.send(mensagem.value);
+    } else {
+        tracing::debug!(dispositivo = %id, capability = %cap, "mqtt: estado não solicitado — ignorado");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::risk::RiskClass;
+    use serde_json::json;
+
+    // ─── Config ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn config_parseia_host_e_porta() {
+        let cfg = MqttAdapterConfig::new("127.0.0.1:1883", None, None).expect("válido");
+        assert_eq!(cfg.broker_host, "127.0.0.1");
+        assert_eq!(cfg.broker_port, 1883);
+        assert_eq!(cfg.client_id, "garra-hardware");
+        assert_eq!(cfg.topic_prefix, "garra");
+        assert_eq!(cfg.timeout, DEFAULT_TIMEOUT);
+        assert!(cfg.username.is_none());
+    }
+
+    #[test]
+    fn config_recusa_broker_malformado() {
+        for broker in ["127.0.0.1", "127.0.0.1:mqtt", "127.0.0.1:0", ":1883", ""] {
+            assert!(
+                MqttAdapterConfig::new(broker, None, None).is_err(),
+                "broker '{broker}' deveria ser recusado"
+            );
+        }
+    }
+
+    #[test]
+    fn config_debug_nunca_mostra_senha() {
+        let cfg = MqttAdapterConfig::new(
+            "127.0.0.1:1883",
+            Some("meu-user".to_string()),
+            Some("senha-super-secreta".to_string()),
+        )
+        .expect("válido");
+        let debug = format!("{cfg:?}");
+        assert!(debug.contains("<redacted>"), "senha redigida: {debug}");
+        assert!(
+            !debug.contains("senha-super-secreta"),
+            "senha vazou: {debug}"
+        );
+        assert!(
+            debug.contains("meu-user"),
+            "username aparece (não é secret)"
+        );
+    }
+
+    // ─── Tópicos ───────────────────────────────────────────────────────────
+
+    /// Os tópicos inbound (manifesto/status/estado) são construídos só por
+    /// quem publica — o gateway não publica neles. Os builders vivem nos
+    /// testes; a convenção fica travada aqui.
+    fn topico_manifesto(prefixo: &str, id: &str) -> String {
+        format!("{prefixo}/devices/{id}/capabilities")
+    }
+
+    fn topico_status(prefixo: &str, id: &str) -> String {
+        format!("{prefixo}/devices/{id}/status")
+    }
+
+    fn topico_estado(prefixo: &str, id: &str, cap: &str) -> String {
+        format!("{prefixo}/devices/{id}/state/{cap}")
+    }
+
+    #[test]
+    fn convencao_de_topicos_e_filtro() {
+        assert_eq!(
+            topico_manifesto("garra", "lampada"),
+            "garra/devices/lampada/capabilities"
+        );
+        assert_eq!(
+            topico_status("garra", "lampada"),
+            "garra/devices/lampada/status"
+        );
+        assert_eq!(
+            topico_get("garra", "lampada", "power"),
+            "garra/devices/lampada/get/power"
+        );
+        assert_eq!(
+            topico_set("garra", "lampada", "power"),
+            "garra/devices/lampada/set/power"
+        );
+        assert_eq!(
+            topico_estado("garra", "lampada", "power"),
+            "garra/devices/lampada/state/power"
+        );
+        assert_eq!(
+            filtros_assinatura("garra"),
+            [
+                "garra/devices/+/capabilities".to_string(),
+                "garra/devices/+/status".to_string(),
+                "garra/devices/+/state/+".to_string(),
+            ]
+        );
+    }
+
+    // ─── Manifesto ─────────────────────────────────────────────────────────
+
+    fn manifesto_ok() -> Value {
+        json!({
+            "id": "sensor-1",
+            "capabilities": [
+                { "name": "temperature", "risk": "r0", "read_only": true },
+                {
+                    "name": "power",
+                    "risk": "r1",
+                    "read_only": false,
+                    "args_schema": {
+                        "type": "object",
+                        "properties": { "on": { "type": "boolean" } },
+                        "required": ["on"]
+                    }
+                }
+            ]
+        })
+    }
+
+    #[test]
+    fn manifesto_parseia_risco_e_schema() {
+        let m = parse_manifesto(manifesto_ok().to_string().as_bytes()).expect("válido");
+        assert_eq!(m.id, "sensor-1");
+        assert_eq!(m.capabilities.len(), 2);
+        let power = &m.capabilities[1];
+        assert_eq!(power.risk, RiskClass::R1);
+        assert!(!power.read_only);
+        assert!(power.args_schema.is_some());
+    }
+
+    #[test]
+    fn manifesto_invalido_recusado_na_fronteira() {
+        // read_only com R3 — viola a invariante leitura↔R0.
+        let json = json!({
+            "id": "s",
+            "capabilities": [{ "name": "x", "risk": "r3", "read_only": true }]
+        });
+        let err = parse_manifesto(json.to_string().as_bytes()).expect_err("recusado");
+        assert!(err.to_string().contains("R3"), "erro cita o risco: {err}");
+
+        // risk fora da tabela não desserializa.
+        let json = json!({
+            "id": "s",
+            "capabilities": [{ "name": "x", "risk": "r9", "read_only": false }]
+        });
+        assert!(parse_manifesto(json.to_string().as_bytes()).is_err());
+
+        // nome com '/' quebraria a convenção de tópicos.
+        let json = json!({
+            "id": "s",
+            "capabilities": [{ "name": "a/b", "risk": "r1", "read_only": false }]
+        });
+        let err = parse_manifesto(json.to_string().as_bytes()).expect_err("recusado");
+        assert!(err.to_string().contains("a/b"), "erro cita o nome: {err}");
+
+        // id com caractere de wildcard de tópico.
+        let json = json!({
+            "id": "sen+sor",
+            "capabilities": [{ "name": "x", "risk": "r1", "read_only": false }]
+        });
+        assert!(parse_manifesto(json.to_string().as_bytes()).is_err());
+    }
+
+    // ─── Mini-validador ────────────────────────────────────────────────────
+
+    #[test]
+    fn validar_args_aceita_tipos_primitivos() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "on": { "type": "boolean" },
+                "percent": { "type": "integer" },
+                "tempo": { "type": "number" },
+                "nome": { "type": "string" },
+                "lista": { "type": "array" },
+                "extra": { "type": "object" },
+                "nada": { "type": "null" }
+            },
+            "required": ["on"]
+        });
+        let args = json!({
+            "on": true, "percent": 50, "tempo": 1.5,
+            "lista": [1, 2], "extra": {}, "nada": null
+        });
+        assert!(validar_args(&args, Some(&schema), "dev", "cap").is_ok());
+    }
+
+    #[test]
+    fn validar_args_recusa_erros_tipicos() {
+        let schema = json!({
+            "type": "object",
+            "properties": { "on": { "type": "boolean" } },
+            "required": ["on"]
+        });
+        // obrigatório ausente
+        let err = validar_args(&json!({}), Some(&schema), "dev", "power").expect_err("recusa");
+        assert!(err.to_string().contains("obrigatório"), "{err}");
+        // tipo errado
+        let err = validar_args(&json!({ "on": "sim" }), Some(&schema), "dev", "power")
+            .expect_err("recusa");
+        assert!(err.to_string().contains("boolean"), "{err}");
+        // 50.5 não é integer
+        let schema_int =
+            json!({ "type": "object", "properties": { "percent": { "type": "integer" } } });
+        let err = validar_args(&json!({ "percent": 50.5 }), Some(&schema_int), "dev", "cap")
+            .expect_err("recusa");
+        assert!(err.to_string().contains("integer"), "{err}");
+        // args não-objeto
+        let err = validar_args(&json!(true), Some(&schema), "dev", "power").expect_err("recusa");
+        assert!(err.to_string().contains("objeto"), "{err}");
+    }
+
+    #[test]
+    fn validar_args_sem_schema_recusa_argumentos() {
+        assert!(validar_args(&json!({}), None, "dev", "power").is_ok());
+        assert!(validar_args(&json!(null), None, "dev", "power").is_ok());
+        let err = validar_args(&json!({ "x": 1 }), None, "dev", "power").expect_err("recusa");
+        assert!(err.to_string().contains("não declara argumentos"), "{err}");
+    }
+
+    #[test]
+    fn validar_args_fail_closed_em_schema_que_nao_entende() {
+        // tipo de propriedade desconhecido
+        let schema = json!({ "type": "object", "properties": { "x": { "type": "bloco" } } });
+        let err =
+            validar_args(&json!({ "x": 1 }), Some(&schema), "dev", "cap").expect_err("recusa");
+        assert!(err.to_string().contains("fail-closed"), "{err}");
+        // propriedade sem type declarado
+        let schema = json!({ "type": "object", "properties": { "x": {} } });
+        let err =
+            validar_args(&json!({ "x": 1 }), Some(&schema), "dev", "cap").expect_err("recusa");
+        assert!(err.to_string().contains("não declara o tipo"), "{err}");
+        // schema de nível de topo não-objeto
+        let err = validar_args(&json!({}), Some(&json!([])), "dev", "cap").expect_err("recusa");
+        assert!(err.to_string().contains("objeto JSON"), "{err}");
+    }
+
+    // ─── Integração (broker embutido rumqttd) ──────────────────────────────
+
+    const P: &str = "garra";
+
+    /// Escolhe uma porta livre (efêmera) e devolve para o broker do teste.
+    fn porta_livre() -> u16 {
+        std::net::TcpListener::bind(("127.0.0.1", 0))
+            .expect("bind efêmero")
+            .local_addr()
+            .expect("addr")
+            .port()
+    }
+
+    /// rumqttd in-process, thread própria: `Broker::start` é blocking e
+    /// spawna os servers em threads internas. RouterConfig precisa de
+    /// valores reais (o Default tem zeros que o router recusa/panica).
+    fn subir_broker(porta: u16) {
+        let config = rumqttd::Config {
+            id: 1,
+            router: rumqttd::RouterConfig {
+                max_connections: 32,
+                max_outgoing_packet_count: 100_000,
+                max_segment_size: 1024 * 1024,
+                max_segment_count: 1000,
+                ..rumqttd::RouterConfig::default()
+            },
+            v4: Some(
+                std::iter::once((
+                    "teste".to_string(),
+                    rumqttd::ServerSettings {
+                        name: "teste".to_string(),
+                        listen: std::net::SocketAddr::from(([127, 0, 0, 1], porta)),
+                        tls: None,
+                        next_connection_delay_ms: 0,
+                        connections: rumqttd::ConnectionSettings {
+                            connection_timeout_ms: 10_000,
+                            max_payload_size: 1024 * 1024,
+                            max_inflight_count: 100,
+                            auth: None,
+                            external_auth: None,
+                            dynamic_filters: false,
+                        },
+                    },
+                ))
+                .collect::<std::collections::HashMap<String, rumqttd::ServerSettings>>(),
+            ),
+            ..rumqttd::Config::default()
+        };
+        std::thread::spawn(move || {
+            let mut broker = rumqttd::Broker::new(config);
+            let _ = broker.start();
+        });
+    }
+
+    /// Espera o broker aceitar TCP (o start() do rumqttd é assíncrono em
+    /// relação ao chamador).
+    async fn esperar_broker(porta: u16) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
+        loop {
+            if std::net::TcpStream::connect_timeout(
+                &std::net::SocketAddr::from(([127, 0, 0, 1], porta)),
+                Duration::from_millis(200),
+            )
+            .is_ok()
+            {
+                return;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "broker não subiu na porta {porta}"
+            );
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    }
+
+    fn config_manager(porta: u16) -> MqttAdapterConfig {
+        MqttAdapterConfig::new(&format!("127.0.0.1:{porta}"), None, None)
+            .expect("config válida")
+            .com_client_id(format!("garra-hw-{porta}"))
+            .com_timeout(Duration::from_secs(10))
+    }
+
+    /// Client MQTT do "dispositivo" do teste.
+    fn client_device(porta: u16, id: &str) -> (AsyncClient, EventLoop) {
+        AsyncClient::new(
+            rumqttc::MqttOptions::new(format!("dev-{id}-{porta}"), "127.0.0.1", porta),
+            16,
+        )
+    }
+
+    async fn esperar(mut cond: impl FnMut() -> bool, descricao: &str) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        while !cond() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timeout esperando: {descricao}"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    /// Espera a presença do dispositivo chegar ao estado esperado no store.
+    async fn esperar_presenca(
+        state: &Arc<DeviceStateStore>,
+        id: &str,
+        esperado_online: bool,
+        descricao: &str,
+    ) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            let bate = match state.estado(id).await {
+                Ok(Some(p)) => p.online == esperado_online,
+                _ => false,
+            };
+            if bate {
+                return;
+            }
+            assert!(std::time::Instant::now() < deadline, "timeout: {descricao}");
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    /// O ciclo completo da issue #1126 sobre um broker embutido: manifesto
+    /// retained → descoberta; get→state com request_id → leitura; set com
+    /// args validados → execução (o device recebe); manifesto com id
+    /// divergente não registra; status "offline" marca presença.
+    #[tokio::test]
+    async fn ciclo_completo_descoberta_leitura_e_execucao() {
+        let porta = porta_livre();
+        subir_broker(porta);
+        esperar_broker(porta).await;
+
+        // O "dispositivo": assina get/set e responde get com estado fixo.
+        let (device_client, mut device_ev) = client_device(porta, "sensor-1");
+        // O responder consome um clone do client; o original publica mais
+        // tarde (manifesto divergente, status offline).
+        let device_responder = device_client.clone();
+        device_client
+            .subscribe(topico_get(P, "sensor-1", "+"), QoS::AtLeastOnce)
+            .await
+            .expect("assina get");
+        device_client
+            .subscribe(topico_set(P, "sensor-1", "+"), QoS::AtLeastOnce)
+            .await
+            .expect("assina set");
+        device_client
+            .publish(
+                topico_manifesto(P, "sensor-1"),
+                QoS::AtLeastOnce,
+                true,
+                manifesto_ok().to_string(),
+            )
+            .await
+            .expect("publica manifesto retained");
+        device_client
+            .publish(
+                topico_status(P, "sensor-1"),
+                QoS::AtLeastOnce,
+                true,
+                "online",
+            )
+            .await
+            .expect("publica status retained");
+
+        let recebidos: Arc<Mutex<Vec<(String, Value)>>> = Arc::default();
+        let task_recebidos = recebidos.clone();
+        let device_task = device_responder;
+        tokio::spawn(async move {
+            loop {
+                match device_ev.poll().await {
+                    Ok(Event::Incoming(Incoming::Publish(p))) => {
+                        if !(p.topic.contains("/get/") || p.topic.contains("/set/")) {
+                            continue;
+                        }
+                        let Ok(carga) = serde_json::from_slice::<Value>(&p.payload) else {
+                            continue;
+                        };
+                        task_recebidos
+                            .lock()
+                            .await
+                            .push((p.topic.clone(), carga.clone()));
+                        if p.topic.contains("/get/") {
+                            let cap = p.topic.rsplit('/').next().unwrap_or("");
+                            let rid = carga["request_id"].as_str().unwrap_or("").to_string();
+                            let _ = device_task
+                                .publish(
+                                    topico_estado(P, "sensor-1", cap),
+                                    QoS::AtLeastOnce,
+                                    false,
+                                    json!({ "request_id": rid, "value": { "celsius": 23.0 } })
+                                        .to_string(),
+                                )
+                                .await;
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(_) => break,
+                }
+            }
+        });
+
+        let registry = Arc::new(DeviceRegistry::new());
+        let state = Arc::new(DeviceStateStore::em_memoria().expect("store"));
+        let manager =
+            MqttAdapterManager::spawn(config_manager(porta), registry.clone(), Some(state.clone()))
+                .expect("manager sobe");
+
+        // 1. Descoberta: o manifesto retained chega na assinatura.
+        esperar(
+            || registry.get("sensor-1").is_some(),
+            "dispositivo registrado",
+        )
+        .await;
+        let dev = registry.get("sensor-1").expect("registrado");
+        let caps = dev.capabilities();
+        let nomes: Vec<&str> = caps.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(
+            nomes,
+            vec!["temperature", "power"],
+            "capabilities do manifesto"
+        );
+
+        // Presença marcada online pela descoberta.
+        esperar_presenca(&state, "sensor-1", true, "presença online pela descoberta").await;
+
+        // 2. Leitura com correlação request_id.
+        let valor = dev.read("temperature").await.expect("lê temperature");
+        assert_eq!(valor, json!({ "celsius": 23.0 }));
+        esperar(
+            || {
+                recebidos
+                    .try_lock()
+                    .map(|r| {
+                        r.iter().any(|(t, c)| {
+                            t.ends_with("/get/temperature") && c["request_id"].is_string()
+                        })
+                    })
+                    .unwrap_or(false)
+            },
+            "get chegou no dispositivo",
+        )
+        .await;
+
+        // 3. Execução: args válidos são publicados com request_id.
+        let resultado = dev
+            .execute("power", json!({ "on": true }))
+            .await
+            .expect("executa");
+        assert_eq!(resultado["published"], json!(true));
+        assert_eq!(resultado["device"], json!("sensor-1"));
+        esperar(
+            || {
+                recebidos
+                    .try_lock()
+                    .map(|r| {
+                        r.iter().any(|(t, c)| {
+                            t.ends_with("/set/power") && c["args"] == json!({ "on": true })
+                        })
+                    })
+                    .unwrap_or(false)
+            },
+            "set chegou no dispositivo",
+        )
+        .await;
+
+        // 4. Args fora do schema são recusados antes de virar publish.
+        let err = dev
+            .execute("power", json!({ "on": "sim" }))
+            .await
+            .expect_err("recusa tipo errado");
+        assert!(err.to_string().contains("boolean"), "{err}");
+        let err = dev
+            .execute("power", json!({}))
+            .await
+            .expect_err("recusa obrigatório ausente");
+        assert!(err.to_string().contains("obrigatório"), "{err}");
+        assert!(dev.read("nada").await.is_err(), "capability desconhecida");
+
+        // 5. Manifesto com id divergente do tópico: fail-closed, não registra.
+        let ghost = json!({
+            "id": "outro-id",
+            "capabilities": [{ "name": "x", "risk": "r1", "read_only": false }]
+        });
+        device_client
+            .publish(
+                topico_manifesto(P, "ghost"),
+                QoS::AtLeastOnce,
+                true,
+                ghost.to_string(),
+            )
+            .await
+            .expect("publica manifesto divergente");
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        assert!(
+            registry.get("ghost").is_none(),
+            "id divergente não registra (fail-closed)"
+        );
+
+        // 6. Status "offline" marca presença.
+        device_client
+            .publish(
+                topico_status(P, "sensor-1"),
+                QoS::AtLeastOnce,
+                false,
+                "offline",
+            )
+            .await
+            .expect("publica offline");
+        esperar_presenca(&state, "sensor-1", false, "presença offline pelo status").await;
+
+        manager.encerrar().await;
+    }
+
+    /// O aceite "LWT/availability": o dispositivo desconecta, o broker
+    /// publica a will em `status`, o manager marca offline no store.
+    #[tokio::test]
+    async fn lwt_do_dispositivo_marca_offline() {
+        let porta = porta_livre();
+        subir_broker(porta);
+        esperar_broker(porta).await;
+
+        let mut opts = rumqttc::MqttOptions::new(format!("dev-lwt-{porta}"), "127.0.0.1", porta);
+        opts.set_last_will(rumqttc::LastWill {
+            topic: topico_status(P, "sensor-2"),
+            message: "offline".into(),
+            qos: QoS::AtLeastOnce,
+            retain: false,
+        });
+        let (device_client, mut device_ev) = AsyncClient::new(opts, 16);
+        // AsyncClient só funciona com o event loop sendo drenado — a task
+        // abaixo é quem mantém a conexão viva; abortá-la derruba o socket.
+        let task_device = tokio::spawn(async move { while device_ev.poll().await.is_ok() {} });
+        let manifesto = json!({
+            "id": "sensor-2",
+            "capabilities": [{ "name": "temperature", "risk": "r0", "read_only": true }]
+        });
+        device_client
+            .publish(
+                topico_manifesto(P, "sensor-2"),
+                QoS::AtLeastOnce,
+                true,
+                manifesto.to_string(),
+            )
+            .await
+            .expect("publica manifesto");
+
+        let registry = Arc::new(DeviceRegistry::new());
+        let state = Arc::new(DeviceStateStore::em_memoria().expect("store"));
+        let manager =
+            MqttAdapterManager::spawn(config_manager(porta), registry.clone(), Some(state.clone()))
+                .expect("manager sobe");
+        esperar(
+            || registry.get("sensor-2").is_some(),
+            "dispositivo registrado",
+        )
+        .await;
+        esperar_presenca(&state, "sensor-2", true, "presença online pela descoberta").await;
+
+        // Mata o dispositivo: a task do event loop é abortada, o socket fecha e
+        // o broker publica a will.
+        task_device.abort();
+        let _ = task_device.await;
+        esperar_presenca(&state, "sensor-2", false, "presença offline após LWT").await;
+
+        manager.encerrar().await;
+    }
+}

--- a/crates/garraia-hardware/src/error.rs
+++ b/crates/garraia-hardware/src/error.rs
@@ -38,6 +38,11 @@ pub enum HardwareError {
     #[error("falha no dispositivo '{dispositivo}': {fonte}")]
     Adapter { dispositivo: String, fonte: String },
 
+    /// Erro do transporte MQTT no manager (#1126) — sem dispositivo
+    /// associado (config malformada, assinatura, event loop).
+    #[error("erro MQTT: {0}")]
+    Mqtt(String),
+
     /// Erro do SQLite (o store de presença).
     #[error("erro de SQLite no estado de hardware: {0}")]
     Sqlite(#[from] rusqlite::Error),

--- a/crates/garraia-hardware/src/lib.rs
+++ b/crates/garraia-hardware/src/lib.rs
@@ -22,9 +22,11 @@
 //!
 //! Nenhum dispositivo físico é conectado aqui. Sem adaptador registrado, o
 //! [`DeviceRegistry`] fica vazio e as tools do agente (`device_list`,
-//! `device_read`, `device_execute`, em `garraia-agents`) listam nada. I/O
-//! físico de verdade só existe a partir de #1126, cada adapter com o próprio
-//! risco avaliado no PR correspondente.
+//! `device_read`, `device_execute`, em `garraia-agents`) listam nada. O
+//! primeiro transporte real é o adapter MQTT (#1126), em [`adapter_mqtt`],
+//! atrás da feature `mqtt` — OFF por default, mesmo padrão do `storage-s3`:
+//! quem não usa transporte de rede não paga a árvore de deps. Cada adapter
+//! traz o próprio risco avaliado no PR correspondente.
 //!
 //! O estado online/offline dos dispositivos ([`DeviceStateStore`]) segue o
 //! padrão do repo: SQLite via rusqlite bundled, acesso sync sob mutex.
@@ -40,6 +42,9 @@ pub mod state;
 #[cfg(feature = "mock-device")]
 pub mod mock;
 
+#[cfg(feature = "mqtt")]
+pub mod adapter_mqtt;
+
 pub use capability::Capability;
 pub use device::{Device, DeviceSummary};
 pub use error::HardwareError;
@@ -50,6 +55,9 @@ pub use state::DeviceStateStore;
 
 #[cfg(feature = "mock-device")]
 pub use mock::MockDevice;
+
+#[cfg(feature = "mqtt")]
+pub use adapter_mqtt::{DeviceManifest, MqttAdapterConfig, MqttAdapterManager, MqttDevice};
 
 /// Resultado das operações de hardware.
 pub type Result<T> = std::result::Result<T, HardwareError>;


### PR DESCRIPTION
Implementa a issue #1126 (adapter MQTT do `garraia-hardware`), segundo slice do epic #1124 — em cima do `fa63cf6a` da #1161 (fundação #1125+#1129).

## O que entra

**Crate `garraia-hardware` — feature `mqtt` (OFF por default, mesmo padrão do `storage-s3`):**

- `adapter_mqtt.rs` (~1300 linhas, 38 testes) — adapter completo sobre `rumqttc 0.25`:
  - **Convenção de tópicos** (documentada no header do módulo): `{p}/devices/{id}/capabilities` (manifesto, **retained** — resolve a corrida de descoberta), `{p}/devices/{id}/status` ("online"/"offline", LWT, retained recomendado), `{p}/devices/{id}/get/{cap}` (`{"request_id"}`), `{p}/devices/{id}/state/{cap}` (`{"request_id", "value"}`), `{p}/devices/{id}/set/{cap}` (`{"request_id", "args"}`).
  - **Descoberta**: manifesto JSON (`DeviceManifest`) validado fail-closed — id não vazio, id = segmento do tópico, segmentos sem `/`, `+`, `#`, nome de capability higiênico, e cada capability passa por `Capability::validar()` (invariante leitura↔R0). Manifesto violador recusa **o dispositivo inteiro**.
  - **Leitura**: publica `get/{cap}` com `request_id` (`req-N`, contador do processo) e espera `state/{cap}` correlacionado via mapa de oneshots — sem resposta no timeout (default 5s), erro claro para o modelo, entrada removida do mapa.
  - **Execução**: `set/{cap}` com args mini-validados contra o schema truncado do manifesto (type/properties/required, tipos primitivos; `None` schema → args precisam ser vazios) e devolve `{"published": true, "request_id"}` — **honesto**: confirma o que o broker aceitou, não o que o dispositivo aplicou; o gate R0–R5 continua na tool.
  - **Risco**: vem do manifesto declarado — **nunca** inferido de payload em tempo de execução.
  - **Presença**: `status` e LWT marcam o `DeviceStateStore`; reconnect do rumqttc re-assina os três filtros a cada `ConnAck` (o rumqttc não re-assina sozinho com `clean_session: true`).
  - **Senha**: `MqttAdapterConfig` recebe o valor **já resolvido** do env; `Debug` redige; nunca serializada nem logada.
- Testes de integração sobem um **broker rumqttd 0.20 in-process** (sem docker): ciclo completo manifesto-retained → descoberta → presença → leitura correlacionada → execução → status offline, e um teste de LWT. Nota de setup descoberta a duras penas: o `RouterConfig::default()` do rumqttd é tudo zeros — `max_connections: 0` rejeita conexão e `CommitLog::new` entra em pânico com `max_segment_size < 1024`; o harness seta valores reais.

**Config (`garraia-config`):**

- `[hardware.mqtt]`: `broker` (`host:porta`), `username`, `password_env` (**nome** da env que guarda a senha — write-only, nunca o valor) e `client_id_prefix` (default `"garra"`; o pid completa a unicidade — dois clientes com o mesmo id se des-conectam em loop).
- `AppConfig::hardware_db_path()` — fonte única do caminho do store de presença (`<data_dir>/hardware.db`), mesmo contrato do `memory_db_path()`: gateway e CLI abrem o mesmo arquivo.
- `check.rs`: `validate_hardware` valida broker `host:porta`, porta 0/não-numérica e prefixo vazio — `garra config check` mostra os mesmos erros antes do boot.

**Wiring (gateway + CLI — função única `spawn_mqtt_adapter`):**

- Com `hardware.mqtt` configurado, o boot sobe o `MqttAdapterManager` (event loop em task tokio), abre o `DeviceStateStore` e liga `DeviceToolsConfig::com_estado` — as tools `device_list/read/execute` passam a enxergar dispositivos reais, com online/offline.
- **Fail-soft no boot**: broker malformado, `password_env` apontando para env vazia/ausente ou store que não abre → warn dizendo o que faltou, registry segue vazio; nada derruba o gateway. O warn cita o **nome** da env, jamais a senha.
- Sem a seção no config, nada muda: registry vazio, `device_list` lista nada (fail-closed, estado default do deploy).
- `garra chat` sobe o mesmo transporte pela **mesma função** do gateway (`garraia_gateway::bootstrap::spawn_mqtt_adapter`) — wiring único, warns idênticos.
- A feature `mqtt` fica ligada no `garraia-gateway` incondicionalmente (gateway é o host de hardware; rumqttc é cliente Rust puro, sem runtime C) — o **boot** decide pelo config se o transporte sobe.

**CI ("mesmo buraco" do #1089):** step novo compila e testa a feature off-by-default que o `--workspace` não tocava: `cargo clippy -p garraia-hardware --features mqtt --all-targets -- -D warnings` + `cargo test -p garraia-hardware --features mqtt --lib`.

## Verificação local

- `cargo clippy -p garraia-hardware --features mqtt --all-targets -- -D warnings` — limpo
- `cargo test -p garraia-hardware --features mqtt --lib` — 38/38
- `cargo test -p garraia-config --lib` — 137/137 (novo teste dos caminhos `memory.db`/`hardware.db`)
- `cargo test -p garraia` — 476/476 (o teste estrito prompt↔registro ficou verde)
- `cargo check --workspace --exclude garraia-desktop` — limpo (desktop segue dependendo das libs de sistema que só o CI tem)

## O que fica para os próximos slices

- #1127 (Home Assistant) — o `Device`/`Capability`/gate já prontos recebem o próximo transporte.
- #1128 (automações) — boot declarativo de adapters e o handle do manager para reload.
- #1130 (Serial/GPIO), #1131 (skills).

Closes #1126 (parte do epic #1124).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
