### PR TITLE
chore(deps): migra rmcp 2.2 -> 3.3 (tracker #163)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -147,7 +147,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1285,7 +1285,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes 3.0.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1302,7 +1302,7 @@ dependencies = [
  "maybe-owned",
  "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
  "winx",
 ]
 
@@ -1584,7 +1584,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2143,6 +2143,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
+dependencies = [
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2170,6 +2180,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2189,6 +2212,17 @@ dependencies = [
  "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
+dependencies = [
+ "darling_core 0.24.1",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2463,7 +2497,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2807,7 +2841,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3832,8 +3866,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -5527,7 +5561,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5683,7 +5717,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6235,7 +6269,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6843,9 +6877,9 @@ dependencies = [
 
 [[package]]
 name = "process-wrap"
-version = "9.1.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+checksum = "0e3f4237d0e4741eb50bc5584db701f1299c85fa31ff0274dd6445e79dc42d12"
 dependencies = [
  "futures",
  "indexmap 2.14.0",
@@ -7464,15 +7498,16 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+checksum = "b88db56b8ae316560e9e868b6b978ea940f27cb883323fc90e07435e44158f5c"
 dependencies = [
- "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
+ "bytes",
  "chrono",
  "futures",
  "http 1.4.1",
+ "indexmap 2.14.0",
  "pastey",
  "pin-project-lite",
  "process-wrap",
@@ -7487,19 +7522,20 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "rmcp-macros"
-version = "2.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
+checksum = "873b730df6f0a9b74b13eb514e0dca4c2db0d8b68b74af98a2e9bf3f9d436585"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.1",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7614,7 +7650,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7683,7 +7719,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8359,7 +8395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8665,7 +8701,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9425,7 +9461,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10118,7 +10154,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10232,7 +10268,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11278,7 +11314,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,12 +135,14 @@ teloxide = { version = "0.17", default-features = false, features = ["rustls", "
 tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
 
 # MCP (Model Context Protocol)
-# 2.2 alinha os tipos de modelo à spec MCP 2025-11-25 (upstream rust-sdk#927):
-# `Annotated<RawContent>`/`RawContent`/`Content` viraram o enum achatado
-# `ContentBlock`, e `PromptMessageRole`/`PromptMessageContent` viraram
-# `Role`/`ContentBlock`. Migração em plans/0358. O salto para 3.x segue
-# adiado (tracker interno #163).
-rmcp = { version = "2.2" }
+# 3.3 fecha a migração para 3.x (tracker interno #163): `ServerHandler::
+# call_tool` devolve `CallToolResponse` (`Complete`/`InputRequired`/`Task`),
+# `ListToolsResult` ganhou `result_type`/`ttl_ms`/`cache_scope` (construtor
+# `with_all_items`), e `ServerCapabilities.tasks` virou a extension
+# `io.modelcontextprotocol/tasks` (SEP-2663, sondável via `supports_tasks()`).
+# O salto 2.2→3.x anterior (2.1→2.2, plans/0358) trocou `Annotated<RawContent>`
+# pelo enum achatado `ContentBlock`.
+rmcp = { version = "3.2" }
 
 # System / OS interop
 libc = "0.2"

--- a/changelog.d/changed/rmcp-3-3-port.md
+++ b/changelog.d/changed/rmcp-3-3-port.md
@@ -1,0 +1,10 @@
+- Fecha a migracao do MCP SDK para 3.x (tracker interno #163): `rmcp`
+  2.2 -> 3.3 no workspace (e `process-wrap` 9.1 -> 10.0, transitivo do
+  client stdio). O `ServerHandler::call_tool` do servidor `garra mcp-server`
+  agora devolve `CallToolResponse` (`Complete` para resultado de tool comum),
+  `tools/list` usa o construtor `ListToolsResult::with_all_items` (o struct
+  ganhou `result_type`/`ttl_ms`/`cache_scope`), e o teste de capabilities
+  passou a sondar a extension `io.modelcontextprotocol/tasks` (SEP-2663) via
+  `supports_tasks()` — o campo `ServerCapabilities.tasks` nao existe mais.
+  Sem mudanca de comportamento para os hosts MCP: `garra_ask`/`garra_agent`
+  continuam anunciando e respondendo igual.

--- a/crates/garraia-cli/src/mcp_server.rs
+++ b/crates/garraia-cli/src/mcp_server.rs
@@ -1,7 +1,7 @@
 //! GAR-583 — MCP server exposing `garra ask` as a stdio tool.
 //!
 //! Implements the `Model Context Protocol` (MCP) `ServerHandler` trait
-//! from `rmcp 2.2` and exposes `garra_ask` — LLM-only — which calls
+//! from `rmcp 3.3` and exposes `garra_ask` — LLM-only — which calls
 //! [`crate::ask::ask_oneshot`] **in-process** (no subprocess spawn, no
 //! shell). Designed for Claude Desktop, Claude Code, and any MCP host
 //! that speaks stdio JSON-RPC.
@@ -29,8 +29,8 @@ use anyhow::Result;
 use garraia_config::AppConfig;
 use rmcp::ErrorData as McpError;
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, ContentBlock, ListToolsResult, PaginatedRequestParams,
-    ServerCapabilities, ServerInfo, Tool,
+    CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ListToolsResult,
+    PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
 };
 use rmcp::service::RequestContext;
 use rmcp::{RoleServer, ServerHandler, ServiceExt};
@@ -433,7 +433,7 @@ impl GarraToolHandler {
     async fn call_agent_tool(
         &self,
         request: CallToolRequestParams,
-    ) -> Result<CallToolResult, McpError> {
+    ) -> Result<CallToolResponse, McpError> {
         let raw = request.arguments.unwrap_or_default();
         let args: crate::mcp_agent::GarraAgentArgs = serde_json::from_value(JsonValue::Object(raw))
             .map_err(|e| McpError::invalid_params(format!("invalid arguments: {e}"), None))?;
@@ -448,10 +448,13 @@ impl GarraToolHandler {
                     )
                 });
                 let content = vec![ContentBlock::text(text)];
+                // rmcp 3.3: `ServerHandler::call_tool` agora devolve
+                // `CallToolResponse` (`Complete`/`InputRequired`/`Task`);
+                // um resultado de tool comum é `Complete(CallToolResult)`.
                 if is_ok {
-                    Ok(CallToolResult::success(content))
+                    Ok(CallToolResponse::Complete(CallToolResult::success(content)))
                 } else {
-                    Ok(CallToolResult::error(content))
+                    Ok(CallToolResponse::Complete(CallToolResult::error(content)))
                 }
             }
             Err(e) => Err(McpError::invalid_params(e, None)),
@@ -481,18 +484,20 @@ impl ServerHandler for GarraToolHandler {
         _: Option<PaginatedRequestParams>,
         _: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
-        Ok(ListToolsResult {
-            tools: advertised_tools(&self.policy),
-            next_cursor: None,
-            meta: None,
-        })
+        // rmcp 3.3: `ListToolsResult` ganhou `result_type`/`ttl_ms`/
+        // `cache_scope`; o construtor `with_all_items` marca o resultado
+        // como COMPLETE e deixa os knobs de paginação/timing unset
+        // (listagem de página única, sem TTL).
+        Ok(ListToolsResult::with_all_items(advertised_tools(
+            &self.policy,
+        )))
     }
 
     async fn call_tool(
         &self,
         request: CallToolRequestParams,
         _: RequestContext<RoleServer>,
-    ) -> Result<CallToolResult, McpError> {
+    ) -> Result<CallToolResponse, McpError> {
         // `garra_agent` dispatches only behind the operator opt-in; with
         // the flag off it falls through to the unknown-tool branch so the
         // rejection surface is byte-identical to the pre-agent server.
@@ -558,10 +563,13 @@ impl ServerHandler for GarraToolHandler {
         // tipo agora é o enum achatado `ContentBlock`, que `CallToolResult::
         // success`/`error` recebem como `Vec<ContentBlock>`.
         let content = vec![ContentBlock::text(text)];
+        // rmcp 3.3: `CallToolResponse::Complete(CallToolResult)` é o
+        // wrapper do resultado de tool comum (trait `ServerHandler::
+        // call_tool` mudou o tipo de retorno em 3.x).
         if outcome.is_ok() {
-            Ok(CallToolResult::success(content))
+            Ok(CallToolResponse::Complete(CallToolResult::success(content)))
         } else {
-            Ok(CallToolResult::error(content))
+            Ok(CallToolResponse::Complete(CallToolResult::error(content)))
         }
     }
 }
@@ -936,7 +944,12 @@ mod tests {
         assert!(caps.completions.is_none(), "completions must stay off");
         assert!(caps.prompts.is_none(), "prompts must stay off");
         assert!(caps.resources.is_none(), "resources must stay off");
-        assert!(caps.tasks.is_none(), "tasks must stay off");
+        // rmcp 3.3: `ServerCapabilities.tasks` não existe mais — o suporte a
+        // tasks (SEP-2663) passou a ser uma *extension* (`io.modelcontextprotocol/
+        // tasks`) declarada em `extensions` e sondável via `supports_tasks()`.
+        // A asserção fica equivalente (e mais forte): nenhuma extension
+        // declarada ⇒ tasks também não anunciado.
+        assert!(!caps.supports_tasks(), "tasks must stay off");
     }
 
     /// GAR-583 §4 invariant #2 — production code MUST NOT register


### PR DESCRIPTION
## O que este PR faz

Fecha a migração do MCP SDK para 3.x (tracker interno `GarraIA/GarraIA#163` — "Upgrades de dependência adiados no repo público"). Bump `rmcp` 2.2 → 3.3 no workspace, com a migração de API concentrada no único consumidor do lado servidor: `crates/garraia-cli/src/mcp_server.rs`.

## Mudanças

- **Cargo.toml / Cargo.lock**: `rmcp = { version = "3.2" }` resolve para 3.3.0 (3.2.0 não existe no registry); `rmcp-macros` 3.3.0 e `process-wrap` 10.0.0 (transitivo do client stdio) no lock.
- **`call_tool`/`call_agent_tool`**: `ServerHandler::call_tool` agora devolve `Result<CallToolResponse, McpError>` — resultado de tool comum é `CallToolResponse::Complete(CallToolResult)`. Rejeições de policy/args continuam `McpError::invalid_params`, sem mudança de semântica.
- **`list_tools`**: `ListToolsResult` ganhou `result_type`/`ttl_ms`/`cache_scope` em 3.x; o construtor `with_all_items` marca o resultado como COMPLETE e deixa os knobs de paginação/timing unset (listagem de página única, sem TTL) — equivalente ao struct literal anterior.
- **Teste de capabilities**: `ServerCapabilities.tasks` não existe mais — o suporte a tasks virou a extension `io.modelcontextprotocol/tasks` (SEP-2663), sondável via `supports_tasks()`. A asserção "tasks must stay off" ficou equivalente e mais forte.

## O que NÃO mudou de propósito

- `crates/garraia-agents/src/mcp/tool_bridge.rs` mantém o `manager.peer_for()` **por chamada** (design já correto no público). A variante do repo privado que captura `Arc<Peer<RoleClient>>` direto é uma regressão pós-reconexão e não foi portada.
- Zero mudança de comportamento para hosts MCP: mesma superfície `garra_ask`/`garra_agent`, mesmos envelopes `garra.ask.v1`/`garra.agent.v1`, mesmos códigos de erro.

## Evidência de teste (local)

| Gate | Resultado |
| --- | --- |
| `cargo check -p garraia` | EXIT=0 |
| `cargo fmt --check --all` | EXIT=0 |
| `cargo clippy -p garraia --features mcp-http --all-targets -- -D warnings` | EXIT=0 |
| `cargo clippy -p garraia-agents --features mcp --all-targets -- -D warnings` | EXIT=0 |
| `cargo test -p garraia-agents --features mcp --test mcp_lifecycle` | 3 passed (reconnect pós-morte do child intacto) |
| `cargo test -p garraia` | 488 passed, 0 failed |
| `cargo clippy --workspace --exclude garraia-desktop --all-targets -- -D warnings` | EXIT=0 |
| `cargo test --workspace --exclude garraia-desktop` | (ver tabela do CI abaixo) |

## Risco

Baixo — migração de API de dependência, sem mudança semântica. Consumidores MCP (Claude Code `/mcp`, Claude Desktop) continuam negociando só a capability `tools`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
