### PR TITLE
feat(hardware): motor de automacoes declarativas (#1128)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,6 +408,19 @@ jobs:
           cargo test -p garraia-hardware --features home-assistant
           echo "::endgroup::"
 
+          # Mesmo buraco para a feature `automations` (#1128): o motor de
+          # regras declarativas (TOML/JSON → eventos → gate → acao). SEM
+          # `--lib`, porque a feature traz o teste de integracao em tests/
+          # que roda o pipeline completo (carga de spec, condicao, teto de
+          # risco, rate limit, debounce) contra o MockDevice — o fluxo que
+          # decide se um dispositivo fisico liga sozinho. A combinacao com
+          # os adapters e a que o gateway usa; o `--workspace` de cima mais
+          # o gate do gateway cobre o resto.
+          echo "::group::garraia-hardware --features automations"
+          cargo clippy -p garraia-hardware --features automations --all-targets -- -D warnings
+          cargo test -p garraia-hardware --features automations
+          echo "::endgroup::"
+
   # Supply-chain gate: license allow-list + crate bans + registry source bans
   # + RustSec advisories. Uses deny.toml at the repo root. Runs in parallel
   # with clippy. Now invokes the `cargo-deny-action` default `command: check`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3708,6 +3708,8 @@ version = "0.4.1"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
+ "chrono",
+ "croner",
  "futures",
  "garraia-common",
  "reqwest 0.12.28",
@@ -3719,6 +3721,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tokio-tungstenite 0.29.0",
+ "toml 1.1.5+spec-1.1.0",
  "tracing",
  "url",
 ]

--- a/changelog.d/added/1128-motor-automacoes.md
+++ b/changelog.d/added/1128-motor-automacoes.md
@@ -1,0 +1,24 @@
+- O gateway arma um motor de automacoes declarativas (#1128, epic #1124,
+  ADR 0020) dentro do `garraia-hardware`. Com a secao `hardware.automations`
+  no config (`dir` com as regras e `risk_ceiling` — default `r1`), o boot
+  carrega os arquivos `*.toml`/`*.json` do dir, compila as regras e o motor
+  assina o barramento de eventos que os adapters (#1126/#1127) publicam.
+- Regra declarativa: gatilho `state_changed` (entidade) ou `cron`; condicoes
+  em expressao (`to.state > 32`, avaliadas com fail-closed — erro de
+  avaliacao nunca vira `false` silencioso); acoes `device_execute` em
+  sequencia; knobs `debounce_secs` (rajada de eventos colapsa em uma
+  execucao) e rate limit `max_per_hour` (janela deslizante de 1h).
+- O gate de risco rege sem excecao: automacao roda sem canal de confirmacao
+  (ninguem vai apertar "aprovar" as 3 da manha), entao o teto de risco do
+  config corta o que ela pode pedir — `r0`, `r1` ou `r2`, nunca R3+: acao
+  acima do teto fica bloqueada, com a negativa na auditoria. `garra config
+  check` recusa `risk_ceiling` fora de `r0`/`r1`/`r2`.
+- Toda execucao fica auditada no `automations.db` (mesmo data dir do resto
+  do hardware): disparo, resultado (`executada`, `bloqueada_risco`,
+  `condicao_falsa`, `condicao_erro`, `rate_limited`, `erro`), o detalhe de
+  cada acao e a duracao. Regra desabilitada nao arma; spec quebrada nao sobe
+  silenciosa — warn no boot e o motor fica fora ate o arquivo consertar.
+- Feature `automations` OFF por default no crate; o gateway (e `garra chat`,
+  pela mesma funcao de bootstrap) a liga, e o config decide se o motor arma.
+  Sem a secao `hardware.automations`, nada muda — nenhum arquivo de regra e
+  lido e o motor nao sobe.

--- a/crates/garraia-config/src/check.rs
+++ b/crates/garraia-config/src/check.rs
@@ -1603,6 +1603,9 @@ fn validate_hardware(
     if let Some(ha) = &hardware.home_assistant {
         valida_home_assistant(ha, findings, push_err);
     }
+    if let Some(automacoes) = &hardware.automations {
+        valida_automacoes(automacoes, findings, push_err);
+    }
 }
 
 /// #1127: a URL do HA precisa de esquema http/https e host — é ela que o
@@ -1651,6 +1654,36 @@ fn valida_home_assistant(
             "hardware.home_assistant.token_env must be non-empty (HA has no anonymous API)"
                 .to_string(),
         );
+    }
+}
+
+/// #1128: o diretório de regras precisa existir como valor — config que
+/// cita `dir` vazio sobe com o motor sem regras e ninguém percebe. O teto
+/// tem que ser uma das três formas canônicas (`r0`/`r1`/`r2`): um typo
+/// ("R2" maiúsculo é aceito no engine, mas "r3" não é um teto — R3+ nem
+/// existe aqui) vira erro na carga, não um teto silenciosamente mais alto.
+fn valida_automacoes(
+    automacoes: &crate::model::AutomationsConfig,
+    findings: &mut Vec<Finding>,
+    push_err: &impl Fn(&mut Vec<Finding>, &str, String),
+) {
+    if automacoes.dir.trim().is_empty() {
+        push_err(
+            findings,
+            "hardware.automations.dir",
+            "hardware.automations.dir must be non-empty (the rules directory)".to_string(),
+        );
+    }
+    match automacoes.risk_ceiling.trim().to_ascii_lowercase().as_str() {
+        "r0" | "r1" | "r2" => {}
+        outro => push_err(
+            findings,
+            "hardware.automations.risk_ceiling",
+            format!(
+                "hardware.automations.risk_ceiling ({:?}) must be one of \"r0\", \"r1\", \"r2\" (got {:?}) — R3+ is not configurable for automations",
+                automacoes.risk_ceiling, outro
+            ),
+        ),
     }
 }
 
@@ -2503,6 +2536,7 @@ mod tests {
         use crate::model::{HardwareConfig, MqttConfig};
         let cfg = AppConfig {
             hardware: HardwareConfig {
+                automations: None,
                 mqtt: Some(MqttConfig {
                     broker: "127.0.0.1".to_string(), // sem :port
                     username: None,
@@ -2527,6 +2561,7 @@ mod tests {
         use crate::model::{HardwareConfig, MqttConfig};
         let cfg = AppConfig {
             hardware: HardwareConfig {
+                automations: None,
                 mqtt: Some(MqttConfig {
                     broker: "127.0.0.1:mqtt".to_string(),
                     username: None,
@@ -2551,6 +2586,7 @@ mod tests {
         use crate::model::{HardwareConfig, MqttConfig};
         let cfg = AppConfig {
             hardware: HardwareConfig {
+                automations: None,
                 mqtt: Some(MqttConfig {
                     broker: "127.0.0.1:1883".to_string(),
                     username: Some("garra".to_string()),
@@ -2576,6 +2612,7 @@ mod tests {
         use crate::model::{HaConfig, HardwareConfig};
         let cfg = AppConfig {
             hardware: HardwareConfig {
+                automations: None,
                 home_assistant: Some(HaConfig {
                     url: "ftp://homeassistant.local:8123".to_string(),
                     token_env: "GARRA_HA_TOKEN".to_string(),
@@ -2598,6 +2635,7 @@ mod tests {
         use crate::model::{HaConfig, HardwareConfig};
         let cfg = AppConfig {
             hardware: HardwareConfig {
+                automations: None,
                 home_assistant: Some(HaConfig {
                     url: "homeassistant.local".to_string(), // sem esquema
                     token_env: "GARRA_HA_TOKEN".to_string(),
@@ -2620,6 +2658,7 @@ mod tests {
         use crate::model::{HaConfig, HardwareConfig};
         let cfg = AppConfig {
             hardware: HardwareConfig {
+                automations: None,
                 home_assistant: Some(HaConfig {
                     url: "http://127.0.0.1:8123".to_string(),
                     token_env: "  ".to_string(),
@@ -2643,6 +2682,7 @@ mod tests {
         use crate::model::{HaConfig, HardwareConfig};
         let cfg = AppConfig {
             hardware: HardwareConfig {
+                automations: None,
                 home_assistant: Some(HaConfig {
                     url: "http://homeassistant.local:8123".to_string(),
                     token_env: "GARRA_HA_TOKEN".to_string(),
@@ -2666,6 +2706,7 @@ mod tests {
         use crate::model::{HaConfig, HardwareConfig, MqttConfig};
         let cfg = AppConfig {
             hardware: HardwareConfig {
+                automations: None,
                 mqtt: Some(MqttConfig {
                     broker: "127.0.0.1:1883".to_string(),
                     username: None,
@@ -2683,6 +2724,103 @@ mod tests {
         assert!(
             findings.iter().all(|f| !f.field.starts_with("hardware")),
             "both adapters valid mas encontrou findings: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn automations_valid_config_is_clean() {
+        // #1128: teto canônico + dir não vazio — o caso real da casa.
+        use crate::model::{AutomationsConfig, HardwareConfig};
+        let cfg = AppConfig {
+            hardware: HardwareConfig {
+                automations: Some(AutomationsConfig {
+                    dir: "rules/automations".to_string(),
+                    risk_ceiling: "r2".to_string(),
+                }),
+                mqtt: None,
+                home_assistant: None,
+            },
+            ..AppConfig::default()
+        };
+        let findings = validate(&cfg);
+        assert!(
+            findings.iter().all(|f| !f.field.starts_with("hardware")),
+            "valid automations config produced findings: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn automations_risk_ceiling_desconhecido_e_error() {
+        // "r3" não é um teto — R3+ nem existe para automação (não há quem
+        // confirme). Um typo tem que virar erro na carga, não um teto
+        // silenciosamente mais alto.
+        use crate::model::{AutomationsConfig, HardwareConfig};
+        let cfg = AppConfig {
+            hardware: HardwareConfig {
+                automations: Some(AutomationsConfig {
+                    dir: "rules".to_string(),
+                    risk_ceiling: "r3".to_string(),
+                }),
+                mqtt: None,
+                home_assistant: None,
+            },
+            ..AppConfig::default()
+        };
+        let findings = validate(&cfg);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.severity == Severity::Error
+                    && f.field == "hardware.automations.risk_ceiling"),
+            "expected error on unknown risk ceiling: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn automations_dir_vazio_e_error() {
+        use crate::model::{AutomationsConfig, HardwareConfig};
+        let cfg = AppConfig {
+            hardware: HardwareConfig {
+                automations: Some(AutomationsConfig {
+                    dir: "   ".to_string(),
+                    risk_ceiling: "r1".to_string(),
+                }),
+                mqtt: None,
+                home_assistant: None,
+            },
+            ..AppConfig::default()
+        };
+        let findings = validate(&cfg);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.severity == Severity::Error && f.field == "hardware.automations.dir"),
+            "expected error on empty dir: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn automations_risk_ceiling_maiusculo_e_aceito() {
+        // O engine normaliza (trim + lowercase), então "R2" é aceito — o
+        // check não pode ser mais estrito que a carga.
+        use crate::model::{AutomationsConfig, HardwareConfig};
+        let cfg = AppConfig {
+            hardware: HardwareConfig {
+                automations: Some(AutomationsConfig {
+                    dir: "rules".to_string(),
+                    risk_ceiling: "R2".to_string(),
+                }),
+                mqtt: None,
+                home_assistant: None,
+            },
+            ..AppConfig::default()
+        };
+        let findings = validate(&cfg);
+        assert!(
+            findings
+                .iter()
+                .all(|f| f.field != "hardware.automations.risk_ceiling"),
+            "R2 maiúsculo não deve flag: {findings:?}"
         );
     }
 

--- a/crates/garraia-config/src/model.rs
+++ b/crates/garraia-config/src/model.rs
@@ -111,6 +111,34 @@ pub struct HardwareConfig {
     /// registry não ganha as entidades do hub (fail-closed).
     #[serde(default)]
     pub home_assistant: Option<HaConfig>,
+    /// Motor de automações (#1128). `None` = sem automações — o motor não
+    /// sobe e nenhum arquivo de regra é lido (fail-closed).
+    #[serde(default)]
+    pub automations: Option<AutomationsConfig>,
+}
+
+/// ADR 0020 / #1128 — configuração do motor de automações.
+///
+/// As regras são arquivos declarativos TOML/JSON versionáveis no `dir`; o
+/// teto de risco (`risk_ceiling`) é a policy do que uma automação pode
+/// pedir — o análogo dos modos do runtime para quem não está no chat. R3 e
+/// acima **não é configurável**: automação roda desacompanhada, não há quem
+/// confirme (approval que ninguém pode dar não é approval).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AutomationsConfig {
+    /// Diretório com os arquivos de regras (`*.toml`/`*.json`). Caminho
+    /// relativo resolve contra o data dir efetivo (ver
+    /// [`AppConfig::automations_dir`]).
+    pub dir: String,
+    /// Teto de risco das execuções: `"r0"`, `"r1"` ou `"r2"`. Default
+    /// `"r1"` — power/brightness/temperature sem confirmação; covers só
+    /// com o teto explicitamente em `"r2"`.
+    #[serde(default = "default_risk_ceiling")]
+    pub risk_ceiling: String,
+}
+
+fn default_risk_ceiling() -> String {
+    "r1".to_string()
 }
 
 /// Conexão com o broker MQTT (#1126). Credencial de senha é **write-only**:
@@ -509,6 +537,37 @@ impl AppConfig {
     /// reconectado do adapter reescreveria so a sua copia.
     pub fn hardware_db_path(&self) -> std::path::PathBuf {
         self.resolved_data_dir().join("hardware.db")
+    }
+
+    /// Caminho do banco de automações (#1128) — retrato das regras no ar e
+    /// auditoria de execuções. Mesmo contrato do `hardware_db_path`: fonte
+    /// única, a CLI e o gateway abrem o mesmo arquivo.
+    pub fn automations_db_path(&self) -> std::path::PathBuf {
+        self.resolved_data_dir().join("automations.db")
+    }
+
+    /// O diretório das regras de automação (#1128), já resolvido: caminho
+    /// absoluto vence; relativo resolve contra o data dir efetivo. `None`
+    /// quando a seção `hardware.automations` não existe — sem seção, o
+    /// motor não sobe.
+    pub fn automations_dir(&self) -> Option<std::path::PathBuf> {
+        self.hardware.automations.as_ref().map(|a| {
+            let caminho = std::path::Path::new(&a.dir);
+            if caminho.is_absolute() {
+                caminho.to_path_buf()
+            } else {
+                self.resolved_data_dir().join(caminho)
+            }
+        })
+    }
+
+    /// O teto de risco declarado, já validado pela forma canônica. `None`
+    /// quando a seção não existe.
+    pub fn automations_risk_ceiling(&self) -> Option<&str> {
+        self.hardware
+            .automations
+            .as_ref()
+            .map(|a| a.risk_ceiling.as_str())
     }
 }
 
@@ -1127,6 +1186,25 @@ mod tests {
         );
     }
 
+    /// #1128: o banco de automações segue o mesmo contrato — `automations.db`
+    /// sob o data_dir resolvido, fonte única para gateway e CLI.
+    #[test]
+    fn automations_db_path_lives_under_the_resolved_data_dir() {
+        let config = AppConfig::default();
+        assert_eq!(
+            config.automations_db_path(),
+            config.resolved_data_dir().join("automations.db")
+        );
+        let custom = AppConfig {
+            data_dir: Some(std::path::PathBuf::from("/tmp/garra-data")),
+            ..AppConfig::default()
+        };
+        assert_eq!(
+            custom.automations_db_path(),
+            std::path::PathBuf::from("/tmp/garra-data/automations.db")
+        );
+    }
+
     #[test]
     fn agent_persona_defaults_to_friendly() {
         // Plan 0250 (GAR-771): the warm persona is the default; persona_lang
@@ -1205,6 +1283,66 @@ hardware:
         assert_eq!(mqtt.username.as_deref(), Some("garra"));
         assert_eq!(mqtt.password_env.as_deref(), Some("GARRA_MQTT_PASS"));
         assert_eq!(mqtt.client_id_prefix, "garra");
+    }
+
+    // ── ADR 0020 / #1128: seção `hardware.automations:` (motor de regras) ──
+
+    #[test]
+    fn hardware_automations_parses_dir_e_risk_ceiling() {
+        let raw = r#"
+hardware:
+  automations:
+    dir: "rules/automations"
+    risk_ceiling: "r2"
+"#;
+        let config: AppConfig = serde_yaml::from_str(raw).expect("yaml should parse");
+        let automacoes = config
+            .hardware
+            .automations
+            .as_ref()
+            .expect("automations should be Some");
+        assert_eq!(automacoes.dir, "rules/automations");
+        assert_eq!(automacoes.risk_ceiling, "r2");
+        // E os helpers de resolucao.
+        assert_eq!(
+            config.automations_dir(),
+            Some(config.resolved_data_dir().join("rules/automations"))
+        );
+        assert_eq!(config.automations_risk_ceiling(), Some("r2"));
+    }
+
+    #[test]
+    fn hardware_automations_risk_ceiling_default_e_r1() {
+        let raw = r#"
+hardware:
+  automations:
+    dir: "rules"
+"#;
+        let config: AppConfig = serde_yaml::from_str(raw).expect("yaml should parse");
+        let automacoes = config.hardware.automations.expect("automations");
+        assert_eq!(automacoes.risk_ceiling, "r1", "teto default é r1");
+    }
+
+    #[test]
+    fn hardware_sem_automations_e_none_e_dir_none() {
+        let config = AppConfig::default();
+        assert!(config.hardware.automations.is_none());
+        assert!(config.automations_dir().is_none());
+        assert!(config.automations_risk_ceiling().is_none());
+    }
+
+    #[test]
+    fn hardware_automations_dir_absoluto_vence() {
+        let raw = r#"
+hardware:
+  automations:
+    dir: "/etc/garraia/regras"
+"#;
+        let config: AppConfig = serde_yaml::from_str(raw).expect("yaml should parse");
+        assert_eq!(
+            config.automations_dir(),
+            Some(std::path::PathBuf::from("/etc/garraia/regras"))
+        );
     }
 
     #[test]

--- a/crates/garraia-gateway/Cargo.toml
+++ b/crates/garraia-gateway/Cargo.toml
@@ -14,11 +14,13 @@ garraia-agents = { workspace = true, features = ["mcp"] }
 # ADR 0020 (epic #1124): o registry de dispositivos que alimenta as tools
 # device_list/read/execute. Sem adapter registrado, fica vazio (#1128 liga
 # o boot de adapters via config). As features de transporte (`mqtt`,
-# `home-assistant`) ficam ligadas aqui incondicionalmente: o gateway e o
-# host de hardware, o boot decide pelo config se cada transporte sobe
-# (`hardware.mqtt` / `hardware.home_assistant`) — rumqttc e cliente Rust
-# puro, sem runtime C; o HA vai por REST + WebSocket atrás do guard SSRF.
-garraia-hardware = { workspace = true, features = ["mqtt", "home-assistant"] }
+# `home-assistant`) e o motor de automacoes (`automations`) ficam ligadas
+# aqui incondicionalmente: o gateway e o host de hardware, o boot decide
+# pelo config se cada transporte sobe (`hardware.mqtt` /
+# `hardware.home_assistant`) e se o motor arma (`hardware.automations`) —
+# rumqttc e cliente Rust puro, sem runtime C; o HA vai por REST + WebSocket
+# atrás do guard SSRF.
+garraia-hardware = { workspace = true, features = ["mqtt", "home-assistant", "automations"] }
 garraia-runtime = { workspace = true }
 garraia-db = { workspace = true }
 garraia-security = { workspace = true }

--- a/crates/garraia-gateway/src/api.rs
+++ b/crates/garraia-gateway/src/api.rs
@@ -1320,6 +1320,7 @@ mod slash_dispatch_tests {
     use garraia_agents::AgentRuntime;
     use garraia_channels::ChannelRegistry;
     use garraia_config::AppConfig;
+    use garraia_security::Allowlist;
     use std::sync::Arc;
 
     fn state_with_commands() -> SharedState {
@@ -1328,6 +1329,12 @@ mod slash_dispatch_tests {
             Arc::new(AgentRuntime::new()),
             ChannelRegistry::new(),
         ));
+        // Isolamento do host: AppState::new carrega o allowlist do config
+        // dir real (ex.: ~/.config/garraia/allowlist.json), e numa maquina
+        // com instalacao com dono o /start nasce com dono sem nem exercitar
+        // o dispatch. O contrato destes testes e "instalacao nova": allowlist
+        // restricted vazia, sem dono e sem path (nada persiste em disco).
+        *state.allowlist.lock().unwrap() = Allowlist::restricted([]);
         crate::commands::register_commands(&mut state.command_registry.write().unwrap());
         state
     }

--- a/crates/garraia-gateway/src/bootstrap/mod.rs
+++ b/crates/garraia-gateway/src/bootstrap/mod.rs
@@ -10,9 +10,10 @@ use garraia_agents::{
 };
 use garraia_config::{AppConfig, provider_key_env};
 use garraia_db::MemoryStore;
+use garraia_hardware::automations::{EngineConfig, TetoRisco};
 use garraia_hardware::{
-    DeviceRegistry, DeviceStateStore, HaAdapterConfig, HaAdapterManager, MqttAdapterConfig,
-    MqttAdapterManager,
+    AutomationEngine, AutomationStore, DeviceRegistry, DeviceStateStore, HaAdapterConfig,
+    HaAdapterManager, HardwareEventBus, MqttAdapterConfig, MqttAdapterManager, carregar_automacoes,
 };
 use tracing::{info, warn};
 
@@ -1093,6 +1094,12 @@ pub fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
 /// mostram. `None` quando nao ha nenhuma secao de hardware no config, ou
 /// quando o store nao abre (nenhum adapter sobe sem presenca).
 ///
+/// O barramento de eventos (#1128) nasce aqui e os adapters publicam nele
+/// o que veem; o motor de automacoes assina quando `hardware.automations`
+/// esta configurado (regras do dir, auditoria em `automations.db`, teto de
+/// risco do config). Automations sem nenhum adapter configurado nao sobe —
+/// nenhum evento chegaria ao barramento — e o warn diz isso.
+///
 /// Fail-soft no boot: qualquer problema (broker malformado, `password_env`/
 /// `token_env` apontando para env vazia ou inexistente, URL vetada recusada
 /// pelo guard SSRF) nao derruba o processo — o registry segue com os
@@ -1107,6 +1114,12 @@ pub fn spawn_hardware_adapters(
     registry: Arc<DeviceRegistry>,
 ) -> Option<Arc<DeviceStateStore>> {
     if config.hardware.mqtt.is_none() && config.hardware.home_assistant.is_none() {
+        if config.hardware.automations.is_some() {
+            warn!(
+                "hardware: automations configurado sem nenhum adapter (mqtt/home_assistant); \
+                 o motor nao sobe porque nenhum evento chegaria ao barramento"
+            );
+        }
         return None;
     }
 
@@ -1135,22 +1148,33 @@ pub fn spawn_hardware_adapters(
         }
     };
 
+    // Barramento de eventos (#1128): adapters publicam o que veem e o motor
+    // de automacoes assina. Publicar sem assinante custa zero (o canal
+    // descarta), entao ele existe sempre que ha hardware no ar.
+    let bus = Arc::new(HardwareEventBus::nova());
+
     // Cada adapter decide sozinho se sobe e explica o que faltou. O
     // operador pode ter os dois, um so, ou nenhum — o registry soma.
     let mut algum_no_ar = false;
-    algum_no_ar |= sobe_mqtt(config, registry.clone(), state.clone());
-    algum_no_ar |= sobe_home_assistant(config, registry, state.clone());
+    algum_no_ar |= sobe_mqtt(config, registry.clone(), state.clone(), Some(bus.clone()));
+    algum_no_ar |= sobe_home_assistant(config, registry.clone(), state.clone(), Some(bus.clone()));
+
+    // O motor de automacoes (#1128) arma por conta do config, independente
+    // de quantos adapters subiram — cada falha anterior ja teve o seu warn.
+    sobe_automacoes(config, bus, registry);
 
     algum_no_ar.then_some(state)
 }
 
 /// Sobe o adapter MQTT (#1126) quando `hardware.mqtt` esta configurado.
-/// Fail-soft: cada problema vira warn e devolve `false` — o deploy segue no
-/// ar, sem o transporte.
+/// Publica presenca e estado no barramento (`bus`) que o motor de
+/// automacoes (#1128) assina. Fail-soft: cada problema vira warn e devolve
+/// `false` — o deploy segue no ar, sem o transporte.
 fn sobe_mqtt(
     config: &AppConfig,
     registry: Arc<DeviceRegistry>,
     state: Arc<DeviceStateStore>,
+    bus: Option<Arc<HardwareEventBus>>,
 ) -> bool {
     let Some(mqtt) = config.hardware.mqtt.as_ref() else {
         return false;
@@ -1195,7 +1219,7 @@ fn sobe_mqtt(
     // O handle do manager fica solto de proposito: o event loop vive pela
     // vida do processo (reconnect do rumqttc e interno), e o reload de
     // config que o pararia e trabalho da #1128.
-    if let Err(e) = MqttAdapterManager::spawn(adapter_config, registry, Some(state)) {
+    if let Err(e) = MqttAdapterManager::spawn(adapter_config, registry, Some(state), bus) {
         warn!("hardware.mqtt: {e}; adapter MQTT nao sobe e o registry de dispositivos fica vazio");
         return false;
     }
@@ -1209,10 +1233,10 @@ fn sobe_mqtt(
 
 /// Sobe o adapter Home Assistant (#1127) quando `hardware.home_assistant`
 /// esta configurado — REST (descoberta `/api/states`, leitura, servicos) +
-/// WebSocket (`state_changed` → presenca), tudo atras do guard SSRF
-/// (`IpScope::AllowPrivate`: hub na LAN/loopback e alvo legitimo). As
-/// entidades viram dispositivos com risco por dominio: sensor/binary_sensor
-/// R0, light/switch/climate R1, cover R2, lock R3.
+/// WebSocket (`state_changed` → presenca + barramento #1128), tudo atras do
+/// guard SSRF (`IpScope::AllowPrivate`: hub na LAN/loopback e alvo
+/// legitimo). As entidades viram dispositivos com risco por dominio:
+/// sensor/binary_sensor R0, light/switch/climate R1, cover R2, lock R3.
 ///
 /// O token vem do env apontado por `token_env` (write-only: nunca logado,
 /// o warn cita so o NOME da env). Fail-soft igual ao MQTT.
@@ -1220,6 +1244,7 @@ fn sobe_home_assistant(
     config: &AppConfig,
     registry: Arc<DeviceRegistry>,
     state: Arc<DeviceStateStore>,
+    bus: Option<Arc<HardwareEventBus>>,
 ) -> bool {
     let Some(ha) = config.hardware.home_assistant.as_ref() else {
         return false;
@@ -1250,12 +1275,71 @@ fn sobe_home_assistant(
     // O handle do manager fica solto de proposito: o loop vive pela vida do
     // processo (reconexao do WebSocket e interna), e o reload de config que
     // o pararia e trabalho da #1128.
-    HaAdapterManager::spawn(adapter_config, registry, Some(state));
+    HaAdapterManager::spawn(adapter_config, registry, Some(state), bus);
     info!(
         url = %ha.url,
         "hardware.home_assistant no ar — descoberta por /api/states, presenca por eventos state_changed"
     );
     true
+}
+
+/// Arma o motor de automacoes (#1128) quando `hardware.automations` esta
+/// configurado: regras compiladas do dir (TOML/JSON), auditoria em
+/// `automations.db` e o teto de risco do config. Fail-soft igual aos
+/// adapters — cada problema vira warn e o boot segue sem o motor. Regra
+/// quebrada nunca derruba o deploy, mas tambem nunca sobe silenciosa.
+fn sobe_automacoes(config: &AppConfig, bus: Arc<HardwareEventBus>, registry: Arc<DeviceRegistry>) {
+    let Some(dir) = config.automations_dir() else {
+        return; // sem secao no config — o motor nao sobe (fail-closed)
+    };
+
+    // Auditoria e pre-condicao do motor: execucao sem auditoria quebraria
+    // o contrato #1128, entao sem store nao ha motor. O diretorio do
+    // `automations.db` e o mesmo do store de presenca, ja criado acima.
+    let store_path = config.automations_db_path();
+    let store = match AutomationStore::abrir_em(&store_path) {
+        Ok(store) => Arc::new(store),
+        Err(e) => {
+            warn!(
+                "hardware.automations: nao abri a auditoria em {} ({e}); motor nao sobe",
+                store_path.display()
+            );
+            return;
+        }
+    };
+
+    // Regras do dir: arquivo quebrado nomeia o arquivo no erro, e dir
+    // ausente tambem e erro — o operador declarou `dir`, e "nenhuma regra
+    // no ar" tem que ser dito, nao presumido.
+    let specs = match carregar_automacoes(&dir) {
+        Ok(specs) => specs,
+        Err(e) => {
+            warn!(
+                "hardware.automations: {e} — regras de {}; motor nao sobe com spec quebrada",
+                dir.display()
+            );
+            return;
+        }
+    };
+
+    // Teto do config, com o default r1 do schema se ausente. `de_texto` so
+    // aceita r0/r1/r2 — o `garra config check` ja recusa R3+ antes do boot.
+    let teto = config
+        .automations_risk_ceiling()
+        .and_then(TetoRisco::de_texto)
+        .unwrap_or(TetoRisco::R1);
+
+    // O handle fica solto de proposito — o motor vive pela vida do
+    // processo, igual aos event loops dos adapters.
+    if let Err(e) = AutomationEngine::spawn(EngineConfig { specs, teto }, bus, registry, store) {
+        warn!("hardware.automations: {e}; motor nao sobe");
+        return;
+    }
+    info!(
+        regras = %dir.display(),
+        teto = teto.as_str(),
+        "hardware.automations no ar — regras compiladas, motor assinando o barramento"
+    );
 }
 
 /// Build MCP tools from merged config (config.yml + mcp.json).

--- a/crates/garraia-hardware/Cargo.toml
+++ b/crates/garraia-hardware/Cargo.toml
@@ -19,6 +19,10 @@ mqtt = ["dep:rumqttc"]
 # padrão. `garraia-common/ssrf` traz o guard de URL (a chamada REST vai por
 # cliente pinado — o token do HA é credencial de admin do hub).
 home-assistant = ["dep:reqwest", "dep:tokio-tungstenite", "dep:futures", "dep:url", "dep:garraia-common"]
+# Motor de automações (#1128): specs TOML/JSON + avaliador de expressões +
+# engine sobre o barramento de eventos. OFF por default — quem não usa
+# automação não paga croner/chrono/toml.
+automations = ["dep:croner", "dep:chrono", "dep:toml"]
 default = ["mock-device"]
 
 [dependencies]
@@ -53,6 +57,12 @@ futures = { workspace = true, optional = true }
 # A URL base vetada (`VettedUrl.url` do ssrf) é `url::Url` — manter o tipo
 # em vez de remontar paths na mão (`Url::join` evita `//api/states`).
 url = { workspace = true, optional = true }
+# Feature `automations` (#1128): croner para os gatilhos cron (mesmo parser
+# do `garraia-db`/recorrência), chrono para o fuso local do host e toml para
+# as specs declarativas versionáveis do usuário.
+croner = { workspace = true, optional = true }
+chrono = { workspace = true, optional = true }
+toml = { workspace = true, optional = true }
 
 [dev-dependencies]
 # Broker MQTT embutido para os testes de integração da feature `mqtt`

--- a/crates/garraia-hardware/src/adapter_homeassistant.rs
+++ b/crates/garraia-hardware/src/adapter_homeassistant.rs
@@ -10,7 +10,7 @@
 //! | `GET /api/states` | REST | descoberta — entidades por domínio |
 //! | `GET /api/states/{entity_id}` | REST | [`crate::Device::read`] |
 //! | `POST /api/services/{domain}/{service}` | REST | [`crate::Device::execute`] |
-//! | `ws(s)://…/api/websocket` | WebSocket | eventos `state_changed` → presença |
+//! | `ws(s)://…/api/websocket` | WebSocket | eventos `state_changed` → presença + barramento |
 //!
 //! # Contratos
 //!
@@ -35,6 +35,10 @@
 //!   [`DeviceStateStore`] (`state == "unavailable"` → offline); a descoberta
 //!   marca quem respondeu. Desconexão do WebSocket → reconexão em loop
 //!   (mesmo padrão do canal Slack), presença segue no retorno.
+//! - **Barramento (#1128)**: cada `state_changed` também é publicado no
+//!   [`HardwareEventBus`] (`Option` — quem não quer o barramento passa
+//!   `None`), com o estado novo e o velho inteiros — o motor de automações
+//!   assina e casa as regras do usuário sobre este fluxo.
 //!
 //! # O que este slice NÃO faz
 //!
@@ -47,6 +51,7 @@ use crate::Result;
 use crate::capability::Capability;
 use crate::device::Device;
 use crate::error::HardwareError;
+use crate::events::{EstadoObservado, HardwareEvent, HardwareEventBus, StateChanged};
 use crate::registry::DeviceRegistry;
 use crate::risk::RiskClass;
 use crate::schema::validar_args;
@@ -522,8 +527,9 @@ impl HaAdapterManager {
         config: HaAdapterConfig,
         registry: Arc<DeviceRegistry>,
         state: Option<Arc<DeviceStateStore>>,
+        bus: Option<Arc<HardwareEventBus>>,
     ) -> Self {
-        let tarefa = tokio::spawn(rodar(Arc::new(config), registry, state));
+        let tarefa = tokio::spawn(rodar(Arc::new(config), registry, state, bus));
         Self { tarefa }
     }
 
@@ -538,6 +544,7 @@ async fn rodar(
     config: Arc<HaAdapterConfig>,
     registry: Arc<DeviceRegistry>,
     state: Option<Arc<DeviceStateStore>>,
+    bus: Option<Arc<HardwareEventBus>>,
 ) {
     // Cada rodada = descoberta + eventos. A descoberta é refeita a cada
     // reconexão de propósito: o hub pode não estar no ar no boot (a task
@@ -571,11 +578,11 @@ async fn rodar(
         }
 
         // Loop de eventos: conecta, autentica, assina `state_changed`; caiu,
-        // espera e reconecta (mesmo padrão do canal Slack). Presença é o
-        // consumo do slice — a #1128 liga as automações neste fluxo depois.
+        // espera e reconecta (mesmo padrão do canal Slack). Presença e
+        // barramento são o consumo: o motor de automações assina o fluxo.
         match conectar_ws(&config).await {
             Ok(mut ws) => match autenticar_e_assinar(&mut ws, &config.token).await {
-                Ok(()) => consumir_eventos(ws, state.as_ref()).await,
+                Ok(()) => consumir_eventos(ws, state.as_ref(), bus.as_ref()).await,
                 Err(e) => tracing::warn!("hardware.home_assistant: handshake falhou: {e}"),
             },
             Err(e) => tracing::warn!("hardware.home_assistant: WebSocket indisponível: {e}"),
@@ -738,6 +745,7 @@ fn exigir_msg(msg: &str, esperado: &str) -> Result<()> {
 async fn consumir_eventos(
     ws: WebSocketStream<MaybeTlsStream<TcpStream>>,
     state: Option<&Arc<DeviceStateStore>>,
+    bus: Option<&Arc<HardwareEventBus>>,
 ) {
     let (mut tx, mut rx) = ws.split();
     let mut ping = tokio::time::interval(PING_INTERVAL);
@@ -765,11 +773,24 @@ async fn consumir_eventos(
             }
             msg = rx.next() => match msg {
                 Some(Ok(Message::Text(t))) => {
-                    if let Some((entity_id, online)) = entidade_do_evento(t.as_str())
-                        && let Some(store) = state
-                        && let Err(err) = store.marcar(&entity_id, online).await
-                    {
-                        tracing::warn!(entity = %entity_id, "presença: {err}");
+                    if let Some(evento) = evento_de_ha(t.as_str()) {
+                        if let Some(store) = state
+                            && let Err(err) = store.marcar(&evento.entity_id, evento.online).await
+                        {
+                            tracing::warn!(entity = %evento.entity_id, "presença: {err}");
+                        }
+                        // #1128: o estado inteiro vai para o barramento — o
+                        // motor de automações assina e casa as regras. Publicar
+                        // nunca bloqueia (`let _ = send`): slow subscriber
+                        // recebe Lagged, o hub segue.
+                        if let Some(bus) = bus {
+                            bus.publicar(HardwareEvent::StateChanged(StateChanged {
+                                device_id: evento.entity_id.clone(),
+                                novo: evento.novo,
+                                velho: evento.velho,
+                                em_milis: crate::events::milis_agora(),
+                            }));
+                        }
                     }
                 }
                 Some(Ok(_)) => continue,
@@ -786,10 +807,22 @@ async fn consumir_eventos(
     }
 }
 
-/// Extrai `(entity_id, online)` de um evento `state_changed`:
-/// `{"id":1,"type":"event","event":{"event_type":"state_changed","data":
-/// {"entity_id":"light.sala","new_state":{"state":"on",…}}}}`.
-fn entidade_do_evento(msg: &str) -> Option<(String, bool)> {
+/// Um evento `state_changed` do HA já destilado: quem mudou, como ficou e
+/// como estava.
+#[derive(Debug, Clone, PartialEq)]
+struct EventoHa {
+    entity_id: String,
+    novo: EstadoObservado,
+    velho: Option<EstadoObservado>,
+    online: bool,
+}
+
+/// Destila um evento `state_changed` do HA para [`EventoHa`]:
+/// `{"event":{"event_type":"state_changed","data":{"entity_id":"light.sala",
+/// "new_state":{"state":"on","attributes":{…}},"old_state":{…}}}}`.
+/// `new_state` null/ausente é estado removido → offline sem estado; os
+/// atributos seguem inteiros — condições do motor avaliam `to.attributes.x`.
+fn evento_de_ha(msg: &str) -> Option<EventoHa> {
     let v: Value = serde_json::from_str(msg).ok()?;
     let evento = v.get("event")?;
     if evento.get("event_type")?.as_str()? != "state_changed" {
@@ -797,11 +830,27 @@ fn entidade_do_evento(msg: &str) -> Option<(String, bool)> {
     }
     let dados = evento.get("data")?;
     let entity_id = dados.get("entity_id")?.as_str()?.to_string();
-    let online = match dados.get("new_state") {
-        Some(Value::Null) | None => false,
-        Some(novo) => novo.get("state").and_then(Value::as_str) != Some("unavailable"),
+    let estado_de = |objeto: Option<&Value>| match objeto {
+        Some(Value::Null) | None => None,
+        Some(objeto) => Some(EstadoObservado {
+            state: objeto
+                .get("state")
+                .and_then(Value::as_str)
+                .map(String::from),
+            attributes: objeto.get("attributes").cloned().unwrap_or(Value::Null),
+            online: objeto.get("state").and_then(Value::as_str) != Some("unavailable"),
+        }),
     };
-    Some((entity_id, online))
+    // `new_state` null/ausente é estado removido → offline sem estado.
+    let novo = estado_de(dados.get("new_state")).unwrap_or_else(|| EstadoObservado::simples(false));
+    let velho = estado_de(dados.get("old_state"));
+    let online = novo.online;
+    Some(EventoHa {
+        entity_id,
+        novo,
+        velho,
+        online,
+    })
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -992,8 +1041,8 @@ mod tests {
         assert!(sensor.caps.iter().all(|c| c.risk == RiskClass::R0));
     }
 
-    /// O evento `state_changed` do HA rende (entity_id, online) — e eventos
-    /// de outro tipo não.
+    /// O evento `state_changed` do HA rende [`EventoHa`] completo — estado novo
+    /// e velho com atributos, presença derivada — e eventos de outro tipo não.
     #[test]
     fn evento_state_changed_rende_presenca() {
         let evento = json!({
@@ -1002,15 +1051,24 @@ mod tests {
                 "event_type": "state_changed",
                 "data": {
                     "entity_id": "light.sala",
-                    "old_state": {"state": "off"},
-                    "new_state": {"state": "on", "attributes": {}}
+                    "old_state": {"state": "off", "attributes": {"brightness": 0}},
+                    "new_state": {"state": "on", "attributes": {"brightness": 128}}
                 }
             }
         })
         .to_string();
+        let destilado = evento_de_ha(&evento).expect("evento válido");
+        assert_eq!(destilado.entity_id, "light.sala");
+        assert!(destilado.online);
+        assert_eq!(destilado.novo.state.as_deref(), Some("on"));
+        assert_eq!(destilado.novo.attributes["brightness"], 128);
         assert_eq!(
-            entidade_do_evento(&evento),
-            Some(("light.sala".to_string(), true))
+            destilado.velho.as_ref().unwrap().state.as_deref(),
+            Some("off")
+        );
+        assert_eq!(
+            destilado.velho.as_ref().unwrap().attributes["brightness"],
+            0
         );
 
         let offline = json!({
@@ -1020,26 +1078,43 @@ mod tests {
             }}
         })
         .to_string();
-        assert_eq!(
-            entidade_do_evento(&offline),
-            Some(("light.sala".to_string(), false))
-        );
+        let destilado = evento_de_ha(&offline).expect("offline válido");
+        assert!(!destilado.online);
+        assert!(destilado.velho.is_none());
 
-        // Estado removido (new_state: null) → offline.
+        // Estado removido (new_state: null) → offline sem estado.
         let removido = json!({
             "id": 1, "type": "event",
             "event": {"event_type": "state_changed", "data": {"entity_id": "light.sala", "new_state": null}}
         })
         .to_string();
+        let destilado = evento_de_ha(&removido).expect("removido válido");
+        assert!(!destilado.online);
+        assert_eq!(destilado.novo.state, None);
+
+        // Estado numérico (o caso do sensor do motor: "33.5" como string) —
+        // o estado segue verbatim; a coerção string→número é do avaliador.
+        let sensor = json!({
+            "id": 1, "type": "event",
+            "event": {"event_type": "state_changed", "data": {
+                "entity_id": "sensor.garagem",
+                "old_state": {"state": "31.0", "attributes": {"unit": "C"}},
+                "new_state": {"state": "33.5", "attributes": {"unit": "C", "battery": 87}}
+            }}
+        })
+        .to_string();
+        let destilado = evento_de_ha(&sensor).expect("sensor válido");
+        assert_eq!(destilado.novo.state.as_deref(), Some("33.5"));
+        assert_eq!(destilado.novo.attributes["battery"], 87);
         assert_eq!(
-            entidade_do_evento(&removido),
-            Some(("light.sala".to_string(), false))
+            destilado.velho.as_ref().unwrap().state.as_deref(),
+            Some("31.0")
         );
 
         // Outro tipo de evento → None.
         let outro =
             json!({"id": 2, "type": "event", "event": {"event_type": "call_service"}}).to_string();
-        assert_eq!(entidade_do_evento(&outro), None);
+        assert_eq!(evento_de_ha(&outro), None);
     }
 
     /// Debug redige o token — o hub do HA é admin total da casa.

--- a/crates/garraia-hardware/src/adapter_mqtt.rs
+++ b/crates/garraia-hardware/src/adapter_mqtt.rs
@@ -40,6 +40,7 @@ use crate::Result;
 use crate::capability::Capability;
 use crate::device::Device;
 use crate::error::HardwareError;
+use crate::events::{EstadoObservado, HardwareEvent, HardwareEventBus, StateChanged};
 use crate::registry::DeviceRegistry;
 use crate::state::DeviceStateStore;
 use async_trait::async_trait;
@@ -406,6 +407,7 @@ impl MqttAdapterManager {
         config: MqttAdapterConfig,
         registry: Arc<DeviceRegistry>,
         state: Option<Arc<DeviceStateStore>>,
+        bus: Option<Arc<HardwareEventBus>>,
     ) -> Result<Self> {
         let mut opts = MqttOptions::new(
             config.client_id.clone(),
@@ -425,6 +427,7 @@ impl MqttAdapterManager {
             client.clone(),
             registry,
             state,
+            bus,
             pendentes,
         ));
         Ok(Self { client, tarefa })
@@ -449,6 +452,7 @@ async fn rodar(
     client: AsyncClient,
     registry: Arc<DeviceRegistry>,
     state: Option<Arc<DeviceStateStore>>,
+    bus: Option<Arc<HardwareEventBus>>,
     pendentes: Arc<Pendentes>,
 ) {
     let prefixo = config.topic_prefix.clone();
@@ -469,6 +473,7 @@ async fn rodar(
                     &client,
                     &registry,
                     state.as_ref(),
+                    bus.as_ref(),
                     &pendentes,
                     config.timeout,
                 )
@@ -491,6 +496,7 @@ async fn processa_publish(
     client: &AsyncClient,
     registry: &DeviceRegistry,
     state: Option<&Arc<DeviceStateStore>>,
+    bus: Option<&Arc<HardwareEventBus>>,
     pendentes: &Arc<Pendentes>,
     timeout: Duration,
 ) {
@@ -517,8 +523,8 @@ async fn processa_publish(
             .await;
         }
         [id, "status"] => {
-            if let Some(store) = state {
-                aplicar_status(id, &p.payload, store).await;
+            if state.is_some() || bus.is_some() {
+                aplicar_status(id, &p.payload, state, bus).await;
             }
         }
         [id, "state", cap] => {
@@ -575,7 +581,12 @@ async fn registrar_dispositivo(
     tracing::info!(dispositivo = %id_topico, "mqtt: dispositivo descoberto e registrado");
 }
 
-async fn aplicar_status(id: &str, payload: &[u8], store: &Arc<DeviceStateStore>) {
+async fn aplicar_status(
+    id: &str,
+    payload: &[u8],
+    state: Option<&Arc<DeviceStateStore>>,
+    bus: Option<&Arc<HardwareEventBus>>,
+) {
     let texto = String::from_utf8_lossy(payload).trim().to_ascii_lowercase();
     let online = match texto.as_str() {
         "online" => true,
@@ -585,8 +596,26 @@ async fn aplicar_status(id: &str, payload: &[u8], store: &Arc<DeviceStateStore>)
             return;
         }
     };
-    if let Err(e) = store.marcar(id, online).await {
+    if let Some(store) = state
+        && let Err(e) = store.marcar(id, online).await
+    {
         tracing::warn!(dispositivo = %id, error = %e, "mqtt: falha ao marcar presença");
+    }
+    // #1128: o status é o state_changed do mundo MQTT (a convenção da
+    // #1126 correlaciona leitura/escrita por request_id, sem report não
+    // solicitado) — presença publicada como estado, para o motor de
+    // automações casar `to.state == "offline"`.
+    if let Some(bus) = bus {
+        bus.publicar(HardwareEvent::StateChanged(StateChanged {
+            device_id: id.to_string(),
+            novo: EstadoObservado::com(
+                Some(if online { "online" } else { "offline" }.into()),
+                serde_json::Value::Null,
+                online,
+            ),
+            velho: None,
+            em_milis: crate::events::milis_agora(),
+        }));
     }
 }
 
@@ -1061,9 +1090,13 @@ mod tests {
 
         let registry = Arc::new(DeviceRegistry::new());
         let state = Arc::new(DeviceStateStore::em_memoria().expect("store"));
-        let manager =
-            MqttAdapterManager::spawn(config_manager(porta), registry.clone(), Some(state.clone()))
-                .expect("manager sobe");
+        let manager = MqttAdapterManager::spawn(
+            config_manager(porta),
+            registry.clone(),
+            Some(state.clone()),
+            None,
+        )
+        .expect("manager sobe");
 
         // 1. Descoberta: o manifesto retained chega na assinatura.
         esperar(
@@ -1206,9 +1239,13 @@ mod tests {
 
         let registry = Arc::new(DeviceRegistry::new());
         let state = Arc::new(DeviceStateStore::em_memoria().expect("store"));
-        let manager =
-            MqttAdapterManager::spawn(config_manager(porta), registry.clone(), Some(state.clone()))
-                .expect("manager sobe");
+        let manager = MqttAdapterManager::spawn(
+            config_manager(porta),
+            registry.clone(),
+            Some(state.clone()),
+            None,
+        )
+        .expect("manager sobe");
         esperar(
             || registry.get("sensor-2").is_some(),
             "dispositivo registrado",

--- a/crates/garraia-hardware/src/automations/cron.rs
+++ b/crates/garraia-hardware/src/automations/cron.rs
@@ -1,0 +1,46 @@
+//! Cron para os gatilhos de automação — casca fina sobre [`croner`], o
+//! mesmo parser que `garraia-db` já usa para recorrência de tarefas.
+//!
+//! O fuso é o do host (`chrono::Local`): uma casa funciona no fuso de quem
+//! mora nela, e o config do usuário versiona regras tipo "todo dia às 19h".
+
+use chrono::{DateTime, Local};
+use std::str::FromStr;
+
+/// Parseia e valida uma expressão cron (5 campos; 6 com segundos também
+/// aceito, como o `garraia-db`).
+pub fn parse_cron(expr: &str) -> Result<Cron, String> {
+    Cron::from_str(expr).map_err(|e| format!("'{expr}': {e}"))
+}
+
+/// Primeira ocorrência estritamente depois de `depois`, no fuso local.
+pub fn proxima_ocorrencia(expr: &str, depois: DateTime<Local>) -> Result<DateTime<Local>, String> {
+    let cron = parse_cron(expr)?;
+    cron.find_next_occurrence(&depois, false)
+        .map_err(|e| format!("sem ocorrência futura para '{expr}': {e}"))
+}
+
+pub use croner::Cron;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parseia_cron_valido_e_rejeita_lixo() {
+        assert!(parse_cron("0 19 * * *").is_ok());
+        assert!(parse_cron("*/15 * * * *").is_ok());
+        assert!(parse_cron("nao-e-cron").is_err());
+        assert!(parse_cron("").is_err());
+    }
+
+    #[test]
+    fn proxima_ocorrencia_e_no_futuro() {
+        let agora = Local::now();
+        let proximo = proxima_ocorrencia("* * * * *", agora).expect("a cada minuto");
+        assert!(
+            proximo > agora,
+            "ocorrência tem que ser estritamente futura"
+        );
+    }
+}

--- a/crates/garraia-hardware/src/automations/engine.rs
+++ b/crates/garraia-hardware/src/automations/engine.rs
@@ -1,0 +1,578 @@
+//! O motor de automações — assina o barramento, casa gatilhos, avalia
+//! condições, respeita debounce/rate limit e executa ações pela **mesma
+//! policy do runtime** (nada de bypass).
+//!
+//! O [`HardwareGate`] aqui é sempre o `sem_canal_confirmacao()`: automação
+//! roda desacompanhada, então R3/R4/R5 são negadas por natureza (approval
+//! que ninguém pode dar não é approval). O que o operador controla é o
+//! [`TetoRisco`] no config — o teto do que uma automação pode pedir:
+//!
+//! - R0 (leitura): sempre pode;
+//! - R1 (`PolicyGated`): executada com teto R1 ou R2;
+//! - R2 (`PolicyRateLimited`): executada só com teto R2 — e **toda**
+//!   execução respeita o rate limit da regra, seja qual for o risco;
+//! - R3/R4/R5: nunca (`HumanConfirmation`/`ExplicitApproval`/`Denied`
+//!   sem canal humano viram execução bloqueada, com auditoria).
+//!
+//! Ordem do pipeline por evento: debounce (no loop, atômico) → condições
+//! (AND, no task) → rate limit (atômico, pós-condições — protege o efeito,
+//! não a avaliação) → delay → ações em sequência → auditoria.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, Local};
+use tokio::sync::{Mutex, broadcast};
+use tokio::time;
+
+use crate::error::HardwareError;
+use crate::events::{HardwareEvent, HardwareEventBus, StateChanged};
+use crate::gate::HardwareGate;
+use crate::registry::DeviceRegistry;
+use crate::risk::ExecutionDecision;
+use crate::schema::validar_args;
+
+use super::cron;
+use super::expr::Expr;
+use super::spec::{ActionSpec, AutomationSpec, TriggerSpec};
+use super::store::{AutomationStore, Execucao, ResultadoExecucao};
+
+/// O teto de risco que o operador declarou para as automações no config.
+///
+/// É a policy da automação — o análogo dos modos do runtime para quem não
+/// está no chat. R3 e acima não existem aqui: não há quem confirme.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TetoRisco {
+    /// Só leitura (R0).
+    R0,
+    /// Leitura + ações domésticas básicas (R1: power/brightness/temperature).
+    R1,
+    /// Até R2 (covers, scenes) — o teto máximo; R3 e acima nunca.
+    R2,
+}
+
+impl TetoRisco {
+    pub fn de_texto(s: &str) -> Option<Self> {
+        Some(match s.trim().to_ascii_lowercase().as_str() {
+            "r0" => TetoRisco::R0,
+            "r1" => TetoRisco::R1,
+            "r2" => TetoRisco::R2,
+            _ => return None,
+        })
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TetoRisco::R0 => "r0",
+            TetoRisco::R1 => "r1",
+            TetoRisco::R2 => "r2",
+        }
+    }
+}
+
+/// A configuração do motor: as specs carregadas e o teto de risco.
+#[derive(Debug, Clone)]
+pub struct EngineConfig {
+    pub specs: Vec<AutomationSpec>,
+    pub teto: TetoRisco,
+}
+
+/// A condição compilada — o fonte para a auditoria, a árvore para avaliar.
+struct Condicao {
+    fonte: String,
+    expr: Expr,
+}
+
+/// A regra compilada — condições parseadas na carga, não a cada evento.
+struct Regra {
+    spec: AutomationSpec,
+    condicoes: Vec<Condicao>,
+    /// Expressões cron, na ordem em que aparecem nos gatilhos — alinhado
+    /// com `EstadoRuntime::proximos_cron`.
+    crons: Vec<String>,
+}
+
+impl Regra {
+    fn compilar(spec: AutomationSpec) -> Result<Self, HardwareError> {
+        let mut condicoes = Vec::new();
+        for c in &spec.condition {
+            let expr = Expr::parse(&c.expr).map_err(|e| {
+                HardwareError::Automations(format!(
+                    "condição inválida na automação '{}': {}",
+                    spec.name, e
+                ))
+            })?;
+            condicoes.push(Condicao {
+                fonte: c.expr.clone(),
+                expr,
+            });
+        }
+        let crons = spec
+            .trigger
+            .iter()
+            .filter_map(|t| match t {
+                TriggerSpec::Cron { expr } => Some(expr.clone()),
+                _ => None,
+            })
+            .collect();
+        Ok(Self {
+            spec,
+            condicoes,
+            crons,
+        })
+    }
+}
+
+/// O estado de runtime de uma automação — vivo só em memória: reinício do
+/// gateway zera debounce/janela de rate (o pior caso é um disparo extra no
+/// boot, nunca um bypass).
+#[derive(Default)]
+struct EstadoRuntime {
+    ultima_execucao: Option<Instant>,
+    janela_rate: Vec<Instant>,
+    /// Próxima ocorrência de cada gatilho cron (alinhado a `Regra::crons`).
+    proximos_cron: Vec<Option<DateTime<Local>>>,
+}
+
+/// O que o motor compartilha com as tasks de execução.
+struct Compartilhado {
+    regras: Vec<Regra>,
+    estados: Mutex<HashMap<String, EstadoRuntime>>,
+    registry: Arc<DeviceRegistry>,
+    store: Arc<AutomationStore>,
+    gate: HardwareGate,
+    teto: TetoRisco,
+}
+
+/// O motor. Um task em loop (`select!` sobre o barramento e o tick de cron);
+/// `encerrar` aborta.
+pub struct AutomationEngine {
+    tarefa: tokio::task::JoinHandle<()>,
+}
+
+impl AutomationEngine {
+    /// Compila as specs e sobe o motor. Condição que não parses é erro de
+    /// spawn — regra quebrada não sobe silenciosa.
+    pub fn spawn(
+        config: EngineConfig,
+        bus: Arc<HardwareEventBus>,
+        registry: Arc<DeviceRegistry>,
+        store: Arc<AutomationStore>,
+    ) -> Result<Self, HardwareError> {
+        let mut regras = Vec::new();
+        for spec in config.specs {
+            if !spec.enabled {
+                continue; // desabilitada não arma — segue registrada no store
+            }
+            regras.push(Regra::compilar(spec)?);
+        }
+        let mut estados = HashMap::new();
+        for regra in &regras {
+            estados.insert(
+                regra.spec.name.clone(),
+                EstadoRuntime {
+                    proximos_cron: vec![None; regra.crons.len()],
+                    ..Default::default()
+                },
+            );
+        }
+        let compartilhado = Arc::new(Compartilhado {
+            regras,
+            estados: Mutex::new(estados),
+            registry,
+            store,
+            gate: HardwareGate::sem_canal_confirmacao(),
+            teto: config.teto,
+        });
+        let tarefa = tokio::spawn(rodar(bus, compartilhado));
+        Ok(Self { tarefa })
+    }
+
+    /// Para o motor (aborta o task — o barramento segue vivo para os
+    /// próximos).
+    pub fn encerrar(self) {
+        self.tarefa.abort();
+    }
+}
+
+/// A cadência do tick de cron: o croner é consultado a cada 30s — sobra
+/// no máximo 30s de atraso em um gatilho que fala em minutos.
+const TICK_CRON: Duration = Duration::from_secs(30);
+
+async fn rodar(bus: Arc<HardwareEventBus>, sh: Arc<Compartilhado>) {
+    let mut rx = bus.subscrever();
+    let mut tick = time::interval(TICK_CRON);
+    // O primeiro tick do `interval` dispara imediato — não é "todo mundo
+    // vencido de uma vez", é só o construtor.
+    tick.tick().await;
+    loop {
+        tokio::select! {
+            evento = rx.recv() => match evento {
+                Ok(ev) => processar_evento(&sh, ev).await,
+                Err(broadcast::error::RecvError::Lagged(perdidos)) => {
+                    tracing::warn!(perdidos, "automations: assinante lento, eventos perdidos");
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    tracing::info!("automations: barramento fechado, motor encerrado");
+                    return;
+                }
+            },
+            _ = tick.tick() => disparar_crons(&sh).await,
+        }
+    }
+}
+
+async fn processar_evento(sh: &Arc<Compartilhado>, evento: HardwareEvent) {
+    let HardwareEvent::StateChanged(mudanca) = evento;
+    for regra in &sh.regras {
+        if !regra_casa_evento(regra, &mudanca) {
+            continue;
+        }
+        // Debounce é reserva atômica no loop: dois eventos em rajada não
+        // correm dois pipelines da mesma regra dentro da janela.
+        let agora = Instant::now();
+        let janela = Duration::from_secs(regra.spec.debounce_secs.unwrap_or(0));
+        {
+            let mut estados = sh.estados.lock().await;
+            let estado = estados.entry(regra.spec.name.clone()).or_default();
+            if let Some(ultima) = estado.ultima_execucao
+                && agora.duration_since(ultima) < janela
+            {
+                tracing::debug!(
+                    automacao = %regra.spec.name,
+                    entidade = %mudanca.device_id,
+                    "automations: debounce absorveu o evento"
+                );
+                continue;
+            }
+            estado.ultima_execucao = Some(agora);
+        }
+        let sh_task = sh.clone();
+        let mudanca = mudanca.clone();
+        let nome = regra.spec.name.clone();
+        tokio::spawn(async move {
+            executar_por_evento(sh_task, &nome, mudanca).await;
+        });
+    }
+}
+
+fn regra_casa_evento(regra: &Regra, mudanca: &StateChanged) -> bool {
+    regra.spec.trigger.iter().any(|t| match t {
+        TriggerSpec::StateChanged { entity } => entity == &mudanca.device_id,
+        _ => false,
+    })
+}
+
+/// O pipeline pós-debounce para um gatilho de evento.
+async fn executar_por_evento(sh: Arc<Compartilhado>, nome: &str, mudanca: StateChanged) {
+    let ctx = contexto_do_evento(&mudanca);
+    let gatilho = serde_json::json!({
+        "entity_id": mudanca.device_id,
+        "state": mudanca.novo.state,
+        "online": mudanca.novo.online,
+    });
+    executar_pipeline(sh, nome, &ctx, &gatilho).await;
+}
+
+/// O pipeline compartilhado entre gatilho de evento e gatilho de cron:
+/// condições → rate limit → delay → ações → auditoria. A regra é procurada
+/// aqui dentro: o borrow vive enquanto o `Arc` é dono local, sem mover.
+async fn executar_pipeline(
+    sh: Arc<Compartilhado>,
+    nome: &str,
+    ctx: &serde_json::Value,
+    gatilho: &serde_json::Value,
+) {
+    let Some(regra) = sh.regras.iter().find(|r| r.spec.name == nome) else {
+        return; // regra sumiu? não deve acontecer — o pool é fixo
+    };
+    let inicio = Instant::now();
+
+    // 1. Condições — todas devem avaliar `true`. Erro de avaliação não é
+    //    `false`: condição quebrada fica registrada como tal, e a ação não
+    //    roda.
+    for condicao in &regra.condicoes {
+        let veredito = match condicao.expr.avaliar(ctx) {
+            Ok(serde_json::Value::Bool(true)) => None,
+            Ok(serde_json::Value::Bool(false)) => {
+                Some(serde_json::json!([{ "expr": condicao.fonte, "avaliacao": false }]))
+            }
+            Ok(outro) => Some(serde_json::json!([{
+                "expr": condicao.fonte,
+                "erro": format!("resultado não booleano: {outro}"),
+            }])),
+            Err(erro) => Some(serde_json::json!([{
+                "expr": condicao.fonte,
+                "erro": erro.to_string(),
+            }])),
+        };
+        if let Some(detalhe) = veredito {
+            let resultado = if detalhe[0].get("erro").is_some() {
+                ResultadoExecucao::CondicaoErro
+            } else {
+                ResultadoExecucao::CondicaoFalsa
+            };
+            tracing::info!(
+                automacao = %regra.spec.name,
+                resultado = resultado.as_str(),
+                "automations: condição não passou — ação não roda"
+            );
+            auditar(
+                &sh,
+                regra,
+                gatilho,
+                resultado,
+                inicio.elapsed().as_millis() as u64,
+                detalhe,
+            )
+            .await;
+            return;
+        }
+    }
+
+    // 2. Rate limit — reserva atômica: ou a execução entra na janela agora,
+    //    ou é rejeitada com auditoria. Janela deslizante de 1 hora.
+    if let Some(limite) = regra.spec.rate_limit {
+        let agora = Instant::now();
+        let janela = Duration::from_secs(3600);
+        {
+            let mut estados = sh.estados.lock().await;
+            let estado = estados.entry(regra.spec.name.clone()).or_default();
+            estado
+                .janela_rate
+                .retain(|t| agora.duration_since(*t) < janela);
+            if estado.janela_rate.len() >= limite.max_per_hour as usize {
+                tracing::warn!(
+                    automacao = %regra.spec.name,
+                    limite = limite.max_per_hour,
+                    "automations: rate limit atingido — execução rejeitada"
+                );
+                auditar(
+                    &sh,
+                    regra,
+                    gatilho,
+                    ResultadoExecucao::RateLimited,
+                    inicio.elapsed().as_millis() as u64,
+                    serde_json::json!({ "max_per_hour": limite.max_per_hour }),
+                )
+                .await;
+                return;
+            }
+            estado.janela_rate.push(agora);
+        }
+    }
+
+    // 3. Delay — a espera fixa entre condição satisfeita e ação.
+    if let Some(secs) = regra.spec.delay_secs {
+        time::sleep(Duration::from_secs(secs)).await;
+    }
+
+    // 4. Ações, em sequência. Cada uma avalia o próprio resultado; a soma
+    //    vira o resultado geral da execução.
+    let mut detalhe = Vec::new();
+    let mut executadas = 0usize;
+    let mut bloqueadas = 0usize;
+    let mut erros = 0usize;
+    for acao in &regra.spec.action {
+        let resultado = executar_acao(&sh, acao).await;
+        match resultado.get("resultado").and_then(|r| r.as_str()) {
+            Some("executada") => executadas += 1,
+            Some("bloqueada") => bloqueadas += 1,
+            _ => erros += 1,
+        }
+        detalhe.push(resultado);
+    }
+    let resultado_geral = if bloqueadas > 0 && executadas == 0 {
+        ResultadoExecucao::BloqueadaRisco
+    } else if erros > 0 {
+        ResultadoExecucao::Erro
+    } else {
+        ResultadoExecucao::Executada
+    };
+    tracing::info!(
+        automacao = %regra.spec.name,
+        resultado = resultado_geral.as_str(),
+        acoes = detalhe.len(),
+        "automations: execução concluída"
+    );
+    auditar(
+        &sh,
+        regra,
+        gatilho,
+        resultado_geral,
+        inicio.elapsed().as_millis() as u64,
+        serde_json::Value::Array(detalhe),
+    )
+    .await;
+}
+
+/// Executa uma ação `device_execute` — registry → gate → validar_args →
+/// device. Falha em qualquer degrau não panica: vira resultado JSON na
+/// auditoria.
+async fn executar_acao(sh: &Compartilhado, acao: &ActionSpec) -> serde_json::Value {
+    let ActionSpec::DeviceExecute {
+        device,
+        capability,
+        args,
+    } = acao;
+    let Some(dispositivo) = sh.registry.get(device) else {
+        tracing::warn!(dispositivo = %device, "automations: dispositivo não registrado");
+        return serde_json::json!({
+            "acao": "device_execute", "device": device, "capability": capability,
+            "resultado": "erro", "motivo": "dispositivo não registrado",
+        });
+    };
+    let Some(cap) = dispositivo
+        .capabilities()
+        .iter()
+        .find(|c| c.name == *capability)
+        .cloned()
+    else {
+        tracing::warn!(dispositivo = %device, capability = %capability, "automations: capability desconhecida");
+        return serde_json::json!({
+            "acao": "device_execute", "device": device, "capability": capability,
+            "resultado": "erro", "motivo": "capability desconhecida",
+        });
+    };
+    let decisao = sh.gate.decide_class(cap.risk, &cap.name);
+    let permitida = match decisao {
+        ExecutionDecision::Auto => true,
+        ExecutionDecision::PolicyGated => sh.teto >= TetoRisco::R1,
+        ExecutionDecision::PolicyRateLimited => sh.teto >= TetoRisco::R2,
+        // Automação roda desacompanhada — sem canal de confirmação, o gate
+        // já nega R3/R4/R5; a linha é defesa em profundidade.
+        ExecutionDecision::HumanConfirmation
+        | ExecutionDecision::ExplicitApproval
+        | ExecutionDecision::Denied => false,
+    };
+    if !permitida {
+        tracing::warn!(
+            dispositivo = %device, capability = %cap.name,
+            classe = cap.risk.as_str(),
+            teto = sh.teto.as_str(),
+            "automations: ação bloqueada pelo modelo de risco"
+        );
+        return serde_json::json!({
+            "acao": "device_execute", "device": device, "capability": capability,
+            "resultado": "bloqueada", "classe": cap.risk.as_str(), "teto": sh.teto.as_str(),
+        });
+    }
+    if let Err(erro) = validar_args(args, cap.args_schema.as_ref(), device, capability) {
+        return serde_json::json!({
+            "acao": "device_execute", "device": device, "capability": capability,
+            "resultado": "erro", "motivo": erro.to_string(),
+        });
+    }
+    match dispositivo.execute(capability, args.clone()).await {
+        Ok(resposta) => serde_json::json!({
+            "acao": "device_execute", "device": device, "capability": capability,
+            "resultado": "executada", "resposta": resposta,
+        }),
+        Err(erro) => serde_json::json!({
+            "acao": "device_execute", "device": device, "capability": capability,
+            "resultado": "erro", "motivo": erro.to_string(),
+        }),
+    }
+}
+
+/// O contexto das condições, na forma do docs do módulo `expr`.
+fn contexto_do_evento(mudanca: &StateChanged) -> serde_json::Value {
+    let mut ctx = serde_json::json!({
+        "to": estado_json(&mudanca.novo),
+        "entity_id": mudanca.device_id,
+        "domain": dominio_de(&mudanca.device_id),
+    });
+    if let Some(velho) = &mudanca.velho {
+        ctx["from"] = estado_json(velho);
+    }
+    ctx
+}
+
+fn estado_json(estado: &crate::events::EstadoObservado) -> serde_json::Value {
+    serde_json::json!({
+        "state": estado.state,
+        "attributes": estado.attributes,
+        "online": estado.online,
+    })
+}
+
+/// A parte antes do ponto da `entity_id` — sensor, light, cover…
+fn dominio_de(entity_id: &str) -> String {
+    entity_id.split('.').next().unwrap_or("").to_string()
+}
+
+/// Os gatilhos cron devidos: a cada tick, cada regra com cron verifica a
+/// próxima ocorrência; vencida, dispara o pipeline com contexto de cron e
+/// recomputa.
+async fn disparar_crons(sh: &Arc<Compartilhado>) {
+    let agora = Local::now();
+    let mut disparos: Vec<(String, String)> = Vec::new(); // (regra, expr)
+    {
+        let mut estados = sh.estados.lock().await;
+        for regra in &sh.regras {
+            if regra.crons.is_empty() {
+                continue;
+            }
+            let estado = estados.entry(regra.spec.name.clone()).or_default();
+            if estado.proximos_cron.len() != regra.crons.len() {
+                estado.proximos_cron = vec![None; regra.crons.len()];
+            }
+            for (i, expr) in regra.crons.iter().enumerate() {
+                if estado.proximos_cron[i].is_none() {
+                    estado.proximos_cron[i] = match cron::proxima_ocorrencia(expr, agora) {
+                        Ok(proximo) => Some(proximo),
+                        Err(erro) => {
+                            tracing::warn!(
+                                automacao = %regra.spec.name,
+                                cron = %expr,
+                                "automations: cron sem ocorrência futura ({erro})"
+                            );
+                            None
+                        }
+                    };
+                }
+                let devida = estado.proximos_cron[i]
+                    .map(|proximo| proximo <= agora)
+                    .unwrap_or(false);
+                if devida {
+                    estado.proximos_cron[i] = cron::proxima_ocorrencia(expr, agora).ok();
+                    disparos.push((regra.spec.name.clone(), expr.clone()));
+                }
+            }
+        }
+    }
+    for (nome, expr) in disparos {
+        let sh_task = sh.clone();
+        let gatilho = serde_json::json!({ "cron": expr });
+        tokio::spawn(async move {
+            let ctx = serde_json::json!({ "cron": expr });
+            executar_pipeline(sh_task, &nome, &ctx, &gatilho).await;
+        });
+    }
+}
+
+async fn auditar(
+    sh: &Arc<Compartilhado>,
+    regra: &Regra,
+    gatilho: &serde_json::Value,
+    resultado: ResultadoExecucao,
+    duracao_ms: u64,
+    detalhe: serde_json::Value,
+) {
+    let execucao = Execucao {
+        automacao: regra.spec.name.clone(),
+        disparada_em: crate::events::milis_agora(),
+        resultado,
+        gatilho: gatilho.clone(),
+        detalhe,
+        duracao_ms,
+    };
+    if let Err(erro) = sh.store.registrar(&execucao).await {
+        tracing::warn!(
+            automacao = %regra.spec.name,
+            error = %erro,
+            "automations: falha ao registrar execução na auditoria"
+        );
+    }
+}

--- a/crates/garraia-hardware/src/automations/expr.rs
+++ b/crates/garraia-hardware/src/automations/expr.rs
@@ -1,0 +1,759 @@
+//! O avaliador de expressões das condições de automação (#1128).
+//!
+//! Uma linguagem pequena, deliberadamente: literais (número, string, bool,
+//! `null`), caminhos de acesso (`to.state`, `from.attributes.temperature`),
+//! comparações (`== != < <= > >=`), lógica (`&& || !` e as palavras `and`
+//! `or` `not`) e aritmética (`+ - * / %`). Nada mais — sem chamada de
+//! função, sem reflexão, sem acesso ao mundo fora do contexto passado.
+//! Fail-closed em duas camadas: o `parse` rejeita sintaxe inválida na carga
+//! da automação (regra ruim não sobe), e a `avaliar` devolve erro para
+//! caminho ausente e tipo errado (condição quebrada nunca vira `true` por
+//! engano — o motor registra `condition_error` e não executa).
+//!
+//! O contexto é o JSON do evento. Para um gatilho `state_changed`:
+//!
+//! ```json
+//! {
+//!   "to":   { "state": "33.5", "attributes": { ... } },
+//!   "from": { "state": "31.0", "attributes": { ... } },
+//!   "entity_id": "sensor.garagem_temperatura",
+//!   "domain": "sensor"
+//! }
+//! ```
+//!
+//! Valores de estado do hub chegam como string (`"33.5"`); comparar com um
+//! número coerciona quando a string parses (`to.state > 32`). Strings não
+//! numéricas em comparação numérica são erro — `state == "on"` é o caminho
+//! certo para domínios assim.
+
+/// O que pode dar errado — na carga (parse) ou na avaliação.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum ExprError {
+    #[error("sintaxe inválida: {0}")]
+    Sintaxe(String),
+    #[error("caminho '{0}' não existe no contexto do evento")]
+    Caminho(String),
+    #[error("operandos incompatíveis: {0}")]
+    Tipo(String),
+    #[error("divisão por zero")]
+    DivisaoPorZero,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum CmpOp {
+    Igual,
+    Diferente,
+    Menor,
+    MenorIgual,
+    Maior,
+    MaiorIgual,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum AritOp {
+    Soma,
+    Sub,
+    Mul,
+    Div,
+    Mod,
+}
+
+/// A árvore da expressão. `parse` uma vez na carga; `avaliar` a cada evento.
+#[derive(Debug, Clone)]
+pub struct Expr {
+    raiz: Node,
+}
+
+#[derive(Debug, Clone)]
+enum Node {
+    Num(f64),
+    Str(String),
+    Bool(bool),
+    Nulo,
+    Caminho(Vec<String>),
+    Nao(Box<Node>),
+    E(Box<Node>, Box<Node>),
+    Ou(Box<Node>, Box<Node>),
+    Cmp {
+        op: CmpOp,
+        esq: Box<Node>,
+        dir: Box<Node>,
+    },
+    Arit {
+        op: AritOp,
+        esq: Box<Node>,
+        dir: Box<Node>,
+    },
+    Neg(Box<Node>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum Token {
+    Num(f64),
+    Str(String),
+    Path(Vec<String>),
+    Verdadeiro,
+    Falso,
+    Nulo,
+    Cmp(CmpOp),
+    ELogico,
+    OuLogico,
+    NaoLogico,
+    Arit(AritOp),
+    AbrePar,
+    FechaPar,
+    Fim,
+}
+
+fn lexar(entrada: &str) -> Result<Vec<Token>, ExprError> {
+    let chars: Vec<char> = entrada.chars().collect();
+    let mut tokens = Vec::new();
+    let mut i = 0;
+    while i < chars.len() {
+        let c = chars[i];
+        match c {
+            c if c.is_whitespace() => i += 1,
+            '(' => {
+                tokens.push(Token::AbrePar);
+                i += 1;
+            }
+            ')' => {
+                tokens.push(Token::FechaPar);
+                i += 1;
+            }
+            '&' if i + 1 < chars.len() && chars[i + 1] == '&' => {
+                tokens.push(Token::ELogico);
+                i += 2;
+            }
+            '|' if i + 1 < chars.len() && chars[i + 1] == '|' => {
+                tokens.push(Token::OuLogico);
+                i += 2;
+            }
+            '=' if i + 1 < chars.len() && chars[i + 1] == '=' => {
+                tokens.push(Token::Cmp(CmpOp::Igual));
+                i += 2;
+            }
+            '!' if i + 1 < chars.len() && chars[i + 1] == '=' => {
+                tokens.push(Token::Cmp(CmpOp::Diferente));
+                i += 2;
+            }
+            '<' => {
+                if i + 1 < chars.len() && chars[i + 1] == '=' {
+                    tokens.push(Token::Cmp(CmpOp::MenorIgual));
+                    i += 2;
+                } else {
+                    tokens.push(Token::Cmp(CmpOp::Menor));
+                    i += 1;
+                }
+            }
+            '>' => {
+                if i + 1 < chars.len() && chars[i + 1] == '=' {
+                    tokens.push(Token::Cmp(CmpOp::MaiorIgual));
+                    i += 2;
+                } else {
+                    tokens.push(Token::Cmp(CmpOp::Maior));
+                    i += 1;
+                }
+            }
+            '+' => {
+                tokens.push(Token::Arit(AritOp::Soma));
+                i += 1;
+            }
+            '*' => {
+                tokens.push(Token::Arit(AritOp::Mul));
+                i += 1;
+            }
+            '/' => {
+                tokens.push(Token::Arit(AritOp::Div));
+                i += 1;
+            }
+            '%' => {
+                tokens.push(Token::Arit(AritOp::Mod));
+                i += 1;
+            }
+            '-' => {
+                tokens.push(Token::Arit(AritOp::Sub));
+                i += 1;
+            }
+            '!' => {
+                tokens.push(Token::NaoLogico);
+                i += 1;
+            }
+            '"' | '\'' => {
+                let fecha = c;
+                i += 1;
+                let mut texto = String::new();
+                let mut fechou = false;
+                while i < chars.len() {
+                    let c = chars[i];
+                    if c == '\\' && i + 1 < chars.len() {
+                        texto.push(chars[i + 1]);
+                        i += 2;
+                        continue;
+                    }
+                    if c == fecha {
+                        fechou = true;
+                        i += 1;
+                        break;
+                    }
+                    texto.push(c);
+                    i += 1;
+                }
+                if !fechou {
+                    return Err(ExprError::Sintaxe("string sem fechamento".into()));
+                }
+                tokens.push(Token::Str(texto));
+            }
+            c if c.is_ascii_digit() => {
+                let mut num = String::new();
+                let mut ponto = false;
+                while i < chars.len() && (chars[i].is_ascii_digit() || (chars[i] == '.' && !ponto))
+                {
+                    if chars[i] == '.' {
+                        // `1.` e `1.2.3` são sintaxe — o número não engole
+                        // o ponto que não vem seguido de dígito.
+                        if i + 1 >= chars.len() || !chars[i + 1].is_ascii_digit() {
+                            break;
+                        }
+                        ponto = true;
+                    }
+                    num.push(chars[i]);
+                    i += 1;
+                }
+                let valor: f64 = num
+                    .parse()
+                    .map_err(|_| ExprError::Sintaxe(format!("número inválido '{num}'")))?;
+                tokens.push(Token::Num(valor));
+            }
+            c if c.is_ascii_alphabetic() || c == '_' => {
+                let mut segmento = String::new();
+                let mut caminho = Vec::new();
+                loop {
+                    segmento.clear();
+                    while i < chars.len() && (chars[i].is_ascii_alphanumeric() || chars[i] == '_') {
+                        segmento.push(chars[i]);
+                        i += 1;
+                    }
+                    caminho.push(segmento.clone());
+                    if i + 1 < chars.len() && chars[i] == '.' {
+                        let proximo = chars[i + 1];
+                        if proximo.is_ascii_alphabetic() || proximo == '_' {
+                            i += 1; // o '.' vira separador do caminho
+                            continue;
+                        }
+                    }
+                    break;
+                }
+                // Palavras reservadas só valem como token solto (sem ponto).
+                if caminho.len() == 1 {
+                    match caminho[0].as_str() {
+                        "and" => {
+                            tokens.push(Token::ELogico);
+                            continue;
+                        }
+                        "or" => {
+                            tokens.push(Token::OuLogico);
+                            continue;
+                        }
+                        "not" => {
+                            tokens.push(Token::NaoLogico);
+                            continue;
+                        }
+                        "true" => {
+                            tokens.push(Token::Verdadeiro);
+                            continue;
+                        }
+                        "false" => {
+                            tokens.push(Token::Falso);
+                            continue;
+                        }
+                        "null" => {
+                            tokens.push(Token::Nulo);
+                            continue;
+                        }
+                        _ => {}
+                    }
+                }
+                tokens.push(Token::Path(caminho));
+            }
+            outro => {
+                return Err(ExprError::Sintaxe(format!(
+                    "caractere inesperado '{outro}'"
+                )));
+            }
+        }
+    }
+    tokens.push(Token::Fim);
+    Ok(tokens)
+}
+
+struct Parser {
+    tokens: Vec<Token>,
+    pos: usize,
+}
+
+impl Parser {
+    fn olhar(&self) -> &Token {
+        self.tokens.get(self.pos).unwrap_or(&Token::Fim)
+    }
+
+    fn avancar(&mut self) -> Token {
+        let t = self.tokens.get(self.pos).cloned().unwrap_or(Token::Fim);
+        self.pos += 1;
+        t
+    }
+
+    fn esperado(&mut self, o_que: &str) -> Result<(), ExprError> {
+        Err(ExprError::Sintaxe(format!(
+            "esperado {o_que}, encontrei {:?}",
+            self.olhar()
+        )))
+    }
+
+    fn parse_expr(&mut self) -> Result<Node, ExprError> {
+        self.parse_ou()
+    }
+
+    fn parse_ou(&mut self) -> Result<Node, ExprError> {
+        let mut esq = self.parse_e()?;
+        while matches!(self.olhar(), Token::OuLogico) {
+            self.avancar();
+            let dir = self.parse_e()?;
+            esq = Node::Ou(Box::new(esq), Box::new(dir));
+        }
+        Ok(esq)
+    }
+
+    fn parse_e(&mut self) -> Result<Node, ExprError> {
+        let mut esq = self.parse_nao()?;
+        while matches!(self.olhar(), Token::ELogico) {
+            self.avancar();
+            let dir = self.parse_nao()?;
+            esq = Node::E(Box::new(esq), Box::new(dir));
+        }
+        Ok(esq)
+    }
+
+    fn parse_nao(&mut self) -> Result<Node, ExprError> {
+        if matches!(self.olhar(), Token::NaoLogico) {
+            self.avancar();
+            return Ok(Node::Nao(Box::new(self.parse_nao()?)));
+        }
+        self.parse_cmp()
+    }
+
+    fn parse_cmp(&mut self) -> Result<Node, ExprError> {
+        let esq = self.parse_arit()?;
+        let op = match self.olhar() {
+            Token::Cmp(op) => *op,
+            _ => return Ok(esq),
+        };
+        self.avancar();
+        let dir = self.parse_arit()?;
+        Ok(Node::Cmp {
+            op,
+            esq: Box::new(esq),
+            dir: Box::new(dir),
+        })
+    }
+
+    fn parse_arit(&mut self) -> Result<Node, ExprError> {
+        let mut esq = self.parse_mul()?;
+        while let Token::Arit(op @ (AritOp::Soma | AritOp::Sub)) = self.olhar() {
+            let op = *op;
+            self.avancar();
+            let dir = self.parse_mul()?;
+            esq = Node::Arit {
+                op,
+                esq: Box::new(esq),
+                dir: Box::new(dir),
+            };
+        }
+        Ok(esq)
+    }
+
+    fn parse_mul(&mut self) -> Result<Node, ExprError> {
+        let mut esq = self.parse_unario()?;
+        while let Token::Arit(op @ (AritOp::Mul | AritOp::Div | AritOp::Mod)) = self.olhar() {
+            let op = *op;
+            self.avancar();
+            let dir = self.parse_unario()?;
+            esq = Node::Arit {
+                op,
+                esq: Box::new(esq),
+                dir: Box::new(dir),
+            };
+        }
+        Ok(esq)
+    }
+
+    fn parse_unario(&mut self) -> Result<Node, ExprError> {
+        // O '-' na posição de prefixo é negação; no infix, o parse_arit
+        // trata como subtração — a posição desambigua.
+        if matches!(self.olhar(), Token::Arit(AritOp::Sub)) {
+            self.avancar();
+            return Ok(Node::Neg(Box::new(self.parse_unario()?)));
+        }
+        self.parse_primario()
+    }
+
+    fn parse_primario(&mut self) -> Result<Node, ExprError> {
+        match self.avancar() {
+            Token::Num(n) => Ok(Node::Num(n)),
+            Token::Str(s) => Ok(Node::Str(s)),
+            Token::Verdadeiro => Ok(Node::Bool(true)),
+            Token::Falso => Ok(Node::Bool(false)),
+            Token::Nulo => Ok(Node::Nulo),
+            Token::Path(caminho) => Ok(Node::Caminho(caminho)),
+            Token::AbrePar => {
+                let dentro = self.parse_expr()?;
+                if !matches!(self.avancar(), Token::FechaPar) {
+                    self.esperado("')'")?;
+                }
+                Ok(dentro)
+            }
+            outro => Err(ExprError::Sintaxe(format!("token inesperado {outro:?}"))),
+        }
+    }
+}
+
+impl Expr {
+    /// Compila a expressão uma vez — sintaxe ruim é rejeitada na carga da
+    /// automação, não no meio da noite de um sensor barulhento.
+    pub fn parse(entrada: &str) -> Result<Self, ExprError> {
+        if entrada.trim().is_empty() {
+            return Err(ExprError::Sintaxe("expressão vazia".into()));
+        }
+        let tokens = lexar(entrada)?;
+        let mut parser = Parser { pos: 0, tokens };
+        let raiz = parser.parse_expr()?;
+        if !matches!(parser.olhar(), Token::Fim) {
+            return Err(ExprError::Sintaxe(format!(
+                "sobrou conteúdo após a expressão: {:?}",
+                parser.olhar()
+            )));
+        }
+        Ok(Self { raiz })
+    }
+
+    /// Avalia contra o contexto do evento. Caminho ausente e tipo errado
+    /// são **erro** — nunca `false` silencioso.
+    pub fn avaliar(&self, ctx: &serde_json::Value) -> Result<serde_json::Value, ExprError> {
+        avaliar_node(&self.raiz, ctx)
+    }
+}
+
+fn avaliar_node(node: &Node, ctx: &serde_json::Value) -> Result<serde_json::Value, ExprError> {
+    match node {
+        Node::Num(n) => Ok(serde_json::json!(n)),
+        Node::Str(s) => Ok(serde_json::json!(s)),
+        Node::Bool(b) => Ok(serde_json::json!(b)),
+        Node::Nulo => Ok(serde_json::Value::Null),
+        Node::Caminho(segmentos) => {
+            let mut atual = ctx;
+            for seg in segmentos {
+                atual = match atual {
+                    serde_json::Value::Object(mapa) => mapa
+                        .get(seg)
+                        .ok_or_else(|| ExprError::Caminho(segmentos.join(".")))?,
+                    _ => {
+                        return Err(ExprError::Caminho(segmentos.join(".")));
+                    }
+                };
+            }
+            Ok(atual.clone())
+        }
+        Node::Nao(dentro) => {
+            let v = avaliar_node(dentro, ctx)?;
+            let b = como_bool(&v)?;
+            Ok(serde_json::json!(!b))
+        }
+        Node::E(esq, dir) => {
+            let e = como_bool(&avaliar_node(esq, ctx)?)?;
+            // Curto-circuito: o lado direito nem é avaliado quando já é falso.
+            if !e {
+                return Ok(serde_json::json!(false));
+            }
+            let d = como_bool(&avaliar_node(dir, ctx)?)?;
+            Ok(serde_json::json!(d))
+        }
+        Node::Ou(esq, dir) => {
+            let e = como_bool(&avaliar_node(esq, ctx)?)?;
+            if e {
+                return Ok(serde_json::json!(true));
+            }
+            let d = como_bool(&avaliar_node(dir, ctx)?)?;
+            Ok(serde_json::json!(d))
+        }
+        Node::Neg(dentro) => {
+            let v = avaliar_node(dentro, ctx)?;
+            let n = como_num(&v)?;
+            Ok(serde_json::json!(-n))
+        }
+        Node::Cmp { op, esq, dir } => {
+            let a = avaliar_node(esq, ctx)?;
+            let b = avaliar_node(dir, ctx)?;
+            Ok(serde_json::json!(comparar(*op, &a, &b)?))
+        }
+        Node::Arit { op, esq, dir } => {
+            let a = avaliar_node(esq, ctx)?;
+            let b = avaliar_node(dir, ctx)?;
+            let x = como_num(&a)?;
+            let y = como_num(&b)?;
+            let r = match op {
+                AritOp::Soma => x + y,
+                AritOp::Sub => x - y,
+                AritOp::Mul => x * y,
+                AritOp::Div => {
+                    if y == 0.0 {
+                        return Err(ExprError::DivisaoPorZero);
+                    }
+                    x / y
+                }
+                AritOp::Mod => {
+                    if y == 0.0 {
+                        return Err(ExprError::DivisaoPorZero);
+                    }
+                    x % y
+                }
+            };
+            Ok(serde_json::json!(r))
+        }
+    }
+}
+
+fn como_bool(v: &serde_json::Value) -> Result<bool, ExprError> {
+    match v {
+        serde_json::Value::Bool(b) => Ok(*b),
+        outro => Err(ExprError::Tipo(format!(
+            "esperado booleano, encontrei {outro}"
+        ))),
+    }
+}
+
+/// Número direto, ou string que parses como número (estados do hub chegam
+/// como string — `"33.5" > 32` tem que funcionar).
+fn como_num(v: &serde_json::Value) -> Result<f64, ExprError> {
+    match v {
+        serde_json::Value::Number(n) => n
+            .as_f64()
+            .ok_or_else(|| ExprError::Tipo(format!("número fora de faixa: {n}"))),
+        serde_json::Value::String(s) => s
+            .trim()
+            .parse::<f64>()
+            .map_err(|_| ExprError::Tipo(format!("string '{s}' não é um número comparável"))),
+        outro => Err(ExprError::Tipo(format!("valor não numérico: {outro}"))),
+    }
+}
+
+fn comparar(op: CmpOp, a: &serde_json::Value, b: &serde_json::Value) -> Result<bool, ExprError> {
+    // Coerção numérica quando UM dos lados é número e o outro parses.
+    let numerico =
+        matches!(a, serde_json::Value::Number(_)) || matches!(b, serde_json::Value::Number(_));
+    if numerico {
+        let (x, y) = (como_num(a)?, como_num(b)?);
+        return Ok(match op {
+            CmpOp::Igual => x == y,
+            CmpOp::Diferente => x != y,
+            CmpOp::Menor => x < y,
+            CmpOp::MenorIgual => x <= y,
+            CmpOp::Maior => x > y,
+            CmpOp::MaiorIgual => x >= y,
+        });
+    }
+    match (a, b) {
+        (serde_json::Value::String(x), serde_json::Value::String(y)) => Ok(match op {
+            CmpOp::Igual => x == y,
+            CmpOp::Diferente => x != y,
+            CmpOp::Menor => x < y,
+            CmpOp::MenorIgual => x <= y,
+            CmpOp::Maior => x > y,
+            CmpOp::MaiorIgual => x >= y,
+        }),
+        (serde_json::Value::Bool(x), serde_json::Value::Bool(y)) => Ok(match op {
+            CmpOp::Igual => x == y,
+            CmpOp::Diferente => x != y,
+            _ => {
+                return Err(ExprError::Tipo(
+                    "booleanos só comparam por igualdade, não por ordem".to_string(),
+                ));
+            }
+        }),
+        (serde_json::Value::Null, serde_json::Value::Null) => Ok(matches!(
+            op,
+            CmpOp::Igual | CmpOp::MenorIgual | CmpOp::MaiorIgual
+        )),
+        // Um dos lados null e o outro não: desigual por definição.
+        (serde_json::Value::Null, _) | (_, serde_json::Value::Null) => {
+            Ok(matches!(op, CmpOp::Diferente | CmpOp::Menor | CmpOp::Maior))
+        }
+        (x, y) => Err(ExprError::Tipo(format!(
+            "tipos não comparáveis: {x} vs {y}"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn ctx_exemplo() -> serde_json::Value {
+        json!({
+            "to": { "state": "33.5", "attributes": { "temperature": 34.1, "unit": "C" } },
+            "from": { "state": "31.0", "attributes": {} },
+            "entity_id": "sensor.garagem_temperatura",
+            "domain": "sensor"
+        })
+    }
+
+    fn ok(expr: &str, ctx: &serde_json::Value) -> serde_json::Value {
+        Expr::parse(expr)
+            .unwrap_or_else(|e| panic!("parse de '{expr}' falhou: {e}"))
+            .avaliar(ctx)
+            .unwrap_or_else(|e| panic!("avaliar '{expr}' falhou: {e}"))
+    }
+
+    #[test]
+    fn numero_compara_com_estado_string_do_hub() {
+        // O caso do issue: estado do hub é string; a comparação coerciona.
+        assert_eq!(ok("to.state > 32", &ctx_exemplo()), json!(true));
+        assert_eq!(ok("to.state < 32", &ctx_exemplo()), json!(false));
+        assert_eq!(ok("from.state == 31", &ctx_exemplo()), json!(true));
+    }
+
+    #[test]
+    fn string_nao_numerica_vs_numero_e_erro() {
+        let ctx = json!({ "to": { "state": "on" } });
+        let err = Expr::parse("to.state > 32")
+            .unwrap()
+            .avaliar(&ctx)
+            .unwrap_err();
+        assert!(matches!(err, ExprError::Tipo(_)), "{err}");
+    }
+
+    #[test]
+    fn precedencia_aritmetica_e_comparacao() {
+        let ctx = json!({});
+        assert_eq!(ok("1 + 2 * 3 == 7", &ctx), json!(true));
+        assert_eq!(ok("(1 + 2) * 3 == 9", &ctx), json!(true));
+        assert_eq!(ok("10 / 4 == 2.5", &ctx), json!(true));
+        assert_eq!(ok("7 % 3 == 1", &ctx), json!(true));
+        assert_eq!(ok("10 - 4 == 6", &ctx), json!(true));
+        assert_eq!(ok("10 - 4 - 3 == 3", &ctx), json!(true));
+    }
+
+    #[test]
+    fn logica_com_simbolos_e_palavras() {
+        let ctx = ctx_exemplo();
+        assert_eq!(ok("to.state > 32 && from.state < 32", &ctx), json!(true));
+        assert_eq!(ok("to.state > 32 and from.state < 32", &ctx), json!(true));
+        assert_eq!(ok("to.state < 32 || from.state < 32", &ctx), json!(true));
+        assert_eq!(ok("to.state > 32 or from.state < 32", &ctx), json!(true));
+        assert_eq!(ok("!(to.state > 32)", &ctx), json!(false));
+        assert_eq!(ok("not to.state > 32", &ctx), json!(false));
+        // Curto-circuito: lado direito inválido não é avaliado.
+        assert_eq!(ok("false && 1/0 == 1", &ctx), json!(false));
+        assert_eq!(ok("true || 1/0 == 1", &ctx), json!(true));
+    }
+
+    #[test]
+    fn caminho_profundo_ate_atributo() {
+        assert_eq!(
+            ok("to.attributes.temperature > 34", &ctx_exemplo()),
+            json!(true)
+        );
+        assert_eq!(
+            ok("to.attributes.unit == \"C\"", &ctx_exemplo()),
+            json!(true)
+        );
+    }
+
+    #[test]
+    fn caminho_ausente_e_erro_nunca_false() {
+        let err = Expr::parse("to.new_state.state > 32")
+            .unwrap()
+            .avaliar(&ctx_exemplo())
+            .unwrap_err();
+        assert!(matches!(err, ExprError::Caminho(p) if p == "to.new_state.state"));
+    }
+
+    #[test]
+    fn booleanos_sao_estritos() {
+        let ctx = json!({});
+        for expr in [
+            "1 && true",
+            "true && 0",
+            "false || 0",
+            "!\"texto\"",
+            "not 1",
+        ] {
+            let err = Expr::parse(expr).unwrap().avaliar(&ctx).unwrap_err();
+            assert!(matches!(err, ExprError::Tipo(_)), "{expr}: {err}");
+        }
+    }
+
+    #[test]
+    fn resultado_nao_booleano_sai_como_valor() {
+        // O motor exige Bool no topo; o avaliador só entrega o valor.
+        assert_eq!(ok("1 + 1", &json!({})), json!(2.0));
+        assert_eq!(ok("\"on\"", &json!({})), json!("on"));
+    }
+
+    #[test]
+    fn igualdade_de_strings_e_null() {
+        let ctx = json!({ "to": { "state": "on" }, "x": null });
+        assert_eq!(ok("to.state == 'on'", &ctx), json!(true));
+        assert_eq!(ok("to.state != \"off\"", &ctx), json!(true));
+        assert_eq!(ok("x == null", &ctx), json!(true));
+        assert_eq!(ok("x != null", &ctx), json!(false));
+        assert_eq!(ok("to.state == null", &ctx), json!(false));
+    }
+
+    #[test]
+    fn divisao_por_zero_e_erro() {
+        let err = Expr::parse("1 / 0")
+            .unwrap()
+            .avaliar(&json!({}))
+            .unwrap_err();
+        assert!(matches!(err, ExprError::DivisaoPorZero));
+    }
+
+    #[test]
+    fn unario_negativo_e_parenteses() {
+        let ctx = json!({ "a": 5 });
+        assert_eq!(ok("-a + 10 == 5", &ctx), json!(true));
+        assert_eq!(ok("(a - 5) * -1 == 0", &ctx), json!(true));
+    }
+
+    #[test]
+    fn comparacao_de_strings_ordena_lexicografico() {
+        let ctx = json!({ "to": { "state": "heat" } });
+        assert_eq!(ok("to.state >= \"cool\"", &ctx), json!(true));
+        assert_eq!(ok("to.state < \"off\"", &ctx), json!(true));
+    }
+
+    #[test]
+    fn sintaxe_ruim_rejeitada_no_parse() {
+        for expr in [
+            "",
+            "to.. > 3",
+            "\"sem fechar",
+            "1 +",
+            "a < b < c",
+            "(1",
+            "1 2",
+            "== 3",
+            "to.state =! 3",
+        ] {
+            assert!(Expr::parse(expr).is_err(), "'{expr}' deveria falhar");
+        }
+    }
+
+    #[test]
+    fn parser_aceita_a_espec_da_issue() {
+        // A expressão canônica do exemplo do ventilador (docs do módulo).
+        let ctx = ctx_exemplo();
+        assert_eq!(ok("to.state > 32", &ctx), json!(true));
+    }
+}

--- a/crates/garraia-hardware/src/automations/mod.rs
+++ b/crates/garraia-hardware/src/automations/mod.rs
@@ -1,0 +1,23 @@
+//! O motor de automações (#1128) — trigger → condição → ação, pela mesma
+//! policy do runtime (nada de bypass).
+//!
+//! Slice atual: gatilhos `state_changed` (barramento de eventos) e `cron`
+//! (croner), condições avaliadas por [`expr::Expr`], ações `device_execute`
+//! pelo [`crate::registry::DeviceRegistry`] com o [`crate::gate::HardwareGate`]
+//! **sem canal de confirmação** (automação roda desacompanhada — R3/R4/R5
+//! negadas por natureza, R0/R1/R2 pelo teto declarado no config). Ações
+//! `send_message` e `tool call` entram em slice futuro, com a maquinaria de
+//! canal do gateway.
+
+pub mod cron;
+pub mod engine;
+pub mod expr;
+pub mod spec;
+pub mod store;
+
+pub use engine::{AutomationEngine, EngineConfig, TetoRisco};
+pub use expr::Expr;
+pub use spec::{
+    ActionSpec, AutomationSpec, ConditionSpec, RateLimitSpec, TriggerSpec, carregar_dir,
+};
+pub use store::{AutomationStore, Execucao, ResultadoExecucao};

--- a/crates/garraia-hardware/src/automations/spec.rs
+++ b/crates/garraia-hardware/src/automations/spec.rs
@@ -1,0 +1,471 @@
+//! A spec declarativa de uma automação — TOML (ou JSON) versionável no repo
+//! do usuário, o formato do exemplo da issue #1128:
+//!
+//! ```toml
+//! [[automation]]
+//! name = "ventilador-garagem-quente"
+//! [[automation.trigger]]
+//! type = "state_changed"
+//! entity = "sensor.garagem_temperatura"
+//! [[automation.condition]]
+//! expr = "to.state > 32"
+//! [[automation.action]]
+//! type = "device_execute"
+//! device = "fan.garagem"
+//! capability = "power"
+//! args = { on = true }
+//! ```
+//!
+//! Validação no carregamento, fail-closed: nome único e com formato fixo,
+//! pelo menos um gatilho e uma ação, toda expressão de condição parses
+//! ([`crate::automations::expr`]), todo `expr` de cron parses (croner).
+//! Regra quebrada não sobe — o erro nomeia arquivo e automação.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use super::expr::Expr;
+
+/// Um gatilho. `state_changed` observa uma entidade no barramento; `cron`
+/// dispara no relógio (expressão de 5 campos, avaliada no fuso do host —
+/// uma casa funciona no fuso de quem mora nela).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum TriggerSpec {
+    StateChanged {
+        /// O id do dispositivo no registry (para o HA, a `entity_id`).
+        entity: String,
+    },
+    Cron {
+        /// Expressão cron de 5 campos (min hora dia mês dia-semana).
+        expr: String,
+    },
+}
+
+/// Uma condição — todas as listadas têm que passar (AND).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ConditionSpec {
+    pub expr: String,
+}
+
+/// Um limite de cadência por automação — proteção contra loop (automação
+/// que dispara evento que dispara a si mesma).
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct RateLimitSpec {
+    pub max_per_hour: u32,
+}
+
+/// A ação. Slice atual: só `device_execute` — as outras (`send_message`,
+/// `tool`) são rejeitadas no parse com a mensagem dizendo que entram em
+/// slice futuro, para a regra não subir meia-boca.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ActionSpec {
+    DeviceExecute {
+        /// O id do dispositivo no registry.
+        device: String,
+        /// O nome da `Capability` a executar.
+        capability: String,
+        /// Argumentos validados pela mesma `validar_args` das tools.
+        #[serde(default)]
+        args: serde_json::Value,
+    },
+}
+
+/// A automação declarada.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AutomationSpec {
+    /// Nome único, `[a-z0-9-]` — vira chave no store e nas auditorias.
+    pub name: String,
+    /// Desligável sem apagar o arquivo.
+    #[serde(default = "sim")]
+    pub enabled: bool,
+    #[serde(default)]
+    pub trigger: Vec<TriggerSpec>,
+    /// Todas as condições devem avaliar `true` (AND).
+    #[serde(default)]
+    pub condition: Vec<ConditionSpec>,
+    #[serde(default)]
+    pub action: Vec<ActionSpec>,
+    /// Janela de debounce (segundos): eventos repetidos dentro da janela
+    /// não re-disparam.
+    #[serde(default)]
+    pub debounce_secs: Option<u64>,
+    /// Limite de execuções por hora.
+    #[serde(default)]
+    pub rate_limit: Option<RateLimitSpec>,
+    /// Espera fixa entre condição satisfeita e ação (segundos).
+    #[serde(default)]
+    pub delay_secs: Option<u64>,
+}
+
+fn sim() -> bool {
+    true
+}
+
+/// O envelope de um arquivo de specs: uma ou mais `[[automation]]`.
+#[derive(Debug, Deserialize)]
+struct ArquivoSpec {
+    #[serde(default)]
+    automation: Vec<AutomationSpec>,
+}
+
+/// O erro do carregamento — nomeia arquivo e automação, para o autor da
+/// regra saber exatamente o que corrigir.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub struct ErroSpec {
+    pub arquivo: String,
+    pub automacao: Option<String>,
+    pub mensagem: String,
+}
+
+impl std::fmt::Display for ErroSpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.arquivo, self.mensagem)?;
+        if let Some(nome) = &self.automacao {
+            write!(f, " (automação '{nome}')")?;
+        }
+        Ok(())
+    }
+}
+
+fn erro(arquivo: &str, automacao: Option<&str>, mensagem: impl Into<String>) -> ErroSpec {
+    ErroSpec {
+        arquivo: arquivo.to_string(),
+        automacao: automacao.map(|s| s.to_string()),
+        mensagem: mensagem.into(),
+    }
+}
+
+impl AutomationSpec {
+    /// Valida a automação inteira. Toda rejeição aqui é um erro do AUTOR
+    /// da regra (o config do usuário), não do sistema.
+    pub fn validar(&self) -> Result<(), String> {
+        if self.name.is_empty() || self.name.len() > 64 {
+            return Err(format!("nome '{}' fora do formato (1-64 chars)", self.name));
+        }
+        if !self
+            .name
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+            || !self
+                .name
+                .starts_with(|c: char| c.is_ascii_lowercase() || c.is_ascii_digit())
+        {
+            return Err(format!(
+                "nome '{}' fora do formato (lowercase, dígitos e hífen)",
+                self.name
+            ));
+        }
+        if self.trigger.is_empty() {
+            return Err("sem gatilho — a automação nunca dispara".into());
+        }
+        if self.action.is_empty() {
+            return Err("sem ação — a automação não faz nada".into());
+        }
+        for t in &self.trigger {
+            match t {
+                TriggerSpec::StateChanged { entity } => {
+                    if entity.is_empty() {
+                        return Err("gatilho state_changed sem entity".into());
+                    }
+                }
+                TriggerSpec::Cron { expr } => {
+                    if let Err(e) = crate::automations::cron::parse_cron(expr) {
+                        return Err(format!("cron inválido '{expr}': {e}"));
+                    }
+                }
+            }
+        }
+        for c in &self.condition {
+            if let Err(e) = Expr::parse(&c.expr) {
+                return Err(format!("condição inválida '{}': {e}", c.expr));
+            }
+        }
+        if let Some(max) = self.rate_limit
+            && max.max_per_hour == 0
+        {
+            return Err(
+                "rate_limit.max_per_hour = 0 desligaria a automação — use enabled = false".into(),
+            );
+        }
+        for a in &self.action {
+            match a {
+                ActionSpec::DeviceExecute {
+                    device, capability, ..
+                } => {
+                    if device.is_empty() || capability.is_empty() {
+                        return Err("device_execute exige device e capability não vazios".into());
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Carrega todas as specs de um diretório (`*.toml` e `*.json`, em ordem
+/// alfabética). Nomes duplicados entre arquivos são erro — automação com
+/// nome ambíguo não tem auditoria confiável.
+pub fn carregar_dir(dir: &Path) -> Result<Vec<AutomationSpec>, ErroSpec> {
+    let mut entradas: Vec<_> = std::fs::read_dir(dir)
+        .map_err(|e| {
+            erro(
+                &dir.display().to_string(),
+                None,
+                format!("falha ao ler o diretório: {e}"),
+            )
+        })?
+        .filter_map(|entrada| entrada.ok())
+        .map(|entrada| entrada.path())
+        .filter(|p| {
+            matches!(
+                p.extension().and_then(|e| e.to_str()),
+                Some("toml") | Some("json")
+            )
+        })
+        .collect();
+    entradas.sort();
+    let mut todas = Vec::new();
+    for arquivo in &entradas {
+        let nome = arquivo.display().to_string();
+        let conteudo = std::fs::read_to_string(arquivo)
+            .map_err(|e| erro(&nome, None, format!("falha ao ler: {e}")))?;
+        let parsed: ArquivoSpec = match arquivo.extension().and_then(|e| e.to_str()) {
+            Some("toml") => toml::from_str(&conteudo)
+                .map_err(|e| erro(&nome, None, format!("TOML inválido: {e}")))?,
+            _ => serde_json::from_str(&conteudo)
+                .map_err(|e| erro(&nome, None, format!("JSON inválido: {e}")))?,
+        };
+        for spec in parsed.automation {
+            spec.validar()
+                .map_err(|m| erro(&nome, Some(&spec.name), m))?;
+            if todas.iter().any(|j: &AutomationSpec| j.name == spec.name) {
+                return Err(erro(
+                    &nome,
+                    Some(&spec.name),
+                    "nome duplicado em outro arquivo do diretório",
+                ));
+            }
+            todas.push(spec);
+        }
+    }
+    Ok(todas)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn dir_tmp(nome: &str) -> PathBuf {
+        let base = std::env::temp_dir().join(format!("garraia-spec-{nome}-{}", std::process::id()));
+        std::fs::create_dir_all(&base).expect("cria dir");
+        base
+    }
+
+    const EXEMPLO_ISSUE: &str = r#"
+[[automation]]
+name = "ventilador-garagem-quente"
+
+[[automation.trigger]]
+type = "state_changed"
+entity = "sensor.garagem_temperatura"
+
+[[automation.condition]]
+expr = "to.state > 32"
+
+[[automation.action]]
+type = "device_execute"
+device = "fan.garagem"
+capability = "power"
+args = { on = true }
+"#;
+
+    #[test]
+    fn parse_da_espec_da_issue() {
+        let spec: ArquivoSpec = toml::from_str(EXEMPLO_ISSUE).expect("TOML parse");
+        assert_eq!(spec.automation.len(), 1);
+        let a = &spec.automation[0];
+        assert_eq!(a.name, "ventilador-garagem-quente");
+        assert!(a.enabled);
+        assert_eq!(
+            a.trigger,
+            vec![TriggerSpec::StateChanged {
+                entity: "sensor.garagem_temperatura".into()
+            }]
+        );
+        assert_eq!(a.condition.len(), 1);
+        assert_eq!(
+            a.action,
+            vec![ActionSpec::DeviceExecute {
+                device: "fan.garagem".into(),
+                capability: "power".into(),
+                args: serde_json::json!({ "on": true }),
+            }]
+        );
+        a.validar().expect("spec da issue valida");
+    }
+
+    #[test]
+    fn parse_json_equivalente() {
+        let spec: ArquivoSpec = serde_json::from_str(
+            r#"{"automation": [{"name": "luz-noite", "enabled": false,
+                "trigger": [{"type": "cron", "expr": "0 19 * * *"}],
+                "action": [{"type": "device_execute", "device": "light.sala", "capability": "power"}]}]}"#,
+        )
+        .expect("JSON parse");
+        let a = &spec.automation[0];
+        assert!(!a.enabled);
+        a.validar().expect("valida");
+    }
+
+    #[test]
+    fn validacao_rejeita_as_buracos() {
+        let vazio = AutomationSpec {
+            name: "sem-gatilho".into(),
+            enabled: true,
+            trigger: vec![],
+            condition: vec![],
+            action: vec![ActionSpec::DeviceExecute {
+                device: "x".into(),
+                capability: "power".into(),
+                args: serde_json::Value::Null,
+            }],
+            debounce_secs: None,
+            rate_limit: None,
+            delay_secs: None,
+        };
+        assert!(vazio.validar().is_err());
+
+        let nome_feio = AutomationSpec {
+            name: "Luz Sala".into(),
+            ..vazio.clone()
+        };
+        assert!(nome_feio.validar().is_err());
+
+        let sem_acao = AutomationSpec {
+            name: "so-gatilho".into(),
+            trigger: vec![TriggerSpec::StateChanged {
+                entity: "s.x".into(),
+            }],
+            action: vec![],
+            ..vazio
+        };
+        assert!(sem_acao.validar().is_err());
+    }
+
+    #[test]
+    fn condicao_invalida_rejeitada_na_carga() {
+        let spec: ArquivoSpec = toml::from_str(
+            r#"
+[[automation]]
+name = "condicao-quebrada"
+[[automation.trigger]]
+type = "state_changed"
+entity = "sensor.x"
+[[automation.condition]]
+expr = "to. > 32"
+[[automation.action]]
+type = "device_execute"
+device = "light.y"
+capability = "power"
+"#,
+        )
+        .expect("TOML parse");
+        let msg = spec.automation[0].validar().unwrap_err();
+        assert!(msg.contains("condição inválida"), "{msg}");
+    }
+
+    #[test]
+    fn acao_desconhecida_rejeitada_com_mensagem_direita() {
+        // send_message entra em slice futuro — o parse tem que dizer isso.
+        let resultado: Result<ArquivoSpec, _> = toml::from_str(
+            r#"
+[[automation]]
+name = "mensagem"
+[[automation.trigger]]
+type = "state_changed"
+entity = "sensor.x"
+[[automation.action]]
+type = "send_message"
+text = "olá"
+"#,
+        );
+        let err = resultado.expect_err("send_message não é suportado ainda");
+        assert!(err.to_string().contains("unknown variant"), "{err}");
+    }
+
+    #[test]
+    fn cron_invalido_rejeitado_na_carga() {
+        let spec: ArquivoSpec = toml::from_str(
+            r#"
+[[automation]]
+name = "cron-quebrado"
+[[automation.trigger]]
+type = "cron"
+expr = "nao-e-cron"
+[[automation.action]]
+type = "device_execute"
+device = "light.y"
+capability = "power"
+"#,
+        )
+        .expect("TOML parse");
+        let msg = spec.automation[0].validar().unwrap_err();
+        assert!(msg.contains("cron inválido"), "{msg}");
+    }
+
+    #[test]
+    fn rate_limit_zero_rejeitado() {
+        let spec: ArquivoSpec = toml::from_str(
+            r#"
+[[automation]]
+name = "zero"
+[[automation.trigger]]
+type = "state_changed"
+entity = "sensor.x"
+[automation.rate_limit]
+max_per_hour = 0
+[[automation.action]]
+type = "device_execute"
+device = "light.y"
+capability = "power"
+"#,
+        )
+        .expect("TOML parse");
+        let msg = spec.automation[0].validar().unwrap_err();
+        assert!(msg.contains("max_per_hour = 0"), "{msg}");
+    }
+
+    #[test]
+    fn carregar_dir_le_toml_e_json_e_rejeita_duplicado() {
+        let dir = dir_tmp("dupe");
+        std::fs::write(dir.join("a.toml"), EXEMPLO_ISSUE).unwrap();
+        std::fs::write(
+            dir.join("b.json"),
+            r#"{"automation": [{"name": "ventilador-garagem-quente",
+                "trigger": [{"type": "state_changed", "entity": "s.x"}],
+                "action": [{"type": "device_execute", "device": "d", "capability": "power"}]}]}"#,
+        )
+        .unwrap();
+        let err = carregar_dir(&dir).unwrap_err();
+        assert!(err.to_string().contains("duplicado"), "{err}");
+
+        std::fs::remove_file(dir.join("b.json")).unwrap();
+        let specs = carregar_dir(&dir).expect("sem duplicado carrega");
+        assert_eq!(specs.len(), 1);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn carregar_dir_arquivo_quebrado_nomeia_o_arquivo() {
+        let dir = dir_tmp("quebrado");
+        std::fs::write(dir.join("ruim.toml"), "[[automation]]\nname = 3\n").unwrap();
+        let err = carregar_dir(&dir).unwrap_err();
+        assert!(err.arquivo.ends_with("ruim.toml"), "{err}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/crates/garraia-hardware/src/automations/store.rs
+++ b/crates/garraia-hardware/src/automations/store.rs
@@ -1,0 +1,374 @@
+//! O store de automações — persistência SQLite das regras carregadas e do
+//! histórico de execuções (a auditoria da #1128).
+//!
+//! Separação de papéis: o **fonte da verdade** das regras são os arquivos
+//! versionáveis do usuário ([`super::spec::carregar_dir`]); a SQLite guarda
+//! o retrato do que está no ar (para a futura página do console) e a
+//! auditoria de execuções. Mesmo padrão do [`crate::state::DeviceStateStore`]:
+//! `rusqlite` síncrono sob `tokio::sync::Mutex`.
+
+use std::path::Path;
+
+use tokio::sync::Mutex;
+
+use super::spec::AutomationSpec;
+
+/// Como uma execução terminou. Falha de gate é `bloqueada` — automação
+/// tentou fazer o que a policy não deixa, e ficou registrada.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResultadoExecucao {
+    Executada,
+    BloqueadaRisco,
+    CondicaoFalsa,
+    CondicaoErro,
+    RateLimited,
+    Erro,
+}
+
+impl ResultadoExecucao {
+    pub fn de_texto(s: &str) -> Option<Self> {
+        Some(match s {
+            "executada" => Self::Executada,
+            "bloqueada_risco" => Self::BloqueadaRisco,
+            "condicao_falsa" => Self::CondicaoFalsa,
+            "condicao_erro" => Self::CondicaoErro,
+            "rate_limited" => Self::RateLimited,
+            "erro" => Self::Erro,
+            _ => return None,
+        })
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Executada => "executada",
+            Self::BloqueadaRisco => "bloqueada_risco",
+            Self::CondicaoFalsa => "condicao_falsa",
+            Self::CondicaoErro => "condicao_erro",
+            Self::RateLimited => "rate_limited",
+            Self::Erro => "erro",
+        }
+    }
+}
+
+/// Uma linha da auditoria: o que disparou, como terminou, quanto demorou.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Execucao {
+    pub automacao: String,
+    /// Milissegundos desde a época (UTC) do disparo.
+    pub disparada_em: u64,
+    pub resultado: ResultadoExecucao,
+    /// Resumo do gatilho (JSON — `{"entity_id": "…"}` ou `{"cron": "…"}`).
+    pub gatilho: serde_json::Value,
+    /// Detalhe por ação (JSON — array de resultados, args usados não vão
+    /// aqui: o resultado do device já os registra).
+    pub detalhe: serde_json::Value,
+    pub duracao_ms: u64,
+}
+
+/// O teto de auditoria — execuções velhas são podadas para a SQLite não
+/// crescer infinito com um sensor barulhento.
+const TETO_HISTORICO: i64 = 10_000;
+
+pub struct AutomationStore {
+    conn: Mutex<rusqlite::Connection>,
+}
+
+impl AutomationStore {
+    /// Abre (ou cria) o banco em `path`.
+    pub fn abrir_em(path: &Path) -> Result<Self, crate::HardwareError> {
+        if let Some(pai) = path.parent() {
+            std::fs::create_dir_all(pai).map_err(|e| {
+                crate::HardwareError::Automations(format!("criar diretório {}: {e}", pai.display()))
+            })?;
+        }
+        let conn = rusqlite::Connection::open(path).map_err(|e| {
+            crate::HardwareError::Automations(format!("abrir {}: {e}", path.display()))
+        })?;
+        Self::com_conexao(conn)
+    }
+
+    /// Store em memória — os testes e o modo efêmero.
+    pub fn em_memoria() -> Result<Self, crate::HardwareError> {
+        let conn = rusqlite::Connection::open_in_memory()
+            .map_err(|e| crate::HardwareError::Automations(format!("abrir em memória: {e}")))?;
+        Self::com_conexao(conn)
+    }
+
+    fn com_conexao(conn: rusqlite::Connection) -> Result<Self, crate::HardwareError> {
+        conn.pragma_update(None, "journal_mode", "WAL")
+            .map_err(|e| crate::HardwareError::Automations(format!("WAL: {e}")))?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS automacoes (
+                nome TEXT PRIMARY KEY,
+                habilitada INTEGER NOT NULL,
+                spec_json TEXT NOT NULL,
+                arquivo TEXT NOT NULL,
+                atualizada_em INTEGER NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS execucoes (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                automacao TEXT NOT NULL,
+                disparada_em INTEGER NOT NULL,
+                resultado TEXT NOT NULL,
+                gatilho_json TEXT NOT NULL,
+                detalhe_json TEXT NOT NULL,
+                duracao_ms INTEGER NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS execucoes_automacao
+                ON execucoes(automacao, id);",
+        )
+        .map_err(|e| crate::HardwareError::Automations(format!("schema: {e}")))?;
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+
+    /// Substitui o retrato das regras carregadas — o que não está na lista
+    /// sai da tabela (regra apagada do repo não continua no ar). DELETE
+    /// total + reinsert atômico: são dezenas de regras, não milhões de
+    /// linhas, e evita montar `IN (…)` dinâmico (regra 5).
+    pub async fn salvar_specs(&self, specs: &[AutomationSpec]) -> Result<(), crate::HardwareError> {
+        let agora = crate::events::milis_agora();
+        let mut conn = self.conn.lock().await;
+        let tx = conn
+            .transaction()
+            .map_err(|e| crate::HardwareError::Automations(format!("tx: {e}")))?;
+        tx.execute("DELETE FROM automacoes", [])
+            .map_err(|e| crate::HardwareError::Automations(format!("limpar retrato: {e}")))?;
+        for spec in specs {
+            let spec_json = serde_json::to_string(spec)
+                .map_err(|e| crate::HardwareError::Automations(format!("serializar spec: {e}")))?;
+            tx.execute(
+                "INSERT INTO automacoes (nome, habilitada, spec_json, arquivo, atualizada_em)
+                 VALUES (?1, ?2, ?3, ?4, ?5)
+                 ON CONFLICT(nome) DO UPDATE SET
+                    habilitada = excluded.habilitada,
+                    spec_json = excluded.spec_json,
+                    arquivo = excluded.arquivo,
+                    atualizada_em = excluded.atualizada_em",
+                rusqlite::params![spec.name, spec.enabled as i64, spec_json, "", agora,],
+            )
+            .map_err(|e| crate::HardwareError::Automations(format!("salvar {}: {e}", spec.name)))?;
+        }
+        tx.commit()
+            .map_err(|e| crate::HardwareError::Automations(format!("commit: {e}")))?;
+        Ok(())
+    }
+
+    /// Registra uma execução na auditoria, podando o histórico velho de
+    /// tempos em tempos (a cada 256 escritas — custo amortizado).
+    pub async fn registrar(&self, execucao: &Execucao) -> Result<(), crate::HardwareError> {
+        static ESCRITAS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let gatilho = serde_json::to_string(&execucao.gatilho)
+            .map_err(|e| crate::HardwareError::Automations(format!("serializar gatilho: {e}")))?;
+        let detalhe = serde_json::to_string(&execucao.detalhe)
+            .map_err(|e| crate::HardwareError::Automations(format!("serializar detalhe: {e}")))?;
+        {
+            let conn = self.conn.lock().await;
+            conn.execute(
+                "INSERT INTO execucoes
+                    (automacao, disparada_em, resultado, gatilho_json, detalhe_json, duracao_ms)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                rusqlite::params![
+                    execucao.automacao,
+                    execucao.disparada_em as i64,
+                    execucao.resultado.as_str(),
+                    gatilho,
+                    detalhe,
+                    execucao.duracao_ms as i64,
+                ],
+            )
+            .map_err(|e| crate::HardwareError::Automations(format!("registrar: {e}")))?;
+        }
+        let n = ESCRITAS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if n.is_multiple_of(256) {
+            let conn = self.conn.lock().await;
+            conn.execute(
+                "DELETE FROM execucoes
+                 WHERE id NOT IN (
+                    SELECT id FROM execucoes ORDER BY id DESC LIMIT ?1
+                 )",
+                [TETO_HISTORICO],
+            )
+            .map_err(|e| crate::HardwareError::Automations(format!("podar histórico: {e}")))?;
+        }
+        Ok(())
+    }
+
+    /// As últimas `limite` execuções (mais novas primeiro), de uma automação
+    /// ou de todas. Para a auditoria humana e a futura página do console.
+    pub async fn historico(
+        &self,
+        automacao: Option<&str>,
+        limite: u32,
+    ) -> Result<Vec<Execucao>, crate::HardwareError> {
+        let conn = self.conn.lock().await;
+        let mut stmt = conn
+            .prepare(
+                "SELECT automacao, disparada_em, resultado, gatilho_json, detalhe_json, duracao_ms
+                 FROM execucoes
+                 WHERE (?1 IS NULL OR automacao = ?1)
+                 ORDER BY id DESC
+                 LIMIT ?2",
+            )
+            .map_err(|e| crate::HardwareError::Automations(format!("preparar histórico: {e}")))?;
+        let rows = stmt
+            .query_map(rusqlite::params![automacao, limite], |row| {
+                let resultado_txt: String = row.get(2)?;
+                let gatilho_txt: String = row.get(3)?;
+                let detalhe_txt: String = row.get(4)?;
+                Ok(Execucao {
+                    automacao: row.get(0)?,
+                    disparada_em: row.get::<_, i64>(1)? as u64,
+                    resultado: ResultadoExecucao::de_texto(&resultado_txt)
+                        .unwrap_or(ResultadoExecucao::Erro),
+                    gatilho: serde_json::from_str(&gatilho_txt).unwrap_or(serde_json::Value::Null),
+                    detalhe: serde_json::from_str(&detalhe_txt).unwrap_or(serde_json::Value::Null),
+                    duracao_ms: row.get::<_, i64>(5)? as u64,
+                })
+            })
+            .map_err(|e| crate::HardwareError::Automations(format!("histórico: {e}")))?;
+        let mut linhas = Vec::new();
+        for row in rows {
+            linhas.push(row.map_err(|e| crate::HardwareError::Automations(format!("linha: {e}")))?);
+        }
+        Ok(linhas)
+    }
+
+    /// O retrato do que está no ar: `(nome, habilitada)` de todas as regras
+    /// carregadas na última `salvar_specs`.
+    pub async fn listar(&self) -> Result<Vec<(String, bool)>, crate::HardwareError> {
+        let conn = self.conn.lock().await;
+        let mut stmt = conn
+            .prepare("SELECT nome, habilitada FROM automacoes ORDER BY nome")
+            .map_err(|e| crate::HardwareError::Automations(format!("listar: {e}")))?;
+        let rows = stmt
+            .query_map([], |row| Ok((row.get(0)?, row.get::<_, i64>(1)? != 0)))
+            .map_err(|e| crate::HardwareError::Automations(format!("listar: {e}")))?;
+        let mut linhas = Vec::new();
+        for row in rows {
+            linhas.push(row.map_err(|e| crate::HardwareError::Automations(format!("linha: {e}")))?);
+        }
+        Ok(linhas)
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec_exemplo(nome: &str, habilitada: bool) -> AutomationSpec {
+        AutomationSpec {
+            name: nome.into(),
+            enabled: habilitada,
+            trigger: vec![super::super::spec::TriggerSpec::StateChanged {
+                entity: "sensor.x".into(),
+            }],
+            condition: vec![],
+            action: vec![super::super::spec::ActionSpec::DeviceExecute {
+                device: "d".into(),
+                capability: "power".into(),
+                args: serde_json::Value::Null,
+            }],
+            debounce_secs: None,
+            rate_limit: None,
+            delay_secs: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn salvar_e_listar_o_retrato() {
+        let store = AutomationStore::em_memoria().unwrap();
+        store
+            .salvar_specs(&[spec_exemplo("a-luz", true), spec_exemplo("b-fan", false)])
+            .await
+            .unwrap();
+        let lista = store.listar().await.unwrap();
+        assert_eq!(lista, vec![("a-luz".into(), true), ("b-fan".into(), false)]);
+
+        // O retrato é substituído: regra apagada some.
+        store
+            .salvar_specs(&[spec_exemplo("a-luz", true)])
+            .await
+            .unwrap();
+        let lista = store.listar().await.unwrap();
+        assert_eq!(lista, vec![("a-luz".into(), true)]);
+    }
+
+    #[tokio::test]
+    async fn registrar_e_ler_historico() {
+        let store = AutomationStore::em_memoria().unwrap();
+        store
+            .salvar_specs(&[spec_exemplo("a", true)])
+            .await
+            .unwrap();
+        for i in 0..3 {
+            store
+                .registrar(&Execucao {
+                    automacao: "a".into(),
+                    disparada_em: 1000 + i,
+                    resultado: if i == 1 {
+                        ResultadoExecucao::BloqueadaRisco
+                    } else {
+                        ResultadoExecucao::Executada
+                    },
+                    gatilho: serde_json::json!({ "entity_id": "sensor.x" }),
+                    detalhe: serde_json::json!([{ "acao": "executed" }]),
+                    duracao_ms: 5 + i,
+                })
+                .await
+                .unwrap();
+        }
+        let hist = store.historico(Some("a"), 10).await.unwrap();
+        assert_eq!(hist.len(), 3);
+        // Mais novo primeiro.
+        assert_eq!(hist[0].disparada_em, 1002);
+        assert_eq!(hist[1].resultado, ResultadoExecucao::BloqueadaRisco);
+        assert_eq!(hist[2].gatilho["entity_id"], "sensor.x");
+
+        let de_outro = store.historico(Some("inexistente"), 10).await.unwrap();
+        assert!(de_outro.is_empty());
+    }
+
+    #[tokio::test]
+    async fn historico_e_podado_no_teto() {
+        let store = AutomationStore::em_memoria().unwrap();
+        store
+            .salvar_specs(&[spec_exemplo("a", true)])
+            .await
+            .unwrap();
+        // Menos que o intervalo de poda: nada é podado no meio.
+        for i in 0..50 {
+            store
+                .registrar(&Execucao {
+                    automacao: "a".into(),
+                    disparada_em: i,
+                    resultado: ResultadoExecucao::Executada,
+                    gatilho: serde_json::Value::Null,
+                    detalhe: serde_json::Value::Null,
+                    duracao_ms: 1,
+                })
+                .await
+                .unwrap();
+        }
+        let hist = store.historico(Some("a"), 1000).await.unwrap();
+        assert_eq!(hist.len(), 50);
+    }
+
+    #[tokio::test]
+    async fn abrir_em_cria_arquivo_e_schema() {
+        let dir = std::env::temp_dir().join(format!("garraia-store-{}", std::process::id()));
+        let path = dir.join("automations.db");
+        std::fs::remove_dir_all(&dir).ok();
+        let store = AutomationStore::abrir_em(&path).unwrap();
+        store
+            .salvar_specs(&[spec_exemplo("a", true)])
+            .await
+            .unwrap();
+        drop(store);
+        // Reabre e encontra o retrato.
+        let store2 = AutomationStore::abrir_em(&path).unwrap();
+        assert_eq!(store2.listar().await.unwrap().len(), 1);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/crates/garraia-hardware/src/error.rs
+++ b/crates/garraia-hardware/src/error.rs
@@ -48,6 +48,10 @@ pub enum HardwareError {
     #[error("erro do Home Assistant: {0}")]
     HomeAssistant(String),
 
+    /// Erro do motor de automações (#1128) — spec, store ou execução.
+    #[error("erro de automações: {0}")]
+    Automations(String),
+
     /// Erro do SQLite (o store de presença).
     #[error("erro de SQLite no estado de hardware: {0}")]
     Sqlite(#[from] rusqlite::Error),

--- a/crates/garraia-hardware/src/events.rs
+++ b/crates/garraia-hardware/src/events.rs
@@ -1,0 +1,202 @@
+//! O barramento de eventos de hardware — o fio que liga os adapters ao
+//! motor de automações (#1128).
+//!
+//! Os adapters (MQTT #1126, Home Assistant #1127) publicam aqui cada mudança
+//! de estado que veem; o motor assina. Um [`tokio::sync::broadcast`] bastão:
+//! publicar nunca bloqueia o adapter, e assinante lento perde eventos antigos
+//! (`RecvError::Lagged`) — automação não é log, é gatilho; o motor trata o
+//! lag contando o que perdeu e seguindo.
+
+use tokio::sync::broadcast;
+
+/// O estado de um dispositivo no momento da observação — o que o hub falou,
+/// sem inventar formato: no Home Assistant, `state` é a string do hub
+/// (`"33.5"`) e `attributes` o objeto do hub; no MQTT, `state` é o payload
+/// da mensagem (limitado) e `attributes` é nulo. `online = false` cobre
+/// `unavailable`/`offline` — nesse caso `state` costuma ser `None`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EstadoObservado {
+    pub state: Option<String>,
+    pub attributes: serde_json::Value,
+    pub online: bool,
+}
+
+/// A mudança de estado que um adapter viu. `velho` é o estado anterior
+/// quando o transporte o traz (Home Assistant traz; MQTT não — o payload
+/// é stateless).
+#[derive(Debug, Clone, PartialEq)]
+pub struct StateChanged {
+    /// O id do dispositivo no registry (para o HA, a `entity_id`).
+    pub device_id: String,
+    pub novo: EstadoObservado,
+    pub velho: Option<EstadoObservado>,
+    /// Momento da observação, em milissegundos desde a época (UTC).
+    pub em_milis: u64,
+}
+
+/// O evento que cruza o barramento. Uma variante hoje; o enum existe para
+/// que eventos futuros (gatilho binário, telemetria) entrem aditivamente.
+#[derive(Debug, Clone, PartialEq)]
+pub enum HardwareEvent {
+    StateChanged(StateChanged),
+}
+
+impl StateChanged {
+    /// Carimba o momento da observação com o relógio do processo.
+    pub fn agora(
+        device_id: impl Into<String>,
+        novo: EstadoObservado,
+        velho: Option<EstadoObservado>,
+    ) -> Self {
+        Self {
+            device_id: device_id.into(),
+            novo,
+            velho,
+            em_milis: milis_agora(),
+        }
+    }
+}
+
+impl EstadoObservado {
+    /// Um estado sem payload — fixture comum de adapter e teste.
+    pub fn simples(online: bool) -> Self {
+        Self {
+            state: None,
+            attributes: serde_json::Value::Null,
+            online,
+        }
+    }
+
+    /// Um estado com valor e atributos do hub.
+    pub fn com(state: Option<String>, attributes: serde_json::Value, online: bool) -> Self {
+        Self {
+            state,
+            attributes,
+            online,
+        }
+    }
+}
+
+/// Milissegundos desde a época — o único relógio que o barramento precisa.
+pub fn milis_agora() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        // Relógio antes da época só em máquina com relógio quebrado; 0 é
+        // honesto o suficiente para um carimbo de observação.
+        .unwrap_or(0)
+}
+
+/// O barramento. `Arc<HardwareEventBus>` — os adapters seguram um clone
+/// para publicar, o motor segura um para assinar.
+#[derive(Debug, Clone)]
+pub struct HardwareEventBus {
+    tx: broadcast::Sender<HardwareEvent>,
+}
+
+impl HardwareEventBus {
+    /// Barramento novo com fila de 1024 eventos — margem para uma casa
+    /// barulhenta sem que o adapter sinta o motor.
+    pub fn nova() -> Self {
+        let (tx, _) = broadcast::channel(1024);
+        Self { tx }
+    }
+
+    /// Publica sem bloquear. Sem assinantes, o evento cai no chão — é o
+    /// caso do hardware ligado sem motor de automações (o default).
+    pub fn publicar(&self, evento: HardwareEvent) {
+        let _ = self.tx.send(evento);
+    }
+
+    /// Assina o barramento a partir de agora (eventos anteriores não são
+    /// replayados — broadcast, não fila persistente).
+    pub fn subscrever(&self) -> broadcast::Receiver<HardwareEvent> {
+        self.tx.subscribe()
+    }
+
+    /// Quantos consumidores há agora — diagnóstico de wiring (0 = ninguém
+    /// escutando).
+    pub fn receptores(&self) -> usize {
+        self.tx.receiver_count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn publica_e_entrega_para_assinante() {
+        let bus = HardwareEventBus::nova();
+        let mut rx = bus.subscrever();
+        bus.publicar(HardwareEvent::StateChanged(StateChanged::agora(
+            "light.sala",
+            EstadoObservado::com(Some("on".into()), json!({ "brightness": 200 }), true),
+            None,
+        )));
+        let evento = rx.try_recv().expect("evento deveria chegar");
+        let HardwareEvent::StateChanged(mudanca) = evento;
+        assert_eq!(mudanca.device_id, "light.sala");
+        assert_eq!(mudanca.novo.state.as_deref(), Some("on"));
+        assert_eq!(mudanca.novo.attributes["brightness"], 200);
+        assert!(mudanca.novo.online);
+        assert!(mudanca.velho.is_none());
+        assert!(mudanca.em_milis > 0);
+    }
+
+    #[test]
+    fn publicar_sem_assinante_nao_panica() {
+        let bus = HardwareEventBus::nova();
+        assert_eq!(bus.receptores(), 0);
+        bus.publicar(HardwareEvent::StateChanged(StateChanged::agora(
+            "sensor.x",
+            EstadoObservado::simples(true),
+            None,
+        )));
+        assert_eq!(bus.receptores(), 0);
+    }
+
+    #[test]
+    fn assinante_lento_recebe_lagged_e_o_bus_segue() {
+        let bus = HardwareEventBus::nova();
+        let mut rx = bus.subscrever();
+        for i in 0..1200 {
+            bus.publicar(HardwareEvent::StateChanged(StateChanged::agora(
+                format!("sensor.{i}"),
+                EstadoObservado::simples(true),
+                None,
+            )));
+        }
+        // A fila é 1024: os primeiros já caíram — o consumidor enxerga o
+        // Lagged e, depois dele, os eventos vivos.
+        let mut lagged = false;
+        let mut vivos = 0;
+        loop {
+            match rx.try_recv() {
+                Ok(_) => vivos += 1,
+                Err(broadcast::error::TryRecvError::Lagged(n)) => {
+                    lagged = true;
+                    assert!(n >= 100, "perdeu menos do que a fila comporta: {n}");
+                }
+                Err(broadcast::error::TryRecvError::Empty) => break,
+                Err(broadcast::error::TryRecvError::Closed) => break,
+            }
+        }
+        assert!(lagged, "o lag deveria ter sido reportado");
+        assert!(vivos >= 1000 - 16, "eventos vivos somiram: {vivos}");
+    }
+
+    #[test]
+    fn clones_do_bus_compartilham_o_canal() {
+        let bus = HardwareEventBus::nova();
+        let mut rx = bus.subscrever();
+        let clone = bus.clone();
+        clone.publicar(HardwareEvent::StateChanged(StateChanged::agora(
+            "lock.porta",
+            EstadoObservado::simples(false),
+            None,
+        )));
+        assert!(rx.try_recv().is_ok());
+    }
+}

--- a/crates/garraia-hardware/src/lib.rs
+++ b/crates/garraia-hardware/src/lib.rs
@@ -31,17 +31,31 @@
 //! quem não usa transporte de rede não paga a árvore de deps. Cada adapter
 //! traz o próprio risco avaliado no PR correspondente.
 //!
+//! # O motor de automações (#1128)
+//!
+//! O barramento [`HardwareEventBus`] recebe as mudanças de estado que os
+//! adapters veem; o [`automations::AutomationEngine`] assina, casa com as
+//! regras declarativas do usuário (TOML/JSON, feature `automations`) e
+//! executa pela **mesma policy do runtime** — o gate sem canal de confirmação
+//! (automação roda desacompanhada) com teto de risco declarado no config.
+//! Nada de bypass: o que o usuário não pediria ao agente diretamente, a
+//! automação também não faz.
+//!
 //! O estado online/offline dos dispositivos ([`DeviceStateStore`]) segue o
 //! padrão do repo: SQLite via rusqlite bundled, acesso sync sob mutex.
 
 pub mod capability;
 pub mod device;
 pub mod error;
+pub mod events;
 pub mod gate;
 pub mod registry;
 pub mod risk;
 pub mod schema;
 pub mod state;
+
+#[cfg(feature = "automations")]
+pub mod automations;
 
 #[cfg(feature = "mock-device")]
 pub mod mock;
@@ -55,10 +69,16 @@ pub mod adapter_homeassistant;
 pub use capability::Capability;
 pub use device::{Device, DeviceSummary};
 pub use error::HardwareError;
+pub use events::{EstadoObservado, HardwareEvent, HardwareEventBus, StateChanged};
 pub use gate::HardwareGate;
 pub use registry::DeviceRegistry;
 pub use risk::{ExecutionDecision, RiskClass};
 pub use state::DeviceStateStore;
+
+#[cfg(feature = "automations")]
+pub use automations::{
+    AutomationEngine, AutomationSpec, AutomationStore, carregar_dir as carregar_automacoes,
+};
 
 #[cfg(feature = "mock-device")]
 pub use mock::MockDevice;

--- a/crates/garraia-hardware/tests/adapter_homeassistant.rs
+++ b/crates/garraia-hardware/tests/adapter_homeassistant.rs
@@ -246,7 +246,7 @@ async fn descoberta_registra_por_dominio_com_risco() {
     let registry = Arc::new(DeviceRegistry::new());
     let store = Arc::new(DeviceStateStore::em_memoria().expect("store"));
     let config = HaAdapterConfig::new(&hub.url, "token-do-ha".to_string()).expect("config vetada");
-    let manager = HaAdapterManager::spawn(config, registry.clone(), Some(store.clone()));
+    let manager = HaAdapterManager::spawn(config, registry.clone(), Some(store.clone()), None);
 
     let registrado = espera(PRAZO, || async { (registry.len() == 7).then_some(()) }).await;
     assert_eq!(registrado, Some(()), "7 entidades viram dispositivos");
@@ -331,7 +331,7 @@ async fn read_busca_estado_no_hub() {
 
     let registry = Arc::new(DeviceRegistry::new());
     let config = HaAdapterConfig::new(&hub.url, "token-do-ha".to_string()).expect("config");
-    let manager = HaAdapterManager::spawn(config, registry.clone(), None);
+    let manager = HaAdapterManager::spawn(config, registry.clone(), None, None);
 
     let sensor = espera(PRAZO, || async { registry.get("sensor.temp") })
         .await
@@ -371,7 +371,7 @@ async fn execute_mapeia_servico_e_payload() {
 
     let registry = Arc::new(DeviceRegistry::new());
     let config = HaAdapterConfig::new(&hub.url, "token-do-ha".to_string()).expect("config");
-    let manager = HaAdapterManager::spawn(config, registry.clone(), None);
+    let manager = HaAdapterManager::spawn(config, registry.clone(), None, None);
 
     let light = espera(PRAZO, || async { registry.get("light.sala") })
         .await
@@ -459,7 +459,7 @@ async fn execute_recusa_args_invalidos_antes_do_hub() {
 
     let registry = Arc::new(DeviceRegistry::new());
     let config = HaAdapterConfig::new(&hub.url, "token-do-ha".to_string()).expect("config");
-    let manager = HaAdapterManager::spawn(config, registry.clone(), None);
+    let manager = HaAdapterManager::spawn(config, registry.clone(), None, None);
 
     let light = espera(PRAZO, || async { registry.get("light.sala") })
         .await
@@ -496,7 +496,7 @@ async fn ws_marca_presenca_por_evento() {
     let registry = Arc::new(DeviceRegistry::new());
     let store = Arc::new(DeviceStateStore::em_memoria().expect("store"));
     let config = HaAdapterConfig::new(&hub.url, "token-do-ha".to_string()).expect("config");
-    let manager = HaAdapterManager::spawn(config, registry.clone(), Some(store.clone()));
+    let manager = HaAdapterManager::spawn(config, registry.clone(), Some(store.clone()), None);
 
     // Presença inicial da descoberta (cover.janela nasce offline).
     espera(PRAZO, || async {
@@ -579,7 +579,7 @@ async fn ws_token_errado_nao_assina() {
 
     let registry = Arc::new(DeviceRegistry::new());
     let config = HaAdapterConfig::new(&hub.url, "token-errado".to_string()).expect("config");
-    let manager = HaAdapterManager::spawn(config, registry.clone(), None);
+    let manager = HaAdapterManager::spawn(config, registry.clone(), None, None);
 
     // A tentativa de auth chega…
     espera(PRAZO, || async {
@@ -613,7 +613,7 @@ async fn hub_inacessivel_registry_fica_vazio() {
     let registry = Arc::new(DeviceRegistry::new());
     let config = HaAdapterConfig::new(&format!("http://127.0.0.1:{porta}"), "t".to_string())
         .expect("config vetada (loopback)");
-    let manager = HaAdapterManager::spawn(config, registry.clone(), None);
+    let manager = HaAdapterManager::spawn(config, registry.clone(), None, None);
 
     tokio::time::sleep(Duration::from_millis(400)).await;
     assert!(

--- a/crates/garraia-hardware/tests/automations.rs
+++ b/crates/garraia-hardware/tests/automations.rs
@@ -1,0 +1,501 @@
+//! Testes de integração do motor de automações (#1128) contra o
+//! [`MockDevice`] e o barramento de eventos de verdade — o mesmo caminho de
+//! produção: spec TOML carregada por `carregar_dir`, evento entra, regra
+//! casa, condição avalia, ação passa pelo gate sem canal de confirmação e o
+//! device executa. A auditoria é o store em memória, lido de volta pelo
+//! teste.
+
+#![cfg(feature = "automations")]
+
+use garraia_hardware::automations::{
+    ConditionSpec, EngineConfig, Execucao, ResultadoExecucao, TetoRisco,
+};
+use garraia_hardware::{
+    AutomationEngine, AutomationSpec, AutomationStore, Capability, DeviceRegistry, EstadoObservado,
+    HardwareEvent, HardwareEventBus, MockDevice, RiskClass, StateChanged, carregar_automacoes,
+};
+use serde_json::json;
+use std::sync::Arc;
+use std::time::Duration;
+
+// ---------------------------------------------------------------- helpers
+
+/// Espera a primeira execução auditada da automação — o motor é assíncrono,
+/// então nada de sleeps fixos na direção "o motor vai agir".
+async fn espera_historico(store: &AutomationStore, nome: &str) -> Execucao {
+    let fim = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Ok(h) = store.historico(Some(nome), 10).await
+            && let Some(e) = h.into_iter().next()
+        {
+            return e;
+        }
+        assert!(
+            tokio::time::Instant::now() < fim,
+            "execução de '{nome}' não chegou na auditoria"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+/// Espera uma execução com o resultado exato — para os casos em que a
+/// execução ruim também é audita (ex.: rate limit depois de uma executada).
+async fn espera_resultado(
+    store: &AutomationStore,
+    nome: &str,
+    alvo: ResultadoExecucao,
+) -> Execucao {
+    let fim = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Ok(h) = store.historico(Some(nome), 10).await
+            && let Some(e) = h.into_iter().find(|e| e.resultado == alvo)
+        {
+            return e;
+        }
+        assert!(
+            tokio::time::Instant::now() < fim,
+            "resultado {:?} de '{nome}' não chegou na auditoria",
+            alvo
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+/// Espera o mock acumular `n` execuções — prova que a ação chegou ao
+/// dispositivo, não só que a auditoria disse que sim.
+async fn espera_execs(mock: &MockDevice, n: usize) {
+    let fim = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if mock.executed().len() >= n {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < fim,
+            "mock não executou {n} vez(es)"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+/// Um ventilador R1 com `power` — o caso do issue: power on/off pelo teto.
+fn fan_garagem() -> Arc<MockDevice> {
+    let power = Capability::acao(
+        "power",
+        RiskClass::R1,
+        Some(json!({
+            "type": "object",
+            "properties": { "on": { "type": "boolean" } },
+            "required": ["on"],
+        })),
+    )
+    .expect("power é ação válida");
+    Arc::new(MockDevice::new("fan.garagem", vec![power]))
+}
+
+/// Um cover R2 — o teto máximo do que uma automação pode pedir.
+fn cover_garagem() -> Arc<MockDevice> {
+    let abrir = Capability::acao("open_cover", RiskClass::R2, None).expect("R2 válido");
+    Arc::new(MockDevice::new("cover.garagem", vec![abrir]))
+}
+
+/// Carrega specs do texto TOML pelo caminho de produção (`carregar_dir`).
+fn specs_de_toml(rotulo: &str, texto: &str) -> Vec<AutomationSpec> {
+    let dir = std::env::temp_dir().join(format!(
+        "garraia-auto-int-{}-{}",
+        rotulo,
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).expect("cria dir tmp");
+    std::fs::write(dir.join("regra.toml"), texto).expect("escreve toml");
+    let specs = carregar_automacoes(&dir).expect("specs válidas");
+    std::fs::remove_dir_all(&dir).ok();
+    specs
+}
+
+/// Monta o motor com as regras e os devices no registry. Devolve o bus para
+/// o teste publicar eventos e o store para afirmar a auditoria.
+async fn sobe_motor(
+    specs: Vec<AutomationSpec>,
+    teto: TetoRisco,
+    devices: Vec<Arc<MockDevice>>,
+) -> (
+    AutomationEngine,
+    Arc<HardwareEventBus>,
+    Arc<AutomationStore>,
+) {
+    let bus = Arc::new(HardwareEventBus::nova());
+    let registry = Arc::new(DeviceRegistry::new());
+    for device in devices {
+        registry.register(device);
+    }
+    let store = Arc::new(AutomationStore::em_memoria().expect("store em memória"));
+    let engine = AutomationEngine::spawn(
+        EngineConfig { specs, teto },
+        bus.clone(),
+        registry.clone(),
+        store.clone(),
+    )
+    .expect("motor sobe");
+    // O motor assina o barramento dentro do task dele — esperar a
+    // assinatura antes de publicar, ou o primeiro evento cai no chão
+    // (zero receptores é a corrida spawn-vs-publish do teste).
+    let fim = tokio::time::Instant::now() + Duration::from_secs(2);
+    while bus.receptores() == 0 {
+        assert!(
+            tokio::time::Instant::now() < fim,
+            "motor não assinou o barramento"
+        );
+        tokio::task::yield_now().await;
+    }
+    (engine, bus, store)
+}
+
+fn evento_temperatura(valor: &str) -> HardwareEvent {
+    HardwareEvent::StateChanged(StateChanged::agora(
+        "sensor.garagem_temperatura",
+        EstadoObservado::com(Some(valor.into()), json!({ "unit": "C" }), true),
+        None,
+    ))
+}
+
+const SPEC_VENTILADOR: &str = r#"
+[[automation]]
+name = "ventilador-garagem-quente"
+[[automation.trigger]]
+type = "state_changed"
+entity = "sensor.garagem_temperatura"
+[[automation.condition]]
+expr = "to.state > 32"
+[[automation.action]]
+type = "device_execute"
+device = "fan.garagem"
+capability = "power"
+args = { on = true }
+"#;
+
+const SPEC_COVER: &str = r#"
+[[automation]]
+name = "abrir-garagem"
+[[automation.trigger]]
+type = "state_changed"
+entity = "sensor.portao"
+[[automation.action]]
+type = "device_execute"
+device = "cover.garagem"
+capability = "open_cover"
+"#;
+
+// ------------------------------------------------------------------ casos
+
+/// O caminho feliz completo: evento → regra → condição verdadeira → gate
+/// R1 sob teto R1 → device executa → auditoria `executada`.
+#[tokio::test]
+async fn dispara_com_condicao_verdadeira_e_executa_a_acao() {
+    let fan = fan_garagem();
+    let (engine, bus, store) = sobe_motor(
+        specs_de_toml("ventilador", SPEC_VENTILADOR),
+        TetoRisco::R1,
+        vec![fan.clone()],
+    )
+    .await;
+    bus.publicar(evento_temperatura("33.5"));
+
+    let execucao = espera_historico(&store, "ventilador-garagem-quente").await;
+    assert_eq!(execucao.resultado, ResultadoExecucao::Executada);
+    assert_eq!(execucao.gatilho["entity_id"], "sensor.garagem_temperatura");
+    assert_eq!(execucao.detalhe[0]["resultado"], "executada");
+    assert_eq!(execucao.detalhe[0]["resposta"]["ok"], true);
+
+    espera_execs(&fan, 1).await;
+    assert_eq!(
+        fan.executed(),
+        vec![("power".to_string(), json!({ "on": true }))]
+    );
+    engine.encerrar();
+}
+
+/// Condição falsa não é falha — é a regra decidindo não agir, com a
+/// auditoria dizendo o porquê.
+#[tokio::test]
+async fn condicao_falsa_nao_executa_e_fica_auditorada() {
+    let fan = fan_garagem();
+    let (engine, bus, store) = sobe_motor(
+        specs_de_toml("falsa", SPEC_VENTILADOR),
+        TetoRisco::R1,
+        vec![fan.clone()],
+    )
+    .await;
+    bus.publicar(evento_temperatura("28.0"));
+
+    let execucao = espera_historico(&store, "ventilador-garagem-quente").await;
+    assert_eq!(execucao.resultado, ResultadoExecucao::CondicaoFalsa);
+    assert_eq!(execucao.detalhe[0]["avaliacao"], false);
+    assert!(fan.executed().is_empty(), "condição falsa não executa");
+    engine.encerrar();
+}
+
+/// Caminho que não existe no contexto é erro de condição — fail-closed, e
+/// nunca um `false` silencioso (o autor da regra tem que saber que a
+/// expressão não avaliou).
+#[tokio::test]
+async fn condicao_com_caminho_inexistente_vira_condicao_erro() {
+    let mut specs = specs_de_toml("caminho", SPEC_VENTILADOR);
+    specs[0].condition = vec![ConditionSpec {
+        expr: "to.new_state.state > 32".into(), // forma literal da issue não resolve no ctx
+    }];
+    let fan = fan_garagem();
+    let (engine, bus, store) = sobe_motor(specs, TetoRisco::R1, vec![fan.clone()]).await;
+    bus.publicar(evento_temperatura("33.5"));
+
+    let execucao = espera_historico(&store, "ventilador-garagem-quente").await;
+    assert_eq!(execucao.resultado, ResultadoExecucao::CondicaoErro);
+    assert!(
+        execucao.detalhe[0].get("erro").is_some(),
+        "erro nomeado no detalhe"
+    );
+    assert!(fan.executed().is_empty());
+    engine.encerrar();
+}
+
+/// Teto R0 nega a ação R1 — e a negativa fica na auditoria com classe e
+/// teto, não é um silêncio.
+#[tokio::test]
+async fn teto_r0_bloqueia_acao_r1_com_auditoria() {
+    let fan = fan_garagem();
+    let (engine, bus, store) = sobe_motor(
+        specs_de_toml("teto-r0", SPEC_VENTILADOR),
+        TetoRisco::R0,
+        vec![fan.clone()],
+    )
+    .await;
+    bus.publicar(evento_temperatura("33.5"));
+
+    let execucao = espera_historico(&store, "ventilador-garagem-quente").await;
+    assert_eq!(execucao.resultado, ResultadoExecucao::BloqueadaRisco);
+    assert_eq!(execucao.detalhe[0]["classe"], "R1");
+    assert_eq!(execucao.detalhe[0]["teto"], "r0");
+    assert!(fan.executed().is_empty(), "ação bloqueada não executa");
+    engine.encerrar();
+}
+
+/// Teto R1 permite R1 mas nega R2 — o teto máximo é R2, e R1 fica aquém.
+#[tokio::test]
+async fn teto_r1_bloqueia_acao_r2() {
+    let cover = cover_garagem();
+    let (engine, bus, store) = sobe_motor(
+        specs_de_toml("teto-r1", SPEC_COVER),
+        TetoRisco::R1,
+        vec![cover.clone()],
+    )
+    .await;
+    bus.publicar(HardwareEvent::StateChanged(StateChanged::agora(
+        "sensor.portao",
+        EstadoObservado::com(Some("cheguei".into()), json!({}), true),
+        None,
+    )));
+
+    let execucao = espera_historico(&store, "abrir-garagem").await;
+    assert_eq!(execucao.resultado, ResultadoExecucao::BloqueadaRisco);
+    assert_eq!(execucao.detalhe[0]["classe"], "R2");
+    assert_eq!(execucao.detalhe[0]["teto"], "r1");
+    assert!(cover.executed().is_empty());
+    engine.encerrar();
+}
+
+/// Teto R2 permite o cover — e o rate limit da regra rege acima do risco:
+/// segunda execução dentro da hora é rejeitada mesmo sendo permitida.
+#[tokio::test]
+async fn teto_r2_permite_r2_e_rate_limit_ainda_rege() {
+    let spec = {
+        let mut s = specs_de_toml("rate", SPEC_COVER);
+        s[0].rate_limit = Some(garraia_hardware::automations::RateLimitSpec { max_per_hour: 1 });
+        s
+    };
+    let cover = cover_garagem();
+    let (engine, bus, store) = sobe_motor(spec, TetoRisco::R2, vec![cover.clone()]).await;
+    let evento = |v: &str| {
+        HardwareEvent::StateChanged(StateChanged::agora(
+            "sensor.portao",
+            EstadoObservado::com(Some(v.into()), json!({}), true),
+            None,
+        ))
+    };
+
+    bus.publicar(evento("cheguei"));
+    espera_execs(&cover, 1).await;
+    let primeira = espera_resultado(&store, "abrir-garagem", ResultadoExecucao::Executada).await;
+    assert_eq!(primeira.detalhe[0]["resposta"]["ok"], true);
+
+    // Segundo evento dentro da hora: rate limit rejeita.
+    bus.publicar(evento("sai"));
+    let limitada = espera_resultado(&store, "abrir-garagem", ResultadoExecucao::RateLimited).await;
+    assert_eq!(limitada.detalhe["max_per_hour"], 1);
+    assert_eq!(cover.executed().len(), 1, "rate limit rege sobre o risco");
+    engine.encerrar();
+}
+
+/// Dispositivo ausente no registry vira erro auditado — o motor não panica
+/// e o resto do pipeline continua saudável.
+#[tokio::test]
+async fn dispositivo_ausente_vira_erro_auditorado() {
+    let spec_texto = SPEC_VENTILADOR.replace("fan.garagem", "fan.inexistente");
+    let (engine, bus, store) = sobe_motor(
+        specs_de_toml("fantasma", &spec_texto),
+        TetoRisco::R1,
+        vec![fan_garagem()],
+    )
+    .await;
+    bus.publicar(evento_temperatura("33.5"));
+
+    let execucao = espera_historico(&store, "ventilador-garagem-quente").await;
+    assert_eq!(execucao.resultado, ResultadoExecucao::Erro);
+    assert_eq!(execucao.detalhe[0]["motivo"], "dispositivo não registrado");
+    engine.encerrar();
+}
+
+/// Regra desabilitada não arma — nem executa, nem audita.
+#[tokio::test]
+async fn regra_desabilitada_nao_arma() {
+    let mut specs = specs_de_toml("desligada", SPEC_VENTILADOR);
+    specs[0].enabled = false;
+    let fan = fan_garagem();
+    let (engine, bus, store) = sobe_motor(specs, TetoRisco::R1, vec![fan.clone()]).await;
+    bus.publicar(evento_temperatura("33.5"));
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    assert!(fan.executed().is_empty());
+    assert!(
+        store
+            .historico(Some("ventilador-garagem-quente"), 10)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    engine.encerrar();
+}
+
+/// Rajada de eventos dentro da janela de debounce vira uma execução só —
+/// o sensor barulhento não liga o ventilador três vezes.
+#[tokio::test]
+async fn debounce_absorve_rajada_de_eventos() {
+    let mut specs = specs_de_toml("debounce", SPEC_VENTILADOR);
+    specs[0].debounce_secs = Some(2);
+    let fan = fan_garagem();
+    let (engine, bus, store) = sobe_motor(specs, TetoRisco::R1, vec![fan.clone()]).await;
+
+    for _ in 0..3 {
+        bus.publicar(evento_temperatura("33.5"));
+    }
+    espera_execs(&fan, 1).await;
+    // O pipeline único terminou: uma execução auditada, e nenhuma outra
+    // vem — o resto da rajada morreu no debounce.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert_eq!(fan.executed().len(), 1, "debounce colapsa a rajada");
+    assert_eq!(
+        store
+            .historico(Some("ventilador-garagem-quente"), 10)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+    engine.encerrar();
+}
+
+/// Duas ações rodam em sequência e o detalhe registra as duas.
+#[tokio::test]
+async fn multi_acao_executa_em_sequencia_com_detalhe() {
+    let spec_texto = r#"
+[[automation]]
+name = "desligar-tudo"
+[[automation.trigger]]
+type = "state_changed"
+entity = "sensor.garagem_temperatura"
+[[automation.action]]
+type = "device_execute"
+device = "fan.garagem"
+capability = "power"
+args = { on = true }
+[[automation.action]]
+type = "device_execute"
+device = "lampada.sala"
+capability = "power"
+args = { on = false }
+"#;
+    let lampada = Arc::new(MockDevice::new(
+        "lampada.sala",
+        vec![
+            Capability::acao(
+                "power",
+                RiskClass::R1,
+                Some(json!({
+                    "type": "object",
+                    "properties": { "on": { "type": "boolean" } },
+                    "required": ["on"],
+                })),
+            )
+            .expect("power é R1"),
+        ],
+    ));
+    let fan = fan_garagem();
+    let (engine, bus, store) = sobe_motor(
+        specs_de_toml("multi", spec_texto),
+        TetoRisco::R1,
+        vec![fan.clone(), lampada.clone()],
+    )
+    .await;
+    bus.publicar(evento_temperatura("33.5"));
+
+    espera_execs(&lampada, 1).await;
+    let execucao = espera_resultado(&store, "desligar-tudo", ResultadoExecucao::Executada).await;
+    assert_eq!(execucao.detalhe.as_array().map(|a| a.len()), Some(2));
+    assert_eq!(fan.executed().len(), 1);
+    assert_eq!(
+        fan.executed()[0],
+        ("power".to_string(), json!({ "on": true }))
+    );
+    assert_eq!(lampada.executed().len(), 1);
+    assert_eq!(
+        lampada.executed()[0],
+        ("power".to_string(), json!({ "on": false }))
+    );
+    engine.encerrar();
+}
+
+/// Regra com gatilho cron ignora eventos de estado — cada gatilho só casa
+/// com o seu próprio fluxo (o disparo do cron em si é unit-tested em
+/// `cron.rs`; o tick de 30s não é viável num teste rápido).
+#[tokio::test]
+async fn regra_cron_nao_casa_evento_de_estado() {
+    let spec_texto = r#"
+[[automation]]
+name = "jantar-19h"
+[[automation.trigger]]
+type = "cron"
+expr = "0 19 * * *"
+[[automation.action]]
+type = "device_execute"
+device = "fan.garagem"
+capability = "power"
+args = { on = true }
+"#;
+    let fan = fan_garagem();
+    let (engine, bus, store) = sobe_motor(
+        specs_de_toml("cron", spec_texto),
+        TetoRisco::R1,
+        vec![fan.clone()],
+    )
+    .await;
+    bus.publicar(evento_temperatura("33.5"));
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    assert!(fan.executed().is_empty());
+    assert!(
+        store
+            .historico(Some("jantar-19h"), 10)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    engine.encerrar();
+}


### PR DESCRIPTION
## O que este PR faz

Fecha #1128 — o motor de automações declarativas do epic #1124 (ADR 0020), quarto slice do epic após as tools device_* (#1125/#1129), o adapter MQTT (#1126) e o adapter Home Assistant (#1127).

### Barramento de eventos
- Novo `HardwareEventBus` (`events.rs`): canal broadcast de `HardwareEvent::StateChanged`, capac 1024, `publicar` nunca bloqueia.
- Ambos os adapters passam a receber `Option<Arc<HardwareEventBus>>` e publicam o que veem: HA publica as transições completas (`state_changed` do WebSocket, com estado novo/velho/atributos/online); MQTT publica presença como estado (`"online"`/`"offline"` — a convenção dele não tem relatos não-solicitados).

### Motor (feature `automations`, OFF por default no crate)
- Spec declarativa TOML/JSON carregada por `carregar_dir` do dir configurado; gatilhos `state_changed` e `cron`; condições em expressão pequena (`to.state > 32`) com **fail-closed em duas camadas** — parse na carga e erro (nunca `false` silencioso) na avaliação.
- Pipeline por evento: debounce (atômico, no loop) → condições (AND) → rate limit (`max_per_hour`, janela deslizante 1h, pós-condições) → delay → ações `device_execute` em sequência → auditoria.
- **Gate sem bypass**: `HardwareGate::sem_canal_confirmacao()` — automação roda desacompanhada, então R3/R4/R5 são negadas por natureza e o `TetoRisco` do config (`r0`/`r1`/`r2`, default `r1`) corta o que ela pode pedir. `garra config check` recusa `risk_ceiling` fora da faixa.
- Toda execução auditada no `automations.db` (mesmo data dir do resto do hardware), com resultado nomeado (`executada`, `bloqueada_risco`, `condicao_falsa`, `condicao_erro`, `rate_limited`, `erro`), detalhe por ação e duração.

### Bootstrap (gateway e `garra chat`, mesma função)
- `spawn_hardware_adapters` cria o bus e arma `sobe_automacoes` fail-soft: sem seção no config o motor não sobe; store/spec/spawn quebrados viram warn e o deploy segue no ar. Automations sem nenhum adapter configurado também não sobe (nenhum evento chegaria).

### Extras
- CI: novo grupo `garraia-hardware --features automations` (clippy + testes, incluindo o de integração).
- Fix drive-by de isolamento de teste: `start_over_http_never_claims_the_owner` lia o `allowlist.json` do host e falhava em qualquer máquina com instalação com dono — o helper agora nasce com allowlist determinística em memória.

### Validação local
- `cargo test -p garraia-hardware --features automations,mqtt,home-assistant` → 84 lib + 7 adapter HA + 11 integração de automações, tudo verde
- `cargo test -p garraia-config` → 151
- `cargo test -p garraia-gateway --lib` → 1071
- clippy `-D warnings` em hardware (features automations e combinada), config e gateway (test-helpers); `cargo fmt --check` limpo

🤖 Generated with [Claude Code](https://claude.com/claude-code)