### PR TITLE
feat(hardware): adapter Home Assistant REST + WebSocket (#1127)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,6 +398,16 @@ jobs:
           cargo test -p garraia-hardware --features mqtt --lib
           echo "::endgroup::"
 
+          # Mesmo buraco para a feature `home-assistant` (#1127): idem —
+          # aqui SEM `--lib`, porque a feature traz testes de integracao
+          # contra um hub mockado (axum) em tests/, e e exatamente esse
+          # fluxo (descoberta, servicos, WebSocket de presenca) que precisa
+          # de gate.
+          echo "::group::garraia-hardware --features home-assistant"
+          cargo clippy -p garraia-hardware --features home-assistant --all-targets -- -D warnings
+          cargo test -p garraia-hardware --features home-assistant
+          echo "::endgroup::"
+
   # Supply-chain gate: license allow-list + crate bans + registry source bans
   # + RustSec advisories. Uses deny.toml at the repo root. Runs in parallel
   # with clippy. Now invokes the `cargo-deny-action` default `command: check`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3720,6 +3720,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.29.0",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3557,6 +3557,7 @@ dependencies = [
  "tokio",
  "toml 1.1.5+spec-1.1.0",
  "tracing",
+ "url",
  "validator",
 ]
 
@@ -3706,6 +3707,10 @@ name = "garraia-hardware"
 version = "0.4.1"
 dependencies = [
  "async-trait",
+ "axum 0.8.9",
+ "futures",
+ "garraia-common",
+ "reqwest 0.12.28",
  "rumqttc",
  "rumqttd",
  "rusqlite",
@@ -3713,6 +3718,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.20",
  "tokio",
+ "tokio-tungstenite 0.29.0",
  "tracing",
 ]
 

--- a/changelog.d/added/1127-adapter-homeassistant.md
+++ b/changelog.d/added/1127-adapter-homeassistant.md
@@ -1,0 +1,22 @@
+- O gateway fala com o hub Home Assistant (#1127, epic #1124). Com a secao
+  `hardware.home_assistant` no config (`url` do hub e `token_env` — o
+  **nome** da env que guarda o long-lived access token, nunca o token), o
+  boot sobe o adapter REST + WebSocket: descobre entidades por
+  `GET /api/states`, le por `GET /api/states/{entity_id}`, executa por
+  `POST /api/services/{domain}/{service}` e marca presenca pelos eventos
+  `state_changed` do WebSocket, com reconexao automatica.
+- Risco por dominio, pre-avaliado: sensor e binary_sensor so leem (R0);
+  light, switch e climate executam em R1 (power, brightness, temperature);
+  cover em R2 (open, close, set_position); lock em R3 (lock, unlock). Todo
+  dominio fora dessa tabela nao vira dispositivo — fail-closed, sem R4/R5
+  neste slice.
+- Toda chamada ao hub passa pelo guard SSRF (`vet_url` + cliente pinado,
+  regra 14) com escopo de IPs privados: o hub e alvo legitimo da LAN, mas
+  link-local, CGNAT, multicast e addresses nao especificados continuam
+  bloqueados; o WebSocket conecta no mesmo IP pinado, sem re-resolver DNS.
+- `garra chat` sobe o mesmo adapter pela mesma funcao do gateway, e o store
+  de presenca (`hardware.db`) passa a ser compartilhado entre os adapters
+  configurados — uma fonte unica de online/offline.
+- Feature `home-assistant` OFF por default (mesmo padrao do `mqtt` e do
+  `storage-s3`): quem nao usa o hub nao paga a arvore de deps
+  (reqwest + tokio-tungstenite). Sem a secao no config, nada muda.

--- a/crates/garraia-cli/src/chat.rs
+++ b/crates/garraia-cli/src/chat.rs
@@ -18,7 +18,7 @@ use garraia_agents::{
 };
 use garraia_config::AppConfig;
 use garraia_db::SessionStore;
-use garraia_gateway::bootstrap::spawn_mqtt_adapter;
+use garraia_gateway::bootstrap::spawn_hardware_adapters;
 use garraia_hardware::DeviceRegistry;
 use tokio::sync::mpsc;
 
@@ -145,7 +145,8 @@ fn get_api_key(config: &AppConfig, provider_name: &str, env_var: &str) -> Option
 /// `review` is the provider + model `code_review` runs its second LLM call
 /// on; `None` skips it, which is what the tests do because building a real
 /// provider needs a backend. `brave_key` gates `web_search` exactly like the
-/// gateway does. `config` feeds `spawn_mqtt_adapter`: com `hardware.mqtt`
+/// gateway does. `config` feeds `spawn_hardware_adapters`: com
+/// `hardware.mqtt` ou `hardware.home_assistant`
 /// configurado o CLI abre o mesmo transporte e o mesmo store de presenca do
 /// gateway (`AppConfig::hardware_db_path`). `schedule_heartbeat` /
 /// `schedule_recurring` need a
@@ -183,7 +184,7 @@ fn register_cli_tools(
     // senha, client id e store de presença idênticos, inclusive os warns).
     // Sem adapter, `device_list` lista nada (#1128 liga o boot via config).
     let device_registry = Arc::new(DeviceRegistry::new());
-    let device_state = spawn_mqtt_adapter(config, device_registry.clone());
+    let device_state = spawn_hardware_adapters(config, device_registry.clone());
     let device_config = Arc::new(match device_state {
         Some(state) => DeviceToolsConfig::new(device_registry).com_estado(state),
         None => DeviceToolsConfig::new(device_registry),

--- a/crates/garraia-config/Cargo.toml
+++ b/crates/garraia-config/Cargo.toml
@@ -23,3 +23,6 @@ dirs = "6"
 # GAR-391c — AuthConfig::from_env validation + redacted secret wrapping.
 secrecy = { version = "0.10", features = ["serde"] }
 validator = { version = "0.21", features = ["derive"] }
+# #1127 — `valida_home_assistant` no check: mesmo parser de URL que o guard
+# de SSRF vai usar no boot, para o `config check` não concordar com ele.
+url = { workspace = true }

--- a/crates/garraia-config/src/check.rs
+++ b/crates/garraia-config/src/check.rs
@@ -1597,10 +1597,65 @@ fn validate_hardware(
     findings: &mut Vec<Finding>,
     push_err: &impl Fn(&mut Vec<Finding>, &str, String),
 ) {
-    let Some(mqtt) = &hardware.mqtt else {
+    if let Some(mqtt) = &hardware.mqtt {
+        valida_mqtt(mqtt, findings, push_err);
+    }
+    if let Some(ha) = &hardware.home_assistant {
+        valida_home_assistant(ha, findings, push_err);
+    }
+}
+
+/// #1127: a URL do HA precisa de esquema http/https e host — é ela que o
+/// guard de SSRF (`vet_url`) vai vetar e pinar no boot. O `token_env` é
+/// presença-e-conteúdo: o HA API não tem modo anônimo, e config que cita
+/// env vazia/inexistente sobe com o adapter morto e o registry vazio —
+/// melhor o operador ver isso antes de reiniciar.
+fn valida_home_assistant(
+    ha: &crate::model::HaConfig,
+    findings: &mut Vec<Finding>,
+    push_err: &impl Fn(&mut Vec<Finding>, &str, String),
+) {
+    let Ok(url) = url::Url::parse(&ha.url) else {
+        push_err(
+            findings,
+            "hardware.home_assistant.url",
+            format!("hardware.home_assistant.url ({:?}) is not a valid URL", ha.url),
+        );
         return;
     };
+    let scheme = url.scheme();
+    if scheme != "http" && scheme != "https" {
+        push_err(
+            findings,
+            "hardware.home_assistant.url",
+            format!(
+                "hardware.home_assistant.url ({:?}) must use http or https (got {scheme:?})",
+                ha.url
+            ),
+        );
+    }
+    if url.host_str().is_none_or(str::is_empty) {
+        push_err(
+            findings,
+            "hardware.home_assistant.url",
+            format!("hardware.home_assistant.url ({:?}) has no host", ha.url),
+        );
+    }
+    if ha.token_env.trim().is_empty() {
+        push_err(
+            findings,
+            "hardware.home_assistant.token_env",
+            "hardware.home_assistant.token_env must be non-empty (HA has no anonymous API)"
+                .to_string(),
+        );
+    }
+}
 
+fn valida_mqtt(
+    mqtt: &crate::model::MqttConfig,
+    findings: &mut Vec<Finding>,
+    push_err: &impl Fn(&mut Vec<Finding>, &str, String),
+) {
     let (host, port) = match mqtt.broker.rsplit_once(':') {
         Some((host, port)) => (host, port),
         None => {
@@ -2451,6 +2506,7 @@ mod tests {
                     password_env: None,
                     client_id_prefix: "garra".to_string(),
                 }),
+                home_assistant: None,
             },
             ..AppConfig::default()
         };
@@ -2474,6 +2530,7 @@ mod tests {
                     password_env: None,
                     client_id_prefix: "garra".to_string(),
                 }),
+                home_assistant: None,
             },
             ..AppConfig::default()
         };
@@ -2497,6 +2554,7 @@ mod tests {
                     password_env: Some("GARRA_MQTT_PASS".to_string()),
                     client_id_prefix: "garra".to_string(),
                 }),
+                home_assistant: None,
             },
             ..AppConfig::default()
         };
@@ -2508,6 +2566,117 @@ mod tests {
         // Presence-only: nenhum finding carrega o nome da env var como valor
         // (o nome é público de propósito, mas a disciplina de não ecoar
         // segredo vale por princípio — aqui não há segredo para ecoar).
+    }
+
+    #[test]
+    fn ha_url_badscheme_is_error() {
+        use crate::model::{HaConfig, HardwareConfig};
+        let cfg = AppConfig {
+            hardware: HardwareConfig {
+                home_assistant: Some(HaConfig {
+                    url: "ftp://homeassistant.local:8123".to_string(),
+                    token_env: "GARRA_HA_TOKEN".to_string(),
+                }),
+                mqtt: None,
+            },
+            ..AppConfig::default()
+        };
+        let findings = validate(&cfg);
+        assert!(
+            findings.iter().any(|f| f.severity == Severity::Error
+                && f.field == "hardware.home_assistant.url"),
+            "expected error on non-http scheme: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn ha_url_not_a_url_is_error() {
+        use crate::model::{HaConfig, HardwareConfig};
+        let cfg = AppConfig {
+            hardware: HardwareConfig {
+                home_assistant: Some(HaConfig {
+                    url: "homeassistant.local".to_string(), // sem esquema
+                    token_env: "GARRA_HA_TOKEN".to_string(),
+                }),
+                mqtt: None,
+            },
+            ..AppConfig::default()
+        };
+        let findings = validate(&cfg);
+        assert!(
+            findings.iter().any(|f| f.severity == Severity::Error
+                && f.field == "hardware.home_assistant.url"),
+            "expected error on url sem esquema: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn ha_empty_token_env_is_error() {
+        use crate::model::{HaConfig, HardwareConfig};
+        let cfg = AppConfig {
+            hardware: HardwareConfig {
+                home_assistant: Some(HaConfig {
+                    url: "http://127.0.0.1:8123".to_string(),
+                    token_env: "  ".to_string(),
+                }),
+                mqtt: None,
+            },
+            ..AppConfig::default()
+        };
+        let findings = validate(&cfg);
+        assert!(
+            findings.iter().any(|f| f.severity == Severity::Error
+                && f.field == "hardware.home_assistant.token_env"),
+            "expected error on token_env vazia: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn ha_valid_config_is_clean() {
+        use crate::model::{HaConfig, HardwareConfig};
+        let cfg = AppConfig {
+            hardware: HardwareConfig {
+                home_assistant: Some(HaConfig {
+                    url: "http://homeassistant.local:8123".to_string(),
+                    token_env: "GARRA_HA_TOKEN".to_string(),
+                }),
+                mqtt: None,
+            },
+            ..AppConfig::default()
+        };
+        let findings = validate(&cfg);
+        assert!(
+            findings.iter().all(|f| !f.field.starts_with("hardware")),
+            "valid HA config produced findings: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn hardware_both_adapters_at_once_is_clean() {
+        // MQTT e HA no mesmo config é o caso real da casa: o broker para os
+        // zigbee2mqtt e o HA para o resto. Os dois validam em série, sem se
+        // atrapalharem.
+        use crate::model::{HaConfig, HardwareConfig, MqttConfig};
+        let cfg = AppConfig {
+            hardware: HardwareConfig {
+                mqtt: Some(MqttConfig {
+                    broker: "127.0.0.1:1883".to_string(),
+                    username: None,
+                    password_env: None,
+                    client_id_prefix: "garra".to_string(),
+                }),
+                home_assistant: Some(HaConfig {
+                    url: "https://ha.casa.local:8123".to_string(),
+                    token_env: "GARRA_HA_TOKEN".to_string(),
+                }),
+            },
+            ..AppConfig::default()
+        };
+        let findings = validate(&cfg);
+        assert!(
+            findings.iter().all(|f| !f.field.starts_with("hardware")),
+            "both adapters valid mas encontrou findings: {findings:?}"
+        );
     }
 
     #[test]

--- a/crates/garraia-config/src/check.rs
+++ b/crates/garraia-config/src/check.rs
@@ -1619,7 +1619,10 @@ fn valida_home_assistant(
         push_err(
             findings,
             "hardware.home_assistant.url",
-            format!("hardware.home_assistant.url ({:?}) is not a valid URL", ha.url),
+            format!(
+                "hardware.home_assistant.url ({:?}) is not a valid URL",
+                ha.url
+            ),
         );
         return;
     };
@@ -2583,8 +2586,9 @@ mod tests {
         };
         let findings = validate(&cfg);
         assert!(
-            findings.iter().any(|f| f.severity == Severity::Error
-                && f.field == "hardware.home_assistant.url"),
+            findings
+                .iter()
+                .any(|f| f.severity == Severity::Error && f.field == "hardware.home_assistant.url"),
             "expected error on non-http scheme: {findings:?}"
         );
     }
@@ -2604,8 +2608,9 @@ mod tests {
         };
         let findings = validate(&cfg);
         assert!(
-            findings.iter().any(|f| f.severity == Severity::Error
-                && f.field == "hardware.home_assistant.url"),
+            findings
+                .iter()
+                .any(|f| f.severity == Severity::Error && f.field == "hardware.home_assistant.url"),
             "expected error on url sem esquema: {findings:?}"
         );
     }
@@ -2625,8 +2630,10 @@ mod tests {
         };
         let findings = validate(&cfg);
         assert!(
-            findings.iter().any(|f| f.severity == Severity::Error
-                && f.field == "hardware.home_assistant.token_env"),
+            findings
+                .iter()
+                .any(|f| f.severity == Severity::Error
+                    && f.field == "hardware.home_assistant.token_env"),
             "expected error on token_env vazia: {findings:?}"
         );
     }

--- a/crates/garraia-config/src/model.rs
+++ b/crates/garraia-config/src/model.rs
@@ -99,14 +99,18 @@ impl Default for AppConfig {
 
 /// ADR 0020 / #1126 — configuração do transporte de hardware.
 ///
-/// Hoje só o adapter MQTT; adapters futuros (#1127 Home Assistant,
-/// #1130 Serial/GPIO) entram como campos aditivos desta seção.
+/// Hoje os adapters MQTT e Home Assistant; adapters futuros (#1130
+/// Serial/GPIO) entram como campos aditivos desta seção.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct HardwareConfig {
     /// Adapter MQTT (rumqttc). `None` = sem MQTT — o gateway não sobe o
     /// loop de descoberta e o registry fica vazio (fail-closed).
     #[serde(default)]
     pub mqtt: Option<MqttConfig>,
+    /// Adapter Home Assistant (REST + WebSocket). `None` = sem HA — o
+    /// registry não ganha as entidades do hub (fail-closed).
+    #[serde(default)]
+    pub home_assistant: Option<HaConfig>,
 }
 
 /// Conexão com o broker MQTT (#1126). Credencial de senha é **write-only**:
@@ -131,6 +135,22 @@ pub struct MqttConfig {
 
 fn default_mqtt_client_prefix() -> String {
     "garra".to_string()
+}
+
+/// Conexão com o Home Assistant (#1127). O `token_env` é **obrigatório** —
+/// a API do HA não tem modo anônimo e o long-lived access token é
+/// credencial de admin do hub. Write-only como o resto: config carrega o
+/// nome da env, o boot resolve o valor e **nunca loga**.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HaConfig {
+    /// URL base do HA, com esquema e porta (`"http://homeassistant.local:8123"`).
+    /// A chamada REST passa pelo guard de SSRF (`vet_url` + `pinned_client`
+    /// com `IpScope::AllowPrivate` — o HA é alvo legítimo da LAN, e o guard
+    /// ainda bloqueia link-local/CGNAT/multicast).
+    pub url: String,
+    /// Nome da env var que guarda o long-lived access token. Obrigatório
+    /// e não vazio — sem token, o adapter nem sobe.
+    pub token_env: String,
 }
 
 /// Non-secret auth knobs (plan 0046 / GAR-379 slice 3).

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -13,11 +13,12 @@ garraia-channels = { workspace = true, features = ["discord", "telegram", "slack
 garraia-agents = { workspace = true, features = ["mcp"] }
 # ADR 0020 (epic #1124): o registry de dispositivos que alimenta as tools
 # device_list/read/execute. Sem adapter registrado, fica vazio (#1128 liga
-# o boot de adapters via config). A feature `mqtt` fica ligada aqui
-# incondicionalmente: o gateway e o host de hardware, o boot decide pelo
-# config se o transporte sobe (`hardware.mqtt`) — rumqttc e cliente Rust
-# puro, sem runtime C.
-garraia-hardware = { workspace = true, features = ["mqtt"] }
+# o boot de adapters via config). As features de transporte (`mqtt`,
+# `home-assistant`) ficam ligadas aqui incondicionalmente: o gateway e o
+# host de hardware, o boot decide pelo config se cada transporte sobe
+# (`hardware.mqtt` / `hardware.home_assistant`) — rumqttc e cliente Rust
+# puro, sem runtime C; o HA vai por REST + WebSocket atrás do guard SSRF.
+garraia-hardware = { workspace = true, features = ["mqtt", "home-assistant"] }
 garraia-runtime = { workspace = true }
 garraia-db = { workspace = true }
 garraia-security = { workspace = true }

--- a/crates/garraia-gateway/src/bootstrap/mod.rs
+++ b/crates/garraia-gateway/src/bootstrap/mod.rs
@@ -10,7 +10,10 @@ use garraia_agents::{
 };
 use garraia_config::{AppConfig, provider_key_env};
 use garraia_db::MemoryStore;
-use garraia_hardware::{DeviceRegistry, DeviceStateStore, MqttAdapterConfig, MqttAdapterManager};
+use garraia_hardware::{
+    DeviceRegistry, DeviceStateStore, HaAdapterConfig, HaAdapterManager, MqttAdapterConfig,
+    MqttAdapterManager,
+};
 use tracing::{info, warn};
 
 mod channels;
@@ -629,11 +632,12 @@ pub fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
     // `device_execute` honra `tool_confirmation_enabled` (mesma chave do
     // bash): sem canal, R3/R4/R5 são fail-closed BLOCKED dentro da tool.
     let device_registry = Arc::new(DeviceRegistry::new());
-    // #1126: com `hardware.mqtt` configurado, o adapter sobe aqui — event
-    // loop que descobre dispositivos pelos manifestos retained, marca
-    // presenca no store e roteia as respostas de leitura. Sem a secao, o
-    // registry segue vazio: fail-closed, o estado default do deploy.
-    let device_state = spawn_mqtt_adapter(config, device_registry.clone());
+    // #1126/#1127: com `hardware.mqtt` ou `hardware.home_assistant`
+    // configurado, os adapters sobem aqui — descoberta (manifestos retained
+    // / `/api/states`), presenca no store compartilhado e eventos de estado.
+    // Sem secao, o registry segue vazio: fail-closed, o estado default do
+    // deploy.
+    let device_state = spawn_hardware_adapters(config, device_registry.clone());
     let device_config = Arc::new(match device_state {
         Some(state) => DeviceToolsConfig::new(device_registry).com_estado(state),
         None => DeviceToolsConfig::new(device_registry),
@@ -1074,30 +1078,83 @@ pub fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
     runtime
 }
 
-/// Sobe o adapter MQTT (#1126) quando `hardware.mqtt` esta configurado.
+/// Sobe os adapters de hardware configurados (#1126 MQTT, #1127 Home
+/// Assistant) quando houver secao `hardware.mqtt` ou
+/// `hardware.home_assistant` no config.
 ///
 /// Chamado pelo gateway **e** pela CLI (`garra chat`) — e a fonte unica do
-/// wiring: resolucao de senha, client id e caminho do store de presenca
-/// moram aqui, nao em duas copias que divergem. A CLI chama via
-/// `garraia_gateway::bootstrap::spawn_mqtt_adapter`.
+/// wiring: resolucao de segredos, caminho do store de presenca e o fato de
+/// gateway e CLI abrirem o MESMO store moram aqui, nao em copias que
+/// divergem. A CLI chama via
+/// `garraia_gateway::bootstrap::spawn_hardware_adapters`.
 ///
-/// Fail-soft no boot: qualquer problema (broker malformado, `password_env`
-/// apontando para env vazia ou inexistente, store de presenca nao abre) nao
-/// derruba o processo — o registry de dispositivos simplesmente segue vazio
-/// e cada warn diz o que faltou. `garra config check` mostra os mesmos
-/// erros de config antes do boot.
+/// O store de presenca abre **uma vez**, compartilhado entre adapters: os
+/// dois alimentam a mesma fonte de online/offline que as tools de device
+/// mostram. `None` quando nao ha nenhuma secao de hardware no config, ou
+/// quando o store nao abre (nenhum adapter sobe sem presenca).
 ///
-/// Devolve o store de presenca aberto, para as tools de device mostrarem
-/// online/offline — `None` quando nao ha config ou o adapter nao subiu.
+/// Fail-soft no boot: qualquer problema (broker malformado, `password_env`/
+/// `token_env` apontando para env vazia ou inexistente, URL vetada recusada
+/// pelo guard SSRF) nao derruba o processo — o registry segue com os
+/// dispositivos dos adapters que subiram, e cada warn diz o que faltou.
+/// `garra config check` mostra os mesmos erros de config antes do boot.
 ///
-/// Precisa de runtime tokio (spawn do event loop) — gateway e CLI chamam
-/// de dentro de `run()` async. Sem secao `hardware.mqtt`, retorna antes de
+/// Precisa de runtime tokio (spawn dos event loops) — gateway e CLI chamam
+/// de dentro de `run()` async. Sem secao `hardware.*`, retorna antes de
 /// tocar tokio, seguro para testes.
-pub fn spawn_mqtt_adapter(
+pub fn spawn_hardware_adapters(
     config: &AppConfig,
     registry: Arc<DeviceRegistry>,
 ) -> Option<Arc<DeviceStateStore>> {
-    let mqtt = config.hardware.mqtt.as_ref()?;
+    if config.hardware.mqtt.is_none() && config.hardware.home_assistant.is_none() {
+        return None;
+    }
+
+    // Presenca no mesmo padrao do memory.db: fonte unica da resolucao em
+    // `AppConfig::hardware_db_path`, porque gateway e CLI abrem o mesmo
+    // arquivo. O diretorio precisa existir antes de abrir o SQLite — o boot
+    // da memoria cria o dele, mas o hardware pode rodar sem memoria ligada.
+    let state_path = config.hardware_db_path();
+    if let Some(parent) = state_path.parent()
+        && let Err(e) = std::fs::create_dir_all(parent)
+    {
+        warn!(
+            "hardware: nao consegui criar {} ({e}); nenhum adapter de hardware sobe",
+            parent.display()
+        );
+        return None;
+    }
+    let state = match DeviceStateStore::abrir_em(&state_path) {
+        Ok(store) => Arc::new(store),
+        Err(e) => {
+            warn!(
+                "hardware: nao abri o store de presenca em {} ({e}); nenhum adapter de hardware sobe",
+                state_path.display()
+            );
+            return None;
+        }
+    };
+
+    // Cada adapter decide sozinho se sobe e explica o que faltou. O
+    // operador pode ter os dois, um so, ou nenhum — o registry soma.
+    let mut algum_no_ar = false;
+    algum_no_ar |= sobe_mqtt(config, registry.clone(), state.clone());
+    algum_no_ar |= sobe_home_assistant(config, registry, state.clone());
+
+    algum_no_ar.then_some(state)
+}
+
+/// Sobe o adapter MQTT (#1126) quando `hardware.mqtt` esta configurado.
+/// Fail-soft: cada problema vira warn e devolve `false` — o deploy segue no
+/// ar, sem o transporte.
+fn sobe_mqtt(
+    config: &AppConfig,
+    registry: Arc<DeviceRegistry>,
+    state: Arc<DeviceStateStore>,
+) -> bool {
+    let Some(mqtt) = config.hardware.mqtt.as_ref() else {
+        return false;
+    };
 
     // A senha vem do env apontado por `password_env` e nunca e logada — o
     // warn cita so o NOME da env, que nao e segredo. Configurada e vazia/
@@ -1112,7 +1169,7 @@ pub fn spawn_mqtt_adapter(
                     "hardware.mqtt: password_env aponta para env vazia ou inexistente; \
                      adapter MQTT nao sobe e o registry de dispositivos fica vazio"
                 );
-                return None;
+                return false;
             }
         },
         None => None,
@@ -1125,7 +1182,7 @@ pub fn spawn_mqtt_adapter(
             warn!(
                 "hardware.mqtt: {e}; adapter MQTT nao sobe e o registry de dispositivos fica vazio (veja `garra config check`)"
             );
-            return None;
+            return false;
         }
     };
 
@@ -1135,44 +1192,70 @@ pub fn spawn_mqtt_adapter(
     let adapter_config =
         adapter_config.com_client_id(format!("{}-{}", mqtt.client_id_prefix, std::process::id()));
 
-    // Presenca no mesmo padrao do memory.db: fonte unica da resolucao em
-    // `AppConfig::hardware_db_path`, porque gateway e CLI abrem o mesmo
-    // arquivo. O diretório precisa existir antes de abrir o SQLite — o boot
-    // da memoria cria o dele, mas o hardware pode rodar sem memoria ligada.
-    let state_path = config.hardware_db_path();
-    if let Some(parent) = state_path.parent()
-        && let Err(e) = std::fs::create_dir_all(parent)
-    {
-        warn!(
-            "hardware.mqtt: nao consegui criar {} ({e}); adapter MQTT nao sobe",
-            parent.display()
-        );
-        return None;
-    }
-    let state = match DeviceStateStore::abrir_em(&state_path) {
-        Ok(store) => Arc::new(store),
-        Err(e) => {
-            warn!(
-                "hardware.mqtt: nao abri o store de presenca em {} ({e}); adapter MQTT nao sobe",
-                state_path.display()
-            );
-            return None;
-        }
-    };
-
     // O handle do manager fica solto de proposito: o event loop vive pela
     // vida do processo (reconnect do rumqttc e interno), e o reload de
     // config que o pararia e trabalho da #1128.
-    if let Err(e) = MqttAdapterManager::spawn(adapter_config, registry, Some(state.clone())) {
+    if let Err(e) = MqttAdapterManager::spawn(adapter_config, registry, Some(state)) {
         warn!("hardware.mqtt: {e}; adapter MQTT nao sobe e o registry de dispositivos fica vazio");
-        return None;
+        return false;
     }
 
     info!(
         broker = %mqtt.broker,
         "hardware.mqtt no ar — descoberta via manifestos retained, presenca no store"
     );
-    Some(state)
+    true
+}
+
+/// Sobe o adapter Home Assistant (#1127) quando `hardware.home_assistant`
+/// esta configurado — REST (descoberta `/api/states`, leitura, servicos) +
+/// WebSocket (`state_changed` → presenca), tudo atras do guard SSRF
+/// (`IpScope::AllowPrivate`: hub na LAN/loopback e alvo legitimo). As
+/// entidades viram dispositivos com risco por dominio: sensor/binary_sensor
+/// R0, light/switch/climate R1, cover R2, lock R3.
+///
+/// O token vem do env apontado por `token_env` (write-only: nunca logado,
+/// o warn cita so o NOME da env). Fail-soft igual ao MQTT.
+fn sobe_home_assistant(
+    config: &AppConfig,
+    registry: Arc<DeviceRegistry>,
+    state: Arc<DeviceStateStore>,
+) -> bool {
+    let Some(ha) = config.hardware.home_assistant.as_ref() else {
+        return false;
+    };
+
+    let token = match std::env::var(&ha.token_env) {
+        Ok(value) if !value.is_empty() => value,
+        _ => {
+            warn!(
+                env = %ha.token_env,
+                "hardware.home_assistant: token_env aponta para env vazia ou inexistente; \
+                 adapter Home Assistant nao sobe e o registry de dispositivos fica vazio"
+            );
+            return false;
+        }
+    };
+
+    let adapter_config = match HaAdapterConfig::new(&ha.url, token) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            warn!(
+                "hardware.home_assistant: {e}; adapter nao sobe e o registry de dispositivos fica vazio (veja `garra config check`)"
+            );
+            return false;
+        }
+    };
+
+    // O handle do manager fica solto de proposito: o loop vive pela vida do
+    // processo (reconexao do WebSocket e interna), e o reload de config que
+    // o pararia e trabalho da #1128.
+    HaAdapterManager::spawn(adapter_config, registry, Some(state));
+    info!(
+        url = %ha.url,
+        "hardware.home_assistant no ar — descoberta por /api/states, presenca por eventos state_changed"
+    );
+    true
 }
 
 /// Build MCP tools from merged config (config.yml + mcp.json).

--- a/crates/garraia-hardware/Cargo.toml
+++ b/crates/garraia-hardware/Cargo.toml
@@ -15,6 +15,10 @@ mock-device = []
 # Adapter MQTT (#1126, rumqttc): OFF por default — quem não usa transporte
 # de rede não paga a árvore de deps. Mesmo padrão do `storage-s3`.
 mqtt = ["dep:rumqttc"]
+# Adapter Home Assistant (#1127, REST + WebSocket): OFF por default, mesmo
+# padrão. `garraia-common/ssrf` traz o guard de URL (a chamada REST vai por
+# cliente pinado — o token do HA é credencial de admin do hub).
+home-assistant = ["dep:reqwest", "dep:tokio-tungstenite", "dep:futures", "dep:garraia-common"]
 default = ["mock-device"]
 
 [dependencies]
@@ -38,8 +42,20 @@ tokio = { workspace = true }
 # rumqttc é código morto aqui; e rumqttd (dev-dep) aceita `tls: None`.
 # TLS MQTT voltar como slice próprio, com avaliação de supply-chain própria.
 rumqttc = { version = "0.25", optional = true, default-features = false }
+# Feature `home-assistant` (#1127): REST (reqwest, por `pinned_client` do
+# ssrf) + WebSocket (tokio-tungstenite, para eventos `state_changed` —
+# presença hoje, motor de automações da #1128 depois). `garraia-common`
+# entra só pelo `ssrf` (vet_url + pinned_client).
+garraia-common = { workspace = true, features = ["ssrf"], optional = true }
+reqwest = { workspace = true, optional = true }
+tokio-tungstenite = { workspace = true, optional = true }
+futures = { workspace = true, optional = true }
 
 [dev-dependencies]
 # Broker MQTT embutido para os testes de integração da feature `mqtt`
 # (#1126): mesmo time do rumqttc, roda in-process (sem docker).
 rumqttd = { version = "0.20", default-features = false }
+# Mock do Home Assistant para os testes de integração da feature
+# `home-assistant` (#1127): axum serve os handlers REST e o WebSocket —
+# sem docker, na linha do rumqttd acima.
+axum = { workspace = true }

--- a/crates/garraia-hardware/Cargo.toml
+++ b/crates/garraia-hardware/Cargo.toml
@@ -18,7 +18,7 @@ mqtt = ["dep:rumqttc"]
 # Adapter Home Assistant (#1127, REST + WebSocket): OFF por default, mesmo
 # padrão. `garraia-common/ssrf` traz o guard de URL (a chamada REST vai por
 # cliente pinado — o token do HA é credencial de admin do hub).
-home-assistant = ["dep:reqwest", "dep:tokio-tungstenite", "dep:futures", "dep:garraia-common"]
+home-assistant = ["dep:reqwest", "dep:tokio-tungstenite", "dep:futures", "dep:url", "dep:garraia-common"]
 default = ["mock-device"]
 
 [dependencies]
@@ -50,6 +50,9 @@ garraia-common = { workspace = true, features = ["ssrf"], optional = true }
 reqwest = { workspace = true, optional = true }
 tokio-tungstenite = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
+# A URL base vetada (`VettedUrl.url` do ssrf) é `url::Url` — manter o tipo
+# em vez de remontar paths na mão (`Url::join` evita `//api/states`).
+url = { workspace = true, optional = true }
 
 [dev-dependencies]
 # Broker MQTT embutido para os testes de integração da feature `mqtt`

--- a/crates/garraia-hardware/src/adapter_homeassistant.rs
+++ b/crates/garraia-hardware/src/adapter_homeassistant.rs
@@ -1,0 +1,1054 @@
+//! Adapter Home Assistant (#1127) — REST + WebSocket atrás da feature
+//! `home-assistant`.
+//!
+//! O Home Assistant já agregou o zilhão de integrações domésticas (Zigbee,
+//! Z-Wave, Wi-Fi) — em vez de duplicar drivers, este adapter fala a API
+//! oficial e expõe as entidades como [`crate::Device`] no registry:
+//!
+//! | Chamada | Direção | Uso |
+//! |---|---|---|
+//! | `GET /api/states` | REST | descoberta — entidades por domínio |
+//! | `GET /api/states/{entity_id}` | REST | [`crate::Device::read`] |
+//! | `POST /api/services/{domain}/{service}` | REST | [`crate::Device::execute`] |
+//! | `ws(s)://…/api/websocket` | WebSocket | eventos `state_changed` → presença |
+//!
+//! # Contratos
+//!
+//! - **Risco por domínio, nunca por payload**: sensor/binary_sensor → R0
+//!   (leitura), light/switch/climate → R1, cover → R2, lock → R3. Domínio
+//!   desconhecido **não vira dispositivo** (fail-closed — o teto R2 do
+//!   slice é da fundação; nada aqui sobe risco sem avaliação própria).
+//! - **SSRF (regra 14)**: a URL base vem de config, então **toda** chamada
+//!   sai por `garraia_common::ssrf` — `vet_url` com
+//!   `UrlPolicy::http_public(..).with_ip_scope(IpScope::AllowPrivate)` (o HA
+//!   é alvo legítimo da LAN, e o guard ainda bloqueia link-local, CGNAT,
+//!   multicast e unspecified) e `pinned_client` com os IPs vetados. O
+//!   WebSocket conecta no **mesmo IP pinado** (TcpStream manual + handshake
+//!   `client_async_tls_with_config`) — sem re-resolução de DNS, sem janela
+//!   TOCTOU. `read_capped` limita os corpos.
+//! - **Token write-only**: config carrega o **nome** da env (`token_env`);
+//!   o chamador resolve o valor e passa aqui. O `Debug` redige; o token
+//!   nunca é logado nem serializado — os warns citam só o nome da env.
+//! - **Validação de args**: mesma [`crate::schema::validar_args`] do adapter
+//!   MQTT — um validador, dois transports, zero divergência.
+//! - **Presença**: cada `state_changed` marca o dispositivo no
+//!   [`DeviceStateStore`] (`state == "unavailable"` → offline); a descoberta
+//!   marca quem respondeu. Desconexão do WebSocket → reconexão em loop
+//!   (mesmo padrão do canal Slack), presença segue no retorno.
+//!
+//! # O que este slice NÃO faz
+//!
+//! Sem reload de config (desconecta só no shutdown — trabalho da #1128), sem
+//! automações (motor da #1128) e sem registrar domínios além da lista
+//! fechada abaixo — vacuum, media_player etc. continuam invisíveis até
+//! alguém avaliar o risco deles num PR.
+
+use crate::Result;
+use crate::capability::Capability;
+use crate::device::Device;
+use crate::error::HardwareError;
+use crate::registry::DeviceRegistry;
+use crate::risk::RiskClass;
+use crate::schema::validar_args;
+use crate::state::DeviceStateStore;
+use async_trait::async_trait;
+use futures::{SinkExt, StreamExt};
+use garraia_common::ssrf::{IpScope, UrlPolicy, pinned_client, read_capped};
+use serde_json::{Value, json};
+use std::fmt;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::net::TcpStream;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
+
+/// Timeout HTTP do cliente pinado (REST).
+pub const HA_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// User-Agent das chamadas REST.
+const USER_AGENT: &str = "garraia-hardware/home-assistant";
+
+/// Teto dos corpos REST — `/api/states` de uma casa grande fica em ~1 MB;
+/// 16 MiB é folga honesta, e `read_capped` corta o resto.
+const BODY_CAP: usize = 16 * 1024 * 1024;
+
+/// Intervalo entre tentativas de reconexão do WebSocket.
+const INTERVALO_RECONEXAO: Duration = Duration::from_secs(5);
+
+/// Ping do cliente no WebSocket — mantém NAT/TCP vivo e dá write real para
+/// detectar conexão morta cedo (o HA responde pong por baixo, control frame
+/// não sobe pro loop de eventos). O `WebSocketConfig` do tungstenite 0.29
+/// não expõe `ping_interval`, então o ping é nosso, no `select!`.
+const PING_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Silêncio máximo de eventos antes de reconectar, como backstop: casa quieta
+/// não gera `state_changed` por minutos, e a morte silenciosa do TCP (hub
+/// caiu sem FIN) não é detectada por leitura. Uma reconexão a cada
+/// [`KEEPALIVE`] numa casa quieta é barata — re-descoberta + re-subscribe.
+const KEEPALIVE: Duration = Duration::from_secs(600);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Config do adapter — vetting + cliente pinado na fronteira.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Config de transporte do adapter Home Assistant, **já vetada**.
+///
+/// `garraia-hardware` **não** depende de `garraia-config` — o gateway recebe
+/// `hardware.home_assistant` do config, resolve `token_env` e monta esta
+/// struct. O vetting (`UrlPolicy` + resolução pinada) acontece no `new`: a
+/// config que entra aqui já passou pela barreira.
+pub struct HaAdapterConfig {
+    /// URL base vetada (`http://homeassistant.local:8123`), com `/` no fim
+    /// do path — `Url::join` troca o último segmento de um path sem barra
+    /// (`http://hub:8123/ha` + `api/states` → `http://hub:8123/api/states`),
+    /// então a normalização acontece aqui, uma vez, na fronteira.
+    pub base: url::Url,
+    /// Host vetado — os requests REST vão por `http`, pinado nestes IPs.
+    host: String,
+    /// IPs já resolvidos e validados no escopo. O WebSocket conecta num
+    /// deles, sem re-resolver DNS (anti-rebinding no path WS também).
+    addrs: Vec<SocketAddr>,
+    /// Long-lived access token, **já resolvido do env** pelo chamador.
+    /// Nunca logado nem serializado — o `Debug` redige.
+    pub token: String,
+    /// Cliente REST pinado nos IPs vetados, redirects off.
+    pub http: reqwest::Client,
+}
+
+impl HaAdapterConfig {
+    /// Veta a URL base (regra 14) e constrói o cliente pinado.
+    ///
+    /// `IpScope::AllowPrivate` porque o HA é um hub local — LAN e loopback
+    /// são alvos legítimos; link-local (`169.254.169.254`), CGNAT, multicast
+    /// e unspecified continuam bloqueados pelo guard.
+    pub fn new(url_base: &str, token: String) -> Result<Self> {
+        let policy =
+            UrlPolicy::http_public(HA_TIMEOUT, USER_AGENT).with_ip_scope(IpScope::AllowPrivate);
+        let vetted = garraia_common::ssrf::vet_url(url_base, &policy)
+            .map_err(|e| HardwareError::HomeAssistant(format!("url base vetada: {e}")))?;
+        let http = pinned_client(&vetted, &policy)
+            .map_err(|e| HardwareError::HomeAssistant(format!("cliente HTTP pinado: {e}")))?;
+        let mut base = vetted.url;
+        if !base.path().ends_with('/') {
+            let com_barra = format!("{}/", base.path());
+            base.set_path(&com_barra);
+        }
+        Ok(Self {
+            base,
+            host: vetted.host,
+            addrs: vetted.addrs,
+            token,
+            http,
+        })
+    }
+}
+
+impl fmt::Debug for HaAdapterConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HaAdapterConfig")
+            .field("base", &self.base.as_str())
+            .field("host", &self.host)
+            .field("addrs", &self.addrs)
+            .field("token", &"<redacted>")
+            .finish()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Domínio → capability / capability → serviço — o mapa é o contrato.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// As capabilities de um domínio, com o risco avaliado por domínio (#1127):
+/// sensor/binary_sensor R0 · light/switch/climate R1 · cover R2 · lock R3.
+/// Domínio fora da lista → `None` (fail-closed).
+fn capabilities_de(dominio: &str) -> Option<Vec<Capability>> {
+    let estado = || Capability::leitura("state", None);
+    let power = || {
+        Capability::acao(
+            "power",
+            RiskClass::R1,
+            Some(json!({
+                "type": "object",
+                "properties": {"on": {"type": "boolean"}},
+                "required": ["on"]
+            })),
+        )
+        .ok()
+    };
+    let caps = match dominio {
+        "sensor" | "binary_sensor" => vec![estado()],
+        "light" => vec![
+            estado(),
+            power()?,
+            Capability::acao(
+                "brightness",
+                RiskClass::R1,
+                Some(json!({
+                    "type": "object",
+                    "properties": {"brightness_pct": {"type": "integer"}},
+                    "required": ["brightness_pct"]
+                })),
+            )
+            .ok()?,
+        ],
+        "switch" => vec![estado(), power()?],
+        "climate" => vec![
+            estado(),
+            power()?,
+            Capability::acao(
+                "temperature",
+                RiskClass::R1,
+                Some(json!({
+                    "type": "object",
+                    "properties": {"temperature": {"type": "number"}},
+                    "required": ["temperature"]
+                })),
+            )
+            .ok()?,
+        ],
+        "cover" => vec![
+            estado(),
+            Capability::acao("open", RiskClass::R2, None).ok()?,
+            Capability::acao("close", RiskClass::R2, None).ok()?,
+            Capability::acao(
+                "set_position",
+                RiskClass::R2,
+                Some(json!({
+                    "type": "object",
+                    "properties": {"position": {"type": "integer"}},
+                    "required": ["position"]
+                })),
+            )
+            .ok()?,
+        ],
+        "lock" => vec![
+            estado(),
+            Capability::acao("lock", RiskClass::R3, None).ok()?,
+            Capability::acao("unlock", RiskClass::R3, None).ok()?,
+        ],
+        _ => return None,
+    };
+    Some(caps)
+}
+
+/// Mapeia (domínio, capability, args) → (serviço HA, payload REST).
+///
+/// O `entity_id` entra em todo payload — é o alvo do serviço. `None` para
+/// (domínio, capability) fora da tabela: o `execute` recusa antes de falar
+/// com o hub.
+fn servico_de(
+    dominio: &str,
+    capability: &str,
+    args: &Value,
+    entity_id: &str,
+) -> Option<(String, Value)> {
+    let payload = json!({ "entity_id": entity_id });
+    match (dominio, capability) {
+        ("light" | "switch" | "climate", "power") => {
+            let on = args.get("on")?.as_bool()?;
+            let servico = if on { "turn_on" } else { "turn_off" };
+            Some((format!("{dominio}/{servico}"), payload))
+        }
+        ("light", "brightness") => {
+            let pct = args.get("brightness_pct")?.as_i64()?;
+            Some((
+                "light/turn_on".to_string(),
+                com_campo(payload, "brightness_pct", json!(pct)),
+            ))
+        }
+        ("climate", "temperature") => {
+            let t = args.get("temperature")?.as_f64()?;
+            Some((
+                "climate/set_temperature".to_string(),
+                com_campo(payload, "temperature", json!(t)),
+            ))
+        }
+        ("cover", "open") => Some(("cover/open_cover".to_string(), payload)),
+        ("cover", "close") => Some(("cover/close_cover".to_string(), payload)),
+        ("cover", "set_position") => {
+            let p = args.get("position")?.as_i64()?;
+            Some((
+                "cover/set_cover_position".to_string(),
+                com_campo(payload, "position", json!(p)),
+            ))
+        }
+        ("lock", "lock") => Some(("lock/lock".to_string(), payload)),
+        ("lock", "unlock") => Some(("lock/unlock".to_string(), payload)),
+        _ => None,
+    }
+}
+
+/// Insere `valor` num payload JSON — helper para o caso raro de payload com
+/// campo extra (o `json!` macro com `entity_id` fixo + campo variável fica
+/// verboso; assim a tabela acima continua legível).
+fn com_campo(mut payload: Value, chave: &str, valor: Value) -> Value {
+    if let Some(obj) = payload.as_object_mut() {
+        obj.insert(chave.to_string(), valor);
+    }
+    payload
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Descoberta — parse das entidades da API.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Uma entidade do HA que passou na fronteira de descoberta.
+struct Entidade {
+    entity_id: String,
+    dominio: String,
+    caps: Vec<Capability>,
+    /// `state != "unavailable"` na descoberta — presença inicial honesta.
+    online: bool,
+}
+
+/// Parseia a resposta de `GET /api/states` e recusa (não panica) o que não
+/// entende: entity_id malformado, domínio fora da lista, capability que
+/// viola a invariante leitura↔R0. Entidades recusadas simplesmente não
+/// entram no registry.
+fn parse_entidades(body: &[u8]) -> Result<Vec<Entidade>> {
+    let arr: Vec<Value> = serde_json::from_slice(body)
+        .map_err(|e| HardwareError::HomeAssistant(format!("/api/states não é JSON: {e}")))?;
+    let mut out = Vec::new();
+    for v in arr {
+        let Some(id) = v.get("entity_id").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some((dominio, objeto)) = id.split_once('.') else {
+            continue;
+        };
+        let Some(caps) = capabilities_de(dominio) else {
+            continue;
+        };
+        // O `object_id` de um entity_id HA é `[a-z0-9_]+` — nada de espaço,
+        // barra ou caractere que brigue com o path REST
+        // (`GET /api/states/{id}`) ou com logs.
+        if !valida_objeto(objeto) {
+            continue;
+        }
+        for cap in &caps {
+            if let Err(e) = cap.validar() {
+                tracing::warn!(entity = id, "entidade descartada: capability inválida: {e}");
+                continue;
+            }
+        }
+        let online = v.get("state").and_then(Value::as_str) != Some("unavailable");
+        out.push(Entidade {
+            entity_id: id.to_string(),
+            dominio: dominio.to_string(),
+            caps,
+            online,
+        });
+    }
+    Ok(out)
+}
+
+/// O `object_id` de um entity_id HA é `[a-z0-9_]+` — nada de espaço, barra
+/// ou caractere que briguem com o path REST (`GET /api/states/{id}`) ou com
+/// logs.
+fn valida_objeto(objeto: &str) -> bool {
+    !objeto.is_empty()
+        && objeto
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// HaDevice — o Device que fala REST com o hub.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Um dispositivo exposto pelo Home Assistant. O id é o `entity_id`
+/// (`"light.sala"`) — estável, único por hub, e é o que o agente vê na
+/// `device_list`.
+pub struct HaDevice {
+    entity_id: String,
+    dominio: String,
+    caps: Vec<Capability>,
+    config: Arc<HaAdapterConfig>,
+}
+
+#[async_trait]
+impl Device for HaDevice {
+    fn id(&self) -> &str {
+        &self.entity_id
+    }
+
+    fn capabilities(&self) -> Vec<Capability> {
+        self.caps.clone()
+    }
+
+    /// `GET /api/states/{entity_id}` — devolve o objeto inteiro do HA
+    /// (`state`, `attributes`, `last_changed`): o payload do hub, sem
+    /// inventar um formato próprio em cima.
+    async fn read(&self, capability: &str) -> Result<Value> {
+        if capability != "state" {
+            return Err(HardwareError::CapabilityDesconhecida {
+                dispositivo: self.entity_id.clone(),
+                capability: capability.to_string(),
+            });
+        }
+        let path = format!("api/states/{}", self.entity_id);
+        let url = self
+            .config
+            .base
+            .join(&path)
+            .map_err(|e| HardwareError::Adapter {
+                dispositivo: self.entity_id.clone(),
+                fonte: format!("url '{path}' malformada: {e}"),
+            })?;
+        let resp = self
+            .config
+            .http
+            .get(url)
+            .bearer_auth(&self.config.token)
+            .send()
+            .await
+            .map_err(|e| HardwareError::Adapter {
+                dispositivo: self.entity_id.clone(),
+                fonte: format!("GET {path}: {e}"),
+            })?;
+        let status = resp.status();
+        let bytes = read_capped(resp, BODY_CAP)
+            .await
+            .map_err(|e| HardwareError::Adapter {
+                dispositivo: self.entity_id.clone(),
+                fonte: format!("GET {path}: {e}"),
+            })?;
+        if !status.is_success() {
+            return Err(HardwareError::Adapter {
+                dispositivo: self.entity_id.clone(),
+                fonte: format!("GET {path}: HTTP {status}{}", corpo_no_erro(&bytes)),
+            });
+        }
+        serde_json::from_slice(&bytes).map_err(|e| HardwareError::Adapter {
+            dispositivo: self.entity_id.clone(),
+            fonte: format!("GET {path}: corpo não é JSON: {e}"),
+        })
+    }
+
+    /// `POST /api/services/{domain}/{service}` com o payload mapeado, args
+    /// validados pelo mesmo [`crate::schema::validar_args`] do MQTT.
+    ///
+    /// O retorno `{"enviado": true}` é honesto como o `{"published": true}`
+    /// do MQTT: confirma que o **hub** aceitou o comando, não que o
+    /// dispositivo aplicou — para o estado aplicado, `read` na sequência.
+    async fn execute(&self, capability: &str, args: Value) -> Result<Value> {
+        let cap = self.caps.iter().find(|c| c.name == capability).ok_or(
+            HardwareError::CapabilityDesconhecida {
+                dispositivo: self.entity_id.clone(),
+                capability: capability.to_string(),
+            },
+        )?;
+        validar_args(&args, cap.args_schema.as_ref(), &self.entity_id, capability)?;
+
+        let Some((servico, payload)) =
+            servico_de(&self.dominio, capability, &args, &self.entity_id)
+        else {
+            return Err(HardwareError::Adapter {
+                dispositivo: self.entity_id.clone(),
+                fonte: format!("capability '{capability}' não mapeia para um serviço do HA"),
+            });
+        };
+
+        let path = format!("api/services/{servico}");
+        let url = self
+            .config
+            .base
+            .join(&path)
+            .map_err(|e| HardwareError::Adapter {
+                dispositivo: self.entity_id.clone(),
+                fonte: format!("url '{path}' malformada: {e}"),
+            })?;
+        let resp = self
+            .config
+            .http
+            .post(url)
+            .bearer_auth(&self.config.token)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| HardwareError::Adapter {
+                dispositivo: self.entity_id.clone(),
+                fonte: format!("POST {path}: {e}"),
+            })?;
+        let status = resp.status();
+        let bytes = read_capped(resp, BODY_CAP)
+            .await
+            .map_err(|e| HardwareError::Adapter {
+                dispositivo: self.entity_id.clone(),
+                fonte: format!("POST {path}: {e}"),
+            })?;
+        if !status.is_success() {
+            return Err(HardwareError::Adapter {
+                dispositivo: self.entity_id.clone(),
+                fonte: format!("POST {path}: HTTP {status}{}", corpo_no_erro(&bytes)),
+            });
+        }
+        Ok(json!({"enviado": true, "entity_id": self.entity_id, "servico": servico}))
+    }
+}
+
+/// Primeiros 200 bytes do corpo de erro — contexto para o modelo decidir o
+/// próximo passo, sem estourar log com um HTML gigante de 404.
+fn corpo_no_erro(bytes: &[u8]) -> String {
+    let corpo = String::from_utf8_lossy(&bytes[..bytes.len().min(200)]);
+    if corpo.trim().is_empty() {
+        String::new()
+    } else {
+        format!(" — {}", corpo.trim())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// O manager — descoberta, registro e o loop de WebSocket.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Boot e loop de eventos do adapter Home Assistant. Um [`HaAdapterManager`]
+/// por processo: uma conexão REST (descoberta) + um WebSocket de eventos.
+/// Boot e loop de eventos do adapter Home Assistant. Um [`HaAdapterManager`]
+/// por processo: uma conexão REST (descoberta) + um WebSocket de eventos.
+pub struct HaAdapterManager {
+    tarefa: tokio::task::JoinHandle<()>,
+}
+
+impl HaAdapterManager {
+    /// Sobe a descoberta e o loop de eventos em uma task tokio.
+    ///
+    /// Chamar **dentro de um runtime tokio** (gateway e CLI já são). A
+    /// descoberta é o primeiro ato da task: falha → registry vazio e o loop
+    /// de eventos continua tentando (o hub pode só ter demorado a responder;
+    /// um warn por rodada, sem retry agressivo).
+    pub fn spawn(
+        config: HaAdapterConfig,
+        registry: Arc<DeviceRegistry>,
+        state: Option<Arc<DeviceStateStore>>,
+    ) -> Self {
+        let tarefa = tokio::spawn(rodar(Arc::new(config), registry, state));
+        Self { tarefa }
+    }
+
+    /// Para o loop de eventos (reload de config, shutdown de teste).
+    pub async fn encerrar(self) {
+        self.tarefa.abort();
+        let _ = self.tarefa.await;
+    }
+}
+
+async fn rodar(
+    config: Arc<HaAdapterConfig>,
+    registry: Arc<DeviceRegistry>,
+    state: Option<Arc<DeviceStateStore>>,
+) {
+    // Cada rodada = descoberta + eventos. A descoberta é refeita a cada
+    // reconexão de propósito: o hub pode não estar no ar no boot (a task
+    // nasce antes do HA responder), e entidades novas aparecem com o uso.
+    // Re-registrar o mesmo id substitui — o registry nunca guarda versão
+    // velha. (Dispositivos removidos do HA continuam listados até o restart
+    // — o registry não tem remoção; limite consciente do slice.)
+    loop {
+        match descobrir(&config).await {
+            Ok(entidades) => {
+                for e in entidades {
+                    if let Some(store) = &state
+                        && let Err(err) = store.marcar(&e.entity_id, e.online).await
+                    {
+                        tracing::warn!(entity = %e.entity_id, "presença inicial: {err}");
+                    }
+                    registry.register(Arc::new(HaDevice {
+                        entity_id: e.entity_id.clone(),
+                        dominio: e.dominio,
+                        caps: e.caps,
+                        config: config.clone(),
+                    }));
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "hardware.home_assistant: descoberta falhou ({e}); registry segue \
+                     como está — tentando de novo no próximo ciclo"
+                );
+            }
+        }
+
+        // Loop de eventos: conecta, autentica, assina `state_changed`; caiu,
+        // espera e reconecta (mesmo padrão do canal Slack). Presença é o
+        // consumo do slice — a #1128 liga as automações neste fluxo depois.
+        match conectar_ws(&config).await {
+            Ok(mut ws) => match autenticar_e_assinar(&mut ws, &config.token).await {
+                Ok(()) => consumir_eventos(ws, state.as_ref()).await,
+                Err(e) => tracing::warn!("hardware.home_assistant: handshake falhou: {e}"),
+            },
+            Err(e) => tracing::warn!("hardware.home_assistant: WebSocket indisponível: {e}"),
+        }
+        tokio::time::sleep(INTERVALO_RECONEXAO).await;
+    }
+}
+
+/// `GET /api/states` — a lista de entidades do hub, bruta.
+async fn descobrir(config: &HaAdapterConfig) -> Result<Vec<Entidade>> {
+    let body = rest_get(config, "api/states").await?;
+    parse_entidades(&body)
+}
+
+/// GET REST por `pinned_client` + `read_capped` (regra 14: teto de corpo e
+/// redirects desligados são do guard, não da chamada).
+async fn rest_get(config: &HaAdapterConfig, path: &str) -> Result<Vec<u8>> {
+    let url = config.base.join(path).map_err(|e| {
+        HardwareError::HomeAssistant(format!("path '{path}' não junta à base: {e}"))
+    })?;
+    let resp = config
+        .http
+        .get(url)
+        .bearer_auth(&config.token)
+        .send()
+        .await
+        .map_err(|e| HardwareError::HomeAssistant(format!("GET {path}: {e}")))?;
+    let status = resp.status();
+    let body = read_capped(resp, BODY_CAP)
+        .await
+        .map_err(|e| HardwareError::HomeAssistant(format!("GET {path}: {e}")))?;
+    if !status.is_success() {
+        return Err(HardwareError::HomeAssistant(format!(
+            "GET {path}: HTTP {status}{}",
+            corpo_no_erro(&body)
+        )));
+    }
+    Ok(body)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WebSocket — autenticação e eventos `state_changed`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Conecta no **IP pinado** da config (sem re-resolver DNS) e faz o
+/// handshake WebSocket. `client_async_tls_with_config` com connector default
+/// cobre ws (plain) e wss (rustls + webpki-roots) sobre o mesmo TcpStream.
+async fn conectar_ws(
+    config: &HaAdapterConfig,
+) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>> {
+    let ws_url = url_websocket(&config.base)?;
+    let mut ultimo: Option<std::io::Error> = None;
+    for addr in &config.addrs {
+        match TcpStream::connect(addr).await {
+            Ok(s) => {
+                return tokio_tungstenite::client_async_tls_with_config(
+                    ws_url.as_str().to_string(),
+                    s,
+                    None,
+                    None,
+                )
+                .await
+                .map(|(ws, _)| ws)
+                .map_err(|e| HardwareError::HomeAssistant(format!("handshake WebSocket: {e}")));
+            }
+            Err(e) => ultimo = Some(e),
+        }
+    }
+    Err(HardwareError::HomeAssistant(format!(
+        "sem conexão ao hub {}: {:?}",
+        config.host, ultimo
+    )))
+}
+
+/// Deriva a URL do WebSocket da base: `http` → `ws`, `https` → `wss`,
+/// path `/api/websocket`.
+fn url_websocket(base: &url::Url) -> Result<url::Url> {
+    let mut ws = base.clone();
+    let novo = match ws.scheme() {
+        "http" => "ws",
+        "https" => "wss",
+        outro => {
+            return Err(HardwareError::HomeAssistant(format!(
+                "esquema '{outro}' não vira WebSocket (use http/https na base)"
+            )));
+        }
+    };
+    ws.set_scheme(novo)
+        .map_err(|_| HardwareError::HomeAssistant("esquema não trocável".to_string()))?;
+    ws.set_path("/api/websocket");
+    ws.set_query(None);
+    ws.set_fragment(None);
+    Ok(ws)
+}
+
+/// Handshake do protocolo HA: `auth_required` → `auth` (token) →
+/// `auth_ok` → subscribe em `state_changed`. O token viaja aqui uma vez —
+/// é o único lugar fora do header Bearer que o toca, e nunca vira log.
+async fn autenticar_e_assinar(
+    ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>,
+    token: &str,
+) -> Result<()> {
+    exigir_msg(&proxima_msg(ws).await?, "auth_required")?;
+    ws.send(Message::text(
+        json!({"type": "auth", "access_token": token}).to_string(),
+    ))
+    .await
+    .map_err(|e| HardwareError::HomeAssistant(format!("envio de auth: {e}")))?;
+    exigir_msg(&proxima_msg(ws).await?, "auth_ok")?;
+    ws.send(Message::text(
+        json!({"type": "subscribe_events", "event_type": "state_changed", "id": 1}).to_string(),
+    ))
+    .await
+    .map_err(|e| HardwareError::HomeAssistant(format!("envio de subscribe: {e}")))?;
+    Ok(())
+}
+
+/// Próxima mensagem de texto; binário/control é ignorado (o tungstenite
+/// responde ping por baixo), stream fechada é erro.
+async fn proxima_msg(ws: &mut WebSocketStream<MaybeTlsStream<TcpStream>>) -> Result<String> {
+    loop {
+        match ws.next().await {
+            Some(Ok(Message::Text(t))) => return Ok(t.to_string()),
+            Some(Ok(_)) => continue,
+            Some(Err(e)) => {
+                return Err(HardwareError::HomeAssistant(format!(
+                    "WebSocket durante handshake: {e}"
+                )));
+            }
+            None => {
+                return Err(HardwareError::HomeAssistant(
+                    "WebSocket fechou no meio do handshake".to_string(),
+                ));
+            }
+        }
+    }
+}
+
+/// Confirma que a mensagem é `{"type": <esperado>}` — qualquer outra coisa
+/// (inclusive `auth_invalid`) recusa com o que chegou, para o warn dizer o
+/// que o hub mandou.
+fn exigir_msg(msg: &str, esperado: &str) -> Result<()> {
+    let v: Value = serde_json::from_str(msg)
+        .map_err(|e| HardwareError::HomeAssistant(format!("handshake: não é JSON: {e}")))?;
+    if v.get("type").and_then(Value::as_str) == Some(esperado) {
+        Ok(())
+    } else {
+        Err(HardwareError::HomeAssistant(format!(
+            "handshake: esperava '{esperado}', recebi: {msg}"
+        )))
+    }
+}
+
+/// Consome eventos até a conexão morrer (erro, fechamento, ping que não
+/// sai, ou silêncio > [`KEEPALIVE`]). O stream é dividido (`split()`) porque
+/// o `select!` precisa ler eventos **e** pingar — duas futures, cada uma
+/// com seu lado. Cada `state_changed` marca presença do `entity_id`:
+/// `new_state.state == "unavailable"` (ou `new_state: null` — estado
+/// removido) → offline; qualquer estado real → online.
+async fn consumir_eventos(
+    ws: WebSocketStream<MaybeTlsStream<TcpStream>>,
+    state: Option<&Arc<DeviceStateStore>>,
+) {
+    let (mut tx, mut rx) = ws.split();
+    let mut ping = tokio::time::interval(PING_INTERVAL);
+    ping.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        tokio::select! {
+            // Backstop, não falha: casa quieta não gera evento por minutos —
+            // debug, não warn, senão o log vira sinal falso.
+            _ = tokio::time::sleep(KEEPALIVE) => {
+                tracing::debug!(
+                    "hardware.home_assistant: sem eventos por {:?}; reconectando",
+                    KEEPALIVE
+                );
+                break;
+            }
+            // O ping é nosso write: erro aqui = conexão morta. O pong do hub
+            // volta como control frame e não sobe pro loop.
+            _ = ping.tick() => {
+                if tx.send(Message::Ping(Vec::new().into())).await.is_err() {
+                    tracing::warn!(
+                        "hardware.home_assistant: ping sem resposta; reconectando"
+                    );
+                    break;
+                }
+            }
+            msg = rx.next() => match msg {
+                Some(Ok(Message::Text(t))) => {
+                    if let Some((entity_id, online)) = entidade_do_evento(t.as_str())
+                        && let Some(store) = state
+                        && let Err(err) = store.marcar(&entity_id, online).await
+                    {
+                        tracing::warn!(entity = %entity_id, "presença: {err}");
+                    }
+                }
+                Some(Ok(_)) => continue,
+                Some(Err(e)) => {
+                    tracing::warn!("hardware.home_assistant: evento com erro: {e}");
+                    break;
+                }
+                None => {
+                    tracing::warn!("hardware.home_assistant: WebSocket fechado; reconectando");
+                    break;
+                }
+            },
+        }
+    }
+}
+
+/// Extrai `(entity_id, online)` de um evento `state_changed`:
+/// `{"id":1,"type":"event","event":{"event_type":"state_changed","data":
+/// {"entity_id":"light.sala","new_state":{"state":"on",…}}}}`.
+fn entidade_do_evento(msg: &str) -> Option<(String, bool)> {
+    let v: Value = serde_json::from_str(msg).ok()?;
+    let evento = v.get("event")?;
+    if evento.get("event_type")?.as_str()? != "state_changed" {
+        return None;
+    }
+    let dados = evento.get("data")?;
+    let entity_id = dados.get("entity_id")?.as_str()?.to_string();
+    let online = match dados.get("new_state") {
+        Some(Value::Null) | None => false,
+        Some(novo) => novo.get("state").and_then(Value::as_str) != Some("unavailable"),
+    };
+    Some((entity_id, online))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Testes de unidade — o que não precisa de hub: tabelas de risco, mapeamento
+// de serviço, parse de entidades, vetting e derivação de URL.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// O risco por domínio é o contrato da issue: sensor/binary_sensor R0
+    /// (leitura), light/switch/climate R1, cover R2, lock R3 — e nada
+    /// além disso vira capability (sem R4/R5 neste slice).
+    #[test]
+    fn mapeia_riscos_por_dominio() {
+        let caps = capabilities_de("light").expect("light suportado");
+        let nomes: Vec<(&str, RiskClass)> =
+            caps.iter().map(|c| (c.name.as_str(), c.risk)).collect();
+        assert_eq!(
+            nomes,
+            vec![
+                ("state", RiskClass::R0),
+                ("power", RiskClass::R1),
+                ("brightness", RiskClass::R1)
+            ]
+        );
+        assert!(caps.iter().all(|c| c.validar().is_ok()));
+
+        let sensor = capabilities_de("sensor").unwrap();
+        assert_eq!(sensor.len(), 1);
+        assert!(sensor[0].read_only && sensor[0].risk == RiskClass::R0);
+
+        // cover: `state` é leitura R0; open/close/set_position são R2.
+        let cover = capabilities_de("cover").unwrap();
+        let acoes_cover: Vec<RiskClass> = cover
+            .iter()
+            .filter(|c| !c.read_only)
+            .map(|c| c.risk)
+            .collect();
+        assert_eq!(
+            acoes_cover,
+            vec![RiskClass::R2, RiskClass::R2, RiskClass::R2]
+        );
+
+        // lock: `state` é leitura R0; lock/unlock são R3.
+        let lock = capabilities_de("lock").unwrap();
+        let acoes_lock: Vec<RiskClass> = lock
+            .iter()
+            .filter(|c| !c.read_only)
+            .map(|c| c.risk)
+            .collect();
+        assert_eq!(acoes_lock, vec![RiskClass::R3, RiskClass::R3]);
+    }
+
+    /// Domínio fora da lista não vira dispositivo — fail-closed.
+    #[test]
+    fn dominio_desconhecido_e_recusado() {
+        assert!(capabilities_de("vacuum").is_none());
+        assert!(capabilities_de("media_player").is_none());
+        assert!(capabilities_de("").is_none());
+    }
+
+    /// O vetting da config: link-local (metadata de cloud) é bloqueado
+    /// mesmo com `AllowPrivate`; loopback e LAN passam (alvo legítimo).
+    #[test]
+    fn vetting_bloqueia_link_local_e_aceita_loopback() {
+        let token = "t".to_string();
+        let res = HaAdapterConfig::new("http://169.254.169.254:8123/", token.clone());
+        assert!(res.is_err(), "link-local deve ser bloqueado");
+
+        let cfg = HaAdapterConfig::new("http://127.0.0.1:8123", token).expect("loopback ok");
+        assert_eq!(cfg.host, "127.0.0.1");
+        // Base sem `/` no fim é normalizada — senão o `Url::join` de
+        // `api/states` comeria o último segmento de um path tipo `/ha`.
+        assert!(cfg.base.path().ends_with('/'));
+        let j = cfg.base.join("api/states").unwrap();
+        assert_eq!(j.as_str(), "http://127.0.0.1:8123/api/states");
+    }
+
+    /// `http` vira `ws` e `https` vira `wss`, path fixo `/api/websocket`.
+    #[test]
+    fn url_websocket_deriva_da_base() {
+        let base: url::Url = "http://127.0.0.1:8123/".parse().unwrap();
+        let ws = url_websocket(&base).unwrap();
+        assert_eq!(ws.as_str(), "ws://127.0.0.1:8123/api/websocket");
+
+        let base_https: url::Url = "https://ha.exemplo.io/".parse().unwrap();
+        let wss = url_websocket(&base_https).unwrap();
+        assert_eq!(wss.as_str(), "wss://ha.exemplo.io/api/websocket");
+    }
+
+    /// Esquema não-http na base não deriva WebSocket.
+    #[test]
+    fn url_websocket_recusa_esquema_estranho() {
+        let base: url::Url = "ftp://127.0.0.1/".parse().unwrap();
+        assert!(url_websocket(&base).is_err());
+    }
+
+    /// A tabela serviço: power → turn_on/turn_off, brightness → turn_on com
+    /// brightness_pct, lock/unlock → lock/lock e lock/unlock.
+    #[test]
+    fn servico_mapeia_os_comandos_do_agente() {
+        let entity = "light.sala";
+        let (s, p) = servico_de("light", "power", &json!({"on": true}), entity).unwrap();
+        assert_eq!(s, "light/turn_on");
+        assert_eq!(p, json!({"entity_id": entity}));
+
+        let (s, p) = servico_de("light", "power", &json!({"on": false}), entity).unwrap();
+        assert_eq!(s, "light/turn_off");
+        assert_eq!(p, json!({"entity_id": entity}));
+
+        let (s, p) = servico_de(
+            "light",
+            "brightness",
+            &json!({"brightness_pct": 50}),
+            entity,
+        )
+        .unwrap();
+        assert_eq!(s, "light/turn_on");
+        assert_eq!(p, json!({"entity_id": entity, "brightness_pct": 50}));
+
+        let (s, p) = servico_de("lock", "unlock", &json!({}), "lock.porta").unwrap();
+        assert_eq!(s, "lock/unlock");
+        assert_eq!(p, json!({"entity_id": "lock.porta"}));
+
+        let (s, p) = servico_de(
+            "cover",
+            "set_position",
+            &json!({"position": 80}),
+            "cover.janela",
+        )
+        .unwrap();
+        assert_eq!(s, "cover/set_cover_position");
+        assert_eq!(p, json!({"entity_id": "cover.janela", "position": 80}));
+
+        // (domínio, capability) fora da tabela → None.
+        assert!(servico_de("vacuum", "power", &json!({"on": true}), "x").is_none());
+        assert!(servico_de("light", "star_trek_mode", &json!({}), entity).is_none());
+    }
+
+    /// Parse de `/api/states`: só os domínios da lista passam, entity_id
+    /// malformado cai fora, `unavailable` nasce offline.
+    #[test]
+    fn parse_entidades_filtra_e_classifica() {
+        let body = serde_json::to_vec(&json!([
+            {"entity_id": "light.sala", "state": "on", "attributes": {}},
+            {"entity_id": "sensor.temp", "state": "23.5", "attributes": {}},
+            {"entity_id": "binary_sensor.porta", "state": "off", "attributes": {}},
+            {"entity_id": "lock.porta", "state": "locked", "attributes": {}},
+            {"entity_id": "cover.janela", "state": "unavailable", "attributes": {}},
+            {"entity_id": "switch.tomada", "state": "on", "attributes": {}},
+            {"entity_id": "climate.ac", "state": "cool", "attributes": {}},
+            {"entity_id": "vacuum.robo", "state": "cleaning", "attributes": {}},
+            {"entity_id": "sem_ponto", "state": "?", "attributes": {}},
+            {"entity_id": "light.Casa limpa", "state": "on", "attributes": {}},
+            {"state": "on", "attributes": {}}
+        ]))
+        .unwrap();
+
+        let entidades = parse_entidades(&body).unwrap();
+        let ids: Vec<&str> = entidades.iter().map(|e| e.entity_id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec![
+                "light.sala",
+                "sensor.temp",
+                "binary_sensor.porta",
+                "lock.porta",
+                "cover.janela",
+                "switch.tomada",
+                "climate.ac"
+            ],
+            "vacuum/sem_ponto/objeto com espaço/sem entity_id caem fora"
+        );
+
+        let cover = entidades
+            .iter()
+            .find(|e| e.entity_id == "cover.janela")
+            .unwrap();
+        assert!(!cover.online, "unavailable nasce offline");
+
+        let sensor = entidades
+            .iter()
+            .find(|e| e.entity_id == "sensor.temp")
+            .unwrap();
+        assert!(sensor.online);
+        assert!(sensor.caps.iter().all(|c| c.risk == RiskClass::R0));
+    }
+
+    /// O evento `state_changed` do HA rende (entity_id, online) — e eventos
+    /// de outro tipo não.
+    #[test]
+    fn evento_state_changed_rende_presenca() {
+        let evento = json!({
+            "id": 1, "type": "event",
+            "event": {
+                "event_type": "state_changed",
+                "data": {
+                    "entity_id": "light.sala",
+                    "old_state": {"state": "off"},
+                    "new_state": {"state": "on", "attributes": {}}
+                }
+            }
+        })
+        .to_string();
+        assert_eq!(
+            entidade_do_evento(&evento),
+            Some(("light.sala".to_string(), true))
+        );
+
+        let offline = json!({
+            "id": 1, "type": "event",
+            "event": {"event_type": "state_changed", "data": {
+                "entity_id": "light.sala", "new_state": {"state": "unavailable"}
+            }}
+        })
+        .to_string();
+        assert_eq!(
+            entidade_do_evento(&offline),
+            Some(("light.sala".to_string(), false))
+        );
+
+        // Estado removido (new_state: null) → offline.
+        let removido = json!({
+            "id": 1, "type": "event",
+            "event": {"event_type": "state_changed", "data": {"entity_id": "light.sala", "new_state": null}}
+        })
+        .to_string();
+        assert_eq!(
+            entidade_do_evento(&removido),
+            Some(("light.sala".to_string(), false))
+        );
+
+        // Outro tipo de evento → None.
+        let outro =
+            json!({"id": 2, "type": "event", "event": {"event_type": "call_service"}}).to_string();
+        assert_eq!(entidade_do_evento(&outro), None);
+    }
+
+    /// Debug redige o token — o hub do HA é admin total da casa.
+    #[test]
+    fn debug_redige_o_token() {
+        let cfg =
+            HaAdapterConfig::new("http://127.0.0.1:8123/", "tokensecreto".to_string()).unwrap();
+        let s = format!("{cfg:?}");
+        assert!(!s.contains("tokensecreto"), "token vazou no Debug: {s}");
+        assert!(s.contains("<redacted>"));
+    }
+}

--- a/crates/garraia-hardware/src/adapter_mqtt.rs
+++ b/crates/garraia-hardware/src/adapter_mqtt.rs
@@ -806,20 +806,28 @@ mod tests {
             "required": ["on"]
         });
         // obrigatório ausente
-        let err = crate::schema::validar_args(&json!({}), Some(&schema), "dev", "power").expect_err("recusa");
+        let err = crate::schema::validar_args(&json!({}), Some(&schema), "dev", "power")
+            .expect_err("recusa");
         assert!(err.to_string().contains("obrigatório"), "{err}");
         // tipo errado
-        let err = crate::schema::validar_args(&json!({ "on": "sim" }), Some(&schema), "dev", "power")
-            .expect_err("recusa");
+        let err =
+            crate::schema::validar_args(&json!({ "on": "sim" }), Some(&schema), "dev", "power")
+                .expect_err("recusa");
         assert!(err.to_string().contains("boolean"), "{err}");
         // 50.5 não é integer
         let schema_int =
             json!({ "type": "object", "properties": { "percent": { "type": "integer" } } });
-        let err = crate::schema::validar_args(&json!({ "percent": 50.5 }), Some(&schema_int), "dev", "cap")
-            .expect_err("recusa");
+        let err = crate::schema::validar_args(
+            &json!({ "percent": 50.5 }),
+            Some(&schema_int),
+            "dev",
+            "cap",
+        )
+        .expect_err("recusa");
         assert!(err.to_string().contains("integer"), "{err}");
         // args não-objeto
-        let err = crate::schema::validar_args(&json!(true), Some(&schema), "dev", "power").expect_err("recusa");
+        let err = crate::schema::validar_args(&json!(true), Some(&schema), "dev", "power")
+            .expect_err("recusa");
         assert!(err.to_string().contains("objeto"), "{err}");
     }
 
@@ -827,7 +835,8 @@ mod tests {
     fn validar_args_sem_schema_recusa_argumentos() {
         assert!(crate::schema::validar_args(&json!({}), None, "dev", "power").is_ok());
         assert!(crate::schema::validar_args(&json!(null), None, "dev", "power").is_ok());
-        let err = crate::schema::validar_args(&json!({ "x": 1 }), None, "dev", "power").expect_err("recusa");
+        let err = crate::schema::validar_args(&json!({ "x": 1 }), None, "dev", "power")
+            .expect_err("recusa");
         assert!(err.to_string().contains("não declara argumentos"), "{err}");
     }
 
@@ -844,7 +853,8 @@ mod tests {
             .expect_err("recusa");
         assert!(err.to_string().contains("não declara o tipo"), "{err}");
         // schema de nível de topo não-objeto
-        let err = crate::schema::validar_args(&json!({}), Some(&json!([])), "dev", "cap").expect_err("recusa");
+        let err = crate::schema::validar_args(&json!({}), Some(&json!([])), "dev", "cap")
+            .expect_err("recusa");
         assert!(err.to_string().contains("objeto JSON"), "{err}");
     }
 

--- a/crates/garraia-hardware/src/adapter_mqtt.rs
+++ b/crates/garraia-hardware/src/adapter_mqtt.rs
@@ -262,95 +262,6 @@ fn valida_segmento_topico(segmento: &str) -> Result<()> {
     Ok(())
 }
 
-/// O mini-validador de argumentos (#1126): o subset truncado do JSON Schema
-/// que o `args_schema` de [`Capability`] garante — `type` (object),
-/// `properties` (tipos primitivos) e `required`. Chaves extras nos args são
-/// permitidas (semântica JSON Schema); tipo declarado que o validador não
-/// conhece **recusa** (fail-closed — não dá para provar, não passa).
-fn validar_args(
-    args: &Value,
-    schema: Option<&Value>,
-    dispositivo: &str,
-    capability: &str,
-) -> Result<()> {
-    let recusa = |fonte: String| {
-        Err(HardwareError::Adapter {
-            dispositivo: dispositivo.to_string(),
-            fonte,
-        })
-    };
-    let Some(schema) = schema else {
-        // Sem schema, o dispositivo declarou que não recebe argumentos.
-        return if args.as_object().is_some_and(|obj| obj.is_empty()) || args.is_null() {
-            Ok(())
-        } else {
-            recusa(format!(
-                "capability '{capability}' não declara argumentos; recebi {args}"
-            ))
-        };
-    };
-    let Some(obj_schema) = schema.as_object() else {
-        return recusa(format!("args_schema não é um objeto JSON: {schema}"));
-    };
-    if let Some(tipo) = obj_schema.get("type")
-        && tipo != "object"
-    {
-        return recusa(format!(
-            "args_schema suporta apenas type=object neste slice; recebi {tipo}"
-        ));
-    }
-    let Some(obj_args) = args.as_object() else {
-        return recusa(format!(
-            "argumentos precisam ser um objeto JSON; recebi {args}"
-        ));
-    };
-    if let Some(obrigatorios) = obj_schema.get("required").and_then(Value::as_array) {
-        for nome in obrigatorios {
-            let Some(nome) = nome.as_str() else {
-                return recusa(format!(
-                    "args_schema.required contém item não-texto: {nome}"
-                ));
-            };
-            if !obj_args.contains_key(nome) {
-                return recusa(format!("argumento obrigatório '{nome}' ausente"));
-            }
-        }
-    }
-    let Some(propriedades) = obj_schema.get("properties").and_then(Value::as_object) else {
-        return Ok(());
-    };
-    for (nome, spec) in propriedades {
-        let Some(valor) = obj_args.get(nome) else {
-            continue;
-        };
-        let Some(tipo) = spec.get("type").and_then(Value::as_str) else {
-            return recusa(format!(
-                "argumento '{nome}': schema não declara o tipo — o validador truncado só conhece type/properties/required"
-            ));
-        };
-        let ok = match tipo {
-            "string" => valor.is_string(),
-            "boolean" => valor.is_boolean(),
-            "number" => valor.is_number(),
-            "integer" => valor.as_i64().is_some(),
-            "array" => valor.is_array(),
-            "object" => valor.is_object(),
-            "null" => valor.is_null(),
-            _ => {
-                return recusa(format!(
-                    "argumento '{nome}': tipo '{tipo}' não suportado pelo validador (fail-closed)"
-                ));
-            }
-        };
-        if !ok {
-            return recusa(format!(
-                "argumento '{nome}': esperado {tipo}, recebi {valor}"
-            ));
-        }
-    }
-    Ok(())
-}
-
 // ─────────────────────────────────────────────────────────────────────────────
 // MqttDevice — o Device que fala MQTT.
 // ─────────────────────────────────────────────────────────────────────────────
@@ -451,7 +362,7 @@ impl Device for MqttDevice {
 
     async fn execute(&self, capability: &str, args: Value) -> Result<Value> {
         let cap = self.capability(capability)?;
-        validar_args(&args, cap.args_schema.as_ref(), &self.id, capability)?;
+        crate::schema::validar_args(&args, cap.args_schema.as_ref(), &self.id, capability)?;
         let rid = novo_request_id();
         let topico = topico_set(&self.prefixo, &self.id, capability);
         self.client
@@ -884,7 +795,7 @@ mod tests {
             "on": true, "percent": 50, "tempo": 1.5,
             "lista": [1, 2], "extra": {}, "nada": null
         });
-        assert!(validar_args(&args, Some(&schema), "dev", "cap").is_ok());
+        assert!(crate::schema::validar_args(&args, Some(&schema), "dev", "cap").is_ok());
     }
 
     #[test]
@@ -895,28 +806,28 @@ mod tests {
             "required": ["on"]
         });
         // obrigatório ausente
-        let err = validar_args(&json!({}), Some(&schema), "dev", "power").expect_err("recusa");
+        let err = crate::schema::validar_args(&json!({}), Some(&schema), "dev", "power").expect_err("recusa");
         assert!(err.to_string().contains("obrigatório"), "{err}");
         // tipo errado
-        let err = validar_args(&json!({ "on": "sim" }), Some(&schema), "dev", "power")
+        let err = crate::schema::validar_args(&json!({ "on": "sim" }), Some(&schema), "dev", "power")
             .expect_err("recusa");
         assert!(err.to_string().contains("boolean"), "{err}");
         // 50.5 não é integer
         let schema_int =
             json!({ "type": "object", "properties": { "percent": { "type": "integer" } } });
-        let err = validar_args(&json!({ "percent": 50.5 }), Some(&schema_int), "dev", "cap")
+        let err = crate::schema::validar_args(&json!({ "percent": 50.5 }), Some(&schema_int), "dev", "cap")
             .expect_err("recusa");
         assert!(err.to_string().contains("integer"), "{err}");
         // args não-objeto
-        let err = validar_args(&json!(true), Some(&schema), "dev", "power").expect_err("recusa");
+        let err = crate::schema::validar_args(&json!(true), Some(&schema), "dev", "power").expect_err("recusa");
         assert!(err.to_string().contains("objeto"), "{err}");
     }
 
     #[test]
     fn validar_args_sem_schema_recusa_argumentos() {
-        assert!(validar_args(&json!({}), None, "dev", "power").is_ok());
-        assert!(validar_args(&json!(null), None, "dev", "power").is_ok());
-        let err = validar_args(&json!({ "x": 1 }), None, "dev", "power").expect_err("recusa");
+        assert!(crate::schema::validar_args(&json!({}), None, "dev", "power").is_ok());
+        assert!(crate::schema::validar_args(&json!(null), None, "dev", "power").is_ok());
+        let err = crate::schema::validar_args(&json!({ "x": 1 }), None, "dev", "power").expect_err("recusa");
         assert!(err.to_string().contains("não declara argumentos"), "{err}");
     }
 
@@ -924,16 +835,16 @@ mod tests {
     fn validar_args_fail_closed_em_schema_que_nao_entende() {
         // tipo de propriedade desconhecido
         let schema = json!({ "type": "object", "properties": { "x": { "type": "bloco" } } });
-        let err =
-            validar_args(&json!({ "x": 1 }), Some(&schema), "dev", "cap").expect_err("recusa");
+        let err = crate::schema::validar_args(&json!({ "x": 1 }), Some(&schema), "dev", "cap")
+            .expect_err("recusa");
         assert!(err.to_string().contains("fail-closed"), "{err}");
         // propriedade sem type declarado
         let schema = json!({ "type": "object", "properties": { "x": {} } });
-        let err =
-            validar_args(&json!({ "x": 1 }), Some(&schema), "dev", "cap").expect_err("recusa");
+        let err = crate::schema::validar_args(&json!({ "x": 1 }), Some(&schema), "dev", "cap")
+            .expect_err("recusa");
         assert!(err.to_string().contains("não declara o tipo"), "{err}");
         // schema de nível de topo não-objeto
-        let err = validar_args(&json!({}), Some(&json!([])), "dev", "cap").expect_err("recusa");
+        let err = crate::schema::validar_args(&json!({}), Some(&json!([])), "dev", "cap").expect_err("recusa");
         assert!(err.to_string().contains("objeto JSON"), "{err}");
     }
 

--- a/crates/garraia-hardware/src/error.rs
+++ b/crates/garraia-hardware/src/error.rs
@@ -43,6 +43,11 @@ pub enum HardwareError {
     #[error("erro MQTT: {0}")]
     Mqtt(String),
 
+    /// Erro do transporte Home Assistant no manager (#1127) — sem
+    /// dispositivo associado (URL malformada, descoberta, WebSocket).
+    #[error("erro do Home Assistant: {0}")]
+    HomeAssistant(String),
+
     /// Erro do SQLite (o store de presença).
     #[error("erro de SQLite no estado de hardware: {0}")]
     Sqlite(#[from] rusqlite::Error),

--- a/crates/garraia-hardware/src/lib.rs
+++ b/crates/garraia-hardware/src/lib.rs
@@ -37,6 +37,7 @@ pub mod error;
 pub mod gate;
 pub mod registry;
 pub mod risk;
+pub mod schema;
 pub mod state;
 
 #[cfg(feature = "mock-device")]

--- a/crates/garraia-hardware/src/lib.rs
+++ b/crates/garraia-hardware/src/lib.rs
@@ -23,8 +23,11 @@
 //! Nenhum dispositivo físico é conectado aqui. Sem adaptador registrado, o
 //! [`DeviceRegistry`] fica vazio e as tools do agente (`device_list`,
 //! `device_read`, `device_execute`, em `garraia-agents`) listam nada. O
-//! primeiro transporte real é o adapter MQTT (#1126), em [`adapter_mqtt`],
-//! atrás da feature `mqtt` — OFF por default, mesmo padrão do `storage-s3`:
+//! primeiro transporte é o adapter MQTT (#1126), em [`adapter_mqtt`], atrás
+//! da feature `mqtt`; o segundo é o Home Assistant (#1127), em
+//! [`adapter_homeassistant`], atrás da feature `home-assistant` — REST +
+//! WebSocket contra o hub, entidades viram dispositivos por domínio com
+//! risco pré-avaliado. Ambos OFF por default, mesmo padrão do `storage-s3`:
 //! quem não usa transporte de rede não paga a árvore de deps. Cada adapter
 //! traz o próprio risco avaliado no PR correspondente.
 //!
@@ -46,6 +49,9 @@ pub mod mock;
 #[cfg(feature = "mqtt")]
 pub mod adapter_mqtt;
 
+#[cfg(feature = "home-assistant")]
+pub mod adapter_homeassistant;
+
 pub use capability::Capability;
 pub use device::{Device, DeviceSummary};
 pub use error::HardwareError;
@@ -59,6 +65,9 @@ pub use mock::MockDevice;
 
 #[cfg(feature = "mqtt")]
 pub use adapter_mqtt::{DeviceManifest, MqttAdapterConfig, MqttAdapterManager, MqttDevice};
+
+#[cfg(feature = "home-assistant")]
+pub use adapter_homeassistant::{HaAdapterConfig, HaAdapterManager, HaDevice};
 
 /// Resultado das operações de hardware.
 pub type Result<T> = std::result::Result<T, HardwareError>;

--- a/crates/garraia-hardware/src/schema.rs
+++ b/crates/garraia-hardware/src/schema.rs
@@ -7,8 +7,8 @@
 //! (#1127) validam contra o MESMO código, para dois adapters nunca
 //! divergirem no que aceitam.
 
-use crate::error::HardwareError;
 use crate::Result;
+use crate::error::HardwareError;
 
 /// Checa `args` contra `schema` — fail-closed em tudo que o validador não
 /// entende: tipo de schema diferente de `object`, propriedade sem `type`,
@@ -54,7 +54,10 @@ pub fn validar_args(
             "argumentos precisam ser um objeto JSON; recebi {args}"
         ));
     };
-    if let Some(obrigatorios) = obj_schema.get("required").and_then(serde_json::Value::as_array) {
+    if let Some(obrigatorios) = obj_schema
+        .get("required")
+        .and_then(serde_json::Value::as_array)
+    {
         for nome in obrigatorios {
             let Some(nome) = nome.as_str() else {
                 return recusa(format!(
@@ -66,7 +69,9 @@ pub fn validar_args(
             }
         }
     }
-    let Some(propriedades) = obj_schema.get("properties").and_then(serde_json::Value::as_object)
+    let Some(propriedades) = obj_schema
+        .get("properties")
+        .and_then(serde_json::Value::as_object)
     else {
         return Ok(());
     };
@@ -122,7 +127,15 @@ mod tests {
             "required": ["on"]
         });
 
-        assert!(validar_args(&json!({"on": true, "brightness": 200}), Some(&schema), "l", "p").is_ok());
+        assert!(
+            validar_args(
+                &json!({"on": true, "brightness": 200}),
+                Some(&schema),
+                "l",
+                "p"
+            )
+            .is_ok()
+        );
         assert!(validar_args(&json!({"on": true, "nome": "x"}), Some(&schema), "l", "p").is_ok());
         // Faltando o obrigatório.
         assert!(validar_args(&json!({}), Some(&schema), "l", "p").is_err());

--- a/crates/garraia-hardware/src/schema.rs
+++ b/crates/garraia-hardware/src/schema.rs
@@ -1,0 +1,167 @@
+//! Validação truncada de `args` contra o JSON Schema leve da capability.
+//!
+//! O schema que uma [`crate::Device`] declara em `Capability::args_schema`
+//! é um **subconjunto** de JSON Schema — só `type`/`properties`/`required`
+//! são garantidos (ver ADR 0020 §capabilities). Este módulo é a única
+//! implementação do validador: o adapter MQTT (#1126) e o Home Assistant
+//! (#1127) validam contra o MESMO código, para dois adapters nunca
+//! divergirem no que aceitam.
+
+use crate::error::HardwareError;
+use crate::Result;
+
+/// Checa `args` contra `schema` — fail-closed em tudo que o validador não
+/// entende: tipo de schema diferente de `object`, propriedade sem `type`,
+/// tipo primitivo desconhecido → recusa. Chaves extras nos args passam
+/// (o schema truncado não declara `additionalProperties`).
+///
+/// `schema: None` significa "o dispositivo declarou que não recebe
+/// argumentos" — args precisam ser `null` ou objeto vazio.
+pub fn validar_args(
+    args: &serde_json::Value,
+    schema: Option<&serde_json::Value>,
+    dispositivo: &str,
+    capability: &str,
+) -> Result<()> {
+    let recusa = |fonte: String| {
+        Err(HardwareError::Adapter {
+            dispositivo: dispositivo.to_string(),
+            fonte,
+        })
+    };
+    let Some(schema) = schema else {
+        // Sem schema, o dispositivo declarou que não recebe argumentos.
+        return if args.as_object().is_some_and(|obj| obj.is_empty()) || args.is_null() {
+            Ok(())
+        } else {
+            recusa(format!(
+                "capability '{capability}' não declara argumentos; recebi {args}"
+            ))
+        };
+    };
+    let Some(obj_schema) = schema.as_object() else {
+        return recusa(format!("args_schema não é um objeto JSON: {schema}"));
+    };
+    if let Some(tipo) = obj_schema.get("type")
+        && tipo != "object"
+    {
+        return recusa(format!(
+            "args_schema suporta apenas type=object neste slice; recebi {tipo}"
+        ));
+    }
+    let Some(obj_args) = args.as_object() else {
+        return recusa(format!(
+            "argumentos precisam ser um objeto JSON; recebi {args}"
+        ));
+    };
+    if let Some(obrigatorios) = obj_schema.get("required").and_then(serde_json::Value::as_array) {
+        for nome in obrigatorios {
+            let Some(nome) = nome.as_str() else {
+                return recusa(format!(
+                    "args_schema.required contém item não-texto: {nome}"
+                ));
+            };
+            if !obj_args.contains_key(nome) {
+                return recusa(format!("argumento obrigatório '{nome}' ausente"));
+            }
+        }
+    }
+    let Some(propriedades) = obj_schema.get("properties").and_then(serde_json::Value::as_object)
+    else {
+        return Ok(());
+    };
+    for (nome, spec) in propriedades {
+        let Some(valor) = obj_args.get(nome) else {
+            continue;
+        };
+        let Some(tipo) = spec.get("type").and_then(serde_json::Value::as_str) else {
+            return recusa(format!(
+                "argumento '{nome}': schema não declara o tipo — o validador truncado só conhece type/properties/required"
+            ));
+        };
+        let ok = match tipo {
+            "string" => valor.is_string(),
+            "boolean" => valor.is_boolean(),
+            "number" => valor.is_number(),
+            "integer" => valor.as_i64().is_some(),
+            "array" => valor.is_array(),
+            "object" => valor.is_object(),
+            "null" => valor.is_null(),
+            _ => {
+                return recusa(format!(
+                    "argumento '{nome}': tipo '{tipo}' não suportado pelo validador (fail-closed)"
+                ));
+            }
+        };
+        if !ok {
+            return recusa(format!(
+                "argumento '{nome}': esperado {tipo}, recebi {valor}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Os quatro casos que o gate de execução confia: primitivos passam,
+    /// erros típicos recusam, schema ausente recusa argumento, schema que
+    /// o validador não entende recusa por inteiro (fail-closed).
+    #[test]
+    fn aceita_tipos_primitivos_e_recusa_os_erros_tipicos() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "on": { "type": "boolean" },
+                "brightness": { "type": "integer" },
+                "nome": { "type": "string" }
+            },
+            "required": ["on"]
+        });
+
+        assert!(validar_args(&json!({"on": true, "brightness": 200}), Some(&schema), "l", "p").is_ok());
+        assert!(validar_args(&json!({"on": true, "nome": "x"}), Some(&schema), "l", "p").is_ok());
+        // Faltando o obrigatório.
+        assert!(validar_args(&json!({}), Some(&schema), "l", "p").is_err());
+        // Tipo errado.
+        assert!(validar_args(&json!({"on": "sim"}), Some(&schema), "l", "p").is_err());
+        // Args não-objeto.
+        assert!(validar_args(&json!([1]), Some(&schema), "l", "p").is_err());
+        // Chave extra passa (schema truncado não declara additionalProperties).
+        assert!(validar_args(&json!({"on": true, "extra": 1}), Some(&schema), "l", "p").is_ok());
+    }
+
+    #[test]
+    fn sem_schema_so_aceita_vazio_ou_null() {
+        assert!(validar_args(&json!({}), None, "l", "p").is_ok());
+        assert!(validar_args(&serde_json::Value::Null, None, "l", "p").is_ok());
+        assert!(validar_args(&json!({"on": true}), None, "l", "p").is_err());
+    }
+
+    #[test]
+    fn fail_closed_em_schema_que_nao_entende() {
+        // type != object.
+        assert!(validar_args(&json!({}), Some(&json!({"type": "string"})), "l", "p").is_err());
+        // Propriedade sem type.
+        let schema = json!({"type": "object", "properties": {"x": {}}});
+        assert!(validar_args(&json!({"x": 1}), Some(&schema), "l", "p").is_err());
+        // Tipo desconhecido.
+        let schema = json!({"type": "object", "properties": {"x": {"type": "word"}}});
+        assert!(validar_args(&json!({"x": 1}), Some(&schema), "l", "p").is_err());
+        // Schema não-objeto.
+        assert!(validar_args(&json!({}), Some(&json!([1])), "l", "p").is_err());
+    }
+
+    /// O erro cita dispositivo e capability — é o texto que o modelo enxerga.
+    #[test]
+    fn erro_nomeia_dispositivo_e_capability() {
+        let err = validar_args(&json!({"on": true}), None, "light.sala", "power")
+            .expect_err("args sem schema recusa");
+        let msg = err.to_string();
+        assert!(msg.contains("light.sala"), "cita o dispositivo: {msg}");
+        assert!(msg.contains("power"), "cita a capability: {msg}");
+    }
+}

--- a/crates/garraia-hardware/tests/adapter_homeassistant.rs
+++ b/crates/garraia-hardware/tests/adapter_homeassistant.rs
@@ -1,0 +1,625 @@
+//! Testes de integração do adapter Home Assistant (#1127) contra um hub
+//! mockado em axum — sem docker, na linha do rumqttd dos testes MQTT.
+//!
+//! O mock fala o contrato real do HA:
+//!
+//! - `GET /api/states` — descoberta;
+//! - `GET /api/states/{entity_id}` — leitura;
+//! - `POST /api/services/{domain}/{service}` — execução (o corpo é capturado
+//!   para o teste afirmar o payload exato que sairia para o hub);
+//! - `GET /api/websocket` — o protocolo de autenticação do HA
+//!   (`auth_required` → `auth` → `auth_ok` → `subscribe_events`), com um
+//!   sinal para o teste injetar eventos `state_changed`.
+//!
+//! Cada teste sobe o servidor em `127.0.0.1:0`, monta a config pelo mesmo
+//! caminho de produção (`HaAdapterConfig::new` — vetting de verdade, o que
+//! também garante que o guard deixa loopback com `AllowPrivate`) e espera
+//! condições com timeout — nada de sleeps fixos.
+
+#![cfg(feature = "home-assistant")]
+
+use axum::extract::ws::{Message as WsMsg, WebSocket, WebSocketUpgrade};
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use garraia_hardware::{
+    DeviceRegistry, DeviceStateStore, HaAdapterConfig, HaAdapterManager, RiskClass,
+};
+use serde_json::{Value, json};
+use std::sync::Arc;
+use std::time::Duration;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// O hub mockado.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Uma chamada de serviço capturada: (domínio, serviço, corpo).
+#[derive(Debug, Clone)]
+struct Chamada {
+    dominio: String,
+    servico: String,
+    corpo: Value,
+}
+
+/// Estado compartilhado do mock.
+#[derive(Clone)]
+struct MockState {
+    entidades: Arc<tokio::sync::Mutex<Vec<Value>>>,
+    chamadas: Arc<tokio::sync::Mutex<Vec<Chamada>>>,
+    /// Mensagens recebidas no WebSocket, já parseadas (auth, subscribe…).
+    ws_msgs: Arc<tokio::sync::Mutex<Vec<Value>>>,
+    /// Token que o mock exige no handshake — configurar outro testa o
+    /// caminho `auth_invalid`.
+    token_esperado: Arc<tokio::sync::Mutex<String>>,
+    /// Evento `state_changed` a injetar quando o teste sinaliza.
+    evento: Arc<tokio::sync::Mutex<Value>>,
+    /// O teste avisa "injete o evento agora".
+    sinal: Arc<tokio::sync::Notify>,
+}
+
+impl MockState {
+    fn novo() -> Self {
+        Self {
+            entidades: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+            chamadas: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+            ws_msgs: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+            token_esperado: Arc::new(tokio::sync::Mutex::new("token-do-ha".to_string())),
+            evento: Arc::new(tokio::sync::Mutex::new(json!(null))),
+            sinal: Arc::new(tokio::sync::Notify::new()),
+        }
+    }
+}
+
+async fn lista_estados(State(st): State<MockState>) -> Json<Vec<Value>> {
+    Json(st.entidades.lock().await.clone())
+}
+
+async fn estado_de(
+    Path(entity_id): Path<String>,
+    State(st): State<MockState>,
+) -> Result<Json<Value>, StatusCode> {
+    let entidades = st.entidades.lock().await;
+    entidades
+        .iter()
+        .find(|e| e.get("entity_id").and_then(Value::as_str) == Some(entity_id.as_str()))
+        .cloned()
+        .map(Json)
+        .ok_or(StatusCode::NOT_FOUND)
+}
+
+async fn servico(
+    Path((dominio, servico)): Path<(String, String)>,
+    State(st): State<MockState>,
+    Json(corpo): Json<Value>,
+) -> Json<Value> {
+    st.chamadas.lock().await.push(Chamada {
+        dominio,
+        servico,
+        corpo,
+    });
+    // O HA devolve um array vazio no 200.
+    Json(json!([]))
+}
+
+/// O WebSocket `/api/websocket` com o protocolo de auth do HA.
+async fn websocket(upg: WebSocketUpgrade, State(st): State<MockState>) -> axum::response::Response {
+    upg.on_upgrade(move |socket| protocolo_ha(socket, st))
+}
+
+async fn protocolo_ha(mut ws: WebSocket, st: MockState) {
+    // 1. auth_required.
+    if ws
+        .send(WsMsg::Text(
+            json!({"type": "auth_required"}).to_string().into(),
+        ))
+        .await
+        .is_err()
+    {
+        return;
+    }
+    // 2. recebe o auth — registra e valida o token.
+    let Some(Ok(WsMsg::Text(t))) = ws.recv().await else {
+        return;
+    };
+    let auth: Value = serde_json::from_str(t.as_str()).unwrap_or(json!(null));
+    st.ws_msgs.lock().await.push(auth.clone());
+    if auth.get("access_token").and_then(Value::as_str)
+        != Some(st.token_esperado.lock().await.as_str())
+    {
+        let _ = ws
+            .send(WsMsg::Text(
+                json!({"type": "auth_invalid"}).to_string().into(),
+            ))
+            .await;
+        return;
+    }
+    // 3. auth_ok.
+    if ws
+        .send(WsMsg::Text(json!({"type": "auth_ok"}).to_string().into()))
+        .await
+        .is_err()
+    {
+        return;
+    }
+    // 4. recebe o subscribe — registra.
+    let Some(Ok(WsMsg::Text(t))) = ws.recv().await else {
+        return;
+    };
+    st.ws_msgs
+        .lock()
+        .await
+        .push(serde_json::from_str(t.as_str()).unwrap_or(json!(null)));
+
+    // 5. injeta os eventos que o teste pedir, até a conexão morrer.
+    loop {
+        st.sinal.notified().await;
+        let evento = st.evento.lock().await.clone();
+        if ws
+            .send(WsMsg::Text(evento.to_string().into()))
+            .await
+            .is_err()
+        {
+            return;
+        }
+    }
+}
+
+/// Um hub no ar, com URL pronta para a config.
+struct MockHub {
+    url: String,
+    state: MockState,
+}
+
+async fn subir_hub(st: MockState) -> MockHub {
+    let app = Router::new()
+        .route("/api/states", get(lista_estados))
+        .route("/api/states/{entity_id}", get(estado_de))
+        .route("/api/services/{dominio}/{servico}", post(servico))
+        .route("/api/websocket", get(websocket))
+        .with_state(st.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind 127.0.0.1:0");
+    let addr = listener.local_addr().expect("local_addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    MockHub {
+        url: format!("http://{addr}"),
+        state: st,
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Espera até `condicao` devolver `Some` (ou estourar o prazo) — nada de
+/// sleeps fixos: cada teste define a condição que interessa. Closure async
+/// (edition 2024) porque as condições reais (`store.estado`, ws_msgs) são
+/// async.
+async fn espera<T>(prazo: Duration, mut condicao: impl AsyncFnMut() -> Option<T>) -> Option<T> {
+    let fim = tokio::time::Instant::now() + prazo;
+    loop {
+        if let Some(v) = condicao().await {
+            return Some(v);
+        }
+        if tokio::time::Instant::now() >= fim {
+            return None;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+const PRAZO: Duration = Duration::from_secs(5);
+
+/// As entidades de uma casa pequena, com uma armadilha de cada tipo:
+/// domínio fora da lista, entity_id sem ponto, objeto com espaço.
+fn casa_pequena() -> Vec<Value> {
+    vec![
+        json!({"entity_id": "light.sala", "state": "on", "attributes": {"brightness_pct": 80}}),
+        json!({"entity_id": "sensor.temp", "state": "23.5", "attributes": {"unit": "°C"}}),
+        json!({"entity_id": "binary_sensor.porta", "state": "off", "attributes": {}}),
+        json!({"entity_id": "lock.porta", "state": "locked", "attributes": {}}),
+        json!({"entity_id": "cover.janela", "state": "unavailable", "attributes": {}}),
+        json!({"entity_id": "switch.tomada", "state": "on", "attributes": {}}),
+        json!({"entity_id": "climate.ac", "state": "cool", "attributes": {}}),
+        json!({"entity_id": "vacuum.robo", "state": "cleaning", "attributes": {}}),
+        json!({"entity_id": "sem_ponto", "state": "?", "attributes": {}}),
+        json!({"entity_id": "light.Casa limpa", "state": "on", "attributes": {}}),
+    ]
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Os testes.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Descoberta: só os domínios da lista viram dispositivos, cada um com o
+/// risco do domínio; `unavailable` nasce offline; presença inicial vai para
+/// o store.
+#[tokio::test]
+async fn descoberta_registra_por_dominio_com_risco() {
+    let hub = subir_hub(MockState::novo()).await;
+    *hub.state.entidades.lock().await = casa_pequena();
+
+    let registry = Arc::new(DeviceRegistry::new());
+    let store = Arc::new(DeviceStateStore::em_memoria().expect("store"));
+    let config = HaAdapterConfig::new(&hub.url, "token-do-ha".to_string()).expect("config vetada");
+    let manager = HaAdapterManager::spawn(config, registry.clone(), Some(store.clone()));
+
+    let registrado = espera(PRAZO, || async { (registry.len() == 7).then_some(()) }).await;
+    assert_eq!(registrado, Some(()), "7 entidades viram dispositivos");
+
+    let ids: Vec<String> = registry.list().iter().map(|d| d.id.clone()).collect();
+    assert_eq!(
+        ids,
+        [
+            "binary_sensor.porta",
+            "climate.ac",
+            "cover.janela",
+            "light.sala",
+            "lock.porta",
+            "sensor.temp",
+            "switch.tomada"
+        ],
+        "vacuum/sem_ponto/'Casa limpa' ficam fora"
+    );
+
+    // Risco por domínio, na capability certa.
+    let light = registry.get("light.sala").expect("light registrado");
+    let caps = light.capabilities();
+    let power = caps.iter().find(|c| c.name == "power").expect("power");
+    assert_eq!(power.risk, RiskClass::R1);
+    assert!(!power.read_only);
+    assert!(caps.iter().all(|c| c.risk <= RiskClass::R1));
+
+    let lock = registry.get("lock.porta").expect("lock registrado");
+    assert!(
+        lock.capabilities()
+            .iter()
+            .filter(|c| !c.read_only)
+            .all(|c| c.risk == RiskClass::R3)
+    );
+
+    let cover = registry.get("cover.janela").expect("cover registrado");
+    assert!(
+        cover
+            .capabilities()
+            .iter()
+            .filter(|c| !c.read_only)
+            .all(|c| c.risk == RiskClass::R2)
+    );
+    assert!(
+        cover
+            .capabilities()
+            .iter()
+            .all(|c| c.read_only || c.risk >= RiskClass::R2)
+    );
+
+    let sensor = registry.get("sensor.temp").expect("sensor registrado");
+    assert!(
+        sensor
+            .capabilities()
+            .iter()
+            .all(|c| c.risk == RiskClass::R0 && c.read_only)
+    );
+
+    // Presença inicial: o estado real da descoberta.
+    let online = store
+        .estado("light.sala")
+        .await
+        .expect("lê")
+        .expect("marcado");
+    assert!(online.online);
+    let offline = store
+        .estado("cover.janela")
+        .await
+        .expect("lê")
+        .expect("marcado");
+    assert!(!offline.online, "unavailable nasce offline");
+
+    manager.encerrar().await;
+}
+
+/// `read` fala `GET /api/states/{entity_id}` e devolve o payload do hub.
+/// Capability que não existe recusa sem sair do processo.
+#[tokio::test]
+async fn read_busca_estado_no_hub() {
+    let hub = subir_hub(MockState::novo()).await;
+    *hub.state.entidades.lock().await = casa_pequena();
+
+    let registry = Arc::new(DeviceRegistry::new());
+    let config = HaAdapterConfig::new(&hub.url, "token-do-ha".to_string()).expect("config");
+    let manager = HaAdapterManager::spawn(config, registry.clone(), None);
+
+    let sensor = espera(PRAZO, || async { registry.get("sensor.temp") })
+        .await
+        .expect("sensor registrado");
+
+    let estado = sensor.read("state").await.expect("lê estado");
+    assert_eq!(estado["entity_id"], json!("sensor.temp"));
+    assert_eq!(estado["state"], json!("23.5"));
+
+    let err = sensor
+        .read("temperature")
+        .await
+        .expect_err("capability inexistente");
+    assert!(
+        err.to_string().contains("temperature"),
+        "erro cita a capability: {err}"
+    );
+
+    // Executar uma leitura também recusa — leitura não vira serviço.
+    let err = sensor
+        .execute("state", json!({}))
+        .await
+        .expect_err("leitura não executa");
+    assert!(
+        err.to_string().contains("não mapeia"),
+        "sensor não tem serviço: {err}"
+    );
+
+    manager.encerrar().await;
+}
+
+/// `execute` mapeia (domínio, capability, args) → serviço e payload exatos.
+#[tokio::test]
+async fn execute_mapeia_servico_e_payload() {
+    let hub = subir_hub(MockState::novo()).await;
+    *hub.state.entidades.lock().await = casa_pequena();
+
+    let registry = Arc::new(DeviceRegistry::new());
+    let config = HaAdapterConfig::new(&hub.url, "token-do-ha".to_string()).expect("config");
+    let manager = HaAdapterManager::spawn(config, registry.clone(), None);
+
+    let light = espera(PRAZO, || async { registry.get("light.sala") })
+        .await
+        .expect("light registrado");
+
+    let r = light
+        .execute("power", json!({"on": true}))
+        .await
+        .expect("liga");
+    assert_eq!(r["enviado"], json!(true));
+    assert_eq!(r["servico"], json!("light/turn_on"));
+
+    let r = light
+        .execute("power", json!({"on": false}))
+        .await
+        .expect("desliga");
+    assert_eq!(r["servico"], json!("light/turn_off"));
+
+    let r = light
+        .execute("brightness", json!({"brightness_pct": 50}))
+        .await
+        .expect("brilho");
+    assert_eq!(r["servico"], json!("light/turn_on"));
+
+    let cover = espera(PRAZO, || async { registry.get("cover.janela") })
+        .await
+        .expect("cover registrado");
+    cover.execute("open", json!({})).await.expect("abre");
+    let r = cover
+        .execute("set_position", json!({"position": 80}))
+        .await
+        .expect("posição");
+    assert_eq!(r["servico"], json!("cover/set_cover_position"));
+
+    let lock = espera(PRAZO, || async { registry.get("lock.porta") })
+        .await
+        .expect("lock registrado");
+    let r = lock.execute("unlock", json!({})).await.expect("destranca");
+    assert_eq!(r["servico"], json!("lock/unlock"));
+
+    let clima = espera(PRAZO, || async { registry.get("climate.ac") })
+        .await
+        .expect("climate registrado");
+    clima
+        .execute("temperature", json!({"temperature": 22.5}))
+        .await
+        .expect("temperatura");
+
+    manager.encerrar().await;
+
+    // O que exatamente saiu para o hub?
+    let chamadas = hub.state.chamadas.lock().await;
+    assert_eq!(chamadas.len(), 7);
+    let caminho = |i: usize| format!("{}/{}", chamadas[i].dominio, chamadas[i].servico);
+    assert_eq!(caminho(0), "light/turn_on");
+    assert_eq!(chamadas[0].corpo, json!({"entity_id": "light.sala"}));
+    assert_eq!(caminho(1), "light/turn_off");
+    assert_eq!(caminho(2), "light/turn_on");
+    assert_eq!(
+        chamadas[2].corpo,
+        json!({"entity_id": "light.sala", "brightness_pct": 50})
+    );
+    assert_eq!(caminho(3), "cover/open_cover");
+    assert_eq!(chamadas[3].corpo, json!({"entity_id": "cover.janela"}));
+    assert_eq!(caminho(4), "cover/set_cover_position");
+    assert_eq!(
+        chamadas[4].corpo,
+        json!({"entity_id": "cover.janela", "position": 80})
+    );
+    assert_eq!(caminho(5), "lock/unlock");
+    assert_eq!(chamadas[5].corpo, json!({"entity_id": "lock.porta"}));
+    assert_eq!(caminho(6), "climate/set_temperature");
+    assert_eq!(
+        chamadas[6].corpo,
+        json!({"entity_id": "climate.ac", "temperature": 22.5})
+    );
+}
+
+/// Args inválidos são recusados pelo mesmo `validar_args` do MQTT — e nada
+/// sai para o hub.
+#[tokio::test]
+async fn execute_recusa_args_invalidos_antes_do_hub() {
+    let hub = subir_hub(MockState::novo()).await;
+    *hub.state.entidades.lock().await = casa_pequena();
+
+    let registry = Arc::new(DeviceRegistry::new());
+    let config = HaAdapterConfig::new(&hub.url, "token-do-ha".to_string()).expect("config");
+    let manager = HaAdapterManager::spawn(config, registry.clone(), None);
+
+    let light = espera(PRAZO, || async { registry.get("light.sala") })
+        .await
+        .expect("light registrado");
+
+    // Schema exige "on" boolean — faltando, errado no tipo, capability
+    // desconhecida: tudo erro, e o mock não vê NENHUM POST.
+    assert!(light.execute("power", json!({})).await.is_err());
+    assert!(light.execute("power", json!({"on": "sim"})).await.is_err());
+    assert!(light.execute("brightness", json!({})).await.is_err());
+    assert!(
+        light
+            .execute("brightness", json!({"brightness_pct": 12.5}))
+            .await
+            .is_err(),
+        "brightness_pct é integer, não number fracionário"
+    );
+    assert!(light.execute("nao_existe", json!({})).await.is_err());
+
+    manager.encerrar().await;
+    assert!(
+        hub.state.chamadas.lock().await.is_empty(),
+        "nenhum POST deveria ter saído"
+    );
+}
+
+/// O WebSocket autentica, assina `state_changed` e marca presença — o fluxo
+/// inteiro do protocolo HA contra um servidor real.
+#[tokio::test]
+async fn ws_marca_presenca_por_evento() {
+    let hub = subir_hub(MockState::novo()).await;
+    *hub.state.entidades.lock().await = casa_pequena();
+
+    let registry = Arc::new(DeviceRegistry::new());
+    let store = Arc::new(DeviceStateStore::em_memoria().expect("store"));
+    let config = HaAdapterConfig::new(&hub.url, "token-do-ha".to_string()).expect("config");
+    let manager = HaAdapterManager::spawn(config, registry.clone(), Some(store.clone()));
+
+    // Presença inicial da descoberta (cover.janela nasce offline).
+    espera(PRAZO, || async {
+        store
+            .estado("cover.janela")
+            .await
+            .ok()
+            .flatten()
+            .map(|_| ())
+    })
+    .await
+    .expect("descoberta marcou presença");
+
+    // O adapter assinou (auth + subscribe registrados no mock)?
+    espera(PRAZO, || async {
+        (hub.state.ws_msgs.lock().await.len() >= 2).then_some(())
+    })
+    .await
+    .expect("handshake completou");
+
+    let ws_msgs = hub.state.ws_msgs.lock().await;
+    assert_eq!(ws_msgs[0]["type"], json!("auth"));
+    assert_eq!(ws_msgs[0]["access_token"], json!("token-do-ha"));
+    assert_eq!(ws_msgs[1]["type"], json!("subscribe_events"));
+    assert_eq!(ws_msgs[1]["event_type"], json!("state_changed"));
+    drop(ws_msgs);
+
+    // Evento de volta online — cover.janela nasceu offline (unavailable).
+    *hub.state.evento.lock().await = json!({
+        "id": 1, "type": "event",
+        "event": {"event_type": "state_changed", "data": {
+            "entity_id": "cover.janela",
+            "new_state": {"state": "open", "attributes": {}}
+        }}
+    });
+    hub.state.sinal.notify_one();
+    espera(PRAZO, || async {
+        store
+            .estado("cover.janela")
+            .await
+            .ok()
+            .flatten()
+            .filter(|p| p.online)
+            .map(|_| ())
+    })
+    .await
+    .expect("evento on marcou online");
+
+    // E de volta offline (unavailable).
+    *hub.state.evento.lock().await = json!({
+        "id": 2, "type": "event",
+        "event": {"event_type": "state_changed", "data": {
+            "entity_id": "cover.janela", "new_state": {"state": "unavailable"}
+        }}
+    });
+    hub.state.sinal.notify_one();
+    espera(PRAZO, || async {
+        store
+            .estado("cover.janela")
+            .await
+            .ok()
+            .flatten()
+            .filter(|p| !p.online)
+            .map(|_| ())
+    })
+    .await
+    .expect("evento unavailable marcou offline");
+
+    manager.encerrar().await;
+}
+
+/// Token errado: o mock responde `auth_invalid` e o adapter nunca chega a
+/// assinar — sem desistir, sem crash.
+#[tokio::test]
+async fn ws_token_errado_nao_assina() {
+    let hub = subir_hub(MockState::novo()).await;
+    *hub.state.entidades.lock().await = casa_pequena();
+    // O hub espera outro token.
+    *hub.state.token_esperado.lock().await = "token-certo".to_string();
+
+    let registry = Arc::new(DeviceRegistry::new());
+    let config = HaAdapterConfig::new(&hub.url, "token-errado".to_string()).expect("config");
+    let manager = HaAdapterManager::spawn(config, registry.clone(), None);
+
+    // A tentativa de auth chega…
+    espera(PRAZO, || async {
+        (!hub.state.ws_msgs.lock().await.is_empty()).then_some(())
+    })
+    .await
+    .expect("auth enviado");
+
+    // …e o subscribe nunca vem.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert_eq!(
+        hub.state.ws_msgs.lock().await.len(),
+        1,
+        "auth_invalid deve interromper antes do subscribe"
+    );
+
+    manager.encerrar().await;
+}
+
+/// Hub fora do ar: a descoberta falha, o registry segue vazio e ninguém
+/// panica — fail-soft, o loop segue tentando.
+#[tokio::test]
+async fn hub_inacessivel_registry_fica_vazio() {
+    // Uma porta com nada escutando.
+    let fantasma = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let porta = fantasma.local_addr().expect("addr").port();
+    drop(fantasma);
+
+    let registry = Arc::new(DeviceRegistry::new());
+    let config = HaAdapterConfig::new(&format!("http://127.0.0.1:{porta}"), "t".to_string())
+        .expect("config vetada (loopback)");
+    let manager = HaAdapterManager::spawn(config, registry.clone(), None);
+
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    assert!(
+        registry.is_empty(),
+        "sem hub, nenhuma entidade pode ter entrado"
+    );
+
+    manager.encerrar().await;
+}


### PR DESCRIPTION
## O quê

Implementa a issue #1127 do epic #1124 (ADR 0020): o adapter Home Assistant do `garraia-hardware`, atrás da feature `home-assistant` (OFF por default, mesmo padrão do `mqtt` do #1163). O HA já agrega o zilhão de integrações domésticas — em vez de duplicar drivers, falamos a API oficial e expomos as entidades como `Device` no registry.

## Contrato da issue #1127, coberto

- **Config**: `hardware.home_assistant { url, token_env }` (já commitada no commit anterior `c0091dc0` deste branch — `HaConfig` em `garraia-config`, validação no `config check`).
- **Descoberta**: `GET /api/states` filtrado por domínio — sensor, binary_sensor, light, switch, climate, cover, lock. Domínio fora da lista **não vira dispositivo** (fail-closed).
- **Leitura**: `GET /api/states/{entity_id}` devolve o payload do hub, sem inventar formato próprio.
- **Execução**: `POST /api/services/{domain}/{service}` com payload mapeado por (domínio, capability, args) — `power` → `turn_on/turn_off`, `brightness` → `light/turn_on` + `brightness_pct`, `temperature` → `climate/set_temperature`, cover → `open_cover/close_cover/set_cover_position`, lock → `lock/lock|unlock`.
- **WebSocket**: `ws(s)://…/api/websocket` com o protocolo de auth do HA (`auth_required` → `auth` → `auth_ok` → `subscribe_events`); eventos `state_changed` marcam presença (`unavailable` → offline). Reconexão em loop com ping do cliente e **re-descoberta a cada rodada** — o hub pode subir depois do boot.
- **Risco por domínio, nunca por payload**: sensor/binary_sensor R0 (leitura), light/switch/climate R1, cover R2, lock R3. Sem R4/R5 neste slice.

## Segurança

- **SSRF (regra 14)**: URL base vem de config, então toda chamada sai por `garraia_common::ssrf` — `vet_url` com `UrlPolicy::http_public(..).with_ip_scope(IpScope::AllowPrivate)` (hub local é alvo legítimo da LAN; link-local, CGNAT, multicast e unspecified seguem bloqueados) + `pinned_client`. O **WebSocket conecta no mesmo IP pinado** (TcpStream manual + `client_async_tls_with_config`), sem re-resolver DNS — sem janela TOCTOU. `read_capped` limita os corpos (16 MiB).
- **Token write-only**: config carrega o nome da env (`token_env`), o bootstrap resolve o valor e passa ao adapter; `Debug` redige; warns citam só o nome da env. Teste cobre a redação.
- **Args**: validados pelo mesmo `validar_args` do adapter MQTT (`schema.rs`) — um validador, dois transports, zero divergência.

## Wiring

- `spawn_mqtt_adapter` → `spawn_hardware_adapters` no bootstrap: abre **um** store de presença compartilhado (`hardware.db`) quando qualquer adapter está configurado, e sobe cada um com fail-soft (warn citando o que faltou, registry soma os que subiram). Gateway e CLI (`garra chat`) compartilham o mesmo caminho, como no #1163.
- CI: grupo `--features home-assistant` no `ci.yml` (mesmo buraco do #1089), agora **com** os testes de integração (`tests/adapter_homeassistant.rs`) — hub mockado em axum, sem docker, incluindo o WebSocket com o protocolo de auth real.

## Testes

- Unidade (adapter): risco por domínio, domínio desconhecido recusado, vetting bloqueia link-local e aceita loopback, derivação `ws`/`wss`, mapeamento de serviços, parse de entidades (armadilhas: vacuum, sem ponto, objeto com espaço, sem entity_id), eventos `state_changed` (on/off/null/outro tipo), redação do token.
- Integração (axum mock): descoberta registra 7 entidades com o risco certo e presença inicial honesta; leitura; execução com **payload exato capturado** para os 7 serviços; args inválidos recusados **antes** do hub (zero POST); WebSocket autentica/assina/marca presença nos dois sentidos; token errado nunca assina (`auth_invalid`); hub inacessível deixa o registry vazio sem panica.
- `cargo test -p garraia-hardware --features home-assistant`: 39 lib + 7 integração ✓ · `--features mqtt --lib`: 42 ✓ · `garraia-config`: 142 ✓ · clippy 0 warnings nas duas features e no workspace tocado ✓ · `cargo fmt --check` ✓ · `cargo deny check` ✓

Closes #1127 · Epic #1124

🤖 Generated with [Claude Code](https://claude.com/claude-code)
